### PR TITLE
EQ-226 Use SHA256 instead of SHA1 for cookie signing

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -11,6 +11,7 @@ from app.navigation.navigation_history import FlaskNavigationHistory
 from app.validation.validation_store import FlaskValidationStore
 from app import settings
 from app.authentication.authenticator import Authenticator
+from app.authentication.cookie_session import SHA256SecureCookieSessionInterface
 from app.submitter.submitter import SubmitterFactory
 from datetime import timedelta
 import watchtower
@@ -75,6 +76,8 @@ def create_app(config_name):
 
     application.secret_key = settings.EQ_SECRET_KEY
     application.permanent_session_lifetime = timedelta(seconds=settings.EQ_SESSION_TIMEOUT)
+
+    application.session_interface = SHA256SecureCookieSessionInterface()
 
     Markdown(application, extensions=['gfm'])
 

--- a/app/authentication/cookie_session.py
+++ b/app/authentication/cookie_session.py
@@ -1,0 +1,9 @@
+from flask.sessions import SecureCookieSessionInterface
+import hashlib
+
+
+class SHA256SecureCookieSessionInterface(SecureCookieSessionInterface):
+
+    @staticmethod
+    def digest_method():
+        return hashlib.sha256()


### PR DESCRIPTION
**What**
Force Flask cookie sessions to use SHA256 instead of SHA1

**How to test**
1. First run the application on master, check that the initial cookie on the cover page is about 321kb
2. Checkout this branch, run the application and check the cookie size again.
3. It should now be about 335kb, the additional bytes are due to the SHA256 signing algorithm

**Who can review**
Anyone apart from @warrenbailey 
