### PR TITLE
Fixes #193 minimise js cachebusting

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -282,14 +282,28 @@ def versioned_url_for(endpoint, **values):
     if endpoint == 'static':
         filename = values.get('filename', None)
         if filename:
-            file_path = os.path.join(current_app.root_path, endpoint, filename)
-
+            filename = get_minimized_asset(filename)
             if settings.EQ_GIT_REF:
                 # use the git revision
                 version = settings.EQ_GIT_REF
             else:
                 # timestamp it
+                file_path = os.path.join(current_app.root_path, endpoint, filename)
                 version = int(os.stat(file_path).st_mtime)
-
+            values['filename'] = filename
             values['q'] = version
     return url_for(endpoint, **values)
+
+
+def get_minimized_asset(filename):
+    '''
+    If we're in production and it's a js or css file, return the minified version.
+    :param filename: the original filename
+    :return: the new file name will be .min.css or .min.js
+    '''
+    if settings.EQ_MINIMIZE_ASSETS:
+        if 'css' in filename:
+            filename = filename.replace(".css", ".min.css")
+        elif 'js' in filename:
+            filename = filename.replace(".js", ".min.js")
+    return filename

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,5 @@
 from flask import Flask
 from flask import url_for
-from flask import current_app
 from flask_babel import Babel
 from flask_login import LoginManager
 from app.libs.utils import get_locale
@@ -20,7 +19,6 @@ from datetime import timedelta
 import watchtower
 import logging
 import sys
-import os
 from logging.handlers import RotatingFileHandler
 from flask_analytics import Analytics
 from splunk_handler import SplunkHandler
@@ -283,13 +281,8 @@ def versioned_url_for(endpoint, **values):
         filename = values.get('filename', None)
         if filename:
             filename = get_minimized_asset(filename)
-            if settings.EQ_GIT_REF:
-                # use the git revision
-                version = settings.EQ_GIT_REF
-            else:
-                # timestamp it
-                file_path = os.path.join(current_app.root_path, endpoint, filename)
-                version = int(os.stat(file_path).st_mtime)
+            # use the git revision
+            version = settings.EQ_GIT_REF
             values['filename'] = filename
             values['q'] = version
     return url_for(endpoint, **values)

--- a/app/settings.py
+++ b/app/settings.py
@@ -2,6 +2,7 @@ import os
 import logging
 import pytz
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -31,7 +32,7 @@ EQ_RABBITMQ_URL = os.getenv('EQ_RABBITMQ_URL', 'amqp://localhost:5672/%2F')
 EQ_RABBITMQ_QUEUE_NAME = os.getenv('EQ_RABBITMQ_QUEUE_NAME', 'eq-submissions')
 EQ_RABBITMQ_TEST_QUEUE_NAME = os.getenv('EQ_RABBITMQ_TEST_QUEUE_NAME', 'eq-test')
 EQ_RABBITMQ_ENABLED = parse_mode(os.getenv('EQ_RABBITMQ_ENABLED', 'True'))
-EQ_GIT_REF = os.getenv('EQ_GIT_REF', None)
+EQ_GIT_REF = os.getenv('EQ_GIT_REF', 'unknown')
 EQ_NEW_RELIC_CONFIG_FILE = os.getenv('EQ_NEW_RELIC_CONFIG_FILE', './newrelic.ini')
 EQ_SR_LOG_GROUP = os.getenv('EQ_SR_LOG_GROUP', os.getenv('USER', 'UNKNOWN') + '-local')
 EQ_LOG_LEVEL = os.getenv('EQ_LOG_LEVEL', 'INFO')

--- a/app/settings.py
+++ b/app/settings.py
@@ -23,6 +23,8 @@ def get_key(key_name):
     else:
         return None
 
+EQ_MINIMIZE_ASSETS = parse_mode(os.getenv('EQ_MINIMIZE_ASSETS', 'False'))
+
 EQ_PROFILING = parse_mode(os.getenv('EQ_PROFILING', 'False'))
 
 EQ_RABBITMQ_URL = os.getenv('EQ_RABBITMQ_URL', 'amqp://localhost:5672/%2F')

--- a/application.py
+++ b/application.py
@@ -2,7 +2,7 @@
 
 import os
 from app import create_app
-from flask.ext.script import Manager, Server
+from flask_script import Manager, Server
 
 application = create_app(
     os.getenv('EQ_ENVIRONMENT') or 'development'

--- a/gulp/scripts.js
+++ b/gulp/scripts.js
@@ -2,6 +2,7 @@
 import gulp from 'gulp'
 import gutil from 'gulp-util'
 import eslint from 'gulp-eslint'
+import rename from 'gulp-rename'
 import plumber from 'gulp-plumber'
 import uglify from 'gulp-uglify'
 import browserify from 'browserify'
@@ -12,7 +13,7 @@ import source from 'vinyl-source-stream'
 import buffer from 'vinyl-buffer'
 import sourcemaps from 'gulp-sourcemaps'
 
-import {paths, appPath, distPath} from './paths'
+import {paths, appPath} from './paths'
 import browserSync from './bs'
 
 const b = browserify(Object.assign(watchify.args, {
@@ -34,9 +35,13 @@ export function bundle(watch) {
     .pipe(source('bundle.js'))
     .pipe(buffer())
     .pipe(sourcemaps.init({loadMaps: true}))
+    .pipe(gulp.dest(paths.scripts.output))
+    .pipe(rename({
+      suffix: '.min'
+    }))
     .pipe(uglify())
-    .pipe(sourcemaps.write('./'))
-    .pipe(gulp.dest(`./${distPath}/js`))
+    .pipe(sourcemaps.write('.'))
+    .pipe(gulp.dest(paths.scripts.output))
     .pipe(browserSync.reload({stream: true}))
 }
 
@@ -48,6 +53,10 @@ export function copyScripts() {
     .pipe(sourcemaps.init({loadMaps: true}))
     .pipe(babel())
     .pipe(plumber())
+    .pipe(gulp.dest(paths.scripts.output))
+    .pipe(rename({
+      suffix: '.min'
+    }))
     .pipe(uglify())
     .pipe(sourcemaps.write('./'))
     .pipe(gulp.dest(paths.scripts.output))


### PR DESCRIPTION
### Changes

Fixes #193 - version static assets and serve minimised js and css in production.
### How to test
1. Check out this branch
2. Run the application and check that all static assets are requested with a version (e.g. q=acd4cf308362322b93819e5ffdb961125089e65a)
3. Check minimised assets are being served
4. Set the env variable EQ_MINIMIZE_ASSETS to True
5. Check minimised assets are being served
### Who can test

Anyone apart from @warrenbailey 
