### PR TITLE
Delete all data on submission

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,10 +6,10 @@ from app.libs.utils import get_locale
 from healthcheck import HealthCheck
 from flaskext.markdown import Markdown
 from app.utilities.factory import factory
-from app.responses.response_store import FlaskResponseStore
-from app.navigation.navigation_store import FlaskNavigationStore
-from app.navigation.navigation_history import FlaskNavigationHistory
-from app.validation.validation_store import FlaskValidationStore
+from app.responses.response_store import ResponseStore
+from app.navigation.navigation_store import NavigationStore
+from app.navigation.navigation_history import NavigationHistory
+from app.validation.validation_store import ValidationStore
 from app.authentication.authenticator import Authenticator
 from app.authentication.cookie_session import SHA256SecureCookieSessionInterface
 from app.submitter.submitter import SubmitterFactory
@@ -42,10 +42,10 @@ logger = logging.getLogger(__name__)
 
 # setup the factory
 logger.debug("Registering factory classes")
-factory.register("response-store", FlaskResponseStore)
-factory.register("navigation-store", FlaskNavigationStore)
-factory.register("navigation-history", FlaskNavigationHistory)
-factory.register("validation-store", FlaskValidationStore)
+factory.register("response-store", ResponseStore)
+factory.register("navigation-store", NavigationStore)
+factory.register("navigation-history", NavigationHistory)
+factory.register("validation-store", ValidationStore)
 
 
 def rabbitmq_available():

--- a/app/authentication/session_management.py
+++ b/app/authentication/session_management.py
@@ -74,7 +74,6 @@ class DatabaseSessionManager(SessionManagement):
             eq_session_id = self.create_session_id()
             logger.debug("Created new eq session id %s", eq_session_id)
             session[EQ_SESSION_ID] = eq_session_id
-            session.permanent = True
             eq_session = EQSession(eq_session_id, user_id)
             logger.debug("Constructed EQ Session object %s", eq_session)
         else:
@@ -149,7 +148,6 @@ class DatabaseSessionManager(SessionManagement):
         logger.debug("SessionManager store_user_ik() - session %s", session)
         if USER_IK not in session:
             session[USER_IK] = user_ik
