### PR TITLE
eq-1 date range entry

### DIFF
--- a/app/data/1_0205.json
+++ b/app/data/1_0205.json
@@ -32,7 +32,7 @@
                                   "mandatory":true
                                 },
                                 {
-                                  "id": "6fd644b0-798e-4a58-a393-a438b32fe637",
+                                  "id": "06a6a4b7-6ce4-4687-879d-3443cd8e2ff0",
                                   "q_code": "12",
                                   "label": "To",
                                   "guidance": "",

--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -17,6 +17,22 @@ blueprint.add_app_template_filter(prettify)
 @jinja2.contextfilter
 @blueprint.app_template_filter()
 def dumpobj(context, my_obj):
-    return vars(my_obj)
+    if isinstance(my_obj, str) or isinstance(my_obj, int):
+        return my_obj
+
+    variables = vars(my_obj)
+    output = {}
+    for key, value in variables.items():
+        if key == 'container':
+            output[key] = value
+        elif isinstance(value, str) or isinstance(value, int):
+            output[key] = value
+        elif '__dict__' in dir(value):
+            output[key] = dumpobj(None, value)
+        elif '__iter__' in dir(value):
+            output[key] = []
+            for item in value:
+                output[key].append(dumpobj(None, item))
+    return output
 
 blueprint.add_app_template_filter(dumpobj)

--- a/app/model/block.py
+++ b/app/model/block.py
@@ -6,18 +6,9 @@ class Block(object):
         self.container = None
         self.questionnaire = None
         self.validation = None
+        self.questionniare = None
 
     def add_section(self, section):
         if section not in self.sections:
             self.sections.append(section)
             section.container = self
-
-    def get_item_by_id(self, id):
-        if id == self.id:
-            return self
-        else:
-            for section in self.sections:
-                candidate = section.get_item_by_id(id)
-                if candidate is not None:
-                    return candidate
-            return None

--- a/app/model/group.py
+++ b/app/model/group.py
@@ -7,18 +7,9 @@ class Group(object):
         self.container = None
         self.questionnaire = None
         self.validation = None
+        self.questionnaire = None
 
     def add_block(self, block):
         if block not in self.blocks:
             self.blocks.append(block)
             block.container = self
-
-    def get_item_by_id(self, id):
-        if id == self.id:
-            return self
-        else:
-            for block in self.blocks:
-                candidate = block.get_item_by_id(id)
-                if candidate is not None:
-                    return candidate
-            return None

--- a/app/model/question.py
+++ b/app/model/question.py
@@ -7,18 +7,9 @@ class Question(object):
         self.container = None
         self.questionnaire = None
         self.validation = None
+        self.questionnaire = None
 
     def add_response(self, response):
         if response not in self.responses:
             self.responses.append(response)
             response.container = self
-
-    def get_item_by_id(self, id):
-        if id == self.id:
-            return self
-        else:
-            for response in self.responses:
-                candidate = response.get_item_by_id(id)
-                if candidate is not None:
-                    return candidate
-            return None

--- a/app/model/questionnaire.py
+++ b/app/model/questionnaire.py
@@ -10,18 +10,27 @@ class Questionnaire(object):
         self.description = None
         self.groups = []
         self.validation = None
+        self.items_by_id = {}
 
     def add_group(self, group):
         if group not in self.groups:
             self.groups.append(group)
             group.container = self
 
-    def get_item_by_id(self, id):
-        if id == self.id:
+    def get_item_by_id(self, item_id):
+        if item_id == self.id:
             return self
         else:
-            for group in self.groups:
-                candidate = group.get_item_by_id(id)
-                if candidate is not None:
-                    return candidate
-            return None
+            if item_id in self.items_by_id.keys():
+                return self.items_by_id[item_id]
+            else:
+                raise QuestionnaireException('Unknown id \'{}\''.format(item_id))
+
+    def register(self, item):
+        if item.id in self.items_by_id.keys():
+            raise QuestionnaireException('{} is a duplicate id'.format(item.id))
+
+        self.items_by_id[item.id] = item
+
+        # Build the two-way relationship
+        item.questionnaire = self

--- a/app/model/response.py
+++ b/app/model/response.py
@@ -8,9 +8,4 @@ class Response(object):
         self.container = None
         self.mandatory = None
         self.validation = None
-
-    def get_item_by_id(self, id):
-        if id == self.id:
-            return self
-        else:
-            return None
+        self.questionnaire = None

--- a/app/model/section.py
+++ b/app/model/section.py
@@ -6,18 +6,9 @@ class Section(object):
         self.container = None
         self.questionnaire = None
         self.validation = None
+        self.questionnaire = None
 
     def add_question(self, question):
         if question not in self.questions:
             self.questions.append(question)
             question.container = self
-
-    def get_item_by_id(self, id):
-        if id == self.id:
-            return self
-        else:
-            for question in self.questions:
-                candidate = question.get_item_by_id(id)
-                if candidate is not None:
-                    return candidate
-            return None

--- a/app/parser/v0_0_1/schema_parser.py
+++ b/app/parser/v0_0_1/schema_parser.py
@@ -68,13 +68,13 @@ class SchemaParser(AbstractSchemaParser):
         if questionnaire:
             if "groups" in self._schema.keys():
                 for group_schema in self._schema['groups']:
-                    questionnaire.add_group(self._parse_group(group_schema))
+                    questionnaire.add_group(self._parse_group(group_schema, questionnaire))
             else:
                 raise SchemaParserException('Questionnaire must contain at least one group')
 
         return questionnaire
 
-    def _parse_group(self, schema):
+    def _parse_group(self, schema, questionnaire):
         """Parse a group element
 
         :param schema: The group schema
@@ -92,19 +92,22 @@ class SchemaParser(AbstractSchemaParser):
             group.id = ParserUtils.get_required_string(schema, "id")
             group.title = ParserUtils.get_optional_string(schema, "title")
 
+            # Register the group
+            questionnaire.register(group)
+
         except Exception as e:
             logging.error(e)
             raise e
 
         if "blocks" in schema.keys():
             for block_schema in schema['blocks']:
-                group.add_block(self._parse_block(block_schema))
+                group.add_block(self._parse_block(block_schema, questionnaire))
         else:
             raise SchemaParserException('Group must contain at least one block')
 
         return group
 
-    def _parse_block(self, schema):
+    def _parse_block(self, schema, questionnaire):
         """Parse a block element
 
         :param schema: The block schema
@@ -120,19 +123,22 @@ class SchemaParser(AbstractSchemaParser):
             block.id = ParserUtils.get_required_string(schema, "id")
             block.title = ParserUtils.get_optional_string(schema, "title")
 
+            # register the block
+            questionnaire.register(block)
+
         except Exception as e:
             logging.error(e)
             raise e
 
         if "sections" in schema.keys():
             for section_schema in schema['sections']:
-                block.add_section(self._parse_section(section_schema))
+                block.add_section(self._parse_section(section_schema, questionnaire))
         else:
             raise SchemaParserException('Block must contain at least one section')
 
         return block
 
-    def _parse_section(self, schema):
+    def _parse_section(self, schema, questionnaire):
         """Parse a section element
 
         :param schema: The section schema
@@ -147,19 +153,23 @@ class SchemaParser(AbstractSchemaParser):
         try:
             section.id = ParserUtils.get_required_string(schema, "id")
             section.title = ParserUtils.get_optional_string(schema, "title")
+
+            # regisger the section
+            questionnaire.register(section)
+
         except Exception as e:
             logging.error(e)
             raise e
 
         if 'questions' in schema.keys():
             for question_schema in schema['questions']:
-                section.add_question(self._parse_question(question_schema))
+                section.add_question(self._parse_question(question_schema, questionnaire))
         else:
             raise SchemaParserException('Section must have at least one question')
 
         return section
 
-    def _parse_question(self, schema):
+    def _parse_question(self, schema, questionnaire):
         """Parse a question element
 
         :param schema: The question schema
@@ -175,19 +185,23 @@ class SchemaParser(AbstractSchemaParser):
             question.id = ParserUtils.get_required_string(schema, "id")
             question.title = ParserUtils.get_required_string(schema, "title")
             question.description = ParserUtils.get_required_string(schema, "description")
+
+            # register the question
+            questionnaire.register(question)
+
         except Exception as e:
             logging.error(e)
             raise e
 
         if 'responses' in schema.keys():
             for response_schema in schema['responses']:
-                question.add_response(self._parse_response(response_schema))
+                question.add_response(self._parse_response(response_schema, questionnaire))
         else:
             raise SchemaParserException('Question must contain at least one response')
 
         return question
 
-    def _parse_response(self, schema):
+    def _parse_response(self, schema, questionnaire):
         """Parse a response element
 
         :param schema: The response schema
@@ -206,6 +220,10 @@ class SchemaParser(AbstractSchemaParser):
             response.guidance = ParserUtils.get_optional_string(schema, 'guidance')
             response.type = ParserUtils.get_required_string(schema, 'type')
             response.mandatory = ParserUtils.get_required_boolean(schema, 'mandatory')
+
+            # register the response
+            questionnaire.register(response)
+
         except Exception as e:
             logging.error(e)
             raise e

--- a/app/styles/components/forms/_field.scss
+++ b/app/styles/components/forms/_field.scss
@@ -86,6 +86,7 @@
     }
   }
   .field--year {
+    margin-right: 0;
     @include fixed() {
       width: 7rem;
     }

--- a/app/templates/macros/forms.html
+++ b/app/templates/macros/forms.html
@@ -29,8 +29,7 @@
     "name": response.id,
     "id": response.id,
     "placeholder": response.placeholder,
-    "aria-describedby": "description-" ~ question.id ~ " guidance-" ~ response.id ~ "-link",
-    "aria-labelledby": "label-" ~ response.id
+    "aria-describedby": "description-" ~ question.id ~ " guidance-" ~ response.id ~ "-link"
   } %}
 
   {% if input_has_special_type %}
@@ -52,9 +51,17 @@
     "placeholder": response.placeholder,
     "rows": "4",
     "cols": "60",
-    "aria-describedby": "description-" ~ question.id ~ " guidance-" ~ response.id,
-    "aria-labelledby": "label-" ~ response.id
+    "aria-describedby": "description-" ~ question.id ~ " guidance-" ~ response.id
   } %}
 
   <textarea {{attr|xmlattr}}>{{response.value|e}}</textarea>
 {% endmacro %}
+
+
+{%- macro select(name, values, response) %}
+  <select class="input input--select" name="{{response.id}}-{{name}}" id="{{response.id}}-{{name}}">
+    {% for value in values -%}
+      <option value="{{loop.index}}">{{value}}</option>
+    {%- endfor -%}
+  </select>
+{% endmacro -%}

--- a/app/templates/macros/forms.html
+++ b/app/templates/macros/forms.html
@@ -58,10 +58,10 @@
 {% endmacro %}
 
 
-{%- macro select(name, values, response) %}
+{%- macro select(name, values, default_value, response) %}
   <select class="input input--select" name="{{response.id}}-{{name}}" id="{{response.id}}-{{name}}">
     {% for value in values -%}
-      <option value="{{loop.index}}">{{value}}</option>
+      <option value="{{loop.index}}" {{'selected' if loop.index == default_value}}>{{value}}</option>
     {%- endfor -%}
   </select>
 {% endmacro -%}

--- a/app/templates/partials/question.html
+++ b/app/templates/partials/question.html
@@ -19,16 +19,9 @@
       </div>
     {% endif %}
     <div class="question__responses">
-    {% set grid = question.responses|length > 1 and question.responses[0].type!='DateRange'%}
-    {% set grid = false %}
-
-    {%- if grid %} <div class="grid grid--align-bottom"> {% endif -%}
       {%- for response in question.responses -%}
-        {%- if grid -%} <div class="grid__col m-6"> {%- endif %}
-          {% include 'partials/response.html' %}
-        {%- if grid %} </div> {% endif -%}
+        {% include 'partials/response.html' %}
       {%- endfor -%}
-    {%- if question.grid %}</div>{% endif %}
     </div>
   </fieldset>
 </div>

--- a/app/templates/partials/response.html
+++ b/app/templates/partials/response.html
@@ -1,7 +1,7 @@
 
 {% set is_valid = response.is_valid or response.is_valid is not defined %}
 
-<div class="question__response response {{'response--has-error' if not is_valid}}">
+<div class="question__response response {{'response--has-error' if not is_valid}}" id="{{response.id}}">
 
   {% if not is_valid %}
     {% if response.errors %}

--- a/app/templates/partials/responses/date.html
+++ b/app/templates/partials/responses/date.html
@@ -18,11 +18,3 @@
   <label class="label label--small" for="{{response.name}}-year">{{_('Year')}}</label>
   <input class="input input--number" type="number" name="{{response.id}}-year" value="" placeholder="YYYY">
 </div>
-
-{% if response.is_valid is not none and response.is_valid == False %}
-<ul>
-  {% for error in response.errors %}
-  <li>{{ error }}</li>
-  {% endfor %}
-</ul>
-{% endif %}

--- a/app/templates/partials/responses/date.html
+++ b/app/templates/partials/responses/date.html
@@ -1,24 +1,22 @@
-<div class="field field--day">
-  <label class="label label--small label--block" for="{{response.id}}-day">{{_('Day')}}</label>
-  <select class="input input--select" name="{{response.id}}-day" id="{{response.id}}-day">
-    {% for day in range(31) -%}
-      <option value="{{day+1}}">{{day+1}}</option>
-    {%- endfor -%}
-  </select>
-</div>
 
-<div class="field field--month">
-  <label class="label label--small label--block" for="{{response.id}}-month">{{_('Month')}}</label>
-  <select class="input input--select" name="{{response.id}}-month" id="{{response.id}}-month">
-    {% for month in ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"] -%}
-      <option value="{{loop.index}}">{{_(month)}}</option>
-    {%- endfor %}
-  </select>
+{% with name="day" %}
+<div class="field field--{{name}}">
+  <label class="label label--small" for="{{response.id}}-{{name}}">{{_('Day')}}</label>
+  {{form.select(name, (range(1, 32)), response)}}
 </div>
+{% endwith %}
+
+{% with name="month" %}
+<div class="field field--{{name}}">
+  {% set months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"] %}
+  <label class="label label--small" for="{{response.id}}-{{name}}">{{_('Month')}}</label>
+  {{form.select(name, months, response)}}
+</div>
+{% endwith %}
 
 <div class="field field--year">
-  <label class="label label--small label--block" for="{{response.name}}-year">{{_('Year')}}</label>
-  <input class="input input--number" type="number" name="{{response.id}}-year" value="" min="1980" max="2016" placeholder="YYYY">
+  <label class="label label--small" for="{{response.name}}-year">{{_('Year')}}</label>
+  <input class="input input--number" type="number" name="{{response.id}}-year" value="" placeholder="YYYY">
 </div>
 
 {% if response.is_valid is not none and response.is_valid == False %}

--- a/app/templates/partials/responses/date.html
+++ b/app/templates/partials/responses/date.html
@@ -10,13 +10,21 @@
 <div class="field field--month">
   <label class="label label--small label--block" for="{{response.id}}-month">{{_('Month')}}</label>
   <select class="input input--select" name="{{response.id}}-month" id="{{response.id}}-month">
-    {% for day in ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"] -%}
-      <option value="{{day}}">{{_(day)}}</option>
+    {% for month in ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"] -%}
+      <option value="{{loop.index}}">{{_(month)}}</option>
     {%- endfor %}
   </select>
 </div>
 
 <div class="field field--year">
-  <label class="label label--small label--block" for="{{response.id}}-year">{{_('Year')}}</label>
-  <input class="input input--number" type="number" name="{{response.id}}-year" value="{{response.value}}">
+  <label class="label label--small label--block" for="{{response.name}}-year">{{_('Year')}}</label>
+  <input class="input input--number" type="number" name="{{response.id}}-year" value="" min="1980" max="2016" placeholder="YYYY">
 </div>
+
+{% if response.is_valid is not none and response.is_valid == False %}
+<ul>
+  {% for error in response.errors %}
+  <li>{{ error }}</li>
+  {% endfor %}
+</ul>
+{% endif %}

--- a/app/templates/partials/responses/date.html
+++ b/app/templates/partials/responses/date.html
@@ -1,8 +1,13 @@
+{% if response.value %}
+  {% set response_value = response.value.split('/') %}
+{% else %}
+  {% set response_value = "0/0".split('/') %}
+{% endif %}
 
 {% with name="day" %}
 <div class="field field--{{name}}">
   <label class="label label--small" for="{{response.id}}-{{name}}">{{_('Day')}}</label>
-  {{form.select(name, (range(1, 32)), response)}}
+  {{form.select(name, (range(1, 32)), response_value[0]|int, response)}}
 </div>
 {% endwith %}
 
@@ -10,11 +15,11 @@
 <div class="field field--{{name}}">
   {% set months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"] %}
   <label class="label label--small" for="{{response.id}}-{{name}}">{{_('Month')}}</label>
-  {{form.select(name, months, response)}}
+  {{form.select(name, months, response_value[1]|int, response)}}
 </div>
 {% endwith %}
 
 <div class="field field--year">
   <label class="label label--small" for="{{response.name}}-year">{{_('Year')}}</label>
-  <input class="input input--number" type="number" name="{{response.id}}-year" value="" placeholder="YYYY">
+  <input class="input input--number" type="number" name="{{response.id}}-year" value="{{response_value[2]}}" placeholder="YYYY">
 </div>

--- a/app/validation/date_type_check.py
+++ b/app/validation/date_type_check.py
@@ -1,0 +1,24 @@
+from app.validation.abstract_validator import AbstractValidator
+from app.validation.validation_result import ValidationResult
+import time
+from flask.ext.babel import gettext
+
+
+class DateTypeCheck(AbstractValidator):
+
+    """
+    Validate that the users answer is a valid date
+    :param user_answer: The answer the user provided for the response
+    :return: ValidationResult(): An object containing the result of the validation
+    """
+
+    def validate(self, user_answer):
+        result = ValidationResult(False)
+        try:
+            date = time.strptime(user_answer, "%d/%m/%Y")  # NOQA
+            return ValidationResult(True)
+        except ValueError:
+            result.errors.append(gettext('This is not a valid date'))
+        except TypeError:
+            result.errors.append(gettext('This is not a valid date'))
+        return result

--- a/app/validation/type_validator_factory.py
+++ b/app/validation/type_validator_factory.py
@@ -1,5 +1,6 @@
 from app.validation.integer_type_check import IntegerTypeCheck
 from app.validation.positive_integer_type_check import PositiveIntegerTypeCheck
+from app.validation.date_type_check import DateTypeCheck
 
 
 class TypeValidatorFactoryException(Exception):
@@ -23,6 +24,8 @@ class TypeValidatorFactory(object):
             validators.append(PositiveIntegerTypeCheck())
         elif response_type.upper() == 'CURRENCY':
             validators.append(PositiveIntegerTypeCheck())
+        elif response_type.upper() == 'DATERANGE':
+            validators.append(DateTypeCheck())
         else:
             raise TypeValidatorFactoryException('\'{}\' is not a known response type'.format(response_type))
 

--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -49,6 +49,7 @@ class Validator(object):
     def _validate_item(self, item, item_data):
         # Do "mandatory" check
         if item.mandatory:
+            logger.debug('Item ({}) is mandatory, data is: {}'.format(item.id, item_data))
             result = self._mandatory_check(item, item_data)
             if not result.is_valid:
                 return result
@@ -56,6 +57,7 @@ class Validator(object):
         # Validate if data is present
         if item_data:
             # Implicit -type-checking
+            logger.debug('Type Checking ({}) with data {}'.format(item.id, item_data))
             result = self._type_check(item, item_data)
             if not result.is_valid:
                 return result

--- a/tests/app/model/test_questionnaire.py
+++ b/tests/app/model/test_questionnaire.py
@@ -52,9 +52,36 @@ class QuestionnaireModelTest(unittest.TestCase):
         block2.id = 'block-2'
         group2.add_block(block2)
 
+        self.assertRaises(QuestionnaireException, questionnaire.get_item_by_id, 'group-1')
+        self.assertRaises(QuestionnaireException, questionnaire.get_item_by_id, 'group-2')
+        self.assertRaises(QuestionnaireException, questionnaire.get_item_by_id, 'block-1')
+        self.assertRaises(QuestionnaireException, questionnaire.get_item_by_id, 'block-2')
+
+        questionnaire.register(group1)
+        questionnaire.register(group2)
+        questionnaire.register(block1)
+        questionnaire.register(block2)
+
         self.assertEquals(questionnaire.get_item_by_id('group-1'), group1)
         self.assertEquals(questionnaire.get_item_by_id('group-2'), group2)
         self.assertEquals(questionnaire.get_item_by_id('block-1'), block1)
         self.assertEquals(questionnaire.get_item_by_id('block-2'), block2)
 
-        self.assertIsNone(questionnaire.get_item_by_id('invalid-id'))
+    def test_register_duplicate(self):
+        questionnaire = Questionnaire()
+
+        questionnaire.id = 'some-id'
+        questionnaire.title = 'my questionnaire object'
+
+        group1 = Group()
+        group1.id = 'group-1'
+        questionnaire.add_group(group1)
+        questionnaire.register(group1)
+
+        group = questionnaire.get_item_by_id('group-1')
+        self.assertEqual(group1, group)
+
+        group2 = Group()
+        group2.id = 'group-1'  # Duplicate id
+
+        self.assertRaises(QuestionnaireException, questionnaire.register, group2)

--- a/tests/app/submitter/test_converter.py
+++ b/tests/app/submitter/test_converter.py
@@ -53,6 +53,7 @@ class TestConverter(unittest.TestCase):
         response_2.code = "002"
 
         question = Question()
+        question.id = 'question-1'
         question.add_response(response_1)
         question.add_response(response_2)
 
@@ -60,14 +61,23 @@ class TestConverter(unittest.TestCase):
         section.add_question(question)
 
         block = Block()
+        block.id = 'block-1'
         block.add_section(section)
 
         group = Group()
+        group.id = 'group-1'
         group.add_block(block)
 
         questionniare = Questionnaire()
         questionniare.survey_id = "021"
         questionniare.add_group(group)
+
+        questionniare.register(group)
+        questionniare.register(block)
+        questionniare.register(section)
+        questionniare.register(question)
+        questionniare.register(response_1)
+        questionniare.register(response_2)
 
         json_string = Converter.prepare_responses(user, questionniare, user_response)
         response_object = json.loads(json_string)

--- a/tests/app/validation/test_date_type.py
+++ b/tests/app/validation/test_date_type.py
@@ -1,0 +1,83 @@
+import unittest
+from app.validation.date_type_check import DateTypeCheck
+
+
+class DateTypeTest(unittest.TestCase):
+
+    def test_date_type_validator(self):
+        date_type = DateTypeCheck()
+
+        # validate None
+        result = date_type.validate(None)
+        self.assertFalse(result.is_valid)
+        self.assertEquals(len(result.errors), 1)
+        self.assertEquals('This is not a valid date', result.errors[0])
+
+        # empty string
+        result = date_type.validate('')
+        self.assertFalse(result.is_valid)
+        self.assertEquals(len(result.errors), 1)
+        self.assertEquals('This is not a valid date', result.errors[0])
+
+        # missing day
+        result = date_type.validate('/12/2016')
+        self.assertFalse(result.is_valid)
+        self.assertEquals(len(result.errors), 1)
+        self.assertEquals('This is not a valid date', result.errors[0])
+
+        # missing month
+        result = date_type.validate('01//2016')
+        self.assertFalse(result.is_valid)
+        self.assertEquals(len(result.errors), 1)
+        self.assertEquals('This is not a valid date', result.errors[0])
+
+        # missing year
+        result = date_type.validate('01/12/')
+        self.assertFalse(result.is_valid)
+        self.assertEquals(len(result.errors), 1)
+        self.assertEquals('This is not a valid date', result.errors[0])
+
+        # invalid day
+        result = date_type.validate('40/12/2016')
+        self.assertFalse(result.is_valid)
+        self.assertEquals(len(result.errors), 1)
+        self.assertEquals('This is not a valid date', result.errors[0])
+
+        # invalid month
+        result = date_type.validate('01/13/2016')
+        self.assertFalse(result.is_valid)
+        self.assertEquals(len(result.errors), 1)
+        self.assertEquals('This is not a valid date', result.errors[0])
+
+        # invalid year
+        result = date_type.validate('01/12/16')  # year should be 4 digits
+        self.assertFalse(result.is_valid)
+        self.assertEquals(len(result.errors), 1)
+        self.assertEquals('This is not a valid date', result.errors[0])
+
+        # Leap year
+        result = date_type.validate('29/02/2015')  # 2015 was not a leap year
+        self.assertFalse(result.is_valid)
+        self.assertEquals(len(result.errors), 1)
+        self.assertEquals('This is not a valid date', result.errors[0])
+
+        result = date_type.validate('29/02/2016')  # 2016 WAS a leap year
+        self.assertTrue(result.is_valid)
+        self.assertEquals(len(result.errors), 0)
+
+        # valid dates
+        result = date_type.validate('01/01/2016')
+        self.assertTrue(result.is_valid)
+        self.assertEquals(len(result.errors), 0)
+
+        result = date_type.validate('1/12/2016')
+        self.assertTrue(result.is_valid)
+        self.assertEquals(len(result.errors), 0)
+
+        result = date_type.validate('01/3/2016')
+        self.assertTrue(result.is_valid)
+        self.assertEquals(len(result.errors), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/app/validation/test_type_validation_factory.py
+++ b/tests/app/validation/test_type_validation_factory.py
@@ -1,15 +1,20 @@
 import unittest
 from app.validation.type_validator_factory import TypeValidatorFactory, TypeValidatorFactoryException
 from app.validation.integer_type_check import IntegerTypeCheck
+from app.validation.date_type_check import DateTypeCheck
 
 
 class TypeValidatorFactoryTest(unittest.TestCase):
     def test_get_validators_by_type(self):
 
-        # Currently only Integer type is supported
         validators = TypeValidatorFactory.get_validators_by_type('integer')
 
         self.assertEquals(len(validators), 1)
         self.assertTrue(isinstance(validators[0], IntegerTypeCheck))
+
+        validators = TypeValidatorFactory.get_validators_by_type('daterange')
+
+        self.assertEquals(len(validators), 1)
+        self.assertTrue(isinstance(validators[0], DateTypeCheck))
 
         self.assertRaises(TypeValidatorFactoryException, TypeValidatorFactory.get_validators_by_type, "unknown_type")

--- a/tests/app/validation/test_validator.py
+++ b/tests/app/validation/test_validator.py
@@ -111,28 +111,34 @@ class ValidatorTest(unittest.TestCase):
         group_1 = Group()
         group_1.id = "be0296a5-3235-40e5-a7b0-d1d7dff0ba87"
         questionnaire_1.add_group(group_1)
+        questionnaire_1.register(group_1)
 
         block_1 = Block()
         block_1.id = "ce8d7204-615e-42dd-9e46-17744ac39b04"
         group_1.add_block(block_1)
+        questionnaire_1.register(block_1)
 
         section_1 = Section()
         section_1.id = "e109368f-46f2-4283-982e-eebf76051eac"
         block_1.add_section(section_1)
+        questionnaire_1.register(section_1)
 
         question_1 = Question()
         question_1.id = "0df6fe58-25c9-430f-b157-9dc6b5a7646f"
         section_1.add_question(question_1)
+        questionnaire_1.register(question_1)
 
         response_1 = Response()
         response_1.type = "Integer"
         response_1.id = "69ed19a4-f2ee-4742-924d-b64b9fa09499"
         question_1.add_response(response_1)
+        questionnaire_1.register(response_1)
 
         response_2 = Response()
         response_2.type = "Integer"
         response_2.id = "709c9f96-2757-4cf3-ba48-808c6c616848"
         question_1.add_response(response_2)
+        questionnaire_1.register(response_2)
 
         return questionnaire_1
 


### PR DESCRIPTION
## Changes
- refactored `<select>` elements in date entry template into a macro
- wired back-end validation in to date entries
- upon validation, user-entered data (ie. the date) is retained in date fields
## Test
- `npm run compile`
- submit page without entering a date
  -- confirm "this field is required" error message
- enter an invalid date (eg. 31 February 2016)
  -- confirm "this is not a valid date" error message
