### PR TITLE
EQ-382: Dynamic Employment Date

### DIFF
--- a/app/data/0_star_wars.json
+++ b/app/data/0_star_wars.json
@@ -277,7 +277,7 @@
                             ]
                           }, {
                               "id": "6cc86b54-330c-4465-99b2-34cc7073dc2c",
-                              "title": "When was return of the Jedi released?",
+                              "title": "When was The Empire Strikes Back released?",
                               "description": "Your start and end date can't be more then a month apart",
                               "type" : "DateRange",
                               "responses": [
@@ -315,6 +315,37 @@
                             }
                         ]
                       },
+                      {
+                          "id": "12346782-08a6-4213-9dc9-0780c2996896",
+                          "title":"On {exercise.employment_date:%-d %B %Y} how many Ewokes were employed?",
+                          "description":"If you didn't pick the right employment date for Return of the Jedi its your fault if this question makes no sense",
+                          "questions": [
+                              {
+                                "id": "rt4eedc2-d98c-4d4d-9a7c-997ce10c361f",
+                                "title": "",
+                                "description": "",
+                                "type": "Integer",
+                                "responses": [
+                                    {
+                                      "id": "5rr015b1-f87c-4740-9fd4-f01f707ef558",
+                                      "q_code": "147",
+                                      "label": "",
+                                      "guidance": "",
+                                      "type": "Integer",
+                                      "options":[],
+                                      "mandatory":false,
+                                      "validation": {
+                                        "messages": {
+                                          "NOT_INTEGER": "Please only enter whole numbers into the field.",
+                                          "NEGATIVE_INTEGER": "How can it be negative?",
+                                          "INTEGER_TOO_LARGE": "Thats hotter then the sun, Jar Jar Binks you must be"
+                                        }
+                                      }
+                                    }
+                                  ]
+                              }
+                            ]
+                        },
                       {
                           "id": "94546782-08a6-4213-9dc9-0780c2996896",
                           "title":"Comments",

--- a/app/data/1_0215.json
+++ b/app/data/1_0215.json
@@ -270,7 +270,7 @@
                     "sections": [
                       {
                         "id": "c528d24b-d0dd-45cd-91af-380b61a5725d",
-                        "title": "On 12 January 2016 what was the number of employees for the business named above?",
+                        "title": "On {exercise.employment_date:%-d %B %Y} what was the number of employees for the business named above?",
                         "description": "An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.",
                         "questions": [
                           {

--- a/app/dev_mode/templates/dev-page.html
+++ b/app/dev_mode/templates/dev-page.html
@@ -57,6 +57,10 @@
           TRAD AS:
           <input name="{{UserConstants.TRAD_AS}}" type="text" value="Apple">
         </p>
+        <p>
+          EMPLOYMENT_DATE:
+          <input name="{{UserConstants.EMPLOYMENT_DATE}}" type="text" value="2016-07-12">
+        </p>
         <input type="submit" value="submit" class="qa-btn-submit-dev"/>
       </form>
     </div>

--- a/app/dev_mode/views.py
+++ b/app/dev_mode/views.py
@@ -29,8 +29,9 @@ def dev_mode():
         ru_name = form.get(MetaDataConstants.RU_NAME)
         trad_as = form.get(MetaDataConstants.TRAD_AS)
         return_by = form.get(MetaDataConstants.RETURN_BY)
+        employment_date = form.get(MetaDataConstants.EMPLOYMENT_DATE)
         payload = create_payload(user, exp_time, eq_id, period_str, period_id, form_type, collection_exercise_sid,
-                                 ref_p_start_date, ref_p_end_date, ru_ref, ru_name, trad_as, return_by)
+                                 ref_p_start_date, ref_p_end_date, ru_ref, ru_name, trad_as, return_by, employment_date)
         return redirect("/session?token=" + generate_token(payload).decode())
     else:
         return render_template("dev-page.html", user=os.getenv('USER', 'UNKNOWN'), UserConstants=MetaDataConstants,
@@ -57,7 +58,7 @@ def extract_eq_id_and_form_type(schema_name):
 
 
 def create_payload(user, exp_time, eq_id, period_str, period_id, form_type, collection_exercise_sid, ref_p_start_date,
-                   ref_p_end_date, ru_ref, ru_name, trad_as, return_by):
+                   ref_p_end_date, ru_ref, ru_name, trad_as, return_by, employment_date):
     iat = time.time()
     exp = time.time() + float(exp_time)
     return {
@@ -74,7 +75,8 @@ def create_payload(user, exp_time, eq_id, period_str, period_id, form_type, coll
             MetaDataConstants.RU_REF: ru_ref,
             MetaDataConstants.RU_NAME: ru_name,
             MetaDataConstants.RETURN_BY: return_by,
-            MetaDataConstants.TRAD_AS: trad_as}
+            MetaDataConstants.TRAD_AS: trad_as,
+            MetaDataConstants.EMPLOYMENT_DATE: employment_date}
 
 
 def generate_token(payload):

--- a/app/metadata/metadata_store.py
+++ b/app/metadata/metadata_store.py
@@ -20,6 +20,7 @@ class MetaDataConstants(object):
     FORM_TYPE = 'form_type'
     RETURN_BY = 'return_by'
     TRAD_AS = 'trad_as'
+    EMPLOYMENT_DATE = 'employment_date'
 
 
 class MetaDataStore(object):
@@ -32,7 +33,7 @@ class MetaDataStore(object):
                              MetaDataConstants.RETURN_BY]
 
     def __init__(self, user_id, ru_ref, ru_name, eq_id, collection_exercise_sid, period_id, period_str, ref_p_end_date,
-                 ref_p_start_date, form_type, return_by, trad_as):
+                 ref_p_start_date, form_type, return_by, trad_as, employment_date):
         self.user_id = user_id
         self.ru_ref = ru_ref
         self.ru_name = ru_name
@@ -45,6 +46,7 @@ class MetaDataStore(object):
         self.form_type = form_type
         self.return_by = return_by
         self.trad_as = trad_as
+        self.employment_date = employment_date
 
     def get_ru_ref(self):
         return self.ru_ref
@@ -82,6 +84,9 @@ class MetaDataStore(object):
     def get_user_id(self):
         return self.user_id
 
+    def get_employment_date(self):
+        return self.employment_date
+
     @staticmethod
     def is_valid(token):
         for value in MetaDataStore.VALUES_FOR_VALIDATION:
@@ -104,11 +109,19 @@ class MetaDataStore(object):
             ref_p_start_date = datetime.strptime(token[MetaDataConstants.REF_P_START_DATE], "%Y-%m-%d")
             form_type = token[MetaDataConstants.FORM_TYPE]
             return_by = datetime.strptime(token[MetaDataConstants.RETURN_BY], "%Y-%m-%d")
+
             # optional values
             trad_as = token[MetaDataConstants.TRAD_AS] if MetaDataConstants.TRAD_AS in token else None
 
+            # TODO remove when rrm implements employment date
+            if MetaDataConstants.EMPLOYMENT_DATE in token and token[MetaDataConstants.EMPLOYMENT_DATE]:
+
+                employment_date = datetime.strptime(token[MetaDataConstants.EMPLOYMENT_DATE], "%Y-%m-%d")
+            else:
+                employment_date = datetime.strptime("2016-06-10", "%Y-%m-%d")
+
             metadata = MetaDataStore(user_id, ru_ref, ru_name, eq_id, collection_exercise_sid, period_id, period_str,
-                                     ref_p_end_date, ref_p_start_date, form_type, return_by, trad_as)
+                                     ref_p_end_date, ref_p_start_date, form_type, return_by, trad_as, employment_date)
 
             frozen = jsonpickle.encode(metadata)
             data = user.get_questionnaire_data()

--- a/app/model/section.py
+++ b/app/model/section.py
@@ -11,7 +11,7 @@ class Section(object):
         self.questionnaire = None
         self.validation = None
         self.questionnaire = None
-        self.templatable_properties = []
+        self.templatable_properties = ['title']
         self.display = Display()
 
     def add_question(self, question):

--- a/app/renderer/renderer.py
+++ b/app/renderer/renderer.py
@@ -16,17 +16,20 @@ class Renderer(object):
 
         start_date = None
         end_date = None
+        employment_date = None
 
         try:
             start_date = self._metadata.get_ref_p_start_date()
             end_date = self._metadata.get_ref_p_end_date()
+            employment_date = self._metadata.get_employment_date()
         except:
             pass
 
         context = {
             "exercise": ObjectFromDict({
                 "start_date": start_date,
-                "end_date": end_date
+                "end_date": end_date,
+                "employment_date": employment_date
             })
         }
 
@@ -74,6 +77,7 @@ class Renderer(object):
             "return_by": None,
             "start_date": None,
             "end_date": None,
+            "employment_date": None,
             "period_str": None
         }
 
