### PR TITLE
[issue-180] error message browser/os strings formatting

### DIFF
--- a/app/templates/layouts/_error.html
+++ b/app/templates/layouts/_error.html
@@ -15,7 +15,7 @@
 
   <div class="u-m-m u-ta-c">
     <div class="u-fw-b">Your system information</div>
-    <div>{{ua.user_agent.family}} {{ua.user_agent.minor}}.{{ua.user_agent.major}}.{{ua.user_agent.patch}}</div>
-    <div>{{ua.os.family}} {{ua.os.minor}}.{{ua.os.major}}.{{ua.os.patch}}</div>
+    <div>{{ua.user_agent.family}} ({{ua.user_agent.major or '0'}}.{{ua.user_agent.minor or '0'}}.{{ua.user_agent.patch or '0'}})</div>
+    <div>{{ua.os.family}} ({{ua.os.major or '0'}}.{{ua.os.minor or '0'}}.{{ua.os.patch or '0'}})</div>
   </div>
 {% endblock %}


### PR DESCRIPTION
Fixes #180
### Changes
- better formatted the strings to capture missing versions and represent as 0
### How to test
- reproduce as per bug description (using Windows/IE)
- confirm strings no longer contain 'None'
### Who can test

Anyone except @hamishtapin
