### PR TITLE
Serverside template testing

### DIFF
--- a/app/dev_mode/views.py
+++ b/app/dev_mode/views.py
@@ -2,12 +2,20 @@ from flask import render_template, redirect, request, abort
 from app.authentication.encoder import Encoder
 from app.authentication.user import UserConstants
 from app.schema_loader.schema_loader import available_schemas
+from flask.ext.cors import cross_origin
 from . import dev_mode_blueprint
 import os
 import time
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+@dev_mode_blueprint.route('/dev/render-template', methods=['POST'])
+@cross_origin()
+def template():
+    payload = request.get_json()
+    return render_template('partials/' + payload['template'] + '.html', **payload['data'])
 
 
 @dev_mode_blueprint.route('/dev', methods=['GET', 'POST'])

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.5.1",
     "babelify": "~7.2.0",
+    "bluebird": "^3.3.4",
     "browser-sync": "^2.11.0",
     "browserify": "~13.0.0",
     "browserify-shim": "^3.8.12",
@@ -89,6 +90,7 @@
     "karma-sinon": "^1.0.4",
     "karma-spec-reporter": "0.0.24",
     "mocha": "^2.3.4",
+    "node-fetch": "^1.4.1",
     "node-fs": "^0.1.7",
     "path": "^0.12.7",
     "phantomjs-polyfill": "0.0.1",
@@ -110,6 +112,7 @@
     "eq-sass": "^1.0.7",
     "gfm.css": "^1.1.1",
     "jquery": "./app/js/vendor/jquery-shim",
+    "lodash": "^4.6.1",
     "parsleyjs": "^2.2.0",
     "pixrem": "^3.0.0",
     "postcss-pseudoelements": "^3.0.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ cryptography==1.1.2
 verlib==0.1
 watchtower==0.1.6
 beautifulsoup4==4.4.1
+flask-cors==2.1.2

--- a/tests/karma/karma.conf.js
+++ b/tests/karma/karma.conf.js
@@ -6,6 +6,12 @@ module.exports = function(config) {
 
     basePath: './../../',
 
+    client: {
+      mocha: {
+        timeout: 4000
+      }
+    },
+
     frameworks: ['browserify', 'mocha', 'chai-sinon', 'chai-as-promised', 'chai'],
 
     files: [
@@ -47,6 +53,6 @@ module.exports = function(config) {
     },
 
     colors: true,
-    logLevel: config.LOG_DEBUG
+    logLevel: config.LOG_INFO
   })
 }

--- a/tests/karma/template-helper.js
+++ b/tests/karma/template-helper.js
@@ -1,0 +1,28 @@
+import fetch from 'node-fetch'
+import bluebird from 'bluebird'
+
+fetch.Promise = bluebird
+
+export default function(template, data) {
+  return fetch('http://localhost:5000/dev/render-template', {
+    method: 'POST',
+    mode: 'no-cors',
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      template: template,
+      data: data
+    })
+  })
+  .then(data => data.text())
+  .then(text => {
+    let wrapper = document.createElement('div')
+    wrapper.innerHTML = text
+    return wrapper.firstChild
+  })
+  .catch(err => {
+    console.log(err)
+  })
+}


### PR DESCRIPTION
## Changes
- Exposes a route `/dev/render-template` where an AJAX call can retrieve a given template rendered against data in the POST.
- Provides a helper function for interfacing with this in a f/e test
## Note
- ~~This branch is pretty untidy as there are commits from other things in here.~~