@@ -85,6 +89,7 @@ class Renderer(object):
             survey_meta["return_by"] = "{dt.day} {dt:%B} {dt.year}".format(dt=self._metadata.get_return_by())
             survey_meta["start_date"] = '{dt.day} {dt:%B} {dt.year}'.format(dt=self._metadata.get_ref_p_start_date())
             survey_meta["end_date"] = '{dt.day} {dt:%B} {dt.year}'.format(dt=self._metadata.get_ref_p_end_date())
+            survey_meta["employment_date"] = '{dt.day} {dt:%B} {dt.year}'.format(dt=self._metadata.get_employment_date())
             survey_meta["period_str"] = self._metadata.get_period_str()
         except:
             # But we can silently ignore them under those circumstanes

--- a/tests/app/metadata/test_metadata_store.py
+++ b/tests/app/metadata/test_metadata_store.py
@@ -328,7 +328,8 @@ class TestMetadataStore(SurveyRunnerTestCase):
         self.assertFalse(valid)
         self.assertEquals(MetaDataConstants.RETURN_BY, reason)
 
-    def test_is_valid_does_not_fail_missing_trading_name(self):
+    #Both trad_as and employment_date are optional and might not be in the token
+    def test_is_valid_does_not_fail_missing_optional_value_in_token(self):
         jwt = {
             MetaDataConstants.USER_ID: "1",
             MetaDataConstants.FORM_TYPE: "a",
@@ -344,6 +345,7 @@ class TestMetadataStore(SurveyRunnerTestCase):
         }
         valid, reason = MetaDataStore.is_valid(jwt)
         self.assertTrue(valid)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/integration/create_token.py
