### PR TITLE
Elastic Beanstalk adding EQ.log

### DIFF
--- a/.ebextensions/bundle-logs.config
+++ b/.ebextensions/bundle-logs.config
@@ -4,4 +4,4 @@ files:
     owner: root
     group: root
     content: |
-      /opt/python/current/app/eq.log.*
+      /opt/python/current/app/eq.log*

--- a/.ebextensions/bundle-logs.config
+++ b/.ebextensions/bundle-logs.config
@@ -1,0 +1,7 @@
+files:
+  "/opt/elasticbeanstalk/tasks/bundlelogs.d/eq.conf" :
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      /opt/python/current/app/eq.log.*

--- a/.ebextensions/log.config
+++ b/.ebextensions/log.config
@@ -1,0 +1,7 @@
+files: 
+  "/opt/elasticbeanstalk/tasks/bundlelogs.d/applogs.conf" :
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      /var/app/current/*.log.*

--- a/.ebextensions/log.config
+++ b/.ebextensions/log.config
@@ -1,7 +1,0 @@
-files: 
-  "/opt/elasticbeanstalk/tasks/bundlelogs.d/applogs.conf" :
-    mode: "000755"
-    owner: root
-    group: root
-    content: |
-      /var/app/current/*.log.*

--- a/.ebextensions/tail-logs.config
+++ b/.ebextensions/tail-logs.config
@@ -1,0 +1,7 @@
+files:
+  "/opt/elasticbeanstalk/tasks/taillogs.d/eq.conf" :
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      /opt/python/current/app/eq.log


### PR DESCRIPTION
### Changes

Adding eq.log to elastic beanstalk log files, so we'll see them when requesting either full logs or the last 100 lines.
### How to test
1. Deploy this branch to elastic beanstalk using eb deploy (or terraform - change deploy_surveyrunner.sh to point to this branch)
2. Request the logs from your elastic beanstalk application and check the eq.log is present.
### Who can review

Anyone apart from @warrenbailey
