### PR TITLE
Kludge the start date and end date while missing from RM data

### DIFF
--- a/app/authentication/authenticator.py
+++ b/app/authentication/authenticator.py
@@ -35,6 +35,13 @@ class Authenticator(object):
             raise NoTokenException("Please provide a token")
         token = self._jwt_decrypt(request)
 
+        # <kludge>
+        # TODO: Remove this once RM is correctly sending dates
+        from app.authentication.user import UserConstants
+        token[UserConstants.REF_P_START_DATE] = '2020-04-01'
+        token[UserConstants.REF_P_END_DATE] = '2020-05-01'
+        # </kludge>
+
         # once we've decrypted the token correct
         # check we have the required user data
         self._check_user_data(token)


### PR DESCRIPTION
**_What**_

Kludges the start and end dates as these are missing from the data sent via the RM, but required by eq.

**_How to test**_

1) checkout the branch
2) Using Dev Mode, create a new token with missing dates
3) Check the start and end dates of the survey are in 2020

**_Who can test**_

Anyone except @weapdiv-david
