### PR TITLE
Revert issue with change your answers link to drop you at the begining of the questionnaire

### DIFF
--- a/app/templates/submission.html
+++ b/app/templates/submission.html
@@ -76,7 +76,7 @@
   </dl>
   <form action="" method="POST" novalidate>
     <button class="btn btn--secondary u-mr-s qa-btn-submit-answers" type="submit" name="action[submit_answers]">Submit answers</button>
-    <a class="u-dib" href="/questionnaire">Change your answers</a>
+    <a class="u-dib" href="/questionnaire/first">Change your answers</a>
   </form>
 </div>
 


### PR DESCRIPTION
### Changes

Revert the change I introduced by merging the selenium tests, causing the fix to the `change your answers` link to fail.
### How to test
1. Check out this branch
2. Complete a survey and then click the change your answers link
3. You should be dropped back at the begining of the questionnaire process.
### Who can test

Anyone but @dhilton 
