### PR TITLE
Fixes trading as, return by date formatting, details link, and #99

### DIFF
--- a/app/main/views/cover_page.py
+++ b/app/main/views/cover_page.py
@@ -23,13 +23,15 @@ def cover_page():
         "legal": questionnaire.introduction.legal,
         "description": questionnaire.introduction.description,
         "address": {
-            "name": current_user.get_ru_name()
+            "name": current_user.get_ru_name(),
+            "trading_as": current_user.get_trad_as()
         },
         "survey_code": questionnaire.survey_id,
-        "period": current_user.get_period_str(),
+        "period_str": current_user.get_period_str(),
+        "period_id": current_user.get_period_id(),
         "respondent_id": current_user.get_ru_ref(),
-        "return_by": current_user.get_return_by(),
         # You'd think there would be an easier way of doing this...
+        "return_by": '{dt.day} {dt:%B} {dt.year}'.format(dt=datetime.strptime(current_user.get_return_by(), "%Y-%m-%d")),
         "start_date": '{dt.day} {dt:%B} {dt.year}'.format(dt=datetime.strptime(current_user.get_ref_p_start_date(), "%Y-%m-%d")),
         "end_date": '{dt.day} {dt:%B} {dt.year}'.format(dt=datetime.strptime(current_user.get_ref_p_end_date(), "%Y-%m-%d"))
     })

--- a/app/templates/cover-page.html
+++ b/app/templates/cover-page.html
@@ -12,7 +12,6 @@
           <div class="cover__address">
             <b>To be completed by</b>
             {% include 'partials/address.html' %}
-            <a class="cover__address-link" href="">Details correct?</a>
           </div>
         </div>
 

--- a/app/templates/layouts/_survey.html
+++ b/app/templates/layouts/_survey.html
@@ -26,7 +26,7 @@
         <h2 class="u-vh">Information about this survey</h2>
         <ul class="info__list">
           <li class="info__item info__item--half">Survey Code: {{ data.survey_code or '' }}</li>
-          <li class="info__item info__item--half">Period: {{ data.period or '' }}</li>
+          <li class="info__item info__item--half">Period: {{ data.period_str or '' }}</li>
           <li class="info__item info__item--last">Reference: {{ data.respondent_id or '' }}</li>
         </ul>
       </div>

--- a/app/templates/partials/address.html
+++ b/app/templates/partials/address.html
@@ -1,3 +1,8 @@
 <div class="vcard address">
   <span class="fn">{{ data.address.name}}</span>
+  {% if data.address.trading_as %}
+  <br />
+  <b>Trading As</b><br />
+  {{ data.address.trading_as }}
+  {% endif %}
 </div>


### PR DESCRIPTION
**_What**_
- Remove the edit address details link (issue #103)
- Displays the Trading As name where supplied (issue #104)
- Formats the Return By date correctly
- Confirms that the period_str is being used by the template as referenced in #99 

**_How to test**_

1) Check out the branch and run the app
2) Confirm that all dates are formatted correctly
3) Confirm that the trading name appears
4) Confirm that the edit address has gone
5) Using dev mode, create a new token and confirm that the value you entered for period_str is displayed at the top right of the page.

**_Who can test**_

Anyone except @weapdiv-david
