### PR TITLE
Put messages on the queue as strings not bytes

### DIFF
--- a/app/submitter/encrypter.py
+++ b/app/submitter/encrypter.py
@@ -35,6 +35,13 @@ class Encrypter (object):
             value = bytes_or_str
         return value
 
+    def _to_str(self, bytes_or_str):
+        if isinstance(bytes_or_str, bytes):
+            value = bytes_or_str.decode()
+        else:
+            value = bytes_or_str
+        return value
+
     def _jwe_protected_header(self):
         return self._base_64_encode(b'{"alg":"RSA-OAEP","enc":"A256GCM"}')
 
@@ -73,4 +80,4 @@ class Encrypter (object):
         # assemble result
         jwe = jwe_protected_header + b"." + encrypted_key + b"." + self._encode_iv(self.iv) + b"." + encoded_ciphertext + b"." + encoded_tag
 
-        return jwe
+        return self._to_str(jwe)

--- a/tests/app/submitter/test_encrypter.py
+++ b/tests/app/submitter/test_encrypter.py
@@ -93,7 +93,7 @@ class TestEncrypter(unittest.TestCase):
         encrypted_data = encrypter.encrypt(SUBMISSION_DATA)
 
         decrypter = Decrypter()
-        unencrypted_data = decrypter.decrypt(encrypted_data.decode())
+        unencrypted_data = decrypter.decrypt(encrypted_data)
 
         self.assertEquals(SUBMISSION_DATA["type"], unencrypted_data["type"])
         self.assertEquals(SUBMISSION_DATA["version"], unencrypted_data["version"])


### PR DESCRIPTION
### Changes

The message put on the queue is a string not a bytes object
### How to test

Test it's not broken
### Who can test

Anyone but @warrenbailey
