### PR TITLE
Remove broken environment url

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,7 +2,7 @@ from flask import Flask
 from flask.ext.babel import Babel
 from flask.ext.login import LoginManager
 from app.libs.utils import get_locale
-from healthcheck import HealthCheck, EnvironmentDump
+from healthcheck import HealthCheck
 from flaskext.markdown import Markdown
 from app.utilities.factory import factory
 from app.responses.response_store import FlaskResponseStore
@@ -83,7 +83,6 @@ def create_app(config_name):
     application.babel = Babel(application)
     application.babel.localeselector(get_locale)
     application.jinja_env.add_extension('jinja2.ext.i18n')
-    application.envdump = EnvironmentDump(application, '/environment')
 
     application.secret_key = settings.EQ_SECRET_KEY
     application.permanent_session_lifetime = timedelta(seconds=settings.EQ_SESSION_TIMEOUT)


### PR DESCRIPTION
**_What**_

Removes the `/environment` url as it is no longer required or functional (Issue #157)

**_How to test**_

1) Check out the branch and run the app
2) Visit [http://localhost:5000/environment](http://localhost:5000/environment)
3) Verify you see the appropriate 404 error page

**_Who can test**_

Anyone except @weapdiv-david
