### PR TITLE
Adding form type to the generated user id

### DIFF
--- a/app/authentication/user_id_generator.py
+++ b/app/authentication/user_id_generator.py
@@ -19,11 +19,12 @@ class UserIDGenerator(object):
         ru_ref = token.get(MetaDataConstants.RU_REF)
         collection_exercise_sid = token.get(MetaDataConstants.COLLECTION_EXERCISE_SID)
         eq_id = token.get(MetaDataConstants.EQ_ID)
+        form_type = token.get(MetaDataConstants.FORM_TYPE)
 
-        if ru_ref and collection_exercise_sid and eq_id:
-            logger.debug("Using values %s, %s and %s with a salt", ru_ref, collection_exercise_sid, eq_id)
+        if ru_ref and collection_exercise_sid and eq_id and form_type:
+            logger.debug("Using values %s, %s, %s and %s with a salt", ru_ref, collection_exercise_sid, eq_id, form_type)
             salt = to_bytes(settings.EQ_SERVER_SIDE_STORAGE_USER_ID_SALT)
-            user_id_material = ru_ref + collection_exercise_sid + eq_id
+            user_id_material = ru_ref + collection_exercise_sid + eq_id + form_type
 
             kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=salt, iterations=settings.EQ_SERVER_SIDE_STORAGE_USER_ID_ITERATIONS, backend=backend)
             generated_user_id = kdf.derive(to_bytes(user_id_material))
@@ -32,5 +33,5 @@ class UserIDGenerator(object):
                 logger.debug("User ID is %s", to_str(user_id))
             return to_str(user_id)
         else:
-            logger.error("Missing values for ru_ref, collection_exercise_sid or eq_id in token %s", token)
+            logger.error("Missing values for ru_ref, collection_exercise_sid, form_type or eq_id in token %s", token)
             raise InvalidTokenException("Missing values in JWT token")

--- a/tests/app/authentication/test_user_id_generator.py
+++ b/tests/app/authentication/test_user_id_generator.py
@@ -11,12 +11,14 @@ class TestUserIDGenerator(unittest.TestCase):
         settings.EQ_SERVER_SIDE_STORAGE = True
 
     def test_generate_id(self):
-        user_id_1 = UserIDGenerator.generate_id(self.create_token('1', '2', '3'))
-        user_id_2 = UserIDGenerator.generate_id(self.create_token('1', '2', '3'))
-        user_id_3 = UserIDGenerator.generate_id(self.create_token('1', '2', '4'))
-        user_id_4 = UserIDGenerator.generate_id(self.create_token('2', '2', '3'))
-        user_id_5 = UserIDGenerator.generate_id(self.create_token('1', '1', '3'))
-        user_id_6 = UserIDGenerator.generate_id(self.create_token('2', '2', '4'))
+        user_id_1 = UserIDGenerator.generate_id(self.create_token('1', '2', '3', '4'))
+        user_id_2 = UserIDGenerator.generate_id(self.create_token('1', '2', '3', '4'))
+        user_id_3 = UserIDGenerator.generate_id(self.create_token('1', '2', '4', '4'))
+        user_id_4 = UserIDGenerator.generate_id(self.create_token('2', '2', '3', '4'))
+        user_id_5 = UserIDGenerator.generate_id(self.create_token('1', '1', '3', '4'))
+        user_id_6 = UserIDGenerator.generate_id(self.create_token('2', '2', '4', '4'))
+        user_id_7 = UserIDGenerator.generate_id(self.create_token('2', '2', '4', '5'))
+        user_id_8 = UserIDGenerator.generate_id(self.create_token('1', '2', '3', '5'))
 
         self.assertEqual(user_id_1, user_id_2)
 
@@ -25,28 +27,33 @@ class TestUserIDGenerator(unittest.TestCase):
         self.assertNotEquals(user_id_1, user_id_4)
         self.assertNotEquals(user_id_1, user_id_5)
         self.assertNotEquals(user_id_1, user_id_6)
+        self.assertNotEquals(user_id_1, user_id_7)
+        self.assertNotEquals(user_id_1, user_id_8)
 
     def test_different_salt_creates_different_userids(self):
-        user_id_1 = UserIDGenerator.generate_id(self.create_token('1', '2', '3'))
+        user_id_1 = UserIDGenerator.generate_id(self.create_token('1', '2', '3', '4'))
         settings.EQ_SERVER_SIDE_STORAGE_USER_ID_SALT = "random"
-        user_id_2 = UserIDGenerator.generate_id(self.create_token('1', '2', '3'))
+        user_id_2 = UserIDGenerator.generate_id(self.create_token('1', '2', '3', '4'))
         self.assertNotEqual(user_id_1, user_id_2)
 
     def test_generate_id_throws_invalid_token_exception(self):
         with self.assertRaises(InvalidTokenException) as ite:
-            UserIDGenerator.generate_id(self.create_token('1', '2', None))
+            UserIDGenerator.generate_id(self.create_token('1', '2', None, '4'))
         with self.assertRaises(InvalidTokenException) as ite:
-            UserIDGenerator.generate_id(self.create_token('1', None, '3'))
+            UserIDGenerator.generate_id(self.create_token('1', None, '3', '4'))
         with self.assertRaises(InvalidTokenException) as ite:
-            UserIDGenerator.generate_id(self.create_token(None, '2', '3'))
+            UserIDGenerator.generate_id(self.create_token(None, '2', '3', '4'))
         with self.assertRaises(InvalidTokenException) as ite:
-            UserIDGenerator.generate_id(self.create_token(None, None, None))
+            UserIDGenerator.generate_id(self.create_token(None, None, None, '4'))
+        with self.assertRaises(InvalidTokenException) as ite:
+            UserIDGenerator.generate_id(self.create_token(None, None, None, None))
 
-    def create_token(self, eq_id, collection_exercise_sid, ru_ref):
+    def create_token(self, eq_id, collection_exercise_sid, ru_ref, form_type):
         return {
                 MetaDataConstants.EQ_ID: eq_id,
                 MetaDataConstants.COLLECTION_EXERCISE_SID: collection_exercise_sid,
-                MetaDataConstants.RU_REF: ru_ref}
+                MetaDataConstants.RU_REF: ru_ref,
+                MetaDataConstants.FORM_TYPE: form_type}
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Changes

Adding form type to the list of values used to generate the user id. This is needed so that the user can complete multiple surveys with the same id but different form types.
### How to test
1. Check out this branch
2. Turn on server side storage
   `
   export EQ_SERVER_SIDE_STORAGE=True
   export EQ_SERVER_SIDE_STORAGE_ENCRYPTION=True
   `
3. Select the MCI survey with form type 0205
4. Partially complete the survey, save it and then check you can return to it later
5. With partially completed data select the MCI survey 0203 and check that you are taken to the landing page.
### Who can test

Anyone apart form @warrenbailey
