### PR TITLE
EQ3 - Adding a text area validator to fix the comments submission issue

### DIFF
--- a/app/data/1_0205.json
+++ b/app/data/1_0205.json
@@ -136,7 +136,12 @@
                                       "label": "Please explain any movements in your data e.g. sale held, branches opened or sold, extreme weather, or temporary closure of shop",
                                       "guidance": "",
                                       "type": "Textarea",
-                                      "mandatory":false
+                                      "mandatory":false,
+                                      "display": {
+                                          "properties": {
+                                              "max_length": "2000"
+                                          }
+                                      }
                                     }
                                   ]
                               }

--- a/app/model/display.py
+++ b/app/model/display.py
@@ -1,0 +1,4 @@
+class Display(object):
+
+    def __init__(self, properties=None):
+        self.properties = properties

--- a/app/model/properties.py
+++ b/app/model/properties.py
@@ -1,0 +1,4 @@
+class Properties(object):
+
+    def __init__(self):
+        self.max_length = None

--- a/app/model/response.py
+++ b/app/model/response.py
@@ -9,3 +9,4 @@ class Response(object):
         self.mandatory = None
         self.validation = None
         self.questionnaire = None
+        self.display = None

--- a/app/parser/v0_0_1/schema_parser.py
+++ b/app/parser/v0_0_1/schema_parser.py
@@ -15,6 +15,8 @@ from app.model.block import Block
 from app.model.section import Section
 from app.model.question import Question
 from app.model.response import Response
+from app.model.display import Display
+from app.model.properties import Properties
 
 import logging
 
@@ -221,6 +223,10 @@ class SchemaParser(AbstractSchemaParser):
             response.type = ParserUtils.get_required_string(schema, 'type')
             response.mandatory = ParserUtils.get_required_boolean(schema, 'mandatory')
 
+            display = ParserUtils.get_optional(schema, "display")
+            if display:
+                response.display = self._parse_display(display)
+
             # register the response
             questionnaire.register(response)
 
@@ -229,3 +235,34 @@ class SchemaParser(AbstractSchemaParser):
             raise e
 
         return response
+
+    def _parse_display(self, schema):
+        """
+        Parse a display element
+        :param schema: the display element
+        :return: A display object
+        """
+        display = Display()
+
+        properties = ParserUtils.get_optional(schema, "properties")
+        if properties:
+            display.properties = self._parse_properties(properties)
+
+        return display
+
+    def _parse_properties(self, schema):
+        """
+         Parse a properties element
+        :param schema: the properties element
+        :return: a properties object
+        """
+        properties = Properties()
+
+        try:
+            properties.max_length = ParserUtils.get_optional_string(schema, 'max_length')
+
+        except Exception as e:
+            logging.error(e)
+            raise e
+
+        return properties

--- a/app/questionnaire/questionnaire_manager.py
+++ b/app/questionnaire/questionnaire_manager.py
@@ -1,3 +1,6 @@
+import bleach
+
+
 class QuestionnaireManager(object):
     def __init__(self, schema, response_store, validator, validation_store, routing_engine, navigator, navigation_history):
         self._schema = schema
@@ -12,12 +15,16 @@ class QuestionnaireManager(object):
         # process incoming post data
         user_responses = self._process_incoming_post_data(post_data)
 
-        # update the response store with data
+        cleaned_user_responses = {}
         for key, value in user_responses.items():
+            cleaned_user_responses[key] = self._clean_input(value)
+
+        # update the response store with data
+        for key, value in cleaned_user_responses.items():
             self._response_store.store_response(key, value)
 
         # run the validator to update the validation_store
-        if self._validator.validate(user_responses):
+        if self._validator.validate(cleaned_user_responses):
             # get the current location in the questionnaire
             current_location = self._navigator.get_current_location()
 
@@ -82,3 +89,6 @@ class QuestionnaireManager(object):
                 user_responses[key] = post_data[key]
 
         return user_responses
+
+    def _clean_input(self, value):
+        return bleach.clean(value)

