### PR TITLE
Catch boto exception when listing schemas

### DIFF
--- a/app/schema_loader/schema_loader.py
+++ b/app/schema_loader/schema_loader.py
@@ -46,8 +46,11 @@ def available_schemas():
         if os.path.isfile(os.path.join(settings.EQ_SCHEMA_DIRECTORY, file)):
             files.append(file)
     if settings.EQ_SCHEMA_BUCKET:
-        s3 = boto3.resource('s3')
-        schemas_bucket = s3.Bucket(settings.EQ_SCHEMA_BUCKET)
-        for key in schemas_bucket.objects.all():
-            files.append(key.key)
+        try:
+            s3 = boto3.resource('s3')
+            schemas_bucket = s3.Bucket(settings.EQ_SCHEMA_BUCKET)
+            for key in schemas_bucket.objects.all():
+                files.append(key.key)
+        except botocore.exceptions.ClientError as e:
+            logging.error("S3 error: %s", e.response['Error']['Code'])
     return files


### PR DESCRIPTION
### Changes

If the schema bucket doesn't exists but the schema bucket variable is set then  then the dev page breaks. This change fixes that.
### How to test
1. Set the schema bucket name variable to a bucket that doesn't exist
2. Run the app
3. Check you can access the dev page
### Who can test

Anyone apart @warrenbailey
