### PR TITLE
Rabbit MQ - Persist messages between restarts

### DIFF
--- a/app/submitter/submitter.py
+++ b/app/submitter/submitter.py
@@ -94,8 +94,14 @@ class RabbitMQSubmitter(Submitter):
         try:
             self._connect()
             channel = self.connection.channel()
-            channel.queue_declare(queue=queue)
-            published = channel.basic_publish(exchange='', routing_key=queue, body=message_as_string, mandatory=True)
+            channel.queue_declare(queue=queue, durable=True)
+            published = channel.basic_publish(exchange='',
+                                              routing_key=queue,
+                                              body=message_as_string,
+                                              mandatory=True,
+                                              properties=pika.BasicProperties(
+                                                  delivery_mode=2
+                                              ))
             if published:
                 logger.info("Sent to rabbit mq " + message_as_string)
             else:


### PR DESCRIPTION
### What is the context of this PR?

Changing the submitter so that it sends persistent messages to rabbit mq and sets the queue to be durable. This means messages are not lost on restart of the Rabbit MQ application as they are now written to disk.
### How to review
1. Check out this branch
2. Run a local copy of rabbit MQ
3. Set the environment variable `export EQ_RABBITMQ_ENABLED=True`
4. Complete a survey
5. Check a message exists on the Rabbit MQ server (`/rabbitmqctl list_queues`)
6. Restart the Rabbit MQ server and check the message still exists
- [ ] Do all commits have sensible commit messages?
- [ ] Is all new code unit tested?
- [ ] Are there integration tests if needed?
- [ ] Is there sufficient logging?
- [ ] Is there documentation or is the code self-describing?
### Who worked on the PR

@warrenbailey
