### PR TITLE
Remove beta banner from error page

### DIFF
--- a/app/templates/layouts/_error.html
+++ b/app/templates/layouts/_error.html
@@ -2,9 +2,6 @@
 
 {% block page_title %}Error{% endblock %}
 
-{% block top_bar %}
-{% endblock %}
-
 {% block survey %}
   <div class="header">
     <h1 class="header__title">Error</h1>
@@ -13,10 +10,7 @@
   <div class="box">
     <div class="u-fw-b">Sorry, something has gone wrong</div>
     <div class="u-fs-s">Error code: {{status_code}}</div>
-    <div class="u-m-s">
-      <a class="u-no-js-hide" href="javascript:history.go(-1)">Return to the previous page</a>
-    </div>
-    <p>If the problem persists please call the number above.</p>
+    <p class="u-m-s u-mb-no">If the problem persists please call the number above.</p>
   </div>
 
   <div class="u-m-m u-ta-c">

--- a/app/templates/layouts/_error.html
+++ b/app/templates/layouts/_error.html
@@ -3,15 +3,6 @@
 {% block page_title %}Error{% endblock %}
 
 {% block top_bar %}
-<div class="bar" role="banner">
-  <div class="skip">
-    <a class="skip__link" href="#main">Skip to content</a>
-  </div>
-  <div class="bar__inner container">
-    <div class="tag tag--amber u-mr-xs">BETA</div>
-    <div class="bar__title"></div>
-  </div>
-</div>
 {% endblock %}
 
 {% block survey %}

--- a/app/templates/layouts/_error.html
+++ b/app/templates/layouts/_error.html
@@ -2,6 +2,18 @@
 
 {% block page_title %}Error{% endblock %}
 
+{% block top_bar %}
+<div class="bar" role="banner">
+  <div class="skip">
+    <a class="skip__link" href="#main">Skip to content</a>
+  </div>
+  <div class="bar__inner container">
+    <div class="tag tag--amber u-mr-xs">BETA</div>
+    <div class="bar__title"></div>
+  </div>
+</div>
+{% endblock %}
+
 {% block survey %}
   <div class="header">
     <h1 class="header__title">Error</h1>

--- a/app/templates/layouts/_survey.html
+++ b/app/templates/layouts/_survey.html
@@ -7,7 +7,7 @@
   </div>
   <div class="bar__inner container">
     <div class="tag tag--amber u-mr-xs">BETA</div>
-    <div class="bar__title">Monthly Business Survey - Retail Sales Index</div>
+    <div class="bar__title">{{ bar_title }}</div>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
### Changes

Removes the beta banner from the error page as per issue #176 
### How to test

1) Check out the branch
2) Cause an error
3) ~~Verify the beta banner is not visible on the error page~~ Verify title does not appear in top bar (the black thing)
4) ???
5) Profit!!!!!
### Who can test

Anybody except @weapdiv-david
