### PR TITLE
Fixes link on submission page

### DIFF
--- a/app/main/views/questionnaire.py
+++ b/app/main/views/questionnaire.py
@@ -8,6 +8,7 @@ from .. import main_blueprint
 from app.model.questionnaire import QuestionnaireException
 from app.main.errors import page_not_found
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -19,6 +20,10 @@ def survey(location):
         return redirect('/questionnaire/thank-you')
 
     questionnaire_manager = create_questionnaire_manager()
+
+    if location == 'first':
+        questionnaire_manager.go_to_first()
+        return redirect('/questionnaire/' + questionnaire_manager.get_current_location())
 
     try:
         # Go to the location in the url.

--- a/app/navigation/navigator.py
+++ b/app/navigation/navigator.py
@@ -60,7 +60,7 @@ class Navigator(object):
             if self._schema.introduction is not None:
                 return 'introduction'
             else:
-                return self._schema.groups[0].blocks[0].id
+                return self.get_first_block()
         else:
             return current_location
 
@@ -77,3 +77,6 @@ class Navigator(object):
             self._store.store_state(state)
         else:
             raise NavigationException('Invalid location: {}'.format(location))
+
+    def get_first_block(self):
+        return self._schema.groups[0].blocks[0].id

--- a/app/questionnaire/questionnaire_manager.py
+++ b/app/questionnaire/questionnaire_manager.py
@@ -109,5 +109,8 @@ class QuestionnaireManager(object):
     def go_to_location(self, location):
         self._navigator.go_to(location)
 
+    def go_to_first(self):
+        self._navigator.go_to(self._navigator.get_first_block())
+
     def get_schema(self):
         return self._schema

--- a/app/templates/submission.html
+++ b/app/templates/submission.html
@@ -78,7 +78,7 @@
   </dl>
   <form action="" method="POST" novalidate>
     <button class="btn btn--secondary u-mr-s" type="submit" name="action[submit_answers]">Submit answers</button>
-    <a class="u-dib" href="/questionnaire">Change your answers</a>
+    <a class="u-dib" href="/questionnaire/first">Change your answers</a>
   </form>
 </div>
 

--- a/tests/integration/mci/test_change_answers.py
+++ b/tests/integration/mci/test_change_answers.py
@@ -1,0 +1,90 @@
+import unittest
+from app import create_app
+from tests.integration.create_token import create_token
+from app import settings
+
+
+class TestHappyPath(unittest.TestCase):
+    def setUp(self):
+        settings.EQ_SERVER_SIDE_STORAGE = False
+        self.application = create_app('development')
+        self.client = self.application.test_client()
+
+    def test_happy_path_203(self):
+        self.happy_path('0203')
+
+    def test_happy_path_205(self):
+        self.happy_path('0205')
+
+    def happy_path(self, form_type_id):
+        # Get a token
+        token = create_token(form_type_id)
+        resp = self.client.get('/session?token=' + token.decode(), follow_redirects=True)
+        self.assertEquals(resp.status_code, 200)
+
+        # We are on the landing page
+        content = resp.get_data(True)
+
+        self.assertRegexpMatches(content, '<title>Introduction</title>')
+        self.assertRegexpMatches(content, '>Get Started<')
+        self.assertRegexpMatches(content, '(?s)Monthly Business Survey - Retail Sales Index.*?Monthly Business Survey - Retail Sales Index')
+
+        # We proceed to the questionnaire
+        post_data = {
+            'action[start_questionnaire]': 'Start Questionnaire'
+        }
+        resp = self.client.post('/questionnaire/introduction', data=post_data, follow_redirects=False)
+        self.assertEquals(resp.status_code, 302)
+
+        block_one_url = resp.headers['Location']
+
+        resp = self.client.get(block_one_url, follow_redirects=False)
+        self.assertEquals(resp.status_code, 200)
+
+        # We are in the Questionnaire
+        content = resp.get_data(True)
+        self.assertRegexpMatches(content, '<title>Survey</title>')
+        self.assertRegexpMatches(content, '>Monthly Business Survey - Retail Sales Index</')
+        self.assertRegexpMatches(content, "What are the dates of the sales period you are reporting for\?")
+        self.assertRegexpMatches(content, ">Save &amp; Continue<")
+
+        # We fill in our answers
+        form_data = {
+            # Start Date
+            "6fd644b0-798e-4a58-a393-a438b32fe637-day": "01",
+            "6fd644b0-798e-4a58-a393-a438b32fe637-month": "4",
+            "6fd644b0-798e-4a58-a393-a438b32fe637-year": "2016",
+            # End Date
+            "06a6a4b7-6ce4-4687-879d-3443cd8e2ff0-day": "30",
+            "06a6a4b7-6ce4-4687-879d-3443cd8e2ff0-month": "04",
+            "06a6a4b7-6ce4-4687-879d-3443cd8e2ff0-year": "2016",
+            # Total Turnover
+            "e81adc6d-6fb0-4155-969c-d0d646f15345": "100000",
+            # User Action
+            "action[save_continue]": "Save &amp; Continue"
+        }
+
+        # We submit the form
+        resp = self.client.post(block_one_url, data=form_data, follow_redirects=False)
+        self.assertEquals(resp.status_code, 302)
+
+        # There are no validation errors
+        self.assertRegexpMatches(resp.headers['Location'], r'\/questionnaire\/summary$')
+
+        summary_url = resp.headers['Location']
+
+        resp = self.client.get(summary_url, follow_redirects=False)
+        self.assertEquals(resp.status_code, 200)
+
+        # We are on the review answers page
+        content = resp.get_data(True)
+        self.assertRegexpMatches(content, '<title>Summary</title>')
+        self.assertRegexpMatches(content, '>Monthly Business Survey - Retail Sales Index</')
+        self.assertRegexpMatches(content, '>Your responses<')
+        self.assertRegexpMatches(content, '>Please check carefully before submission<')
+        self.assertRegexpMatches(content, '>Submit answers<')
+
+        resp = self.client.get('/questionnaire/first', follow_redirects=False)
+        self.assertEquals(resp.status_code, 302)
+
+        self.assertEquals(resp.headers['Location'], block_one_url)

