### PR TITLE
Issue #144 Clear responses on submission

### DIFF
--- a/app/main/views/submission.py
+++ b/app/main/views/submission.py
@@ -46,6 +46,7 @@ def submission():
             submitted_at = submitter.send_responses(current_user, schema, responses)
             # TODO I don't like this but until we sort out the landing/review/submission flow this is the easiest way
             session[SubmitterConstants.SUBMITTED_AT_KEY] = submitted_at.strftime(settings.DISPLAY_DATETIME_FORMAT)
+            response_store.clear_responses()
             return redirect_to_location("submitted")
         except SubmissionFailedException as e:
             return errors.internal_server_error(e)

--- a/app/responses/response_store.py
+++ b/app/responses/response_store.py
@@ -17,6 +17,10 @@ class AbstractResponseStore(metaclass=ABCMeta):
     def get_responses(self):
         raise NotImplementedError()
 
+    @abstractmethod
+    def clear_responses(self):
+        raise NotImplementedError()
+
 
 class FlaskResponseStore(AbstractResponseStore):
 
@@ -40,3 +44,7 @@ class FlaskResponseStore(AbstractResponseStore):
         if RESPONSES not in session.keys():
             session[RESPONSES] = {}
         return session[RESPONSES]
+
+    def clear_responses(self):
+        if RESPONSES in session.keys():
+            del session[RESPONSES]

--- a/tests/app/renderer/test_renderer.py
+++ b/tests/app/renderer/test_renderer.py
@@ -176,3 +176,6 @@ class MockResponseStore(AbstractResponseStore):
 
     def clear(self):
         self._responses.clear()
+
+    def clear_responses(self):
+        self.clear();

--- a/tests/app/validation/test_mci_validation.py
+++ b/tests/app/validation/test_mci_validation.py
@@ -256,6 +256,9 @@ class ValidatorTest(unittest.TestCase):
             def clear(self):
                 self.responses.clear()
 
+            def clear_responses(self):
+                self.clear();
+
         return MockResponseStore()
 
     def _create_mock_validation_store(self):

--- a/tests/app/validation/test_validator.py
+++ b/tests/app/validation/test_validator.py
@@ -159,6 +159,9 @@ class ValidatorTest(unittest.TestCase):
             def clear(self):
                 self._responses.clear()
 
+            def clear_responses(self):
+                self.clear();
+
         return MockResponseStore()
 
     def _create_mock_validation_store(self):


### PR DESCRIPTION
### Changes

Once we've submitted the users data to the queue wipe out the responses for the cookie. This is too double ensure we don't resubmit them.
### How to test
1. Checkout this branch
2. Turn on DEBUG logging
3. Complete a survey and check that the response are removed from the cookie after submission. The log file will log the contents of the cookie on every request.
### Who can test

Anyone apart from @warrenbailey
