### PR TITLE
[hotfix] comment entry

### DIFF
--- a/app/js/app/modules/charlimit.js
+++ b/app/js/app/modules/charlimit.js
@@ -17,7 +17,7 @@ export function updateMsg(el, length, maxLength) {
 export function imposeCharLimit(el, maxLength) {
   const msgEl = el.parentElement.querySelector(`.${msgClass}`)
 
-  updateMsg(msgEl, maxLength, 0)
+  updateMsg(msgEl, maxLength, el.value.length)
 
   el.addEventListener('input', (e) => {
     el.value = applyCharLimit(el.value, maxLength)


### PR DESCRIPTION
## defect
- upon page load, the comment entry character limit display wasn't taking into account characters already in the textarea
## test
- enter characters in the comment box
- don't enter anything else so the entry is invalid
- confirm "characters remaining" is correct (ie. not 2000)
