### PR TITLE
bug-127 guidance collapsed with js disabled

### DIFF
--- a/app/styles/components/_guidance.scss
+++ b/app/styles/components/_guidance.scss
@@ -26,6 +26,10 @@
     vertical-align: middle;
     display: inline-block;
   }
+
+  .no-js & {
+    display: none;
+  }
 }
 
 .guidance__main {
@@ -35,6 +39,7 @@
   opacity: 0;
   transition: all 0;
   max-height: 0;
+  .no-js &,
   .is-expanded & {
     max-height: 10000em;
     height: auto;


### PR DESCRIPTION
Fixes #127.
### Changes
- altered css to show guidance when javascript is disabled
- show guidance button is also hidden
### How to test
- visit questionnaire with javascript disabled
- confirm guidance is visible
### Who can test

Ideally @LJBabbage 
