### PR TITLE
Replaces the numeric error prefix with -

### DIFF
--- a/app/templates/partials/alert.html
+++ b/app/templates/partials/alert.html
@@ -8,7 +8,7 @@
       {% for item_id, errors in all_errors %}
         {% set loop_index = loop.index %}
         {% for error in errors %}
-        <li>{{loop_index}}) {{ error }}. <a href="#response-{{item_id}}">{{_('Go to this error')}}</a></li>
+        <li>- {{ error }}. <a href="#response-{{item_id}}">{{_('Go to this error')}}</a></li>
         {% endfor %}
       {% endfor %}
     </ul>


### PR DESCRIPTION
**_What**_

Replaces the numeric error prefixes with a - as the numeric repfixes were too confusing for users who expected them to match to a question number

**_How to test**_

1) Check out the branch
2) Submit the survey with errors
3) Verify that the errors at the top of the page are prefixed with '-'

**_Who can test**_

Anybody except @weapdiv-david
