### PR TITLE
Token Generation Updates

### DIFF
--- a/app/dev_mode/jwt_encoder.py
+++ b/app/dev_mode/jwt_encoder.py
@@ -2,6 +2,7 @@ from cryptography.hazmat.backends.openssl.backend import backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from app import settings
+from app.utilities import strings
 from app.submitter.encrypter import Encrypter
 import jwt
 import os
@@ -12,9 +13,17 @@ KID = 'EDCRRM'
 
 class Encoder (Encrypter):
     def __init__(self):
-        private_key = self._to_bytes(settings.EQ_USER_AUTHENTICATION_RRM_PRIVATE_KEY)
-        public_key = self._to_bytes(settings.EQ_USER_AUTHENTICATION_SR_PUBLIC_KEY)
-        self.private_key = serialization.load_pem_private_key(private_key, password=b'digitaleq', backend=backend)
+        if settings.EQ_USER_AUTHENTICATION_RRM_PRIVATE_KEY is None:
+            raise Exception("EQ_USER_AUTHENTICATION_RRM_PRIVATE_KEY is None (check EQ_DEV_MODE?)")
+        if settings.EQ_USER_AUTHENTICATION_RRM_PRIVATE_KEY_PASSWORD is None:
+            raise Exception("EQ_USER_AUTHENTICATION_RRM_PRIVATE_KEY_PASSWORD is None (check EQ_DEV_MODE?)")
+        if settings.EQ_USER_AUTHENTICATION_SR_PUBLIC_KEY is None:
+            raise Exception("EQ_USER_AUTHENTICATION_SR_PUBLIC_KEY is None (check EQ_DEV_MODE?)")
+
+        private_key = strings.to_bytes(settings.EQ_USER_AUTHENTICATION_RRM_PRIVATE_KEY)
+        private_key_password = strings.to_bytes(settings.EQ_USER_AUTHENTICATION_RRM_PRIVATE_KEY_PASSWORD)
+        public_key = strings.to_bytes(settings.EQ_USER_AUTHENTICATION_SR_PUBLIC_KEY)
+        self.private_key = serialization.load_pem_private_key(private_key, password=private_key_password, backend=backend)
         self.public_key = serialization.load_pem_public_key(public_key, backend=backend)
 
         # first generate a random key

--- a/app/settings.py
+++ b/app/settings.py
@@ -47,22 +47,34 @@ EQ_SPLUNK_USERNAME = os.getenv('EQ_SPLUNK_USERNAME')
 EQ_SPLUNK_PASSWORD = os.getenv('EQ_SPLUNK_PASSWORD')
 EQ_SPLUNK_INDEX = os.getenv('EQ_SPLUNK_INDEX')
 
-# keys for the RRM token exchange
-EQ_USER_AUTHENTICATION_RRM_PUBLIC_KEY = get_key(os.getenv('EQ_USER_AUTHENTICATION_RRM_PUBLIC_KEY', "./jwt-test-keys/rrm-public.pem"))
-EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY = get_key(os.getenv('EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY', "./jwt-test-keys/sr-private.pem"))
-EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY_PASSWORD = os.getenv("EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY_PASSWORD", "digitaleq")
-
-# keys for encryption of submissions
-EQ_SUBMISSION_SDX_PUBLIC_KEY = get_key(os.getenv('EQ_SUBMISSION_SDX_PUBLIC_KEY', "./jwt-test-keys/sdx-public.pem"))
-EQ_SUBMISSION_SR_PRIVATE_SIGNING_KEY = get_key(os.getenv('EQ_SUBMISSION_SR_PRIVATE_SIGNING_KEY', "./jwt-test-keys/sr-private-encryption.pem"))
-EQ_SUBMISSION_SR_PRIVATE_SIGNING_KEY_PASSWORD = os.getenv("EQ_SUBMISSION_SR_PRIVATE_SIGNING_KEY_PASSWORD", "digitaleq")
-
-# keys for the dev mode
 EQ_DEV_MODE = parse_mode(os.getenv("EQ_DEV_MODE", "False"))
