### PR TITLE
Enable profiling support

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ EQ_LOG_LEVEL - The default logging level (defaults to 'INFO' for local developme
 EQ_SCHEMA_DIRECTORY - The directory that contains the schema files
 EQ_SESSION_TIMEOUT - The duration of the flask session, defaults to 30 minutes
 EQ_SECRET_KEY - The Flask secret key for signing cookies
+EQ_PROFILING - Enables or disables profiling (True/False) Default False/Disabled
 ```
 
 ## JWT Integration
@@ -181,7 +182,14 @@ There is a python script for generating tokens for use in development, to run:
 python token_generator.py
 ```
 
+## profiling
 
+Setting the `EQ_PROFILING` environment variable to `True` will enable profiling of the application.  Profiling information
+will be collected per-request in the `profiling` directory where it can be examined using the Pstats Interactive Browser.
+
+`$ python -m pstats <filename>`
+
+will load the file into the interactive browser where it can be sorted and queried as required.
 
 
 ## Alpha Survey Runner

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -17,6 +17,7 @@ from datetime import timedelta
 import watchtower
 import logging
 from logging.handlers import RotatingFileHandler
+import sys
 
 LOG_NAME = "eq.log"
 LOG_SIZE = 1048576
@@ -153,5 +154,22 @@ def create_app(config_name):
     # workaround flask crazy logging mechanism
     application.logger_name = "nowhere"
     application.logger
+
+    # Setup profiling
+    if settings.EQ_PROFILING:
+        from werkzeug.contrib.profiler import ProfilerMiddleware, MergeStream
+        import os
+
+        profiling_dir = "profiling"
+
+        f = open('profiler.log', 'w')
+        stream = MergeStream(sys.stdout, f)
+
+        if not os.path.exists(profiling_dir):
+            os.makedirs(profiling_dir)
+
+        application.config['PROFILE'] = True
+        application.wsgi_app = ProfilerMiddleware(application.wsgi_app, stream, profile_dir=profiling_dir)
+        application.debug = True
 
     return application

--- a/app/settings.py
+++ b/app/settings.py
@@ -20,6 +20,7 @@ def get_key(key_name):
     logger.debug("Key is %s", contents)
     return contents
 
+EQ_PROFILING = parse_mode(os.getenv('EQ_PROFILING', 'False'))
 
 EQ_RABBITMQ_URL = os.getenv('EQ_RABBITMQ_URL', 'amqp://localhost:5672/%2F')
 EQ_RABBITMQ_QUEUE_NAME = os.getenv('EQ_RABBITMQ_QUEUE_NAME', 'eq-submissions')


### PR DESCRIPTION
**_What**_

Enables profiling of the application

**_How to test**_

1) Check out the branch
2) Set the `EQ_PROFILING` environment varable to `True`
3) Run the application as usual
4) Check for the presence of a `profiling` directory containing one file per request.

**_Who can test**_

Anybody except @weapdiv-david
