### PR TITLE
FIX: Issue when deployed on Elastic BeanStalk without KEYMAT

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -1,7 +1,6 @@
 from flask import Blueprint
 main = Blueprint('main', __name__)
 from app.main.views import root
-from app.main import errors
 
 
 @main.after_request

--- a/app/main/views/root.py
+++ b/app/main/views/root.py
@@ -11,6 +11,10 @@ import os
 
 EQ_URL_QUERY_STRING_JWT_FIELD_NAME = 'token'
 
+
+if (settings.EQ_RRM_PUBLIC_KEY is None or settings.EQ_SR_PRIVATE_KEY is None):
+    raise OSError('KEYMAT not configured correctly.')
+
 decoder = Decoder(settings.EQ_RRM_PUBLIC_KEY, settings.EQ_SR_PRIVATE_KEY, "digitaleq")
 
 


### PR DESCRIPTION
**What**

When deploying survey runner without KEYMAT(public, private keys for JWT) the survey errors as it expects the KEYMAT to be set to file paths not none as os.get.environ returns when an a env var is not found. 

This PR adds an explicit test for the setting of those variables and raises a specific exception if there is not one set. It also removes an unneccesary import that was suppressing the root cause. 

**How to test**
1. Checkout this branch
2. Run `./scripts/run_app.sh` - this will automatically set the KEYMAT variables.
3. Run in the root dir `python application.py` and the script should error out raising an OSError.

**Who can review**

Anyone but @dhilton. 
