### PR TITLE
Public/Private keys need to be environment variables and not file paths

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -45,19 +45,19 @@ EQ_SPLUNK_PASSWORD = os.getenv('EQ_SPLUNK_PASSWORD')
 EQ_SPLUNK_INDEX = os.getenv('EQ_SPLUNK_INDEX')
 
 # keys for the RRM token exchange
-EQ_USER_AUTHENTICATION_RRM_PUBLIC_KEY = get_key(os.getenv('EQ_USER_AUTHENTICATION_RRM_PUBLIC_KEY', "./jwt-test-keys/rrm-public.pem"))
-EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY = get_key(os.getenv('EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY', "./jwt-test-keys/sr-private.pem"))
+EQ_USER_AUTHENTICATION_RRM_PUBLIC_KEY = os.getenv('EQ_USER_AUTHENTICATION_RRM_PUBLIC_KEY', get_key("./jwt-test-keys/rrm-public.pem"))
+EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY = os.getenv('EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY', get_key("./jwt-test-keys/sr-private.pem"))
 EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY_PASSWORD = os.getenv("EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY_PASSWORD", "digitaleq")
 
 # keys for encryption of submissions
-EQ_SUBMISSION_SDX_PUBLIC_KEY = get_key(os.getenv('EQ_SUBMISSION_SDX_PUBLIC_KEY', "./jwt-test-keys/sdx-public.pem"))
-EQ_SUBMISSION_SR_PRIVATE_SIGNING_KEY = get_key(os.getenv('EQ_SUBMISSION_SR_PRIVATE_SIGNING_KEY', "./jwt-test-keys/sr-private-encryption.pem"))
+EQ_SUBMISSION_SDX_PUBLIC_KEY = os.getenv('EQ_SUBMISSION_SDX_PUBLIC_KEY', get_key("./jwt-test-keys/sdx-public.pem"))
+EQ_SUBMISSION_SR_PRIVATE_SIGNING_KEY = os.getenv('EQ_SUBMISSION_SR_PRIVATE_SIGNING_KEY', get_key("./jwt-test-keys/sr-private-encryption.pem"))
 EQ_SUBMISSION_SR_PRIVATE_SIGNING_KEY_PASSWORD = os.getenv("EQ_SUBMISSION_SR_PRIVATE_SIGNING_KEY_PASSWORD", "digitaleq")
 
 # keys for the dev mode
 EQ_DEV_MODE = parse_mode(os.getenv("EQ_DEV_MODE", "False"))
-EQ_USER_AUTHENTICATION_RRM_PRIVATE_KEY = get_key(os.getenv('EQ_RRM_PRIVATE_KEY', "./jwt-test-keys/rrm-private.pem"))
-EQ_USER_AUTHENTICATION_SR_PUBLIC_KEY = get_key(os.getenv('EQ_SR_PUBLIC_KEY', "./jwt-test-keys/sr-public.pem"))
+EQ_USER_AUTHENTICATION_RRM_PRIVATE_KEY = os.getenv('EQ_RRM_PRIVATE_KEY', get_key("./jwt-test-keys/rrm-private.pem"))
+EQ_USER_AUTHENTICATION_SR_PUBLIC_KEY = os.getenv('EQ_SR_PUBLIC_KEY', get_key("./jwt-test-keys/sr-public.pem"))
 
 # non configurable settings
 


### PR DESCRIPTION
### Changes

The key material will be upload as an environment variable in elastic beanstalk, rather than a path to a file.
### How to test

Checkout this branch and check it all still works
### Who can test

Anyone apart from @warrenbailey