-            session.permanent = True
 
     def has_user_ik(self):
         """

--- a/app/main/views/questionnaire.py
+++ b/app/main/views/questionnaire.py
@@ -1,4 +1,5 @@
 import logging
+from app.authentication.session_management import session_manager
 from flask import render_template, request, session
 from flask_login import login_required, current_user
 from flask import redirect
@@ -24,6 +25,9 @@ def survey(eq_id, collection_id, location):
     if location == 'first':
         questionnaire_manager.go_to_first()
         return redirect('/questionnaire/' + eq_id + '/' + collection_id + '/' + questionnaire_manager.get_current_location())
+
+    if location == 'thank-you':
+        delete_user_data()
 
     try:
         # Go to the location in the url.
@@ -51,3 +55,11 @@ def survey(eq_id, collection_id, location):
 
     except QuestionnaireException:
         return page_not_found(404)
+
+
+def delete_user_data():
+    # once the survey has been submitted
+    # delete all user data from the database
+    current_user.delete_questionnaire_data()
+    # and clear out the session state
+    session_manager.clear()

--- a/app/navigation/navigation_history.py
+++ b/app/navigation/navigation_history.py
@@ -1,16 +1,19 @@
 from flask_login import current_user
+from abc import ABCMeta, abstractmethod
 NAV_HISTORY = "history"
 
 
-class NavigationHistory(object):
+class AbstractNavigationHistory(metaclass=ABCMeta):
+    @abstractmethod
     def get_history(self):
         raise NotImplementedError()
 
+    @abstractmethod
     def add_history_entry(self, location):
         raise NotImplementedError()
 
 
-class FlaskNavigationHistory(NavigationHistory):
+class NavigationHistory(AbstractNavigationHistory):
 
     def get_history(self):
         data = current_user.get_questionnaire_data()

--- a/app/navigation/navigation_store.py
+++ b/app/navigation/navigation_store.py
@@ -15,7 +15,7 @@ class INavigationStore(metaclass=ABCMeta):
         pass
 
 
-class FlaskNavigationStore(INavigationStore):
+class NavigationStore(INavigationStore):
     def store_state(self, state):
         data = current_user.get_questionnaire_data()
         data[NAVIGATION_SESSION_KEY] = state.to_dict()

--- a/app/questionnaire/questionnaire_manager.py
+++ b/app/questionnaire/questionnaire_manager.py
@@ -26,14 +26,7 @@ class QuestionnaireManager(object):
 
         # Are we submitting downstram?
         if user_action == 'submit_answers':
-            responses = self._response_store.get_responses()
-            submitter = SubmitterFactory.get_submitter()
-            submitted_at = submitter.send_responses(current_user, self._metadata, self._schema, responses)
-            # TODO I don't like this but until we sort out the landing/review/submission flow this is the easiest way
-            session[SubmitterConstants.SUBMITTED_AT_KEY] = submitted_at.strftime(settings.DISPLAY_DATETIME_FORMAT)
-            self._response_store.clear_responses()
-            self._navigator.go_to('thank-you')
-            return
+            return self.submit()
 
         # Process the responses and see where to go next
         cleaned_user_responses = {}
@@ -61,6 +54,15 @@ class QuestionnaireManager(object):
 
         # now return the location
         return self._navigator.get_current_location()
+
+    def submit(self):
+        responses = self._response_store.get_responses()
+        submitter = SubmitterFactory.get_submitter()
+        submitted_at = submitter.send_responses(current_user, self._metadata, self._schema, responses)
+        # TODO I don't like this but until we sort out the landing/review/submission flow this is the easiest way
+        session[SubmitterConstants.SUBMITTED_AT_KEY] = submitted_at.strftime(settings.DISPLAY_DATETIME_FORMAT)
+        self._navigator.go_to('thank-you')
+        return
 
     def get_rendering_context(self):
         return self.renderer.render()

--- a/app/responses/response_store.py
+++ b/app/responses/response_store.py
@@ -22,7 +22,7 @@ class AbstractResponseStore(metaclass=ABCMeta):
         raise NotImplementedError()
 
 
-class FlaskResponseStore(AbstractResponseStore):
+class ResponseStore(AbstractResponseStore):
 
     def store_response(self, key, value):
         data = current_user.get_questionnaire_data()

--- a/app/validation/validation_store.py
+++ b/app/validation/validation_store.py
@@ -17,7 +17,7 @@ class AbstractValidationStore(metaclass=ABCMeta):
         raise NotImplementedError()
 
 
-class FlaskValidationStore(AbstractValidationStore):
+class ValidationStore(AbstractValidationStore):
 
     def store_result(self, key, value):
         data = current_user.get_questionnaire_data()

--- a/tests/app/navigation/test_navigation_history.py
+++ b/tests/app/navigation/test_navigation_history.py
@@ -1,4 +1,4 @@
-from app.navigation.navigation_history import FlaskNavigationHistory
+from app.navigation.navigation_history import NavigationHistory
 
 from tests.app.framework.sr_unittest import SurveyRunnerTestCase
 import unittest
@@ -8,13 +8,13 @@ class FlaskNavigationHistoryTest(SurveyRunnerTestCase):
 
     def test_add_history(self):
         with self.application.test_request_context():
-            navigation_history = FlaskNavigationHistory()
+            navigation_history = NavigationHistory()
             navigation_history.add_history_entry("test1")
             self.assertIn("test1", navigation_history.get_history())
 
     def test_add_more_history(self):
         with self.application.test_request_context():
-            navigation_history = FlaskNavigationHistory()
+            navigation_history = NavigationHistory()
             navigation_history.add_history_entry("test1")
             self.assertIn("test1", navigation_history.get_history())
             navigation_history.add_history_entry("test2")

--- a/tests/app/navigation/test_navigation_store.py
+++ b/tests/app/navigation/test_navigation_store.py
@@ -1,4 +1,4 @@
-from app.navigation.navigation_store import FlaskNavigationStore
+from app.navigation.navigation_store import NavigationStore
 from app.navigation.navigation_state import NavigationState
 from tests.app.framework.sr_unittest import SurveyRunnerTestCase
 import unittest
@@ -8,7 +8,7 @@ class FlaskNavigationStoreTest(SurveyRunnerTestCase):
 
     def test_add_history(self):
         with self.application.test_request_context():
-            navigation_store = FlaskNavigationStore()
+            navigation_store = NavigationStore()
             navigation_state = NavigationState()
             navigation_state.current_position = "start"
             navigation_store.store_state(navigation_state)

--- a/tests/app/navigation/test_navigator.py
+++ b/tests/app/navigation/test_navigator.py
@@ -1,5 +1,5 @@
 from app.navigation.navigator import Navigator
-from app.navigation.navigation_history import FlaskNavigationHistory
+from app.navigation.navigation_history import NavigationHistory
 from tests.app.framework.sr_unittest import SurveyRunnerTestCase
 from app.model.questionnaire import Questionnaire
 import unittest
@@ -22,7 +22,7 @@ class NavigatorTest(SurveyRunnerTestCase):
             group.add_block(block)
             schema.add_group(group)
 
-            navigation_history = FlaskNavigationHistory()
+            navigation_history = NavigationHistory()
             navigator = Navigator(schema, navigation_history)
             #  brand new session shouldn't have a current location
             self.assertEquals("block-1", navigator.get_current_location())
@@ -32,7 +32,7 @@ class NavigatorTest(SurveyRunnerTestCase):
             schema = Questionnaire()
             schema.introduction = "anything"
 
-            navigation_history = FlaskNavigationHistory()
+            navigation_history = NavigationHistory()
             navigator = Navigator(schema, navigation_history)
             #  brand new session shouldn't have a current location
             self.assertEquals("introduction", navigator.get_current_location())
@@ -49,19 +49,19 @@ class NavigatorTest(SurveyRunnerTestCase):
             group.add_block(block)
             schema.add_group(group)
 
-            navigation_history = FlaskNavigationHistory()
+            navigation_history = NavigationHistory()
             navigator = Navigator(schema, navigation_history)
 
             self.assertRaises(NavigationException, navigator.go_to, 'introduction')
 
-            navigation_history = FlaskNavigationHistory()
+            navigation_history = NavigationHistory()
             navigator = Navigator(schema, navigation_history)
             navigator.go_to("block-1")
             self.assertEquals("block-1", navigator.get_current_location())
 
             schema.introduction = {'description': 'Some sort of intro'}
 
-            navigation_history = FlaskNavigationHistory()
+            navigation_history = NavigationHistory()
             navigator = Navigator(schema, navigation_history)
             navigator.go_to("introduction")
             self.assertEquals("introduction", navigator.get_current_location())

--- a/tests/app/responses/test_response_store.py
+++ b/tests/app/responses/test_response_store.py
@@ -1,4 +1,4 @@
-from app.responses.response_store import FlaskResponseStore
+from app.responses.response_store import ResponseStore
 from tests.app.framework.sr_unittest import SurveyRunnerTestCase
 import unittest
 
@@ -7,7 +7,7 @@ class ResponseStoreTest(SurveyRunnerTestCase):
 
     def test_get_response(self):
         with self.application.test_request_context():
-            response_store = FlaskResponseStore()
+            response_store = ResponseStore()
             response_store.store_response("key1" , "test1")
             self.assertEquals("test1", response_store.get_response("key1"))
 

--- a/tests/integration/mci/test_backwards_navigation_after_submission.py
+++ b/tests/integration/mci/test_backwards_navigation_after_submission.py
@@ -1,7 +1,6 @@
 from .test_happy_path import TestHappyPath
 
 
-
 class TestBackwardsNavigationAfterSubmission(TestHappyPath):
 
     def test_backwards_navigation_205(self):
@@ -11,13 +10,10 @@ class TestBackwardsNavigationAfterSubmission(TestHappyPath):
     def backwards_navigation(self):
         eq_id = "1"
         resp = self.client.get('/questionnaire/' + eq_id + '/789/summary', follow_redirects=False)
-        self.assertEquals(resp.status_code, 302)
-        self.assertRegexpMatches(resp.headers['Location'], '\/thank-you$')
+        self.assertEquals(resp.status_code, 401)
 
         resp = self.client.get('/questionnaire/' + eq_id + '/1/cd3b74d1-b687-4051-9634-a8f9ce10a27d', follow_redirects=False)
-        self.assertEquals(resp.status_code, 302)
-        self.assertRegexpMatches(resp.headers['Location'], '\/thank-you$')
+        self.assertEquals(resp.status_code, 401)
 
         resp = self.client.get('/questionnaire/' + eq_id + '/1/introduction', follow_redirects=False)
-        self.assertEquals(resp.status_code, 302)
-        self.assertRegexpMatches(resp.headers['Location'], '\/thank-you$')
+        self.assertEquals(resp.status_code, 401)

--- a/tests/integration/star_wars/test_backwards_navigation_after_submission.py
+++ b/tests/integration/star_wars/test_backwards_navigation_after_submission.py
@@ -1,6 +1,7 @@
 from .test_light_side_path import TestLightSidePath
 
-class TestbackwardsNavigationAfterSubmission(TestLightSidePath):
+
+class TestBackwardsNavigationAfterSubmission(TestLightSidePath):
 
     def test_backwards_navigation_star_wars(self):
         self.test_light_side_path()
@@ -9,19 +10,20 @@ class TestbackwardsNavigationAfterSubmission(TestLightSidePath):
     def backwards_navigation(self):
         eq_id = "0"
         resp = self.client.get('/questionnaire/' + eq_id + '/789/summary', follow_redirects=False)
-        self.assertEquals(resp.status_code, 302)
-        self.assertRegexpMatches(resp.headers['Location'], '\/thank-you$')
+        self.assertEquals(resp.status_code, 401)
+
+        # Block Three
+        resp = self.client.get('/questionnaire/' + eq_id + '/789/0e41e80a-f45a-2dfd-9fe0-55cc2c7807d0', follow_redirects=False)
+        self.assertEquals(resp.status_code, 401)
 
         # Block Two
-        resp = self.client.get('/questionnaire/' + eq_id + '/789/an3b74d1-b687-4051-9634-a8f9ce10ard', follow_redirects=False)
-        self.assertEquals(resp.status_code, 302)
-        self.assertRegexpMatches(resp.headers['Location'], '\/thank-you$')
+        resp = self.client.get('/questionnaire/' + eq_id + '/789/0e41e80a-f45a-2dfd-9fe0-55cc2c7807d9', follow_redirects=False)
+        self.assertEquals(resp.status_code, 401)
 
         # Block One
-        resp = self.client.get('/questionnaire/' + eq_id + '/789/cd3b74d1-b687-4051-9634-a8f9ce10a27d', follow_redirects=False)
-        self.assertEquals(resp.status_code, 302)
-        self.assertRegexpMatches(resp.headers['Location'], '\/thank-you$')
+        resp = self.client.get('/questionnaire/' + eq_id + '/789/0e41e80a-f45a-4dfd-9ae0-55cc2c7807d9', follow_redirects=False)
+        self.assertEquals(resp.status_code, 401)
 
         resp = self.client.get('/questionnaire/' + eq_id + '/789/introduction', follow_redirects=False)
-        self.assertEquals(resp.status_code, 302)
-        self.assertRegexpMatches(resp.headers['Location'], '\/thank-you$')
+        self.assertEquals(resp.status_code, 401)
+


### PR DESCRIPTION
### What is the context of this PR?

Fixes #276 

Delete all user data from the database and clear users session on submission of data. This means once the thank you page has been displayed you are automatically logged out of EQ and all your questionnaire state is deleted.

Also changing to session cookies, so that when you close the browser your cookie is delete and your session is lost requiring you to log in again. Therefore if you are partially through a survey and close your browser you are required to log back in, though your data will be saved to the database.
### How to review
1. Check out this branch
2. Run the application
3. Check save and resume works
4. Complete a survey
5. After the thank you page has been displayed hit the back button, a 401 response should appear
6. If you now return to the dev page you should be able complete the survey again
- [x] Do all commits have sensible commit messages?
- [x] Is all new code unit tested?
- [x] Are there integration tests if needed?
- [x] Is there sufficient logging?
- [x] Is there documentation or is the code self-describing?
### Who worked on the PR

@warrenbailey

…
