### PR TITLE
Revert to read key material from file

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -1,4 +1,7 @@
 import os
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def parse_mode(str):
@@ -10,16 +13,18 @@ def get_key(key_name):
     TODO remove these once the encrypted key story is finished
     :return:
     """
-    key = open("./jwt-test-keys/" + key_name, 'r')
+    logger.debug("Opening file %", key_name)
+    key = open(key_name, 'r')
     contents = key.read()
+    logger.debug("Key is %s", contents)
     return contents
 
 
 EQ_RABBITMQ_URL = os.getenv('EQ_RABBITMQ_URL', 'amqp://admin:admin@localhost:5672/%2F')
 EQ_RABBITMQ_QUEUE_NAME = os.getenv('EQ_RABBITMQ_QUEUE_NAME', 'eq-submissions')
 EQ_RABBITMQ_TEST_QUEUE_NAME = os.getenv('EQ_RABBITMQ_TEST_QUEUE_NAME', 'eq-test')
-EQ_RRM_PUBLIC_KEY = os.getenv('EQ_RRM_PUBLIC_KEY', get_key("rrm-public.pem"))
-EQ_SR_PRIVATE_KEY = os.getenv('EQ_SR_PRIVATE_KEY', get_key("sr-private.pem"))
+EQ_RRM_PUBLIC_KEY = get_key(os.getenv('EQ_RRM_PUBLIC_KEY', "./jwt-test-keys/rrm-public.pem"))
+EQ_SR_PRIVATE_KEY = get_key(os.getenv('EQ_SR_PRIVATE_KEY', "./jwt-test-keys/sr-private.pem"))
 EQ_SR_PRIVATE_KEY_PASSWORD = os.getenv("EQ_SR_PRIVATE_KEY_PASSWORD", "digitaleq")
 EQ_GIT_REF = os.getenv('EQ_GIT_REF', None)
 EQ_NEW_RELIC_CONFIG_FILE = os.getenv('EQ_NEW_RELIC_CONFIG_FILE', './newrelic.ini')

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -8,13 +8,6 @@ fi
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 echo $DIR
 
-if [ -z "$EQ_RRM_PUBLIC_KEY" ]; then
-  export EQ_RRM_PUBLIC_KEY=`cat $DIR/../jwt-test-keys/rrm-public.pem`
-fi
-
-if [ -z "$EQ_SR_PRIVATE_KEY" ]; then
-  export EQ_SR_PRIVATE_KEY=`cat $DIR/../jwt-test-keys/sr-private.pem`
-fi
 
 # Output the current git revision
 if [ -z "$EQ_GIT_REF" ]; then


### PR DESCRIPTION
**What**
Elastic Beanstalk does not like keys in environment variables. Temporarily revert back to loading key material from file with the environment variable point to the location of file on disk.

**How to test**
1. Check out this branch
2. start the server
3. make sure you can hit the session url

**Who can review**
Anyone apart from @warrenbailey