-EQ_USER_AUTHENTICATION_RRM_PRIVATE_KEY = get_key(os.getenv('EQ_USER_AUTHENTICATION_RRM_PRIVATE_KEY',
-                                                           "./jwt-test-keys/rrm-private.pem" if EQ_DEV_MODE else None))
-EQ_USER_AUTHENTICATION_SR_PUBLIC_KEY = get_key(os.getenv('EQ_USER_AUTHENTICATION_SR_PUBLIC_KEY',
-                                                         "./jwt-test-keys/sr-public.pem" if EQ_DEV_MODE else None))
+
+_KEYS = {
+    'EQ_USER_AUTHENTICATION_RRM_PUBLIC_KEY':    "./jwt-test-keys/rrm-public.pem",
+    'EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY':    "./jwt-test-keys/sr-private.pem",
+    'EQ_SUBMISSION_SDX_PUBLIC_KEY':             "./jwt-test-keys/sdx-public.pem",
+    'EQ_SUBMISSION_SR_PRIVATE_SIGNING_KEY':     "./jwt-test-keys/sr-private-encryption.pem",
+
+    # Only used in DEV MODE:
+    'EQ_USER_AUTHENTICATION_RRM_PRIVATE_KEY':   "./jwt-test-keys/rrm-private.pem",
+    'EQ_USER_AUTHENTICATION_SR_PUBLIC_KEY':     "./jwt-test-keys/sr-public.pem"
+}
+
+_PASSWORDS = {
+    'EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY_PASSWORD':   "digitaleq",
+    'EQ_SUBMISSION_SR_PRIVATE_SIGNING_KEY_PASSWORD':    "digitaleq",
+    'EQ_USER_AUTHENTICATION_RRM_PRIVATE_KEY_PASSWORD':  "digitaleq"
+}
+
+# Load keys and passwords, but only allow developer mode defaults if EQ_DEV_MODE
+# has been enabled explicitly...
+for key_name, dev_location in _KEYS.items():
+    path = os.getenv(key_name, dev_location if EQ_DEV_MODE else None)
+    vars()[key_name] = get_key(path)  # assigns attribute to this module
+
+for password_name, dev_default in _PASSWORDS.items():
+    password = os.getenv(password_name, dev_default if EQ_DEV_MODE else None)
+    vars()[password_name] = password  # assigns attribute to this module
 
 
 # non configurable settings

--- a/app/submitter/encrypter.py
+++ b/app/submitter/encrypter.py
@@ -4,6 +4,7 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 from app import settings
+from app.utilities import strings
 
 import jwt
 import os
@@ -14,10 +15,10 @@ KID = 'EDCSR'
 
 class Encrypter (object):
     def __init__(self):
-        private_key_bytes = self._to_bytes(settings.EQ_SUBMISSION_SR_PRIVATE_SIGNING_KEY)
-        public_key_bytes = self._to_bytes(settings.EQ_SUBMISSION_SDX_PUBLIC_KEY)
+        private_key_bytes = strings.to_bytes(settings.EQ_SUBMISSION_SR_PRIVATE_SIGNING_KEY)
+        public_key_bytes = strings.to_bytes(settings.EQ_SUBMISSION_SDX_PUBLIC_KEY)
         self.private_key = serialization.load_pem_private_key(private_key_bytes,
-                                                              password=self._to_bytes(settings.EQ_SUBMISSION_SR_PRIVATE_SIGNING_KEY_PASSWORD),
+                                                              password=strings.to_bytes(settings.EQ_SUBMISSION_SR_PRIVATE_SIGNING_KEY_PASSWORD),
                                                               backend=backend)
 
         self.public_key = serialization.load_pem_public_key(public_key_bytes, backend=backend)
@@ -27,20 +28,6 @@ class Encrypter (object):
 
         # now generate a random IV
         self.iv = os.urandom(12)  # 96 bit random IV
-
-    def _to_bytes(self, bytes_or_str):
-        if isinstance(bytes_or_str, str):
-            value = bytes_or_str.encode()
-        else:
-            value = bytes_or_str
-        return value
-
-    def _to_str(self, bytes_or_str):
-        if isinstance(bytes_or_str, bytes):
-            value = bytes_or_str.decode()
-        else:
-            value = bytes_or_str
-        return value
 
     def _jwe_protected_header(self):
         return self._base_64_encode(b'{"alg":"RSA-OAEP","enc":"A256GCM"}')
