### PR TITLE
Survey cover page

### DIFF
--- a/app/main/views/root.py
+++ b/app/main/views/root.py
@@ -106,6 +106,11 @@ def mci_survey():
     return render_template('questionnaire.html', questionnaire=data)
 
 
+@main_blueprint.route('/cover-page', methods=['GET'])
+def cover_page():
+    return render_template('cover-page.html')
+
+
 def create_model():
     '''
     Temporary method to hard code a questionnaire model to get hamish started

--- a/app/styles/base/_global.scss
+++ b/app/styles/base/_global.scss
@@ -15,18 +15,6 @@ body {
   background: $color-light-grey;
 }
 
-::-moz-selection {
-  background: $color-selection;
-  color: $color-selection-text;
-  text-shadow: none;
-}
-
-::selection {
-  background: $color-selection;
-  color: $color-selection-text;
-  text-shadow: none;
-}
-
 img {
   vertical-align: middle;
   max-width: 100%;
@@ -36,7 +24,7 @@ img {
 
 a {
   color: $color-links;
-  text-decoration: none;
+  text-decoration: underline;
   &:hover {
     text-decoration: underline;
   }

--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -1,7 +1,8 @@
 @import url("https://fonts.googleapis.com/css?family=Open+Sans:400,300,300italic,400italic,600,600italic,700,700italic");
 
 html {
-  font-size: 112.5%;
+  font-size: 1em;
+  line-height: 1.6;
   -webkit-font-smoothing: antialiased;
 }
 

--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -50,6 +50,7 @@ h5,
 .h4,
 .h5 {
   margin: 0 0 1rem;
+  line-height: 1.2;
 }
 
 code {

--- a/app/styles/components/_address.scss
+++ b/app/styles/components/_address.scss
@@ -1,0 +1,7 @@
+.address {
+  font-size: 0.8rem;
+  line-height: 1.5;
+  margin-bottom: 1rem;
+  text-transform: uppercase;
+  color: #888;
+}

--- a/app/styles/components/_address.scss
+++ b/app/styles/components/_address.scss
@@ -1,7 +1,5 @@
 .address {
   font-size: 0.8rem;
   line-height: 1.5;
-  margin-bottom: 1rem;
   text-transform: uppercase;
-  color: #888;
 }

--- a/app/styles/components/_buttons.scss
+++ b/app/styles/components/_buttons.scss
@@ -9,6 +9,7 @@
   font-size: 0.9rem;
   font-weight: 600;
   text-rendering: optimizeLegibility;
+  text-decoration: none;
   &:focus,
   &:hover {
     // outline: none;

--- a/app/styles/components/_buttons.scss
+++ b/app/styles/components/_buttons.scss
@@ -6,11 +6,14 @@
   margin: 0 0 18px 0;
   border-radius: 3px;
   display: inline-block;
-  font-size: 16px;
+  font-size: 0.9rem;
   font-weight: 600;
+  text-rendering: optimizeLegibility;
   &:focus,
   &:hover {
     // outline: none;
+    text-decoration: none;
+    color: $color;
     background-color: darken($bg, 5%);
   }
 }

--- a/app/styles/components/_cover.scss
+++ b/app/styles/components/_cover.scss
@@ -3,7 +3,7 @@
 }
 
 .cover__info {
-  margin-bottom: 3rem;
+  // margin-bottom: 3rem;
 }
 
 .cover__header {
@@ -13,18 +13,40 @@
 }
 
 .cover__address {
-  margin-bottom: 2rem;
+  margin-bottom: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid $color-light-grey;
   @include mq(s) {
+    border: none;
     margin-bottom: 0;
+    padding-bottom: 0;
+  }
+  .address {
+    color: $color-text-light;
   }
 }
 
+.cover__address-link {
+  font-size: 0.8rem;
+}
+
 .cover__notice {
-  p {
-    margin-bottom: 0.5rem;
-  }
+  color: $color-text-light;
+  margin-bottom: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid $color-light-grey;
   @include mq(s) {
     text-align: right;
+    border: none;
+    margin-bottom: 0;
+    padding-bottom: 0;
+  }
+  p {
+    margin-bottom: 0;
+    font-size: 1rem;
+    @include mq(m) {
+      font-size: 1rem;
+    }
   }
 }
 
@@ -35,14 +57,22 @@
 }
 
 .cover__title {
-  font-size: 1.9rem;
+  font-size: 1.6rem;
   font-weight: 700;
+  @include mq(s) {
+    font-size: 1.9rem;
+  }
 }
 
 .cover__subtitle {
-  font-size: 1rem;
+  font-size: 0.9rem;
+  font-weight: 400;
+  line-height: 1.3;
 }
 
 .cover__header {
-  margin-bottom: 3rem;
+  margin: 0 0 1rem 0;
+  @include mq(s) {
+    margin: 3rem 0;
+  }
 }

--- a/app/styles/components/_cover.scss
+++ b/app/styles/components/_cover.scss
@@ -28,6 +28,12 @@
   }
 }
 
+.cover__main {
+  border-bottom: 1px solid $color-light-grey;
+  padding-bottom: 1rem;
+  margin-bottom: 2rem;
+}
+
 .cover__title {
   font-size: 1.9rem;
   font-weight: 700;

--- a/app/styles/components/_cover.scss
+++ b/app/styles/components/_cover.scss
@@ -1,0 +1,42 @@
+.cover {
+  display: block;
+}
+
+.cover__info {
+  margin-bottom: 3rem;
+}
+
+.cover__header {
+  @include mq(s) {
+    text-align: center;
+  }
+}
+
+.cover__address {
+  margin-bottom: 2rem;
+  @include mq(s) {
+    margin-bottom: 0;
+  }
+}
+
+.cover__notice {
+  p {
+    margin-bottom: 0.5rem;
+  }
+  @include mq(s) {
+    text-align: right;
+  }
+}
+
+.cover__title {
+  font-size: 1.9rem;
+  font-weight: 700;
+}
+
+.cover__subtitle {
+  font-size: 1rem;
+}
+
+.cover__header {
+  margin-bottom: 3rem;
+}

--- a/app/styles/components/_header.scss
+++ b/app/styles/components/_header.scss
@@ -1,11 +1,11 @@
 .header {
   background: $color-black;
   color: $color-white;
-  padding: 0.2rem;
+  padding: 1rem;
   margin-bottom: 0.5rem;
 
   @include mq(m) {
-    padding: 0.4rem;
+    padding: 1rem;
     margin-bottom: 3rem;
   }
 }
@@ -13,4 +13,5 @@
 .header__title {
   font-size: 0.8rem;
   font-weight: 600;
+  margin-bottom: 0;
 }

--- a/app/styles/components/_info.scss
+++ b/app/styles/components/_info.scss
@@ -7,7 +7,7 @@ $icon-width: 3rem;
   position: relative;
   padding-left: $icon-width;
   transition: transform 100ms ease-out;
-  max-width: 300px;
+  max-width: 17rem;
   width: 100%;
   &:hover {
     transform: scale(1.2);
@@ -45,9 +45,10 @@ $icon-width: 3rem;
 
 .info__item {
   font-size: 0.65rem;
+  font-weight: 600;
   list-style: none;
   margin: 0;
-  padding: 0.3rem;
+  padding: 0.3rem 0.5rem;
   border-left: 1px solid $color-borders;
   border-bottom: 1px solid $color-borders;
   flex: 1 100%;

--- a/app/styles/components/_survey-header.scss
+++ b/app/styles/components/_survey-header.scss
@@ -1,14 +1,21 @@
+$bp: 480px;
+// $bp: 32em;
+// $bp: 30rem;
+
 .survey-header {
   display: block;
+  @include mq($bp) {
+    display: flex;
+    align-items: center;
+  }
 }
 
 .survey-header__logo {
   margin-bottom: 1rem;
-
-  @include mq(m) {
+  @include mq($bp) {
     margin-bottom: 0;
+    flex: 1 1 50%;
   }
-
 }
 
 .survey-header__info {
@@ -16,7 +23,10 @@
     max-width: 100%;
   }
 
-  @include mq(m) {
+  @include mq($bp) {
+    margin-left: auto;
     float: right;
+    flex: 1 1 19rem;
+    margin-left: 2rem;
   }
 }

--- a/app/styles/objects/_panel.scss
+++ b/app/styles/objects/_panel.scss
@@ -17,6 +17,6 @@
   padding: 1rem;
 
   @include mq(m) {
-    padding: 2rem 6rem;
+    padding: 2rem 4rem;
   }
 }

--- a/app/styles/utilities/_utilities.scss
+++ b/app/styles/utilities/_utilities.scss
@@ -1,13 +1,3 @@
-.clearfix::before,
-.clearfix::after {
-  content: " ";
-  display: table;
-}
-
-.clearfix::after {
-  clear: both;
-}
-
-.clearfix {
-  *zoom: 1;
+.u-ar {
+  text-align: right;
 }

--- a/app/styles/vars/_colors.scss
+++ b/app/styles/vars/_colors.scss
@@ -2,6 +2,7 @@ $color-white: #fff;
 $color-black: #222;
 $color-grey: #ccc;
 $color-dark-grey: #9b9b9b;
+$color-very-dark-grey: #595959;
 $color-light-grey: #e4e8eb;
 $color-lighter-grey: #f5f5f5;
 
@@ -19,9 +20,8 @@ $color-yellow: yellow;
 
 // assignment
 
-$color-selection: $color-primary;
-$color-selection-text: $color-black;
 $color-text: $color-black;
+$color-text-light: $color-very-dark-grey;
 $color-links: $color-blue;
 $color-borders: $color-grey;
 $color-placeholder: transparent;

--- a/app/templates/cover-page.html
+++ b/app/templates/cover-page.html
@@ -12,7 +12,7 @@
           <div class="cover__address">
             <b>To be completed by</b>
             {% include 'partials/address.html' %}
-            <a href="">Details correct?</a>
+            <a class="cover__address-link" href="">Details correct?</a>
           </div>
         </div>
 

--- a/app/templates/cover-page.html
+++ b/app/templates/cover-page.html
@@ -1,0 +1,53 @@
+{% extends 'layouts/_survey.html' %}
+{% import 'macros/helpers.html' as h %}
+
+{% block survey %}
+
+  <article class="cover">
+    <header class="cover__info">
+
+      <div class="grid grid--align-mid">
+
+        <div class="grid__col s-5">
+          <div class="cover__address">
+            <b>To be completed by</b>
+            {% include 'partials/address.html' %}
+            <a href="">Details correct?</a>
+          </div>
+        </div>
+
+        <div class="grid__col s-7">
+          <div class="cover__notice">
+            <p>Please complete by the 25th November 2015</p>
+            <p><b>Your response is legally required</b></p>
+          </div>
+        </div>
+
+      </div>
+    </header>
+
+    <section class="cover__main">
+
+      <header class="cover__header">
+        <h2 class="cover__title">Monthly Business Survey</h2>
+        <h3 class="cover__subtitle">Notice is given under section 1 of the Statistics of Trade Act 1947</h3>
+      </header>
+
+      <div class="cover__copy">
+        <p>Dear Sir or Madam,</p>
+        <p>Please find below the July 2015 questionnaire for the welcome to my survey about crayons. Your data should cover the period 3 July 2015. If actual figures are not available, please provide informed estimates.</p>
+        <p>The information supplied is used to produce a comprehensive and reliable measure of job vacancies across the economy. Results are published in the monthly Labour Market Statistical Bulletin and used by the Treasury and the Bank of England as a valuable
+          indicator of labour demand.</p>
+        <p>We guarantee that while your employment is less than 10, you will receive no more than 15 monthly questionnaires for this one ONS business survey. You must complete and return all questionnaires on time, after which you will be excluded from all
+          business surveys for at least 3 years. The Annual Survey of Hours and Earnings is not covered by this guarantee.</p>
+        <p>You are required by law to complete this questionnaire. If you do not complete and return this questionnaire by 1 O July 2015, penalties may be incurred (under section 4 of the Statistics of Trade Act 194 7). All the information you provide is kept
+          strictly confidential. It is illegal for us to reveal your data or identify your business to unauthorised persons.</p>
+        <p>Thank you for your co-operation</p>
+        <p><b>Office for National Statistics</b></p>
+      </div>
+    </section>
+
+  </article>
+
+
+{% endblock %}

--- a/app/templates/cover-page.html
+++ b/app/templates/cover-page.html
@@ -47,6 +47,12 @@
       </div>
     </section>
 
+    <footer class="cover__footer">
+
+      <a href="/mci" class="btn">Get Started</a>
+
+    </footer>
+
   </article>
 
 

--- a/app/templates/macros/helpers.html
+++ b/app/templates/macros/helpers.html
@@ -1,0 +1,3 @@
+{% macro include_with(path, data, dataHandle='data') %}
+  {% with dataHandle = data %}{% include path %}{% endwith %}
+{% endmacro %}

--- a/app/templates/partials/address.html
+++ b/app/templates/partials/address.html
@@ -1,0 +1,21 @@
+{% set address = {
+  "name": "Contact Name",
+  "street": [
+    "Office for National Statistics",
+    "Government Buildings",
+    "CARDIFF ROAD"
+  ],
+  "locality": "Duffryn, Newport",
+  "postcode": "NP10 8XG"
+} %}
+
+<div class="vcard address">
+  <span class="fn">{{address.name}}</span>
+  <div class="adr">
+    {% for street in address.street %}
+      <div class="street-address">{{street}}</div>
+    {% endfor %}
+    <div class="locality">{{address.locality}}</div>
+    <div class="postal-code">{{address.postcode}}</div>
+  </div>
+</div>


### PR DESCRIPTION
## Survey Cover Page

<img width="859" alt="screen shot 2016-03-02 at 14 22 06" src="https://cloud.githubusercontent.com/assets/930398/13463014/33099ce6-e082-11e5-8573-0f85dfa86a8a.png">
### Changes
- Added new route at /cover-page with associated template
- Styled various elements
- Re-factored loading json into a helper function which can be exposed to a template (feel free to test this, it's not used yet though)
### How to test
- Do the usual `npm install` `npm run compile` dance.
- Visit /cover-page
- Do that thing where you resize the browser window to check if something is responsive
