### PR TITLE
Support schema files names with no form type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: required
 dist: trusty
 python:
 - '3.5'
+env:
+- EQ_SCHEMA_BUCKET=""
 install:
 - ". $HOME/.nvm/nvm.sh"
 - rm -rf node_modules

--- a/app/dev_mode/views.py
+++ b/app/dev_mode/views.py
@@ -41,18 +41,24 @@ def dev_mode():
 def extract_eq_id_and_form_type(schema_name):
     try:
         logger.debug("schema file name: %s", schema_name)
-        split_schema_name = schema_name.split("_", 1)
-        if len(split_schema_name) != 2:
-            raise ValueError("Schema file name incorrect %", schema_name)
-        eq_id = split_schema_name[0]
+        if "_" in schema_name:
+            split_schema_name = schema_name.split("_", 1)
+            if len(split_schema_name) != 2:
+                raise ValueError("Schema file name incorrect %", schema_name)
+            eq_id = split_schema_name[0]
+            split_rest_of_name = split_schema_name[1].split(".", 1)
+            if len(split_rest_of_name) != 2:
+                raise ValueError("Schema file name incorrect %", schema_name)
+            form_type = split_rest_of_name[0]
+        else:
+            # No form type associated with
+            eq_id = schema_name.split(".", 1)[0]
+            form_type = "0"
         logger.debug("eq-id: %s", eq_id)
-        split_rest_of_name = split_schema_name[1].split(".", 1)
-        if len(split_rest_of_name) != 2:
-            raise ValueError("Schema file name incorrect %", schema_name)
-        form_type = split_rest_of_name[0]
         logger.debug("form_type: " + form_type)
         return eq_id, form_type
-    except Exception:
+    except Exception as e:
+        logger.exception(e)
         logger.error("Invalid schema file %s", schema_name)
         abort(404)
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -49,7 +49,7 @@ EQ_SCHEMA_DIRECTORY = os.getenv('EQ_SCHEMA_DIRECTORY', 'app/data')
 EQ_SESSION_TIMEOUT = int(os.getenv('EQ_SESSION_TIMEOUT', '28800'))
 EQ_SECRET_KEY = os.getenv('EQ_SECRET_KEY', os.urandom(24))
 EQ_UA_ID = os.getenv('EQ_UA_ID', '')
-EQ_SCHEMA_BUCKET = os.getenv('EQ_SCHEMA_BUCKET', '')
+EQ_SCHEMA_BUCKET = os.getenv('EQ_SCHEMA_BUCKET', "eq-schema-files-" + os.getenv('USER', 'UNKNOWN'))
 
 
 EQ_SERVER_SIDE_STORAGE = parse_mode(os.getenv('EQ_SERVER_SIDE_STORAGE', 'False'))


### PR DESCRIPTION
### Changes

Updating the dev page so we can support schema files which don't have the form_type in their name. Also changing the default value for EQ_SCHEMA_BUCKET so that it matches the author application.
### How to test
1. Check out this branch
2. Load a schema file from s3 which is of the form (1.json) - you can use the author application to do this
3. Check you can complete the survey
### Who can test

Anyone apart from @warrenbailey
