### PR TITLE
eq-8 optional response. Update schema/model/parser to allow optional …

### DIFF
--- a/app/data/mci-mini.json
+++ b/app/data/mci-mini.json
@@ -27,7 +27,8 @@
                                       "q_code": "110",
                                       "label": "Male employees working more than 30 hours per week?",
                                       "guidance": "How many men work for your company?",
-                                      "type": "Integer"
+                                      "type": "Integer",
+                                      "required":true
                                     }
                                 ]
                               }

--- a/app/data/mci.json
+++ b/app/data/mci.json
@@ -28,132 +28,100 @@
                                   "q_code": "0011",
                                   "label": "From",
                                   "guidance": "",
-                                  "type": "DateRange"
+                                  "type": "DateRange",
+                                  "required":true
                                 },
                                 {
                                   "id": "6fd644b0-798e-4a58-a393-a438b32fe637",
                                   "q_code": "0012",
                                   "label": "To",
                                   "guidance": "",
-                                  "type": "DateRange"
+                                  "type": "DateRange",
+                                  "required":true
                                 }
                               ]
                             }
                           ]
                         },
-                        {
-                          "id": "d9d25a21-41b8-42b2-ac7b-fb21b1036d71",
-                          "title": "",
-                          "description": "",
-                          "questions": [
-                            {
-                              "id": "eedb9f9f-2f2e-41f4-9186-ba7110d9e6a4",
-                              "title": "Commodities - Retail Turnover",
-                              "description": "<p>- You should enter figures for the reporting period stated above<br>- You should round your figures to the nearest (£) pound</p><h4>Include</h4><ul><li>VAT</li><li>Internet Sales</li></ul>",
-                              "responses": [
-                                {
-                                  "id": "bb8168e6-2272-450d-b5a7-d3170508efb2",
-                                  "q_code": "0022",
-                                  "label": "What was the value of the business's total sales of food?",
-                                  "guidance": "<div> <h4>Include</h4> <ul> <li>VAT</li> <li>internet sales</li> <li>all fresh food</li> <li>other food for human consumption (except chocolate and sugar confectionary)</li> <li>soft drinks</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>sales from catering facilities used by customers</li> </ul> </div>",
-                                  "type": "Currency"
-                                },
-                                {
-                                  "id": "01ac2ebf-d49d-45e8-8f7a-0f847aa7cf25",
-                                  "q_code": "0024",
-                                  "label": "What was the value of the business's total sales of clothing and footwear",
-                                  "guidance": "<h4>Include</h4><ul> <li>VAT</li> <li>internet sales</li> <li>clothing and footwear</li> <li>clothing fabrics</li> <li>haberdashery and furs</li> <li>leather and travel goods</li> <li>handbags</li> <li>umbrellas</li> </ul>",
-                                  "type": "Currency"
-                                },
-                                {
-                                  "id": "7605c4a9-2c3a-483c-908b-e07244105ac4",
-                                  "q_code": "0025",
-                                  "label": "What was the value of the business's total sales of household goods",
-                                  "guidance": "<h4>Include</h4><ul> <li>VAT</li> <li>internet sales</li> <li>carpets, rugs and other floor coverings</li> <li>furniture</li> <li>household textiles and soft furnishings</li> <li>prints and picture frames</li> <li>antiques and works of art</li> <li>domestic electrical appliance, audio/visual equipment and home computers</li> <li>lighting and minor electrical supplies</li> <li>records, compact discs, audio and video tapes</li> <li>musical instruments and goods</li> <li>decorators’ and DIY supplies</li> <li>lawn-mowers</li> <li>hardware</li> <li>china, glassware and cutlery</li> <li>novelties, souvenirs and gifts</li> </ul>",
-                                  "type": "Currency"
-                                },
-                                {
-                                  "id": "fee0b9fe-4c3a-4c14-9611-4fa9e2e9578a",
-                                  "q_code": "0023",
-                                  "label": "What was the value of the business's total sales of alcohol, confectionary and tobacco",
-                                  "guidance": "<div> <h4>Include</h4> <ul> <li>VAT</li> <li>internet sales</li> <li>all fresh food</li> <li>other food for human consumption (except chocolate and sugar confectionary)</li> <li>soft drinks</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>sales from catering facilities used by customers</li> </ul> </div>",
-                                  "type": "Currency"
-                                },
-                                {
-                                  "id": "5843e26e-a139-4645-baa9-51bdb0aba27b",
-                                  "q_code": "0026",
-                                  "label": "What was the value of the business’s total sales of other Goods",
-                                  "guidance": "<div> <h4>Include</h4> <ul> <li>VAT</li> <li>internet sales</li> <li>toiletries and medications (except NHS receipts)</li> <li>newspapers and periodicals</li> <li>books, stationery and office supplies</li> <li>photographic and optical goods</li> <li>spectacles, contact lenses and sunglasses</li> <li>toys and games</li> <li>cycles and cycle accessories</li> <li>sport and camping equipment</li> <li>jewellery</li> <li>silverware and plate, clocks and watches</li> <li>household cleaning products and kitchen paper products</li> <li>pets, pets’ requisites and pet foods</li> <li>cut flowers, plants, seeds and other garden sundries</li> <li>other new and second hand goods</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>revenue from mobile phone network commission and top up </li> <li>lottery sales and commission from lottery sales</li> <li>sales of car accessories and motor vehicles</li> <li>NHS receipts</li> </ul> </div>",
-                                  "type": "Currency"
-                                },
-                                {
-                                  "id": "e81adc6d-6fb0-4155-969c-d0d646f15345",
-                                  "q_code": "0020",
-                                  "label": "What was the value of the business’s total retail turnover?",
-                                  "guidance": "<div> <h4>Include</h4> <ul> <li>VAT</li> <li>internet sales</li> <li>retail sale from outlets in Great Britain to customers abroad</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>revenue from mobile phone network commission and top up </li> <li>lottery sales and commission from lottery sales</li> <li>sales of car accessories and motor vehicles</li> <li>NHS receipts</li> </ul> </div>",
-                                  "type": "Currency"
-                                },
-                                {
-                                  "id": "4b75a6f7-9774-4b2b-82dc-976561189a99",
-                                  "q_code": "0021",
-                                  "label": "Of these figures, how much were from internet sales?",
-                                  "guidance": "<h4>Include</h4><ul> <li>VAT</li> <li>sales from orders received over the internet, irrespective of the payment or delivery method.</li> </ul>",
-                                  "type": "Currency"
-                                },
-                                {
-                                  "id": "b2bac3ed-5504-43ef-a883-f9ca8496aca3",
-                                  "q_code": "0027",
-                                  "label": "What was the value of the business’s total sales of automotive Fuel",
-                                  "type": "Currency"
-                                }
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "id": "2cd99c83-186d-493a-a16d-17cb3c8bd302",
-                          "title":"",
-                          "questions": [
+                      {
+                        "id": "d9d25a21-41b8-42b2-ac7b-fb21b1036d71",
+                        "title": "",
+                        "description": "",
+                        "questions": [
+                          {
+                            "id": "eedb9f9f-2f2e-41f4-9186-ba7110d9e6a4",
+                            "title": "Commodities - Retail Turnover",
+                            "description": "<p>- You should enter figures for the reporting period stated above<br>- You should round your figures to the nearest (£) pound</p><h4>Include</h4><ul><li>VAT</li><li>Internet Sales</li></ul>",
+                            "responses": [
                               {
-                                "id": "4ba2ec8a-582f-4985-b4ed-20355deba55a",
-                                "title": "On 12 January 2016 what was the number of employees for the business named above?",
-                                "description": "<p>An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.</p> <div class=\"grid\"> <div class=\"grid__col s-6\"> <h4>Include:</h4> <ul> <li>all workers paid directly from this business’s payroll(s)</li> <li>those temporarily absent but still being paid, for example on maternity leave</li> </ul> </div> <div class=\"grid__col s-6\"> <h4>Exclude:</h4> <ul> <li>agency workers paid directly from the agency payroll</li> <li>voluntary workers</li> <li>former employees only receiving pension</li> <li>self-employed workers</li> <li><em>working</em> owners who are not paid via PAYE</li> </ul> </div> </div>",
-                                "responses": [
-                                    {
-                                      "id": "29586b4c-fb0c-4755-b67d-b3cd398cb30a",
-                                      "q_code": "0051",
-                                      "label": "Male employees working more than 30 hours per week?",
-                                      "type": "PositiveInteger"
-                                    },
-                                    {
-                                      "id": "3396c36e-cad1-48a4-b279-8ce491856d3d",
-                                      "q_code": "0052",
-                                      "label": "Male employees working less than 30 hours per week?",
-                                      "type": "PositiveInteger"
-                                    },
-                                    {
-                                      "id": "a974ab68-9239-4012-8f19-c13060f55b42",
-                                      "q_code": "0053",
-                                      "label": "Female employees working more than 30 hours per week?",
-                                      "type": "PositiveInteger"
-                                    },
-                                    {
-                                      "id": "34b94f54-4ec1-46ec-ae01-fd9047901054",
-                                      "q_code": "0054",
-                                      "label": "Female employees working less than 30 hours per week?",
-                                      "type": "PositiveInteger"
-                                    },
-                                    {
-                                      "id": "95076e90-23da-4e17-a113-4d0d940ef168",
-                                      "q_code": "0050",
-                                      "label": "Total employees",
-                                      "type": "PositiveInteger"
-                                    }
-                                ]
+                                "id": "bb8168e6-2272-450d-b5a7-d3170508efb2",
+                                "q_code": "0022",
+                                "label": "What was the value of the business's total sales of food?",
+                                "guidance": "<div> <h4>Include</h4> <ul> <li>VAT</li> <li>internet sales</li> <li>all fresh food</li> <li>other food for human consumption (except chocolate and sugar confectionary)</li> <li>soft drinks</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>sales from catering facilities used by customers</li> </ul> </div>",
+                                "type": "Currency",
+                                "required": false
+                              },
+                              {
+                                "id": "01ac2ebf-d49d-45e8-8f7a-0f847aa7cf25",
+                                "q_code": "0024",
+                                "label": "What was the value of the business's total sales of clothing and footwear",
+                                "guidance": "<h4>Include</h4><ul> <li>VAT</li> <li>internet sales</li> <li>clothing and footwear</li> <li>clothing fabrics</li> <li>haberdashery and furs</li> <li>leather and travel goods</li> <li>handbags</li> <li>umbrellas</li> </ul>",
+                                "type": "Currency",
+                                "required": false
+                              },
+                              {
+                                "id": "7605c4a9-2c3a-483c-908b-e07244105ac4",
+                                "q_code": "0025",
+                                "label": "What was the value of the business's total sales of household goods",
+                                "guidance": "<h4>Include</h4><ul> <li>VAT</li> <li>internet sales</li> <li>carpets, rugs and other floor coverings</li> <li>furniture</li> <li>household textiles and soft furnishings</li> <li>prints and picture frames</li> <li>antiques and works of art</li> <li>domestic electrical appliance, audio/visual equipment and home computers</li> <li>lighting and minor electrical supplies</li> <li>records, compact discs, audio and video tapes</li> <li>musical instruments and goods</li> <li>decorators’ and DIY supplies</li> <li>lawn-mowers</li> <li>hardware</li> <li>china, glassware and cutlery</li> <li>novelties, souvenirs and gifts</li> </ul>",
+                                "type": "Currency",
+                                "required": false
+                              },
+                              {
+                                "id": "fee0b9fe-4c3a-4c14-9611-4fa9e2e9578a",
+                                "q_code": "0023",
+                                "label": "What was the value of the business's total sales of alcohol, confectionary and tobacco",
+                                "guidance": "<div> <h4>Include</h4> <ul> <li>VAT</li> <li>internet sales</li> <li>all fresh food</li> <li>other food for human consumption (except chocolate and sugar confectionary)</li> <li>soft drinks</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>sales from catering facilities used by customers</li> </ul> </div>",
+                                "type": "Currency",
+                                "required": false
+                              },
+                              {
+                                "id": "5843e26e-a139-4645-baa9-51bdb0aba27b",
+                                "q_code": "0026",
+                                "label": "What was the value of the business’s total sales of other Goods",
+                                "guidance": "<div> <h4>Include</h4> <ul> <li>VAT</li> <li>internet sales</li> <li>toiletries and medications (except NHS receipts)</li> <li>newspapers and periodicals</li> <li>books, stationery and office supplies</li> <li>photographic and optical goods</li> <li>spectacles, contact lenses and sunglasses</li> <li>toys and games</li> <li>cycles and cycle accessories</li> <li>sport and camping equipment</li> <li>jewellery</li> <li>silverware and plate, clocks and watches</li> <li>household cleaning products and kitchen paper products</li> <li>pets, pets’ requisites and pet foods</li> <li>cut flowers, plants, seeds and other garden sundries</li> <li>other new and second hand goods</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>revenue from mobile phone network commission and top up </li> <li>lottery sales and commission from lottery sales</li> <li>sales of car accessories and motor vehicles</li> <li>NHS receipts</li> </ul> </div>",
+                                "type": "Currency",
+                                "required": false
+                              },
+                              {
+                                "id": "e81adc6d-6fb0-4155-969c-d0d646f15345",
+                                "q_code": "0020",
+                                "label": "What was the value of the business’s total retail turnover?",
+                                "guidance": "<div> <h4>Include</h4> <ul> <li>VAT</li> <li>internet sales</li> <li>retail sale from outlets in Great Britain to customers abroad</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>revenue from mobile phone network commission and top up </li> <li>lottery sales and commission from lottery sales</li> <li>sales of car accessories and motor vehicles</li> <li>NHS receipts</li> </ul> </div>",
+                                "type": "Currency",
+                                "required": true
+                              },
+                              {
+                                "id": "4b75a6f7-9774-4b2b-82dc-976561189a99",
+                                "q_code": "0021",
+                                "label": "Of these figures, how much were from internet sales?",
+                                "guidance": "<h4>Include</h4><ul> <li>VAT</li> <li>sales from orders received over the internet, irrespective of the payment or delivery method.</li> </ul>",
+                                "type": "Currency",
+                                "required": false
+                              },
+                              {
+                                "id": "b2bac3ed-5504-43ef-a883-f9ca8496aca3",
+                                "q_code": "0027",
+                                "label": "What was the value of the business’s total sales of automotive Fuel",
+                                "type": "Currency",
+                                "required": false
                               }
                             ]
-                        },
+                          }
+                        ]
+                      },
                         {
+
                           "id": "94546782-08a6-4213-9dc9-0780c2996896",
                           "title":"Comments",
                           "questions": [
@@ -167,7 +135,8 @@
                                       "q_code": "0146",
                                       "label": "Please explain any movements in your data e.g. sale held, branches opened or sold, extreme weather, or temporary closure of shop",
                                       "guidance": "",
-                                      "type": "Textarea"
+                                      "type": "Textarea",
+                                      "required":false
                                     }
                                   ]
                               }

--- a/app/model/response.py
+++ b/app/model/response.py
@@ -6,7 +6,7 @@ class Response(object):
         self.type = None
         self.code = None
         self.container = None
-        self.required = True
+        self.required = None
         self.validation = None
 
     def get_item_by_id(self, id):

--- a/app/parser/parser_utils.py
+++ b/app/parser/parser_utils.py
@@ -82,6 +82,28 @@ class ParserUtils(object):
             raise SchemaParserException("Required integer '{field}' is not an integer".format(field=key))
 
     @staticmethod
+    def get_required_boolean(obj, key):
+        """Get a required boolean from the dict
+
+        Gets the boolean value associated with the key in the dict, and raises a
+        SchemaParserException if the key is not present or the value is not an
+        boolean.
+
+        :param obj: A dict on json object
+        :param key: The name of the property to retrieve
+
+        :returns: The value as an boolean if found
+
+        :raises: A SchemaParserException if the key is not found, or the value is not an boolean
+
+        """
+        value = ParserUtils.get_required(obj, key)
+        if isinstance(value, bool):
+            return value
+        else:
+            raise SchemaParserException("Required boolean '{field}' is not an boolean".format(field=key))
+
+    @staticmethod
     def get_optional(obj, key):
         """Get an optional property from the dict
 

--- a/app/parser/v0_0_1/schema_parser.py
+++ b/app/parser/v0_0_1/schema_parser.py
@@ -205,6 +205,7 @@ class SchemaParser(AbstractSchemaParser):
             response.label = ParserUtils.get_optional_string(schema, 'label')
             response.guidance = ParserUtils.get_optional_string(schema, 'guidance')
             response.type = ParserUtils.get_required_string(schema, 'type')
+            response.required = ParserUtils.get_required_boolean(schema, 'required')
         except Exception as e:
             logging.error(e)
             raise e

--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -3,9 +3,12 @@
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
 #
+#, fuzzy
+msgid ""
+msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-01-11 15:09+0000\n"
+"POT-Creation-Date: 2016-03-17 12:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,22 +17,54 @@
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: app/templates/index.html:3
-msgid "eQ - Survey Runner"
+#: app/templates/index.html:7
+msgid "Hello"
 msgstr ""
 
-#: app/templates/index.html:6
+#: app/templates/index.html:14
 msgid "Hello World"
 msgstr ""
 
-#: app/templates/index.html:7
+#: app/templates/index.html:16
 msgid "This is the eQ Survey Runner (or at least it will be)"
 msgstr ""
 
-#: app/templates/index.html:8
+#: app/templates/index.html:17
 msgid "If you want to know how I'm doing, you can check my health."
 msgstr ""
 
-#: app/templates/index.html:9
+#: app/templates/index.html:18
 msgid "Click here to check my health"
 msgstr ""
+
+#: app/templates/index.html:19
+msgid "View the pattern library"
+msgstr ""
+
+#: app/templates/layouts/_base.html:10
+msgid "eQ - Survey Runner"
+msgstr ""
+
+#: app/templates/partials/responses/date.html:2
+#: app/templates/partials/responses/daterange.html:10
+msgid "Day"
+msgstr ""
+
+#: app/templates/partials/responses/date.html:11
+#: app/templates/partials/responses/daterange.html:19
+msgid "Month"
+msgstr ""
+
+#: app/templates/partials/responses/date.html:20
+#: app/templates/partials/responses/daterange.html:28
+msgid "Year"
+msgstr ""
+
+#: app/validation/integer_type_check.py:21
+msgid "'{value}' is not a valid number"
+msgstr ""
+
+#: app/validation/required_check.py:22
+msgid "This is a required field"
+msgstr ""
+

--- a/app/validation/integer_type_check.py
+++ b/app/validation/integer_type_check.py
@@ -1,5 +1,6 @@
 from app.validation.abstract_validator import AbstractValidator
 from app.validation.validation_result import ValidationResult
+from gettext import gettext as _
 
 
 class IntegerTypeCheck(AbstractValidator):
@@ -17,6 +18,5 @@ class IntegerTypeCheck(AbstractValidator):
             result.is_valid = True
         except:
             result.is_valid = False
-            result.errors.append("'{value}' is not a whole number".format(value=user_answer))
-
+            result.errors.append(_("'{value}' is not an integer".format(value=user_answer)))
         return result

--- a/app/validation/integer_type_check.py
+++ b/app/validation/integer_type_check.py
@@ -18,5 +18,5 @@ class IntegerTypeCheck(AbstractValidator):
             result.is_valid = True
         except:
             result.is_valid = False
-            result.errors.append(_("'{value}' is not an integer".format(value=user_answer)))
+            result.errors.append(_("'{value}' is not a whole number".format(value=user_answer)))
         return result

--- a/app/validation/required_check.py
+++ b/app/validation/required_check.py
@@ -1,5 +1,6 @@
 from app.validation.abstract_validator import AbstractValidator
 from app.validation.validation_result import ValidationResult
+from gettext import gettext as _
 
 
 class RequiredCheck(AbstractValidator):
@@ -18,5 +19,5 @@ class RequiredCheck(AbstractValidator):
             validation_result.is_valid = True
         else:
             validation_result.is_valid = False
-            validation_result.errors.append("This is a required field")
+            validation_result.errors.append(_('This is a required field'))
         return validation_result

--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -53,17 +53,19 @@ class Validator(object):
             if not result.is_valid:
                 return result
 
-        # Implicit -type-checking
-        result = self._type_check(item, item_data)
-        if not result.is_valid:
-            return result
+        # Validate if data is present
+        if item_data:
+            # Implicit -type-checking
+            result = self._type_check(item, item_data)
+            if not result.is_valid:
+                return result
 
-        # check for additional validation rules
-        if item.validation:
-            for rule in item.validation:
-                result = rule.validate(item_data, self._response_store)
-                if not result.is_valid:
-                    return result
+            # check for additional validation rules
+            if item.validation:
+                for rule in item.validation:
+                    result = rule.validate(item_data, self._response_store)
+                    if not result.is_valid:
+                        return result
 
         # If we've made it this far, the thing is valid
         return ValidationResult(True)

--- a/babel.cfg
+++ b/babel.cfg
@@ -1,3 +1,4 @@
 [python: app/main/**.py]
+[python: app/validation/**.py]
 [jinja2: app/templates/**.html]
 extensions=jinja2.ext.autoescape,jinja2.ext.with_

--- a/tests/app/parser/test_schemas/mci-mini.json
+++ b/tests/app/parser/test_schemas/mci-mini.json
@@ -27,7 +27,8 @@
                                       "q_code": "110",
                                       "label": "Male employees working more than 30 hours per week?",
                                       "guidance": "How many men work for your company?",
-                                      "type": "Integer"
+                                      "type": "Integer",
+                                      "required":true
                                     }
                                 ]
                               }


### PR DESCRIPTION
**What**
Add optional questions, and internationalise error messages

**How to test**
1. Open up the survey and test the form, only "What was the value of the business’s total retail turnover?" should be required.
2.  run pybabel extract -F babel.cfg -o app/translations/messages.pot .  and make sure the pot is updated with results from integer_type_check.py and required_check.py

n.b date from and to will be required but at present they are being worked on in another story

**Who can test**
Anyone but @LJBabbage
