### PR TITLE
Questionnaires without intro jump straight to the questionnaire

### DIFF
--- a/app/main/views/root.py
+++ b/app/main/views/root.py
@@ -82,12 +82,14 @@ def _redirect_to_location(current_location):
     :param current_location: the current location in the questionnaire
     :return: flask redirect to the next page
     """
-    if current_location is None:
+    if current_location == 'introduction':
         return redirect(url_for("main.cover_page"))
     elif current_location == "completed":
         return redirect(url_for("main.thank_you"))
-    else:
+    elif current_location == 'questionnaire':
         return redirect(url_for("main.questionnaire"))
+    else:
+        return errors.page_not_found()
 
 
 def _load_and_parse_schema(eq_id, form_type):

--- a/app/model/questionnaire.py
+++ b/app/model/questionnaire.py
@@ -11,6 +11,7 @@ class Questionnaire(object):
         self.groups = []
         self.validation = None
         self.items_by_id = {}
+        self.introduction = None
 
     def add_group(self, group):
         if group not in self.groups:

--- a/app/navigation/navigator.py
+++ b/app/navigation/navigator.py
@@ -31,7 +31,15 @@ class Navigator(object):
         state = self._store.get_state()
         current_location = state.current_position
         logger.debug("Current location %s", current_location)
-        return current_location
+
+        # We need to have a conversation about what constitutes an addressable element within a questionnaire
+        if current_location is None:
+            if self._schema.introduction is not None:
+                return 'introduction'
+            else:
+                return 'questionnaire'
+        else:
+            return current_location
 
     def go_to(self, location):
         """

--- a/tests/app/navigation/test_navigator.py
+++ b/tests/app/navigation/test_navigator.py
@@ -3,6 +3,7 @@ from app.navigation.navigation_history import FlaskNavigationHistory
 from datetime import timedelta
 from flask import Flask
 import unittest
+from app.model.questionnaire import Questionnaire
 
 
 class NavigatorTest(unittest.TestCase):
@@ -15,15 +16,27 @@ class NavigatorTest(unittest.TestCase):
 
     def test_get_current_location(self):
         with self.application.test_request_context():
-            schema = {}
+            schema = Questionnaire()
+
             navigation_history = FlaskNavigationHistory()
             navigator = Navigator(schema, navigation_history)
             #  brand new session shouldn't have a current location
-            self.assertIsNone(navigator.get_current_location())
+            self.assertEquals("questionnaire", navigator.get_current_location())
+
+    def test_get_current_location_with_intro(self):
+        with self.application.test_request_context():
+            schema = Questionnaire()
+            schema.introduction = "anything"
+
+            navigation_history = FlaskNavigationHistory()
+            navigator = Navigator(schema, navigation_history)
+            #  brand new session shouldn't have a current location
+            self.assertEquals("introduction", navigator.get_current_location())
 
     def test_go_to(self):
         with self.application.test_request_context():
-            schema = {}
+            schema = Questionnaire()
+
             navigation_history = FlaskNavigationHistory()
             navigator = Navigator(schema, navigation_history)
             navigator.go_to("completed")


### PR DESCRIPTION
**_What**_

Cover page is optional.  This change modifies the navigator behaviour to only send the user to the intro page if the schema contains an intro.

**_How to test**_

1) Check out the branch
2) Enable dev mode and visit the dev console
3) Check each questionnaire
4) mci_mini should direct straight to the question, whereas the others will display an intro page

**_Who can test**_

Anybody except @weapdiv-david
