### PR TITLE
Add README.md to data folder to persist existence in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,5 @@ app/styles/base/_sprite.scss
 !.elasticbeanstalk/*.cfg.yml
 !.elasticbeanstalk/*.global.yml
 newrelic.ini
-app/data/*
+app/data/*.json
 tests/serialisation/data/*

--- a/app/data/README.md
+++ b/app/data/README.md
@@ -1,0 +1,3 @@
+This folder exists to hold generated schemas from Python representations of those surveys.
+
+


### PR DESCRIPTION
### What is the context of this PR?

This PR is designed to fix #280, and re-enable the dev page in our production environment

To enable our deployment setup to work correctly, we've added the skeleton data folder
to git so that we can ensure that it always will be present at depoyment.
### How to review
1. Checkout this branch.
2. Check that `/app/data/` folder exists containing one file.
3. Run `./script/run_tests.sh` and then `./scripts/run_app.sh`
4. Check that `/app/data/` folder contains generated schemas.
- [ ] Do all commits have sensible commit messages?
- [ ] Is all new code unit tested?
- [ ] Are there integration tests if needed?
- [ ] Is there sufficient logging?
- [ ] Is there documentation or is the code self-describing?
### Who worked on the PR

Only @dhilton 

Fixes #280