+++ b/tests/integration/create_token.py
@@ -11,8 +11,9 @@ REF_P_START_DATE = "2016-04-01"
 REF_P_END_DATE = "2016-04-30"
 RETURN_BY = "2016-05-06"
 TRAD_AS = "Integration Tests"
+EMPLOYMENT_P_DATE = "1983-06-02"
 
-def create_token(form_type_id, eq_id, start_date=None, end_date=None):
+def create_token(form_type_id, eq_id, start_date=None, end_date=None, employment_date=None):
         user = USER
         exp_time = 3600                         # one hour from now
         eq_id = eq_id
@@ -31,6 +32,11 @@ def create_token(form_type_id, eq_id, start_date=None, end_date=None):
         else:
             ref_p_end_date = end_date
 
+        if employment_date is None:
+            ref_p_employment_date = EMPLOYMENT_P_DATE
+        else:
+            ref_p_employment_date = employment_date
+
         ru_ref = RU_REF
         ru_name = RU_NAME
         trad_as = TRAD_AS
@@ -38,6 +44,6 @@ def create_token(form_type_id, eq_id, start_date=None, end_date=None):
 
         payload = create_payload(user, exp_time, eq_id, period_str, period_id,
                                  form_type, collection_exercise_sid, ref_p_start_date,
-                                 ref_p_end_date, ru_ref, ru_name, trad_as, return_by)
+                                 ref_p_end_date, ru_ref, ru_name, trad_as, return_by, ref_p_employment_date)
 
         return generate_token(payload)

--- a/tests/integration/star_wars/test_piping_employment_date.py
+++ b/tests/integration/star_wars/test_piping_employment_date.py
@@ -1,0 +1,43 @@
+import unittest
+from app import create_app
+from tests.integration.create_token import create_token
+from app import settings
+
+
+class TestPipingEmploymentDate(unittest.TestCase):
+    def setUp(self):
+        settings.EQ_SERVER_SIDE_STORAGE = False
+        self.application = create_app('development')
+        self.client = self.application.test_client()
+
+    def test_piping_employment_date(self):
+        # Get a token
+        token = create_token('star_wars', '0')
+        resp = self.client.get('/session?token=' + token.decode(), follow_redirects=True)
+        self.assertEquals(resp.status_code, 200)
+
+        # We are on the landing page
+        content = resp.get_data(True)
+
+        self.assertRegexpMatches(content, '<title>Introduction</title>')
+        self.assertRegexpMatches(content, '>Get Started<')
+        self.assertRegexpMatches(content, '(?s)Star Wars.*?Star Wars')
+
+         # We proceed to the questionnaire
+        post_data = {
+            'action[start_questionnaire]': 'Start Questionnaire'
+        }
+        resp = self.client.post('/questionnaire/introduction', data=post_data, follow_redirects=False)
+        self.assertEquals(resp.status_code, 302)
+
+        block_one_url = resp.headers['Location']
+
+        resp = self.client.get(block_one_url, follow_redirects=False)
+        self.assertEquals(resp.status_code, 200)
+
+        # We are in the Questionnaire
+        content = resp.get_data(True)
+        self.assertRegexpMatches(content, 'Star Wars Quiz')
+        self.assertRegexpMatches(content, 'May the force be with you young EQ developer')
+        self.assertRegexpMatches(content, ">Save &amp; Continue<")
+        self.assertRegexpMatches(content, 'On 2 June 1983 how many Ewokes were employed?')

--- a/token_generator.py
+++ b/token_generator.py
@@ -23,7 +23,8 @@ def create_payload(user):
             MetaDataConstants.REF_P_END_DATE: "2016-09-01",
             MetaDataConstants.RU_REF: "12346789012A",
             MetaDataConstants.RU_NAME: "Apple",
-            MetaDataConstants.RETURN_BY: "2016-04-30"}
+            MetaDataConstants.RETURN_BY: "2016-04-30",
+            MetaDataConstants.EMPLOYMENT_DATE: "2016-06-10"}
 
 
 def generate_token():


### PR DESCRIPTION
### Changes

Add employment_date into jwt token decode (default if not present) and pipe result into 1_0215.json. Update dev page to include option to change employment_date
### How to test

Use dev to select 1_0215 and change the employment_date at the bottom, make sure the survey works and that the date selected is piped into the employment section
### Who can test

Anyone but @LJBabbage
