### PR TITLE
Fixes #159 Only expose the pattern lib in dev mode

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -99,11 +99,11 @@ def create_app(config_name):
     application.register_blueprint(main_blueprint)
     main_blueprint.config = application.config.copy()
 
-    # import and register the pattern library blueprint
-    from .patternlib import patternlib_blueprint
-    application.register_blueprint(patternlib_blueprint)
-
     if settings.EQ_DEV_MODE:
+        # import and register the pattern library blueprint
+        from .patternlib import patternlib_blueprint
+        application.register_blueprint(patternlib_blueprint)
+
         # import and register the dev mode blueprint
         from .dev_mode import dev_mode_blueprint
         application.register_blueprint(dev_mode_blueprint)


### PR DESCRIPTION
### Changes

The pattern lib blueprint is now only added in DEV mode
### How to test
1. Checkout this branch
2. Enable DEV mode and check you can view the pattern library
3. Disable DEV mode and check you can no longer view the pattern library
### Who can test

Anyone apart from @warrenbailey
