### PR TITLE
Setting the default to match the author application

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -49,7 +49,7 @@ EQ_SCHEMA_DIRECTORY = os.getenv('EQ_SCHEMA_DIRECTORY', 'app/data')
 EQ_SESSION_TIMEOUT = int(os.getenv('EQ_SESSION_TIMEOUT', '28800'))
 EQ_SECRET_KEY = os.getenv('EQ_SECRET_KEY', os.urandom(24))
 EQ_UA_ID = os.getenv('EQ_UA_ID', '')
-EQ_SCHEMA_BUCKET = os.getenv('EQ_SCHEMA_BUCKET', '')
+EQ_SCHEMA_BUCKET = os.getenv('EQ_SCHEMA_BUCKET', "eq-schema-files-"+os.getenv('USER', 'UNKNOWN'))
 
 
 EQ_SERVER_SIDE_STORAGE = parse_mode(os.getenv('EQ_SERVER_SIDE_STORAGE', 'False'))


### PR DESCRIPTION
### Changes

Set the default value for the schema bucket to match the author application
### How to test
1. Run the application
2. Check that it is trying to access the correct schema bucket
### Who can test

Anyone apart @warrenbailey
