### PR TITLE
Add check for statics before building - speed up local startup

### DIFF
--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -26,7 +26,9 @@ fi
 echo "Environment variables in use:"
 env | grep EQ_
 
-npm install
-npm run compile
+if [ ! -s "app/static" ]; then
+  npm install
+  npm run compile
+fi
 
 python application.py runserver


### PR DESCRIPTION
**_What**_

Speed up local application start by only building front end code if not already existing

**_How to test**_

1) Check out the branch
2) Ensure that the `app/static` directory is deleted
2) Run `scripts/run_app.sh`
3) Wait while node.js builds the static resources before the server is started
4) Kill the server with `CTRL+C`
5) Run `scripts/run_app.sh` again to restart the server
6) Notice how the node.js build does not run this time as static resources have already been created

**_Who can test**_

Anyone except @weapdiv-david
