### PR TITLE
Back button bug fix

### DIFF
--- a/app/questionnaire/questionnaire_manager.py
+++ b/app/questionnaire/questionnaire_manager.py
@@ -34,6 +34,9 @@ class QuestionnaireManager(object):
 
             # go to that location
             self._navigator.go_to(next_location)
+        else:
+            # bug fix for using back button which then fails validation
+            self._navigator.go_to('questionnaire')
 
         # now return the location
         return self._navigator.get_current_location()


### PR DESCRIPTION
**What**
If a user completes a questionnaire correctly and goes to the summary page but then goes back and changes a response which would then fail validation the page is still returning to the summary page. This is due to the navigator not updating its state

**How to test**
1. Correctly fill in a questionnaire and click through to the summary page
2. Use the back button to go back to the questionnaire page.
3. Change one of your answers to fail validation
4. Make sure it stays on the questionnaire page and highlights the error

**Who can test**
Anyone but @LJBabbage