--- a/app/validation/textarea_type_check.py
+++ b/app/validation/textarea_type_check.py
@@ -1,0 +1,23 @@
+from app.validation.abstract_validator import AbstractValidator
+from app.validation.validation_result import ValidationResult
+from gettext import gettext as _
+
+
+# TODO we need to think about types as TextArea is tied too much to HTML
+class TextAreaTypeCheck(AbstractValidator):
+
+    """
+    Validate that the users answer is a string and only contains alphanumeric characters
+    :param user_answer: The answer the user provided for the response
+    :return: ValidationResult(): An object containing the result of the validation
+    """
+
+    def validate(self, user_answer):
+        result = ValidationResult(False)
+        try:
+            str_value = str(user_answer)
+            result.is_valid = not str_value.isspace()
+        except:
+            result.is_valid = False
+            result.errors.append(_("'{value}' is not a alphanumeric string".format(value=user_answer)))
+        return result

--- a/app/validation/type_validator_factory.py
+++ b/app/validation/type_validator_factory.py
@@ -1,6 +1,7 @@
 from app.validation.integer_type_check import IntegerTypeCheck
 from app.validation.positive_integer_type_check import PositiveIntegerTypeCheck
 from app.validation.date_type_check import DateTypeCheck
+from app.validation.textarea_type_check import TextAreaTypeCheck
 
 
 class TypeValidatorFactoryException(Exception):
@@ -26,6 +27,8 @@ class TypeValidatorFactory(object):
             validators.append(PositiveIntegerTypeCheck())
         elif response_type.upper() == 'DATERANGE':
             validators.append(DateTypeCheck())
+        elif response_type.upper() == 'TEXTAREA':
+            validators.append(TextAreaTypeCheck())
         else:
             raise TypeValidatorFactoryException('\'{}\' is not a known response type'.format(response_type))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Babel==2.2.0
+bleach==1.4.2
 Flask==0.10.1
 Flask-Babel==0.9
 Flask-Script==2.0.5

--- a/tests/app/parser/test_mci_mini.py
+++ b/tests/app/parser/test_mci_mini.py
@@ -54,7 +54,7 @@ def test_mci_mini():
     section = block.sections[0]
     assert section.id == "2cd99c83-186d-493a-a16d-17cb3c8bd302"
     assert section.title == ""
-    assert len(section.questions) == 1
+    assert len(section.questions) == 2
     assert isinstance(section.questions[0], Question)
 
     # check the question properties
@@ -65,10 +65,20 @@ def test_mci_mini():
     assert len(question.responses) == 1
     assert isinstance(question.responses[0], Response)
 
-    # Check the response proeprties
+    # Check the response properties
     response = question.responses[0]
     assert response.id == "29586b4c-fb0c-4755-b67d-b3cd398cb30a"
     assert response.code == "110"
     assert response.label == "Male employees working more than 30 hours per week?"
     assert response.guidance == "How many men work for your company?"
     assert response.type == "Integer"
+    assert response.display is None
+
+    # check the response properties on question 2
+    question_two = section.questions[1]
+    response = question_two.responses[0]
+    assert response.type == "Textarea"
+    assert response.display is not None
+    assert response.display.properties is not None
+    print(response.display.properties.max_length)
+    assert response.display.properties.max_length == "2000"

--- a/tests/app/parser/test_schemas/mci-mini.json
+++ b/tests/app/parser/test_schemas/mci-mini.json
@@ -31,6 +31,26 @@
                                       "mandatory":true
                                     }
                                 ]
+                              },
+                              {
+                                "id": "fef6edc2-d98c-4d4d-9a7c-997ce10c361f",
+                                "title": "Comments",
+                                "description": "",
+                                "responses": [
+                                    {
+                                      "id": "215015b1-f87c-4740-9fd4-f01f707ef558",
+                                      "q_code": "146",
+                                      "label": "Please explain any movements in your data e.g. sale held, branches opened or sold, extreme weather, or temporary closure of shop",
+                                      "guidance": "",
+                                      "type": "Textarea",
+                                      "mandatory":false,
+                                      "display": {
+                                          "properties": {
+                                              "max_length": "2000"
+                                          }
+                                      }
+                                    }
+                                  ]
                               }
                             ]
                         }


### PR DESCRIPTION
**What**
Fixes the comment entry box by adding the missing validator class. Also cleaning any user input using bleach, this should stop HTML and Javascript injection. I've also added a display properties section to the schema to allow us to specify max length for a text area.

**How to test**
1. Checkout this branch
2. Make sure you can complete a survey with comments
3. Check you cannot enter html or javascript code into the comments box

**Who can review**
Anyone apart from @warrenbailey
