### PR TITLE
Eq 43 basic business landing page

### DIFF
--- a/app/data/1_0203.json
+++ b/app/data/1_0203.json
@@ -1,7 +1,7 @@
 {
     "schema_version": "0.0.1",
     "questionnaire_id": "22",
-    "survey_id": "23",
+    "survey_id": "023",
     "title": "Monthly Business Survey - Retail Sales Index",
     "description": "MCI description",
     "groups": [

--- a/app/data/1_0205.json
+++ b/app/data/1_0205.json
@@ -2,7 +2,7 @@
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
     "questionnaire_id": "23",
-    "survey_id": "23",
+    "survey_id": "023",
     "title": "Monthly Business Survey - Retail Sales Index",
     "description": "MCI description",
     "introduction": {

--- a/app/data/1_0205.json
+++ b/app/data/1_0205.json
@@ -1,10 +1,14 @@
 {
-    "minme_type": "application/json/ons/eq",
+    "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
     "questionnaire_id": "23",
     "survey_id": "23",
     "title": "Monthly Business Survey - Retail Sales Index",
     "description": "MCI description",
+    "introduction": {
+      "legal":"<b>You are required by law to complete this questionnaire.</b> If you do not complete and submit this questionnaire by 6th February 2016, penalties may be incurred (under section 4 of the Statistics of Trade Act 1947). All the information you provide is kept strictly confidential. It is illegal for us to reveal your data or identify your business to unauthorised persons.",
+      "description": "<p>The information supplied is used to produce monthly estimates of the total retail sales in Great Britain where retailing is defined as the sale of goods to the general public for household consumption. The Retail Sales Index is a key indicator of the progress of the economy. It is also used to help estimate consumer spending on retail goods and the output of the retail sector, both of which feed into the compilation of the National Accounts. The results are also used by the Bank of England and HM Treasury to inform decision making by government and in formulating financial policies.</p><p>We guarantee that while your employment is less than 10, you will receive no more than 15 monthly questionnaires for this one ONS business survey. You must complete and return all questionnaires on time, after which you will be excluded from all business surveys for at least 3 years. The Annual Survey of Hours and Earnings is not covered by this guarantee.</p>"
+    },
     "groups": [
         {
             "id": "14ba4707-321d-441d-8d21-b8367366e766",

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -3,6 +3,9 @@ from flask import Blueprint
 main_blueprint = Blueprint('main', __name__)
 
 from app.main.views import root         # NOQA
+from app.main.views import questionnaire  # NOQA
+from app.main.views import cover_page   # NOQA
+from app.main.views import thank_you    # NOQA
 
 
 @main_blueprint.after_request

--- a/app/main/views/cover_page.py
+++ b/app/main/views/cover_page.py
@@ -1,7 +1,8 @@
 from flask import render_template
-from flask_login import login_required
+from flask_login import login_required, current_user
 from .. import main_blueprint
 import logging
+from app.main.views.root import _load_and_parse_schema
 
 
 logger = logging.getLogger(__name__)
@@ -11,4 +12,28 @@ logger = logging.getLogger(__name__)
 @login_required
 def cover_page():
     logger.debug("Requesting cover page")
-    return render_template('cover-page.html')
+    eq_id = current_user.get_eq_id()
+    form_type = current_user.get_form_type()
+    logger.debug("Requested questionnaire %s for form type %s", eq_id, form_type)
+
+    questionnaire = _load_and_parse_schema(eq_id, form_type)
+
+    return render_template('cover-page.html', data={
+        "legal": questionnaire.introduction.legal,
+        "description": questionnaire.introduction.description,
+        "address": {
+            "name": current_user.get_ru_name(),
+            "street": [
+                "3 St Edmunds Ave",
+                "Porthill"
+            ],
+            "locality": "Newcastle, Staffordshire",
+            "postcode": "ST5 0AB"
+        },
+        "survey_code": questionnaire.survey_id,
+        "period": current_user.get_period_str(),
+        "respondent_id": current_user.get_ru_ref(),
+        "return_by": current_user.get_return_by(),
+        "start_date": current_user.get_ref_p_start_date(),
+        "end_date": current_user.get_ref_p_end_date()
+    })

--- a/app/main/views/cover_page.py
+++ b/app/main/views/cover_page.py
@@ -22,13 +22,7 @@ def cover_page():
         "legal": questionnaire.introduction.legal,
         "description": questionnaire.introduction.description,
         "address": {
-            "name": current_user.get_ru_name(),
-            "street": [
-                "3 St Edmunds Ave",
-                "Porthill"
-            ],
-            "locality": "Newcastle, Staffordshire",
-            "postcode": "ST5 0AB"
+            "name": current_user.get_ru_name()
         },
         "survey_code": questionnaire.survey_id,
         "period": current_user.get_period_str(),

--- a/app/main/views/cover_page.py
+++ b/app/main/views/cover_page.py
@@ -1,0 +1,14 @@
+from flask import render_template
+from flask_login import login_required
+from .. import main_blueprint
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+@main_blueprint.route('/cover-page', methods=['GET', 'POST'])
+@login_required
+def cover_page():
+    logger.debug("Requesting cover page")
+    return render_template('cover-page.html')

--- a/app/main/views/questionnaire.py
+++ b/app/main/views/questionnaire.py
@@ -1,0 +1,70 @@
+from flask import render_template, request
+from flask_login import login_required, current_user
+from .. import main_blueprint
+from app.validation.validator import Validator
+from app.routing.routing_engine import RoutingEngine
+from app.navigation.navigator import Navigator
+from app.questionnaire.questionnaire_manager import QuestionnaireManager
+from app.main import errors
+from app.utilities.factory import factory
+import logging
+from app.main.views.root import _load_and_parse_schema
+from app.main.views.root import _redirect_to_location
+
+
+logger = logging.getLogger(__name__)
+
+
+@main_blueprint.route('/questionnaire', methods=['GET', 'POST'])
+@login_required
+def questionnaire():
+
+    logger.debug("Current user %s", current_user)
+
+    eq_id = current_user.get_eq_id()
+    form_type = current_user.get_form_type()
+    logger.debug("Requested questionnaire %s for form type %s", eq_id, form_type)
+
+    schema = _load_and_parse_schema(eq_id, form_type)
+    if not schema:
+        return errors.page_not_found()
+
+    # load the response store
+    response_store = factory.create("response-store")
+
+    # load the validation store
+    validation_store = factory.create("validation-store")
+
+    # Create the validator
+    validator = Validator(schema, validation_store, response_store)
+
+    # Create the routing engine
+    routing_engine = RoutingEngine(schema, response_store)
+
+    # load the navigation history
+    navigation_history = factory.create("navigation-history")
+
+    # create the navigator
+    navigator = Navigator(schema, navigation_history)
+    if navigator.get_current_location() is None:
+        navigator.go_to('questionnaire')
+
+    # instantiate the questionnaire manager
+    questionnaire_manager = QuestionnaireManager(schema,
+                                                 response_store,
+                                                 validator,
+                                                 validation_store,
+                                                 routing_engine,
+                                                 navigator,
+                                                 navigation_history)
+
+    if request.method == 'POST':
+        questionnaire_manager.process_incoming_responses(request.form)
+        current_location = navigator.get_current_location()
+        logger.debug("POST request question - current location %s", current_location)
+
+        return _redirect_to_location(current_location)
+
+    render_data = questionnaire_manager.get_rendering_context()
+
+    return render_template('questionnaire.html', questionnaire=render_data)

--- a/app/main/views/questionnaire.py
+++ b/app/main/views/questionnaire.py
@@ -67,4 +67,8 @@ def questionnaire():
 
     render_data = questionnaire_manager.get_rendering_context()
 
-    return render_template('questionnaire.html', questionnaire=render_data)
+    return render_template('questionnaire.html', questionnaire=render_data, data={
+        "survey_code": schema.survey_id,
+        "period": current_user.get_period_str(),
+        "respondent_id": current_user.get_ru_ref(),
+    })

--- a/app/main/views/thank_you.py
+++ b/app/main/views/thank_you.py
@@ -29,4 +29,8 @@ def thank_you():
 
     submitter = Submitter()
     submitter.send_responses(current_user, schema, response_store.get_responses())
-    return render_template('thank-you.html')
+    return render_template('thank-you.html', data={
+        "survey_code": schema.survey_id,
+        "period": current_user.get_period_str(),
+        "respondent_id": current_user.get_ru_ref(),
+    })

--- a/app/main/views/thank_you.py
+++ b/app/main/views/thank_you.py
@@ -1,0 +1,32 @@
+from flask import render_template
+from flask_login import login_required, current_user
+from .. import main_blueprint
+from app.submitter.submitter import Submitter
+from app.utilities.factory import factory
+import logging
+from app.main.views.root import _load_and_parse_schema
+from app.main import errors
+
+
+logger = logging.getLogger(__name__)
+
+
+@main_blueprint.route('/thank-you', methods=['GET'])
+@login_required
+def thank_you():
+    logger.debug("Requesting thank you page")
+
+    # load the response store
+    response_store = factory.create("response-store")
+
+    eq_id = current_user.get_eq_id()
+    form_type = current_user.get_form_type()
+
+    # load the schema
+    schema = _load_and_parse_schema(eq_id, form_type)
+    if not schema:
+        return errors.page_not_found()
+
+    submitter = Submitter()
+    submitter.send_responses(current_user, schema, response_store.get_responses())
+    return render_template('thank-you.html')

--- a/app/model/introduction.py
+++ b/app/model/introduction.py
@@ -1,0 +1,4 @@
+class Introduction(object):
+    def __init__(self):
+        self.legal = None
+        self.description = None

--- a/app/parser/v0_0_1/schema_parser.py
+++ b/app/parser/v0_0_1/schema_parser.py
@@ -18,6 +18,8 @@ from app.model.response import Response
 from app.model.display import Display
 from app.model.properties import Properties
 
+from app.model.introduction import Introduction
+
 import logging
 
 
@@ -68,6 +70,9 @@ class SchemaParser(AbstractSchemaParser):
             raise e
 
         if questionnaire:
+            if "introduction" in self._schema.keys():
+                questionnaire.introduction = self._parse_introduction(self._schema['introduction'])
+
             if "groups" in self._schema.keys():
                 for group_schema in self._schema['groups']:
                     questionnaire.add_group(self._parse_group(group_schema, questionnaire))
@@ -75,6 +80,14 @@ class SchemaParser(AbstractSchemaParser):
                 raise SchemaParserException('Questionnaire must contain at least one group')
 
         return questionnaire
+
+    def _parse_introduction(self, intro_schema):
+        introduction = Introduction()
+
+        introduction.legal = ParserUtils.get_optional_string(intro_schema, 'legal')
+        introduction.description = ParserUtils.get_optional_string(intro_schema, 'description')
+
+        return introduction
 
     def _parse_group(self, schema, questionnaire):
         """Parse a group element

--- a/app/templates/cover-page.html
+++ b/app/templates/cover-page.html
@@ -47,6 +47,70 @@
       </div>
     </section>
 
+
+
+    <div class="wrapper">
+
+        <div class="masthead">
+          <div class="logo">
+            <img src="img/logo.svg">
+          </div>
+          <div class="survey-info">
+            <div class="survey-icon"><img src="img/info.svg"></div>
+            <ul class="info-group">
+              <li class="info-block">Survey Code: 023</li>
+              <li class="info-block">Period: 201601</li>
+              <li class="info-block-last">Reference: 4990 0000 000</li>
+            </ul>
+          </div>
+          <div class="support">
+            <a href="/"><img src="img/help.svg">Need help?</a>
+          </div>
+        </div>
+
+        <main>
+          <div class="survey-user-info">
+            <div class="address-data">
+              <b>For the attention of</b>
+              <address>
+                CONTACT NAME<br>
+                OFFICE FOR NATIONAL STATISTICS<br>
+                GOVERNMENT BUILDINGS<br>
+                CARDIFF ROAD<br>
+                NEWPORT<br>
+                NP10 8XG
+              </address>
+              <p><a href=""><small>Details correct?</small></a></p>
+            </div>
+            <div class="survey-notice">
+              <h5>Please submit by</h5>
+              <p><date>6th February 2016</date></p>
+              <h5>Period</h5>
+              <p class="period">4/1/2016 to 31/1/2016 (4 Weeks)</p>
+              <p class="attn">NB: Your response is legally required</p>
+            </div>
+          </div>
+          <h2>Monthly Business Survey - Retail Sales Index</h2>
+          <h5>Notice is given under section 1 of the Statistics of Trade Act 1947</h5>
+          <div class="intro-text">
+            <p><b>You are required by law to complete this questionnaire.</b> If you do not complete and submit this questionnaire by 6th February 2016, penalties may be incurred (under section 4 of the Statistics of Trade Act 1947). All the information you provide is kept strictly confidential. It is illegal for us to reveal your data or identify your business to unauthorised persons.</p>
+
+            <p class="callout"><i>i</i> If actual figures are not available, please provide informed estimates.</p>
+
+            <div class="panels">
+                <input type="checkbox" id="instructions">
+                <label for="instructions"><span></span>How is your information used?</label>
+                <article>
+                  <p>The information supplied is used to produce monthly estimates of the total retail sales in Great Britain where retailing is defined as the sale of goods to the general public for household consumption. The Retail Sales Index is a key indicator of the progress of the economy. It is also used to help estimate consumer spending on retail goods and the output of the retail sector, both of which feed into the compilation of the National Accounts. The results are also used by the Bank of England and HM Treasury to inform decision making by government and in formulating financial policies.</p>
+                  <p>We guarantee that while your employment is less than 10, you will receive no more than 15 monthly questionnaires for this one ONS business survey. You must complete and return all questionnaires on time, after which you will be excluded from all business surveys for at least 3 years. The Annual Survey of Hours and Earnings is not covered by this guarantee.</p>
+                </article>
+            </div>
+
+
+            <p><b>Office for National Statistics</b></p>
+
+
+
     <footer class="cover__footer">
 
       <a href="/questionnaire" class="btn">Get Started</a>

--- a/app/templates/cover-page.html
+++ b/app/templates/cover-page.html
@@ -18,8 +18,11 @@
 
         <div class="grid__col s-7">
           <div class="cover__notice">
-            <p>Please complete by the 25th November 2015</p>
-            <p><b>Your response is legally required</b></p>
+            <h5>Please submit by</h5>
+            <p><date>{{ data.return_by }}</date></p>
+            <h5>Period</h5>
+            <p class="period">{{ data.start_date }} to {{ data.end_date}}</p>
+            <p class="attn">NB: Your response is legally required</p>
           </div>
         </div>
 
@@ -34,81 +37,20 @@
       </header>
 
       <div class="cover__copy">
-        <p>Dear Sir or Madam,</p>
-        <p>Please find below the July 2015 questionnaire for the welcome to my survey about crayons. Your data should cover the period 3 July 2015. If actual figures are not available, please provide informed estimates.</p>
-        <p>The information supplied is used to produce a comprehensive and reliable measure of job vacancies across the economy. Results are published in the monthly Labour Market Statistical Bulletin and used by the Treasury and the Bank of England as a valuable
-          indicator of labour demand.</p>
-        <p>We guarantee that while your employment is less than 10, you will receive no more than 15 monthly questionnaires for this one ONS business survey. You must complete and return all questionnaires on time, after which you will be excluded from all
-          business surveys for at least 3 years. The Annual Survey of Hours and Earnings is not covered by this guarantee.</p>
-        <p>You are required by law to complete this questionnaire. If you do not complete and return this questionnaire by 1 O July 2015, penalties may be incurred (under section 4 of the Statistics of Trade Act 194 7). All the information you provide is kept
-          strictly confidential. It is illegal for us to reveal your data or identify your business to unauthorised persons.</p>
-        <p>Thank you for your co-operation</p>
+        <p><b>{{ data.legal | safe }}</p>
+
+        <p class="callout"><i>i</i> If actual figures are not available, please provide informed estimates.</p>
+
+        <div class="panels">
+            <input type="checkbox" id="instructions">
+            <label for="instructions"><span></span>How is your information used?</label>
+            <article>
+              {{ data.description | safe }}
+            </article>
+        </div>
         <p><b>Office for National Statistics</b></p>
       </div>
     </section>
-
-
-
-    <div class="wrapper">
-
-        <div class="masthead">
-          <div class="logo">
-            <img src="img/logo.svg">
-          </div>
-          <div class="survey-info">
-            <div class="survey-icon"><img src="img/info.svg"></div>
-            <ul class="info-group">
-              <li class="info-block">Survey Code: 023</li>
-              <li class="info-block">Period: 201601</li>
-              <li class="info-block-last">Reference: 4990 0000 000</li>
-            </ul>
-          </div>
-          <div class="support">
-            <a href="/"><img src="img/help.svg">Need help?</a>
-          </div>
-        </div>
-
-        <main>
-          <div class="survey-user-info">
-            <div class="address-data">
-              <b>For the attention of</b>
-              <address>
-                CONTACT NAME<br>
-                OFFICE FOR NATIONAL STATISTICS<br>
-                GOVERNMENT BUILDINGS<br>
-                CARDIFF ROAD<br>
-                NEWPORT<br>
-                NP10 8XG
-              </address>
-              <p><a href=""><small>Details correct?</small></a></p>
-            </div>
-            <div class="survey-notice">
-              <h5>Please submit by</h5>
-              <p><date>6th February 2016</date></p>
-              <h5>Period</h5>
-              <p class="period">4/1/2016 to 31/1/2016 (4 Weeks)</p>
-              <p class="attn">NB: Your response is legally required</p>
-            </div>
-          </div>
-          <h2>Monthly Business Survey - Retail Sales Index</h2>
-          <h5>Notice is given under section 1 of the Statistics of Trade Act 1947</h5>
-          <div class="intro-text">
-            <p><b>You are required by law to complete this questionnaire.</b> If you do not complete and submit this questionnaire by 6th February 2016, penalties may be incurred (under section 4 of the Statistics of Trade Act 1947). All the information you provide is kept strictly confidential. It is illegal for us to reveal your data or identify your business to unauthorised persons.</p>
-
-            <p class="callout"><i>i</i> If actual figures are not available, please provide informed estimates.</p>
-
-            <div class="panels">
-                <input type="checkbox" id="instructions">
-                <label for="instructions"><span></span>How is your information used?</label>
-                <article>
-                  <p>The information supplied is used to produce monthly estimates of the total retail sales in Great Britain where retailing is defined as the sale of goods to the general public for household consumption. The Retail Sales Index is a key indicator of the progress of the economy. It is also used to help estimate consumer spending on retail goods and the output of the retail sector, both of which feed into the compilation of the National Accounts. The results are also used by the Bank of England and HM Treasury to inform decision making by government and in formulating financial policies.</p>
-                  <p>We guarantee that while your employment is less than 10, you will receive no more than 15 monthly questionnaires for this one ONS business survey. You must complete and return all questionnaires on time, after which you will be excluded from all business surveys for at least 3 years. The Annual Survey of Hours and Earnings is not covered by this guarantee.</p>
-                </article>
-            </div>
-
-
-            <p><b>Office for National Statistics</b></p>
-
 
 
     <footer class="cover__footer">

--- a/app/templates/cover-page.html
+++ b/app/templates/cover-page.html
@@ -37,7 +37,7 @@
       </header>
 
       <div class="cover__copy">
-        <p><b>{{ data.legal | safe }}</p>
+        <p><b>{{ data.legal | safe }}</b></p>
 
         <p class="callout"><i>i</i> If actual figures are not available, please provide informed estimates.</p>
 

--- a/app/templates/layouts/_survey.html
+++ b/app/templates/layouts/_survey.html
@@ -24,9 +24,9 @@
       <div class="info survey-header__info" role="contentinfo">
         <h2 class="u-vh">Information about this survey</h2>
         <ul class="info__list">
-          <li class="info__item info__item--half">Survey Code: 023</li>
-          <li class="info__item info__item--half">Period: 201403</li>
-          <li class="info__item info__item--last">Reference: 4990 0000 000</li>
+          <li class="info__item info__item--half">Survey Code: {{ data.survey_code }}</li>
+          <li class="info__item info__item--half">Period: {{ data.period }}</li>
+          <li class="info__item info__item--last">Reference: {{ data.respondent_id }}</li>
         </ul>
       </div>
 

--- a/app/templates/partials/address.html
+++ b/app/templates/partials/address.html
@@ -1,17 +1,3 @@
-{% set address = {
-  "name": data.address.name,
-  "street": data.address.street,
-  "locality": data.address.locality,
-  "postcode": data.address.postcode
-} %}
-
 <div class="vcard address">
-  <span class="fn">{{ address.name}}</span>
-  <div class="adr">
-    {% for street in address.street %}
-      <div class="street-address">{{street}}</div>
-    {% endfor %}
-    <div class="locality">{{address.locality}}</div>
-    <div class="postal-code">{{address.postcode}}</div>
-  </div>
+  <span class="fn">{{ data.address.name}}</span>
 </div>

--- a/app/templates/partials/address.html
+++ b/app/templates/partials/address.html
@@ -1,16 +1,12 @@
 {% set address = {
-  "name": "Contact Name",
-  "street": [
-    "Office for National Statistics",
-    "Government Buildings",
-    "CARDIFF ROAD"
-  ],
-  "locality": "Duffryn, Newport",
-  "postcode": "NP10 8XG"
+  "name": data.address.name,
+  "street": data.address.street,
+  "locality": data.address.locality,
+  "postcode": data.address.postcode
 } %}
 
 <div class="vcard address">
-  <span class="fn">{{address.name}}</span>
+  <span class="fn">{{ address.name}}</span>
   <div class="adr">
     {% for street in address.street %}
       <div class="street-address">{{street}}</div>

--- a/tests/app/parser/test_mci_mini.py
+++ b/tests/app/parser/test_mci_mini.py
@@ -6,79 +6,112 @@ from app.model.block import Block
 from app.model.section import Section
 from app.model.question import Question
 from app.model.response import Response
+from app.model.introduction import Introduction
 import os
 import json
+import unittest
 
 
-def test_mci_mini():
-    # Load the json file as a dict
-    schema_file = open(os.path.join(os.path.dirname(__file__), 'test_schemas/mci-mini.json'))
-    schema = schema_file.read()
-    schema = json.loads(schema)
+class MciMiniParsingTest(unittest.TestCase):
+    def test_mci_mini(self):
+        # Load the json file as a dict
+        schema_file = open(os.path.join(os.path.dirname(__file__), 'test_schemas/mci-mini.json'))
+        schema = schema_file.read()
+        schema = json.loads(schema)
 
-    # create a parser
-    parser = SchemaParserFactory.create_parser(schema)
+        # create a parser
+        parser = SchemaParserFactory.create_parser(schema)
 
-    assert isinstance(parser, AbstractSchemaParser)
+        assert isinstance(parser, AbstractSchemaParser)
 
-    questionnaire = parser.parse()
+        questionnaire = parser.parse()
 
-    # Check the parser version
-    assert parser.get_parser_version() == '0.0.1'
+        # Check the parser version
+        assert parser.get_parser_version() == '0.0.1'
 
-    # check the questionniare properties
-    assert isinstance(questionnaire, Questionnaire)
-    assert questionnaire.id == "22"
-    assert questionnaire.survey_id == "23"
-    assert questionnaire.title == "Monthly Business Survey - Retail Sales Index"
-    assert questionnaire.description == "MCI description"
-    assert len(questionnaire.groups) == 1
-    assert isinstance(questionnaire.groups[0], Group)
+        # check the questionniare properties
+        assert isinstance(questionnaire, Questionnaire)
+        assert questionnaire.id == "22"
+        assert questionnaire.survey_id == "23"
+        assert questionnaire.title == "Monthly Business Survey - Retail Sales Index"
+        assert questionnaire.description == "MCI description"
+        assert len(questionnaire.groups) == 1
+        assert isinstance(questionnaire.groups[0], Group)
 
-    # check the group properties
-    group = questionnaire.groups[0]
+        # check the group properties
+        group = questionnaire.groups[0]
 
-    assert group.id == "14ba4707-321d-441d-8d21-b8367366e766"
-    assert group.title == ""
-    assert len(group.blocks) == 1
-    assert isinstance(group.blocks[0], Block)
+        assert group.id == "14ba4707-321d-441d-8d21-b8367366e766"
+        assert group.title == ""
+        assert len(group.blocks) == 1
+        assert isinstance(group.blocks[0], Block)
 
-    # check the block properties
-    block = group.blocks[0]
-    assert block.id == "cd3b74d1-b687-4051-9634-a8f9ce10a27d"
-    assert block.title == "Monthly Business Survey"
-    assert len(block.sections) == 1
-    assert isinstance(block.sections[0], Section)
+        # check the block properties
+        block = group.blocks[0]
+        assert block.id == "cd3b74d1-b687-4051-9634-a8f9ce10a27d"
+        assert block.title == "Monthly Business Survey"
+        assert len(block.sections) == 1
+        assert isinstance(block.sections[0], Section)
 
-    # check the section properties
-    section = block.sections[0]
-    assert section.id == "2cd99c83-186d-493a-a16d-17cb3c8bd302"
-    assert section.title == ""
-    assert len(section.questions) == 2
-    assert isinstance(section.questions[0], Question)
+        # check the section properties
+        section = block.sections[0]
+        assert section.id == "2cd99c83-186d-493a-a16d-17cb3c8bd302"
+        assert section.title == ""
+        assert len(section.questions) == 2
+        assert isinstance(section.questions[0], Question)
 
-    # check the question properties
-    question = section.questions[0]
-    assert question.id == "4ba2ec8a-582f-4985-b4ed-20355deba55a"
-    assert question.title == "On 12 January 2016 what was the number of employees for the business named above?"
-    assert question.description == "An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme."
-    assert len(question.responses) == 1
-    assert isinstance(question.responses[0], Response)
+        # check the question properties
+        question = section.questions[0]
+        assert question.id == "4ba2ec8a-582f-4985-b4ed-20355deba55a"
+        assert question.title == "On 12 January 2016 what was the number of employees for the business named above?"
+        assert question.description == "An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme."
+        assert len(question.responses) == 1
+        assert isinstance(question.responses[0], Response)
 
-    # Check the response properties
-    response = question.responses[0]
-    assert response.id == "29586b4c-fb0c-4755-b67d-b3cd398cb30a"
-    assert response.code == "110"
-    assert response.label == "Male employees working more than 30 hours per week?"
-    assert response.guidance == "How many men work for your company?"
-    assert response.type == "Integer"
-    assert response.display is None
+        # Check the response properties
+        response = question.responses[0]
+        assert response.id == "29586b4c-fb0c-4755-b67d-b3cd398cb30a"
+        assert response.code == "110"
+        assert response.label == "Male employees working more than 30 hours per week?"
+        assert response.guidance == "How many men work for your company?"
+        assert response.type == "Integer"
+        assert response.display is None
 
-    # check the response properties on question 2
-    question_two = section.questions[1]
-    response = question_two.responses[0]
-    assert response.type == "Textarea"
-    assert response.display is not None
-    assert response.display.properties is not None
-    print(response.display.properties.max_length)
-    assert response.display.properties.max_length == "2000"
+        # check the response properties on question 2
+        question_two = section.questions[1]
+        response = question_two.responses[0]
+        assert response.type == "Textarea"
+        assert response.display is not None
+        assert response.display.properties is not None
+        print(response.display.properties.max_length)
+        assert response.display.properties.max_length == "2000"
+
+    def test_mci_mini_with_intro(self):
+        # Load the json file as a dict
+        schema_file = open(os.path.join(os.path.dirname(__file__), 'test_schemas/mci-mini-with-intro.json'))
+        schema = schema_file.read()
+        schema = json.loads(schema)
+
+        # create a parser
+        parser = SchemaParserFactory.create_parser(schema)
+
+        assert isinstance(parser, AbstractSchemaParser)
+
+        questionnaire = parser.parse()
+
+        # Check the parser version
+        assert parser.get_parser_version() == '0.0.1'
+
+        # check the questionniare properties
+        assert isinstance(questionnaire, Questionnaire)
+        assert questionnaire.id == "22"
+        assert questionnaire.survey_id == "23"
+        assert questionnaire.title == "Monthly Business Survey - Retail Sales Index"
+        assert questionnaire.description == "MCI description"
+        assert len(questionnaire.groups) == 1
+        assert isinstance(questionnaire.groups[0], Group)
+
+        self.assertIsNotNone(questionnaire.introduction)
+        self.assertIsInstance(questionnaire.introduction, Introduction)
+        self.assertEquals(questionnaire.introduction.legal, "<b>This is the legal bit.</b>")
+        self.assertEquals(questionnaire.introduction.description, "<p>This is the description.</p>")

--- a/tests/app/parser/test_schemas/mci-mini-with-intro.json
+++ b/tests/app/parser/test_schemas/mci-mini-with-intro.json
@@ -1,0 +1,46 @@
+{
+    "schema_version": "0.0.1",
+    "questionnaire_id": "22",
+    "survey_id": "23",
+    "title": "Monthly Business Survey - Retail Sales Index",
+    "description": "MCI description",
+    "introduction": {
+      "legal":"<b>This is the legal bit.</b>",
+      "description": "<p>This is the description.</p>"
+    },
+    "groups": [
+        {
+            "id": "14ba4707-321d-441d-8d21-b8367366e766",
+            "title": "",
+            "blocks": [
+                {
+                    "id": "cd3b74d1-b687-4051-9634-a8f9ce10a27d",
+                    "title": "Monthly Business Survey",
+                    "sections": [
+                        {
+                          "id": "2cd99c83-186d-493a-a16d-17cb3c8bd302",
+                          "title":"",
+                          "questions": [
+                              {
+                                "id": "4ba2ec8a-582f-4985-b4ed-20355deba55a",
+                                "title": "On 12 January 2016 what was the number of employees for the business named above?",
+                                "description": "An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.",
+                                "responses": [
+                                    {
+                                      "id": "29586b4c-fb0c-4755-b67d-b3cd398cb30a",
+                                      "q_code": "110",
+                                      "label": "Male employees working more than 30 hours per week?",
+                                      "guidance": "How many men work for your company?",
+                                      "type": "Integer",
+                                      "mandatory":true
+                                    }
+                                ]
+                              }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
**_What**_

Data-driven cover-page.
- Updates the schema, the parser, and the model to provide support for an 'introduction' to the questionnaire.
- Updates the cover-page to draw information from the questionnaire and the current_user token
- Refactors some of the views in root.py

**_How to test**_

1) Checkout the branch
2) Test everything is still working.

**_Who can test**_

Anybody except @weapdiv-david

**_Still to do**_
- Hamish still needs to update the front end code and make it look less of a dogs dinner
- We still need to provide the respondents address
