### PR TITLE
Fix git revision elasticbeanstalk

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ EQ_RABBITMQ_URL - the RabbitMQ connection string
 EQ_RABBITMQ_QUEUE_NAME - the name of the submission queue
 EQ_RABBITMQ_TEST_QUEUE_NAME - the name of the test queue
 EQ_PRODUCTION - flag to indicate if we're running in production or dev mode
+EQ_GIT_REF - the latest git ref of HEAD on master
 ```
 
 ## JWT Integration

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,6 +7,7 @@ from flaskext.markdown import Markdown
 
 from app.submitter.submitter import Submitter
 import logging
+import os
 
 DISPLAY_DATETIME_FORMAT = '%A %d %B %Y at %H:%M'
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
@@ -22,20 +23,14 @@ def rabbitmq_available():
 
 
 def get_git_revision():
-    try:
-        revision_log = open("revision.log")
-        revision = revision_log.readlines()
-        revision_log.close()
-        return True, revision
-    except FileNotFoundError:
-        logging.exception("Git revision file missing")
-        return False, "Git revision not available"
+    git_revision = settings.EQ_GIT_REF
+    return git_revision
 
 GIT_REVISION = get_git_revision()
 
 
 def git_revision():
-    return GIT_REVISION
+    return True, GIT_REVISION
 
 
 def create_app(config_name):

--- a/app/main/views/root.py
+++ b/app/main/views/root.py
@@ -11,11 +11,11 @@ import os
 
 EQ_URL_QUERY_STRING_JWT_FIELD_NAME = 'token'
 
-
-if (settings.EQ_RRM_PUBLIC_KEY is None or settings.EQ_SR_PRIVATE_KEY is None):
-    raise OSError('KEYMAT not configured correctly.')
-
-decoder = Decoder(settings.EQ_RRM_PUBLIC_KEY, settings.EQ_SR_PRIVATE_KEY, "digitaleq")
+if settings.EQ_PRODUCTION.upper() != 'FALSE':
+    if (settings.EQ_RRM_PUBLIC_KEY is None or settings.EQ_SR_PRIVATE_KEY is None):
+        raise OSError('KEYMAT not configured correctly.')
+    else:
+        decoder = Decoder(settings.EQ_RRM_PUBLIC_KEY, settings.EQ_SR_PRIVATE_KEY, "digitaleq")
 
 
 @main.before_request

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,10 +1,10 @@
 import os
 
 
-EQ_RABBITMQ_URL             = os.getenv('EQ_RABBITMQ_URL', 'amqp://admin:admin@localhost:5672/%2F')
-EQ_RABBITMQ_QUEUE_NAME      = os.getenv('EQ_RABBITMQ_QUEUE_NAME', 'eq-submissions')
+EQ_RABBITMQ_URL = os.getenv('EQ_RABBITMQ_URL', 'amqp://admin:admin@localhost:5672/%2F')
+EQ_RABBITMQ_QUEUE_NAME = os.getenv('EQ_RABBITMQ_QUEUE_NAME', 'eq-submissions')
 EQ_RABBITMQ_TEST_QUEUE_NAME = os.getenv('EQ_RABBITMQ_TEST_QUEUE_NAME', 'eq-test')
-EQ_PRODUCTION               = os.getenv("EQ_PRODUCTION", 'True')
-EQ_RRM_PUBLIC_KEY           = os.getenv('EQ_RRM_PUBLIC_KEY')
-EQ_SR_PRIVATE_KEY           = os.getenv('EQ_SR_PRIVATE_KEY')
-EQ_GIT_REF                  = os.getenv('EQ_GIT_REF', None)
+EQ_PRODUCTION = os.getenv("EQ_PRODUCTION", 'True')
+EQ_RRM_PUBLIC_KEY = os.getenv('EQ_RRM_PUBLIC_KEY')
+EQ_SR_PRIVATE_KEY = os.getenv('EQ_SR_PRIVATE_KEY')
+EQ_GIT_REF = os.getenv('EQ_GIT_REF', None)

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,9 +1,10 @@
 import os
 
 
-EQ_RABBITMQ_URL = os.getenv('EQ_RABBITMQ_URL', 'amqp://admin:admin@localhost:5672/%2F')
-EQ_RABBITMQ_QUEUE_NAME = os.getenv('EQ_RABBITMQ_QUEUE_NAME', 'eq-submissions')
+EQ_RABBITMQ_URL             = os.getenv('EQ_RABBITMQ_URL', 'amqp://admin:admin@localhost:5672/%2F')
+EQ_RABBITMQ_QUEUE_NAME      = os.getenv('EQ_RABBITMQ_QUEUE_NAME', 'eq-submissions')
 EQ_RABBITMQ_TEST_QUEUE_NAME = os.getenv('EQ_RABBITMQ_TEST_QUEUE_NAME', 'eq-test')
-EQ_PRODUCTION = os.getenv("EQ_PRODUCTION", 'True')
-EQ_RRM_PUBLIC_KEY = os.getenv('EQ_RRM_PUBLIC_KEY')
-EQ_SR_PRIVATE_KEY = os.getenv('EQ_SR_PRIVATE_KEY')
+EQ_PRODUCTION               = os.getenv("EQ_PRODUCTION", 'True')
+EQ_RRM_PUBLIC_KEY           = os.getenv('EQ_RRM_PUBLIC_KEY')
+EQ_SR_PRIVATE_KEY           = os.getenv('EQ_SR_PRIVATE_KEY')
+EQ_GIT_REF                  = os.getenv('EQ_GIT_REF', None)

--- a/application.py
+++ b/application.py
@@ -6,7 +6,7 @@ from app import create_app
 from flask.ext.script import Manager, Server
 
 application = create_app(
-    os.getenv('SR_ENVIRONMENT') or 'development'
+    os.getenv('EQ_ENVIRONMENT') or 'development'
 )
 application.debug = True
 manager = Manager(application)

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -26,7 +26,7 @@ fi
 echo "Environment variables in use:"
 env | grep EQ_
 
-#npm install
-#npm run compile
+npm install
+npm run compile
 
 python application.py runserver

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -17,14 +17,16 @@ if [ -z "$EQ_SR_PRIVATE_KEY" ]; then
 fi
 
 # Output the current git revision
-git rev-parse HEAD > revision.log
+if [ -z "$EQ_GIT_REF" ]; then
+  export EQ_GIT_REF=`git rev-parse HEAD`
+fi
 
 # Use default environment vars for localhost if not already set
 
 echo "Environment variables in use:"
 env | grep EQ_
 
-npm install
-npm run compile
+#npm install
+#npm run compile
 
 python application.py runserver


### PR DESCRIPTION
**What**

The change merged in 94315c9e5404798fb6d445a3ee21c934a41fa0d7 to add a git ref to the healthcheck, fails when deployed to elasticbeanstalk if the file doesn't exist. This change moves the file based approach to an environment variable - populating the elasticbeanstalk environment with the correct git ref for HEAD revision

This PR also fixes an issue when running the survey runner in development mode, whereby the check for  KEYMAT was always being run even if the developer explicitly switched off JWT support via the EQ_PRODUCTION feature flag. This now seems to behave.

**How to test**
1. Checkout this branch
2. With an existing elasticbeanstalk environment run: `eb init` 
3. Select `eu-west` region and your correct application 
4. Run `eb setenv EQ_PRODUCTION=false`
5. Run `eb setenv EQ_GIT_REF=1234567`
6. Run `eb deploy`

Wait till the application is deployed and then check the resulting healthcheck to ensure that the correct values are given for git ref and that you can access the pattern library without having to have a JWT in the url.

**Who can test**

Anyone but @dhilton
