### PR TITLE
bug-141 Guidance body focus

### DIFF
--- a/app/js/app/modules/details-toggle.js
+++ b/app/js/app/modules/details-toggle.js
@@ -3,7 +3,7 @@ import domready from './domready'
 
 export const classDetails = 'js-details'
 export const classTrigger = 'js-details-trigger'
-export const classMain = 'js-details-main'
+export const classBody = 'js-details-body'
 export const classLabel = 'js-details-label'
 export const classExpandedState = 'is-expanded'
 
@@ -11,6 +11,7 @@ export const attrShowLbl = 'data-show-label'
 export const attrHideLbl = 'data-hide-label'
 export const attrAriaExpanaded = 'aria-expanded'
 export const attrAriaHidden = 'aria-hidden'
+export const attrTabIndex = 'tabindex'
 
 export default function() {
   return detailsToggle()
@@ -23,32 +24,40 @@ export function detailsToggle() {
 }
 
 export function applyDetailsToggle(elDetails) {
-  const elTrigger = elDetails.parentElement.getElementsByClassName(classTrigger)[0]
-  const elMain = elDetails.getElementsByClassName(classMain)[0]
+  const elTrigger = elDetails.getElementsByClassName(classTrigger)[0]
+  const elBody = elDetails.getElementsByClassName(classBody)[0]
   const elLabel = elDetails.getElementsByClassName(classLabel)[0]
   let toggled = false
 
   elTrigger.addEventListener('click', (e) => {
     e.preventDefault()
-    toggled = toggle(toggled, elDetails, elTrigger, elMain, elLabel)
+    toggled = toggle(toggled, elDetails, elTrigger, elBody, elLabel)
     return false
   })
+
+  return {elDetails, elTrigger, elBody}
 }
 
-export function toggle(toggled, elDetails, elTrigger, elMain, elLabel) {
-  elTrigger.setAttribute(attrAriaExpanaded, toggled)
-  elMain.setAttribute(attrAriaHidden, !toggled)
+export function open(elDetails, elBody, elLabel, elTrigger) {
+  elDetails.classList.add(classExpandedState)
+  elBody.focus()
+  elLabel.innerHTML = elDetails.getAttribute(attrHideLbl)
+  elTrigger.setAttribute(attrAriaExpanaded, true)
+  elBody.setAttribute(attrAriaHidden, false)
+  elBody.setAttribute(attrTabIndex, '0')
+}
 
-  if (!toggled) {
-    elDetails.classList.add(classExpandedState)
-    elMain.focus()
-    elLabel.innerHTML = elDetails.getAttribute(attrHideLbl)
-  } else {
-    elDetails.classList.remove(classExpandedState)
-    elMain.blur()
-    elLabel.innerHTML = elDetails.getAttribute(attrShowLbl)
-  }
+export function close(elDetails, elBody, elLabel, elTrigger) {
+  elDetails.classList.remove(classExpandedState)
+  elBody.blur()
+  elLabel.innerHTML = elDetails.getAttribute(attrShowLbl)
+  elTrigger.setAttribute(attrAriaExpanaded, false)
+  elBody.setAttribute(attrAriaHidden, true)
+  elBody.removeAttribute(attrTabIndex)
+}
 
+export function toggle(toggled, elDetails, elTrigger, elBody, elLabel) {
+  !toggled ? open(elDetails, elBody, elLabel, elTrigger) : close(elDetails, elBody, elLabel, elTrigger)
   return !toggled
 }
 

--- a/app/templates/partials/guidance.html
+++ b/app/templates/partials/guidance.html
@@ -1,7 +1,6 @@
 <div class="guidance js-details" data-show-label="{{_('Show further guidance')}}" data-hide-label="{{_('Hide further guidance')}}">
-  <a class="guidance__link js-details-trigger" href="#guidance-{{response.id}}" id="guidance-{{response.id}}-link" aria-controls="guidance-{{response.id}}-main" aria-expanded="false"><span class="u-vh">Click here to </span><span class="js-details-label">Show further guidance</span>
-  </a>
-  <div class="guidance__main js-details-main" id="guidance-{{response.id}}-main" tabIndex="0" aria-hidden="true">
+  <a class="guidance__link js-details-trigger" href="#guidance-{{response.id}}" id="guidance-{{response.id}}-body" aria-controls="guidance-{{response.id}}-body" aria-expanded="false"><span class="u-vh">Click here to </span><span class="js-details-label">Show further guidance</span></a>
+  <div class="guidance__main js-details-body" id="guidance-{{response.id}}-body" aria-hidden="true">
     <div class="guidance__content">
       {{response.guidance|safe}}
     </div>

--- a/tests/karma/spec/details-toggle.spec.js
+++ b/tests/karma/spec/details-toggle.spec.js
@@ -1,33 +1,41 @@
-import { applyDetailsToggle, classTrigger, classDetails, classMain, classExpandedState } from 'app/modules/details-toggle'
+import { applyDetailsToggle, classTrigger, classDetails, classBody, classExpandedState } from 'app/modules/details-toggle'
 
 const strTemplate = `<div class="guidance ${classDetails}" data-show-label="Show further guidance" data-hide-label="Hide further guidance">
   <a class="guidance__link ${classTrigger}" href="#guidance-response" id="guidance-response-link" aria-controls="guidance-response-main" aria-expanded="false"><span class="u-vh">Click here to </span><span class="js-details-label">Show further guidance</span>
   </a>
-  <div class="guidance__main ${classMain}" id="guidance-response-main" tabIndex="0" aria-hidden="true">
+  <div class="guidance__main ${classBody}" id="guidance-response-main" aria-hidden="true">
     Vestibulum id ligula porta felis euismod semper. Curabitur blandit tempus porttitor. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Donec sed odio dui. Aenean lacinia bibendum nulla sed consectetur.
   </div>
 </div>`
 
-let elTemplate
+let elDetails, elTrigger, elBody
 
 describe('Details Toggle', () => {
   before('Add template to DOM', () => {
     let wrapper = document.createElement('div')
     wrapper.innerHTML = strTemplate
-    elTemplate = wrapper
-    document.body.appendChild(elTemplate)
+    elDetails = wrapper.firstChild
+    document.body.appendChild(elDetails)
+    let el = applyDetailsToggle(elDetails)
+    ;({elTrigger, elBody} = el)
   })
 
   it('DOM should contain the template', () => {
-    expect(document.body.contains(elTemplate)).to.equal(true)
+    expect(document.body.contains(elDetails)).to.equal(true)
   })
 
   it(`Should toggle class '.${classExpandedState}' when clicked`, () => {
-    applyDetailsToggle(elTemplate)
-    const elTrigger = elTemplate.parentElement.getElementsByClassName(classTrigger)[0]
     elTrigger.click()
-    expect(elTemplate.classList.contains(classExpandedState)).to.equal(true)
+    expect(elDetails.classList.contains(classExpandedState)).to.equal(true)
     elTrigger.click()
-    expect(elTemplate.classList.contains(classExpandedState)).to.equal(false)
+    expect(elDetails.classList.contains(classExpandedState)).to.equal(false)
+  })
+
+  it('Body should not recieve focus when collapsed', () => {
+    elBody.focus()
+    expect(document.activeElement.classList.contains(classBody)).to.equal(false)
+    elTrigger.click()
+    elBody.focus()
+    expect(document.activeElement.classList.contains(classBody)).to.equal(true)
   })
 })


### PR DESCRIPTION
Fixes #141 
### Changes
- removed `tabindex` attribute from guidance body when collapsed
- added test to confirm element cannot receive focus when guidance is collapsed
- some refactoring
### How to test
- `npm run test`
- confirm tests pass
- try to reproduce bug using reproduction steps from #141
### Who can test
- anyone except @hamishtaplin
