### PR TITLE
EQ-246: Session Timeout Extension

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -34,7 +34,7 @@ EQ_SR_LOG_GROUP = os.getenv('EQ_SR_LOG_GROUP', os.getenv('USER', 'UNKNOWN') + '-
 EQ_LOG_LEVEL = os.getenv('EQ_LOG_LEVEL', 'INFO')
 EQ_CLOUDWATCH_LOGGING = parse_mode(os.getenv("EQ_CLOUDWATCH_LOGGING", 'True'))
 EQ_SCHEMA_DIRECTORY = os.getenv('EQ_SCHEMA_DIRECTORY', 'app/data')
-EQ_SESSION_TIMEOUT = int(os.getenv('EQ_SESSION_TIMEOUT', '1800'))
+EQ_SESSION_TIMEOUT = int(os.getenv('EQ_SESSION_TIMEOUT', '28800'))
 EQ_SECRET_KEY = os.getenv('EQ_SECRET_KEY', os.urandom(24))
 
 # keys for the dev mode


### PR DESCRIPTION
**What**
Extend session timeout to 8 hours (28800 seconds)

**How to test**
1. Start filling in the questionnaire, ....**STOP**....
2. Wait 7 hours and see if the session data is still there
3. Repeat but now wait over 8 hours and make sure the session data isn't there

**Who can test**
Anyone but @LJBabbage
