### PR TITLE
EQ 107 JWT Generator

### DIFF
--- a/.ebignore
+++ b/.ebignore
@@ -25,4 +25,4 @@ tests/coverage
 !newrelic.ini
 
 # Token generation file
-token.py
+token_generator.py

--- a/.ebignore
+++ b/.ebignore
@@ -23,3 +23,6 @@ tests/coverage
 
 # New relic file
 !newrelic.ini
+
+# Token generation file
+token.py

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Run the server with
 ./scripts/run_app.sh
 
 ```
+
+This will generate a JWT for you to log into the application. The script prints out the URL with the token included.
+
 ---
 
 ### Front-end Toolkit
@@ -166,12 +169,15 @@ The JOSE header of the final JWE must include:
 - alg - the key encryption algorithm (must be RSA-OAEP)
 - enc - the key encryption encoding (must be A256GCM)
 
-When running in production mode every request to the survey runner must append the follow url parameter: `token`. This
-parameter must be set to a valid JWE encrypted JWT token. Only encrypted tokens are allowed in production mode.
+To access the application you must provide a valid JWT. To do this browse to the /session url and append a token parameter.
+This parameter must be set to a valid JWE encrypted JWT token. Only encrypted tokens are allowed.
 
-When running in dev mode the token is not mandatory, however it can be supplied and if so will be decrypted/decoded and
-used. Also when in dev mode, unencrypted signed and unencrypted unsigned tokens can be also used in the url parameter
-'token'.
+There is a python script for generating tokens for use in development, to run:
+```
+python token_generator.py
+```
+
+
 
 
 ## Alpha Survey Runner

--- a/README.md
+++ b/README.md
@@ -138,7 +138,6 @@ EQ_SR_PRIVATE_KEY - location on disk of the SR private key
 EQ_RABBITMQ_URL - the RabbitMQ connection string
 EQ_RABBITMQ_QUEUE_NAME - the name of the submission queue
 EQ_RABBITMQ_TEST_QUEUE_NAME - the name of the test queue
-EQ_PRODUCTION - flag to indicate if we're running in production or dev mode
 EQ_CLOUDWATCH_LOGGING - feature flag to enable AWS cloudwatch logging
 EQ_GIT_REF - the latest git ref of HEAD on master
 EQ_SR_LOG_GROUP - The name of the log group to create (defaults to `username-local` for local development)

--- a/app/authentication/authenticator.py
+++ b/app/authentication/authenticator.py
@@ -1,7 +1,6 @@
 from app.authentication.jwt_decoder import Decoder
 from app.authentication.session_management import session_manager
 from app.authentication.no_token_exception import NoTokenException
-from app import settings
 from flask.ext.login import UserMixin
 import logging
 
@@ -32,51 +31,16 @@ class Authenticator(object):
 
     def jwt_login(self, request):
         """
-        Login using a JWT token, in production this must be an encrypted JWT. If developer mode is enabled
-        then the token can be either encrypted, signed or plain or can be left off completely.
+        Login using a JWT token, this must be an encrypted JWT.
         :param request: The flask request
         :return: the decrypted and unencoded token
         """
-        if settings.EQ_PRODUCTION:
-            logger.info("Production mode")
-            if request.args.get(EQ_URL_QUERY_STRING_JWT_FIELD_NAME) is None:
-                raise NoTokenException("Please provide a token")
-            return self._jwt_decrypt(request)
-        else:
-            logger.warning("Developer mode")
-            return self._developer_mode_login(request)
-
-    def _developer_mode_login(self, request):
-        token = request.args.get(EQ_URL_QUERY_STRING_JWT_FIELD_NAME)
-        if token:
-            if token.count(".") == 4:
-                logger.debug("Decrypting JWT token " + token)
-                return self._jwt_decrypt(request)
-            else:
-                tokens = token.split(".")
-                if len(tokens) == 3 and tokens[2]:
-                    logger.debug("Decoding signed JWT token " + token)
-                    return self._jwt_decode_signed(request)
-                else:
-                    logger.debug("Decoding JWT token " + token)
-                    return self._jwt_decode(request)
-        else:
-            return "developer-mode"
+        if request.args.get(EQ_URL_QUERY_STRING_JWT_FIELD_NAME) is None:
+            raise NoTokenException("Please provide a token")
+        return self._jwt_decrypt(request)
 
     def _jwt_decrypt(self, request):
         encrypted_token = request.args.get(EQ_URL_QUERY_STRING_JWT_FIELD_NAME)
         decoder = Decoder()
         token = decoder.decrypt_jwt_token(encrypted_token)
-        return token
-
-    def _jwt_decode_signed(self, request):
-        signed_token = request.args.get(EQ_URL_QUERY_STRING_JWT_FIELD_NAME)
-        decoder = Decoder()
-        token = decoder.decode_signed_jwt_token(signed_token)
-        return token
-
-    def _jwt_decode(self, request):
-        unsigned_token = request.args.get(EQ_URL_QUERY_STRING_JWT_FIELD_NAME)
-        decoder = Decoder()
-        token = decoder.decode_jwt_token(unsigned_token)
         return token

--- a/app/settings.py
+++ b/app/settings.py
@@ -7,7 +7,6 @@ def parse_mode(str):
 EQ_RABBITMQ_URL = os.getenv('EQ_RABBITMQ_URL', 'amqp://admin:admin@localhost:5672/%2F')
 EQ_RABBITMQ_QUEUE_NAME = os.getenv('EQ_RABBITMQ_QUEUE_NAME', 'eq-submissions')
 EQ_RABBITMQ_TEST_QUEUE_NAME = os.getenv('EQ_RABBITMQ_TEST_QUEUE_NAME', 'eq-test')
-EQ_PRODUCTION = parse_mode(os.getenv("EQ_PRODUCTION", 'True'))
 EQ_RRM_PUBLIC_KEY = os.getenv('EQ_RRM_PUBLIC_KEY')
 EQ_SR_PRIVATE_KEY = os.getenv('EQ_SR_PRIVATE_KEY')
 EQ_SR_PRIVATE_KEY_PASSWORD = os.getenv("EQ_SR_PRIVATE_KEY_PASSWORD", "digitaleq")

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -39,4 +39,6 @@ if [ ! -s "app/static" ]; then
   npm run compile
 fi
 
+python token_generator.py
 python application.py runserver
+

--- a/tests/app/views/test_jwt_authentication.py
+++ b/tests/app/views/test_jwt_authentication.py
@@ -23,21 +23,15 @@ class FlaskClientAuthenticationTestCase(unittest.TestCase):
         self.app_context.pop()
 
     def test_no_token(self):
-        # set to production mode
-        settings.EQ_PRODUCTION = True
         response = self.client.get('/session')
         self.assertEquals(401, response.status_code)
 
     def test_invalid_token(self):
-        # set to production mode
-        settings.EQ_PRODUCTION = True
         token = "invalid"
         response = self.client.get('/session?token=' + token)
         self.assertEquals(403, response.status_code)
 
     def test_fully_encrypted(self):
-        # set to production mode
-        settings.EQ_PRODUCTION = True
         encoder = Encoder()
         iat = time.time()
         exp = time.time() + (5 * 60)
@@ -45,30 +39,6 @@ class FlaskClientAuthenticationTestCase(unittest.TestCase):
         token = encoder.encode(payload)
         encrypted_token = encoder.encrypt(token)
         response = self.client.get('/session?token=' + encrypted_token.decode())
-        self.assertEquals(302, response.status_code)
-
-    def test_signed(self):
-        # set to dev mode - production does not allow unencrypted
-        settings.EQ_PRODUCTION = False
-        encoder = Encoder()
-        iat = time.time()
-        exp = time.time() + (5 * 60)
-        payload = {'user': 'jimmy', 'iat': str(int(iat)), 'exp': str(int(exp))}
-        token = encoder.encode(payload)
-        response = self.client.get('/session?token=' + token.decode())
-        self.assertEquals(302, response.status_code)
-
-    def test_encoded(self):
-        # set to dev mode - production does not allow unencrypted and unsigned
-        settings.EQ_PRODUCTION = False
-        encoder = Encoder()
-        iat = time.time()
-        exp = time.time() + (5 * 60)
-        payload = {'user': 'jimmy', 'iat': str(int(iat)), 'exp': str(int(exp))}
-        token = encoder.encode(payload)
-        tokens = token.decode().split(".")
-        new_token = tokens[0] + "." + tokens[1] + "."
-        response = self.client.get('/session?token=' + new_token)
         self.assertEquals(302, response.status_code)
 
 if __name__ == '__main__':

--- a/token_generator.py
+++ b/token_generator.py
@@ -15,4 +15,4 @@ def generate_token():
 
 
 if __name__ == '__main__':
-    print("http://localhost:5000/session?token=" + generate_token().decode())
+    print("http://localhost:5000/session?token=" + generate_token().decode())  # NOQA

--- a/token_generator.py
+++ b/token_generator.py
@@ -1,0 +1,18 @@
+from tests.app.authentication.encoder import Encoder
+import os
+import time
+
+
+def generate_token():
+    encoder = Encoder()
+    user = os.getenv('USER', 'UNKNOWN')
+    iat = time.time()
+    exp = time.time() + (5 * 60)
+    payload = {'user': user, 'iat': str(int(iat)), 'exp': str(int(exp))}
+    token = encoder.encode(payload)
+    encrypted_token = encoder.encrypt(token)
+    return encrypted_token
+
+
+if __name__ == '__main__':
+    print("http://localhost:5000/session?token=" + generate_token().decode())


### PR DESCRIPTION
**What**
Removing the EQ_PRODUCTION flag as it's causing us issues. The application will now always be in production mode and required an encrypted JWT to access it. This pull request also provides a convenient way of generating that token.

**How to test**
1. Check out this branch
2. Run the run_app.sh script
3. It should output a URL with a valid token
4. Browse to that URL
5. You should be logged in and redirected to /questionnaire/1

**Who can review**
Anyone apart from @warrenbailey