--- a/tests/integration/multipage/test_change_answers.py
+++ b/tests/integration/multipage/test_change_answers.py
@@ -1,0 +1,149 @@
+import unittest
+from app import create_app
+from tests.integration.create_token import create_token
+
+
+class TestHappyPath(unittest.TestCase):
+    def setUp(self):
+        self.application = create_app('development')
+        self.client = self.application.test_client()
+
+    def test_happy_path(self):
+        # Get a token
+        token = create_token("999")
+        resp = self.client.get('/session?token=' + token.decode(), follow_redirects=True)
+        self.assertEquals(resp.status_code, 200)
+
+        # We are on the landing page
+        content = resp.get_data(True)
+
+        self.assertRegexpMatches(content, '<title>Introduction</title>')
+        self.assertRegexpMatches(content, '>Get Started<')
+        self.assertRegexpMatches(content, '>Test Survey<')
+
+        # We proceed to the questionnaire
+        post_data = {
+            'action[start_questionnaire]': 'Start Questionnaire'
+        }
+        resp = self.client.post('/questionnaire/introduction', data=post_data, follow_redirects=False)
+        self.assertEquals(resp.status_code, 302)
+
+        page_one_url = resp.headers['Location']
+
+        resp = self.client.get(page_one_url, follow_redirects=False)
+        self.assertEquals(resp.status_code, 200)
+
+        # We are in the Questionnaire
+        content = resp.get_data(True)
+        self.assertRegexpMatches(content, '<title>Survey</title>')
+        self.assertRegexpMatches(content, ">What are the dates of the retail spending period you are reporting for\?</")
+        self.assertRegexpMatches(content, ">Save &amp; Continue<")
+
+        # We fill in our answers
+        form_data = {
+            # Start Date
+            "1ce2045f-e773-4ef4-9767-a864cbfc8577-day": "01",
+            "1ce2045f-e773-4ef4-9767-a864cbfc8577-month": "4",
+            "1ce2045f-e773-4ef4-9767-a864cbfc8577-year": "2016",
+            # End Date
+            "fa0e74dc-cd84-45b8-8761-23bb1f4af1cb-day": "30",
+            "fa0e74dc-cd84-45b8-8761-23bb1f4af1cb-month": "04",
+            "fa0e74dc-cd84-45b8-8761-23bb1f4af1cb-year": "2016",
+            # Preferred contact number
+            "ddd33acb-3d9c-4b27-b99e-1407935cdd16": "01234567890",
+            # Total Food
+            "047cf8f5-e9c4-4a6c-a3f0-293bdf54dd0d": "250",
+            # Total Alchohol, Confectionary and Tobacco
+            "8075e95f-cfb4-40e4-bc1c-f90b373ca22a": "100",
+            # Clothing and footwear
+            "b01820e9-7437-4383-a557-48d736898924": "50",
+            # Total Retail spending
+            "f77ae356-6f42-4afe-a476-747b1aab4a6c": "400",
+            # User Action
+            "action[save_continue]": "Save &amp; Continue"
+        }
+
+        # We submit the form
+        resp = self.client.post(page_one_url, data=form_data, follow_redirects=False)
+        self.assertEquals(resp.status_code, 302)
+
+        # There are no validation errors
+        self.assertNotEquals(resp.headers['Location'], page_one_url)
+
+        # On to page two
+        page_two_url = resp.headers['Location']
+
+        resp = self.client.get(page_two_url, follow_redirects=False)
+        self.assertEquals(resp.status_code, 200)
+
+        # We are in the Questionnaire
+        content = resp.get_data(True)
+        self.assertRegexpMatches(content, '<title>Survey</title>')
+        self.assertRegexpMatches(content, ">How many people usually live in your household\?</")
+        self.assertRegexpMatches(content, ">Save &amp; Continue<")
+
+        # We fill in our answers
+        form_data = {
+            # People in household
+            "a5c43b5b-f6e9-412f-834d-2d6cc83b5436": 5,
+            # Overnight
+            "d5f9db59-9cc0-433f-9318-39f83b63d4d8": 5,
+            # number of rooms
+            "863d4afa-17e8-4537-bbae-65d19a6894c1": 8,
+            # User Action
+            "action[save_continue]": "Save &amp; Continue"
+        }
+
+        # We submit the form
+        resp = self.client.post(page_two_url, data=form_data, follow_redirects=False)
+        self.assertEquals(resp.status_code, 302)
+
+        # There are no validation errors
+        self.assertNotEquals(resp.headers['Location'], page_two_url)
+
+        # On to page three
+        page_three_url = resp.headers['Location']
+
+        resp = self.client.get(page_three_url, follow_redirects=False)
+        self.assertEquals(resp.status_code, 200)
+
+        # We are in the Questionnaire
+        content = resp.get_data(True)
+        self.assertRegexpMatches(content, '<title>Survey</title>')
+        self.assertRegexpMatches(content, ">Please give any comments about completing this survey</")
+        self.assertRegexpMatches(content, ">Save &amp; Continue<")
+
+        # Fill in the comments
+        form_data = {
+            # comments box
+            "6a3c8f46-112b-49df-aed8-0f7572074cec": "Much better than paper, I always spill coffee on it",
+            # User Action
+            "action[save_continue]": "Save &amp; Continue"
+        }
+
+        resp = self.client.post(page_three_url, data=form_data, follow_redirects=False)
+        self.assertEquals(resp.status_code, 302)
+
+        # There are no validation errors
+        self.assertNotEquals(resp.headers['Location'], page_three_url)
+
+        # Check we are on the summary page
+        self.assertRegexpMatches(resp.headers['Location'], r'\/questionnaire\/summary$')
+
+        summary_url = resp.headers['Location']
+
+        resp = self.client.get(summary_url, follow_redirects=False)
+        self.assertEquals(resp.status_code, 200)
+
+        # We are on the review answers page
+        content = resp.get_data(True)
+        self.assertRegexpMatches(content, '<title>Summary</title>')
+        self.assertRegexpMatches(content, '>Your responses<')
+        self.assertRegexpMatches(content, '>Please check carefully before submission<')
+        self.assertRegexpMatches(content, '>Submit answers<')
+
+        resp = self.client.get('/questionnaire/first', follow_redirects=False)
+        self.assertEquals(resp.status_code, 302)
+
+        # We sare being redirected to the first page
+        self.assertEquals(resp.headers['Location'], page_one_url)


### PR DESCRIPTION
### Changes

Fixes the change answers link on the summary page by introducing a new url... (Issue #222)

`/questionnaire/first` will always redirect to the first block in the questionnaire.
### How to test

1) Check out the branch
2) Run the tests
3) Run the app and fill in the questionniare and pause at the summary page.
4) Click the link to change your answers
5) Verify that you are back at the first page of the questionnaire
### Who can test

Anyone except @weapdiv-david