@@ -80,4 +67,4 @@ class Encrypter (object):
         # assemble result
         jwe = jwe_protected_header + b"." + encrypted_key + b"." + self._encode_iv(self.iv) + b"." + encoded_ciphertext + b"." + encoded_tag
 
-        return self._to_str(jwe)
+        return strings.to_str(jwe)

--- a/app/utilities/strings.py
+++ b/app/utilities/strings.py
@@ -1,0 +1,14 @@
+def to_bytes(bytes_or_str):
+    if isinstance(bytes_or_str, str):
+        value = bytes_or_str.encode()
+    else:
+        value = bytes_or_str
+    return value
+
+
+def to_str(bytes_or_str):
+    if isinstance(bytes_or_str, bytes):
+        value = bytes_or_str.decode()
+    else:
+        value = bytes_or_str
+    return value

--- a/requirements.txt
+++ b/requirements.txt
@@ -191,8 +191,6 @@ traceback2==1.4.0 \
 linecache2==1.0.0 \
     --hash=sha256:e78be9c0a0dfcbac712fe04fbf92b96cddae80b1b842f24248214c8496f006ef \
     --hash=sha256:4b26ff4e7110db76eeb6f5a7b64a82623839d595c2038eeda662f2a2db78e97c
-markupsafe==0.23 \
-    --hash=sha256:a4ec1aff59b95a14b45eb2e23761a0179e98319da5a7eb76b56ea8cdc7b871c3
 Flask-Analytics==0.5.5 \
     --hash=sha256:5c614f87f4f31542c908dea2f01b5176729d9992f423b75d7372aecb5e3e7911 \
     --hash=sha256:c49aaa4cc5b103886a7153acd141bf3753a7cf3909159bed24c3f2826a483106

--- a/tests/app/utilities/test_strings.py
+++ b/tests/app/utilities/test_strings.py
@@ -1,0 +1,32 @@
+
+from app.utilities import strings
+import unittest
+
+class TestStrings(unittest.TestCase):
+
+    def test_to_bytes_with_string(self):
+        b = strings.to_bytes('abc')
+        self.assertEqual(b, b'abc')
+
+    def test_to_bytes_with_bytes(self):
+        b = strings.to_bytes(b'def')
+        self.assertEqual(b, b'def')
+
+    def test_to_bytes_with_None(self):
+        b = strings.to_bytes(None)
+        self.assertEqual(b, None)
+
+    def test_to_string_with_string(self):
+        s = strings.to_str('hij')
+        self.assertEqual(s, 'hij')
+
+    def test_to_string_with_bytes(self):
+        s = strings.to_str(b'klm')
+        self.assertEqual(s, 'klm')
+
+    def test_to_string_with_None(self):
+        s = strings.to_str(None)
+        self.assertEqual(s, None)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/token_generator.py
+++ b/token_generator.py
@@ -7,8 +7,9 @@ from app.dev_mode.jwt_encoder import Encoder
 
 
 def create_payload(user):
+    EXPIRE_AFTER_SECONDS = 12 * 60 * 60
     iat = time.time()
-    exp = time.time() + (5 * 60 * 60)
+    exp = time.time() + EXPIRE_AFTER_SECONDS
     return {
             UserConstants.USER_ID: user,
             'iat': str(int(iat)),


### PR DESCRIPTION
### Changes
- Some changes made whilst working with pen testers (to give them some JWT tokens for testing)
- PIP complained about a duplicate package in requirements.txt, so removed it.
- token_generator exploded without EQ_DEV_MODE enabled so added a more useful error message when this scenario occurs
- Remove hard-coded key password for EQ_USER_AUTHENTICATION_RRM_PRIVATE_KEY used by token generator
- Factored out duplicate to_str and to_bytes functions into utility class with tests (needed to convert EQ_USER_AUTHENTICATION_RRM_PRIVATE_KEY_PASSWORD).
- Updated token generator expiration to 12 hours and made units clear (seconds)
### How to test
- Run unit tests, all should pass
- Run  token_generator.py without EQ_DEV_MODE set, observe useful exception message
- Set EQ_DEV_MODE and re-run token_generator.py, check token works.
- Run Flask app locally with EQ_DEV_MODE enabled and test via /dev, should work as normal.
- Try setting the keys/passwords settings as environment vars and see they are picked up correctly (e.g. set to invalid path/password and see failure)
### Who can test
- Anyone but @collisdigital
