### PR TITLE
[issue-171] characters remaining copy

### DIFF
--- a/app/js/app/modules/charlimit.js
+++ b/app/js/app/modules/charlimit.js
@@ -3,13 +3,15 @@ import forEach from 'lodash/forEach'
 
 export const inputClass = 'js-charlimit-input'
 export const msgClass = 'js-charlimit-msg'
-export const maxLengthAttr = 'data-maxlength'
+export const msgLabel = 'js-charlimit-label'
+export const attrMaxLength = 'data-maxlength'
+export const attrRemainingMsg = 'data-remaining-msg'
 
 export default function charLimit() {
   const nodeList = document.getElementsByClassName(inputClass)
 
   forEach(nodeList, (el) => {
-    const maxLength = el.getAttribute(maxLengthAttr)
+    const maxLength = el.getAttribute(attrMaxLength)
     if (typeof maxLength !== 'undefined') {
       imposeCharLimit(el, maxLength)
     }
@@ -31,13 +33,15 @@ export function updateMsg(el, length, maxLength) {
 }
 
 export function imposeCharLimit(el, maxLength) {
-  const msgEl = el.parentElement.querySelector(`.${msgClass}`)
+  const elMsg = el.parentElement.querySelector(`.${msgClass}`)
+  const elLabel = el.parentElement.getElementsByClassName(msgLabel)[0]
+  elLabel.innerHTML = elLabel.getAttribute(attrRemainingMsg)
 
-  updateMsg(msgEl, maxLength, el.value.length)
+  updateMsg(elMsg, maxLength, el.value.length)
 
   el.addEventListener('input', (e) => {
     el.value = applyCharLimit(el.value, maxLength)
-    updateMsg(msgEl, maxLength, el.value.length)
+    updateMsg(elMsg, maxLength, el.value.length)
   })
 }
 

--- a/app/templates/macros/forms.html
+++ b/app/templates/macros/forms.html
@@ -60,7 +60,7 @@
 
   {% if maxChars %}
     <div class="input__helper">
-      {{_('Characters remaining')}}: <span class="js-charlimit-msg">{{maxChars}}</span>
+      <span class="js-charlimit-label" data-remaining-msg="{{_('Characters remaining')}}">{{_('Maximum characters')}}</span>: <span class="js-charlimit-msg">{{maxChars}}</span>
     </div>
   {% endif %}
 {% endmacro %}

--- a/app/templates/macros/forms.html
+++ b/app/templates/macros/forms.html
@@ -46,6 +46,8 @@
 
   {% set maxChars = "2000" %}
 
+  {% set response_helper = response.id ~ "-helper" %}
+
   {% set attr = {
     "class": "input input--textarea js-charlimit-input",
     "name": response.id,
@@ -53,13 +55,15 @@
     "placeholder": response.placeholder,
     "rows": "8",
     "cols": "60",
-    "data-maxlength": maxChars
+    "data-maxlength": maxChars,
+    "aria-describedby": response_helper
   } %}
+
 
   <textarea {{attr|xmlattr}}>{{response.value|e}}</textarea>
 
   {% if maxChars %}
-    <div class="input__helper">
+    <div class="input__helper" id="{{response_helper}}">
       <span class="js-charlimit-label" data-remaining-msg="{{_('Characters remaining')}}">{{_('Maximum characters')}}</span>: <span class="js-charlimit-msg">{{maxChars}}</span>
     </div>
   {% endif %}


### PR DESCRIPTION
Fixes #171
### Changes
- adds more sensible fallback copy for "characters remaining" when JS is disabled
- exposes all strings so they can be localised in template
### How to test
- recreate as per #171
- confirm copy states "Maximum characters: 2000"
- enable JS
- confirm copy states "Characters remaining: 2000" and funcionality still works
### Who can test

Anyone except @hamishtaplin
