### PR TITLE
EQ-399 Refactor MetaDataStore to use self describing items

### DIFF
--- a/app/authentication/user_id_generator.py
+++ b/app/authentication/user_id_generator.py
@@ -46,10 +46,10 @@ class UserIDGenerator(object):
 
     @staticmethod
     def _get_token_data(token):
-        ru_ref = token.get(MetaDataConstants.RU_REF)
-        collection_exercise_sid = token.get(MetaDataConstants.COLLECTION_EXERCISE_SID)
-        eq_id = token.get(MetaDataConstants.EQ_ID)
-        form_type = token.get(MetaDataConstants.FORM_TYPE)
+        ru_ref = token.get(MetaDataConstants.RU_REF.claim_id)
+        collection_exercise_sid = token.get(MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id)
+        eq_id = token.get(MetaDataConstants.EQ_ID.claim_id)
+        form_type = token.get(MetaDataConstants.FORM_TYPE.claim_id)
         if ru_ref and collection_exercise_sid and eq_id and form_type:
             return collection_exercise_sid, eq_id, form_type, ru_ref
         else:

--- a/app/dev_mode/templates/dev-page.html
+++ b/app/dev_mode/templates/dev-page.html
@@ -7,7 +7,7 @@
       <form action="" method="POST" xmlns="http://www.w3.org/1999/html">
         <p>
           User ID:
-          <input name="{{UserConstants.USER_ID}}" type="text" value="{{user}}" class="qa-user-id">
+          <input name="{{MetaDataConstants.USER_ID.claim_id}}" type="text" value="{{user}}" class="qa-user-id">
         </p>
         <p>
           Schemas:
@@ -23,43 +23,43 @@
         </p>
         <p>
           Period String:
-          <input name="{{UserConstants.PERIOD_STR}}" type="text" value="May 2016">
+          <input name="{{MetaDataConstants.PERIOD_STR.claim_id}}" type="text" value="May 2016">
         </p>
         <p>
           Period ID:
-          <input name="{{UserConstants.PERIOD_ID}}" type="text" value="201605">
+          <input name="{{MetaDataConstants.PERIOD_ID.claim_id}}" type="text" value="201605">
         </p>
         <p>
           Collection Exercise SID:
-          <input name="{{UserConstants.COLLECTION_EXERCISE_SID}}" type="text" value="789">
+          <input name="{{MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id}}" type="text" value="789">
         </p>
         <p>
           RU REF:
-          <input name="{{UserConstants.RU_REF}}" type="text" value="12346789012A">
+          <input name="{{MetaDataConstants.RU_REF.claim_id}}" type="text" value="12346789012A">
         </p>
         <p>
           RU NAME:
-          <input name="{{UserConstants.RU_NAME}}" type="text" value="Apple">
+          <input name="{{MetaDataConstants.RU_NAME.claim_id}}" type="text" value="Apple">
         </p>
         <p>
           REF P Start Date:
-          <input name="{{UserConstants.REF_P_START_DATE}}" type="text" value="2016-05-01">
+          <input name="{{MetaDataConstants.REF_P_START_DATE.claim_id}}" type="text" value="2016-05-01">
         </p>
         <p>
           REF P End Date:
-          <input name="{{UserConstants.REF_P_END_DATE}}" type="text" value="2016-05-31">
+          <input name="{{MetaDataConstants.REF_P_END_DATE.claim_id}}" type="text" value="2016-05-31">
         </p>
         <p>
           RETURN BY:
-          <input name="{{UserConstants.RETURN_BY}}" type="text" value="2016-06-12">
+          <input name="{{MetaDataConstants.RETURN_BY.claim_id}}" type="text" value="2016-06-12">
         </p>
         <p>
           TRAD AS:
-          <input name="{{UserConstants.TRAD_AS}}" type="text" value="Apple">
+          <input name="{{MetaDataConstants.TRAD_AS.claim_id}}" type="text" value="Apple">
         </p>
         <p>
           EMPLOYMENT_DATE:
-          <input name="{{UserConstants.EMPLOYMENT_DATE}}" type="text" value="2016-06-10">
+          <input name="{{MetaDataConstants.EMPLOYMENT_DATE.claim_id}}" type="text" value="2016-06-10">
         </p>
         <input type="submit" value="submit" class="qa-btn-submit-dev"/>
       </form>

--- a/app/dev_mode/views.py
+++ b/app/dev_mode/views.py
@@ -16,20 +16,20 @@ logger = logging.getLogger(__name__)
 def dev_mode():
     if request.method == "POST":
         form = request.form
-        user = form.get(MetaDataConstants.USER_ID)
+        user = form.get(MetaDataConstants.USER_ID.claim_id)
         exp_time = form.get("exp")
         schema = form.get("schema")
         eq_id, form_type = extract_eq_id_and_form_type(schema)
-        period_str = form.get(MetaDataConstants.PERIOD_STR)
-        period_id = form.get(MetaDataConstants.PERIOD_ID)
-        collection_exercise_sid = form.get(MetaDataConstants.COLLECTION_EXERCISE_SID)
-        ref_p_start_date = form.get(MetaDataConstants.REF_P_START_DATE)
-        ref_p_end_date = form.get(MetaDataConstants.REF_P_END_DATE)
-        ru_ref = form.get(MetaDataConstants.RU_REF)
-        ru_name = form.get(MetaDataConstants.RU_NAME)
-        trad_as = form.get(MetaDataConstants.TRAD_AS)
-        return_by = form.get(MetaDataConstants.RETURN_BY)
-        employment_date = form.get(MetaDataConstants.EMPLOYMENT_DATE)
+        period_str = form.get(MetaDataConstants.PERIOD_STR.claim_id)
+        period_id = form.get(MetaDataConstants.PERIOD_ID.claim_id)
+        collection_exercise_sid = form.get(MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id)
+        ref_p_start_date = form.get(MetaDataConstants.REF_P_START_DATE.claim_id)
+        ref_p_end_date = form.get(MetaDataConstants.REF_P_END_DATE.claim_id)
+        ru_ref = form.get(MetaDataConstants.RU_REF.claim_id)
+        ru_name = form.get(MetaDataConstants.RU_NAME.claim_id)
+        trad_as = form.get(MetaDataConstants.TRAD_AS.claim_id)
+        return_by = form.get(MetaDataConstants.RETURN_BY.claim_id)
+        employment_date = form.get(MetaDataConstants.EMPLOYMENT_DATE.claim_id)
         payload = create_payload(user, exp_time, eq_id, period_str, period_id, form_type, collection_exercise_sid,
                                  ref_p_start_date, ref_p_end_date, ru_ref, ru_name, trad_as, return_by, employment_date)
         return redirect("/session?token=" + generate_token(payload).decode())
@@ -68,21 +68,21 @@ def create_payload(user, exp_time, eq_id, period_str, period_id, form_type, coll
     iat = time.time()
     exp = time.time() + float(exp_time)
     return {
-            MetaDataConstants.USER_ID: user,
+            MetaDataConstants.USER_ID.claim_id: user,
             'iat': str(int(iat)),
             'exp': str(int(exp)),
-            MetaDataConstants.EQ_ID: eq_id,
-            MetaDataConstants.PERIOD_STR: period_str,
-            MetaDataConstants.PERIOD_ID: period_id,
-            MetaDataConstants.FORM_TYPE: form_type,
-            MetaDataConstants.COLLECTION_EXERCISE_SID: collection_exercise_sid,
-            MetaDataConstants.REF_P_START_DATE: ref_p_start_date,
-            MetaDataConstants.REF_P_END_DATE: ref_p_end_date,
-            MetaDataConstants.RU_REF: ru_ref,
-            MetaDataConstants.RU_NAME: ru_name,
-            MetaDataConstants.RETURN_BY: return_by,
-            MetaDataConstants.TRAD_AS: trad_as,
-            MetaDataConstants.EMPLOYMENT_DATE: employment_date}
+            MetaDataConstants.EQ_ID.claim_id: eq_id,
+            MetaDataConstants.PERIOD_STR.claim_id: period_str,
+            MetaDataConstants.PERIOD_ID.claim_id: period_id,
+            MetaDataConstants.FORM_TYPE.claim_id: form_type,
+            MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id: collection_exercise_sid,
+            MetaDataConstants.REF_P_START_DATE.claim_id: ref_p_start_date,
+            MetaDataConstants.REF_P_END_DATE.claim_id: ref_p_end_date,
+            MetaDataConstants.RU_REF.claim_id: ru_ref,
+            MetaDataConstants.RU_NAME.claim_id: ru_name,
+            MetaDataConstants.RETURN_BY.claim_id: return_by,
+            MetaDataConstants.TRAD_AS.claim_id: trad_as,
+            MetaDataConstants.EMPLOYMENT_DATE.claim_id: employment_date}
 
 
 def generate_token(payload):

--- a/app/dev_mode/views.py
+++ b/app/dev_mode/views.py
@@ -34,7 +34,7 @@ def dev_mode():
                                  ref_p_start_date, ref_p_end_date, ru_ref, ru_name, trad_as, return_by, employment_date)
         return redirect("/session?token=" + generate_token(payload).decode())
     else:
-        return render_template("dev-page.html", user=os.getenv('USER', 'UNKNOWN'), UserConstants=MetaDataConstants,
+        return render_template("dev-page.html", user=os.getenv('USER', 'UNKNOWN'), MetaDataConstants=MetaDataConstants,
                                available_schemas=available_schemas())
 
 

--- a/tests/app/authentication/test_user_id_generator.py
+++ b/tests/app/authentication/test_user_id_generator.py
@@ -88,10 +88,10 @@ class TestUserIDGenerator(unittest.TestCase):
 
     def create_token(self, eq_id, collection_exercise_sid, ru_ref, form_type):
         return {
-                MetaDataConstants.EQ_ID: eq_id,
-                MetaDataConstants.COLLECTION_EXERCISE_SID: collection_exercise_sid,
-                MetaDataConstants.RU_REF: ru_ref,
-                MetaDataConstants.FORM_TYPE: form_type}
+                MetaDataConstants.EQ_ID.claim_id: eq_id,
+                MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id: collection_exercise_sid,
+                MetaDataConstants.RU_REF.claim_id: ru_ref,
+                MetaDataConstants.FORM_TYPE.claim_id: form_type}
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/app/metadata/test_metadata_store.py
+++ b/tests/app/metadata/test_metadata_store.py
@@ -11,17 +11,17 @@ class TestMetadataStore(SurveyRunnerTestCase):
     def setUp(self):
         super().setUp()
         self.jwt = {
-            MetaDataConstants.USER_ID: "1",
-            MetaDataConstants.FORM_TYPE: "a",
-            MetaDataConstants.COLLECTION_EXERCISE_SID: "test-sid",
-            MetaDataConstants.EQ_ID: "2",
-            MetaDataConstants.PERIOD_ID: "3",
-            MetaDataConstants.PERIOD_STR: "2016-01-01",
-            MetaDataConstants.REF_P_START_DATE: "2016-02-02",
-            MetaDataConstants.REF_P_END_DATE: "2016-03-03",
-            MetaDataConstants.RU_REF: "2016-04-04",
-            MetaDataConstants.RU_NAME: "Apple",
-            MetaDataConstants.RETURN_BY: "2016-07-07"
+            MetaDataConstants.USER_ID.claim_id: "1",
+            MetaDataConstants.FORM_TYPE.claim_id: "a",
+            MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id: "test-sid",
+            MetaDataConstants.EQ_ID.claim_id: "2",
+            MetaDataConstants.PERIOD_ID.claim_id: "3",
+            MetaDataConstants.PERIOD_STR.claim_id: "2016-01-01",
+            MetaDataConstants.REF_P_START_DATE.claim_id: "2016-02-02",
+            MetaDataConstants.REF_P_END_DATE.claim_id: "2016-03-03",
+            MetaDataConstants.RU_REF.claim_id: "2016-04-04",
+            MetaDataConstants.RU_NAME.claim_id: "Apple",
+            MetaDataConstants.RETURN_BY.claim_id: "2016-07-07"
         }
         with self.application.test_request_context():
             user = User("1", "2")
@@ -29,35 +29,35 @@ class TestMetadataStore(SurveyRunnerTestCase):
 
     def test_form_type(self):
         with self.application.test_request_context():
-            self.assertEquals(self.jwt.get(MetaDataConstants.FORM_TYPE), self.metadata_store.form_type)
+            self.assertEquals(self.jwt.get(MetaDataConstants.FORM_TYPE.claim_id), self.metadata_store.form_type)
 
     def test_collection_id(self):
         with self.application.test_request_context():
-            self.assertEquals(self.jwt.get(MetaDataConstants.COLLECTION_EXERCISE_SID), self.metadata_store.collection_exercise_sid)
+            self.assertEquals(self.jwt.get(MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id), self.metadata_store.collection_exercise_sid)
 
     def test_get_eq_id(self):
         with self.application.test_request_context():
-            self.assertEquals(self.jwt.get(MetaDataConstants.EQ_ID), self.metadata_store.eq_id)
+            self.assertEquals(self.jwt.get(MetaDataConstants.EQ_ID.claim_id), self.metadata_store.eq_id)
 
     def test_get_period_id(self):
         with self.application.test_request_context():
-            self.assertEquals(self.jwt.get(MetaDataConstants.PERIOD_ID), self.metadata_store.period_id)
+            self.assertEquals(self.jwt.get(MetaDataConstants.PERIOD_ID.claim_id), self.metadata_store.period_id)
 
     def test_get_period_str(self):
         with self.application.test_request_context():
-            self.assertEquals(self.jwt.get(MetaDataConstants.PERIOD_STR), self.metadata_store.period_str)
+            self.assertEquals(self.jwt.get(MetaDataConstants.PERIOD_STR.claim_id), self.metadata_store.period_str)
 
     def test_ref_p_start_date(self):
         with self.application.test_request_context():
-            self.assertEquals(self.jwt.get(MetaDataConstants.REF_P_START_DATE), self.metadata_store.ref_p_start_date.strftime('%Y-%m-%d'))
+            self.assertEquals(self.jwt.get(MetaDataConstants.REF_P_START_DATE.claim_id), self.metadata_store.ref_p_start_date.strftime('%Y-%m-%d'))
 
     def test_ref_p_end_date(self):
         with self.application.test_request_context():
-            self.assertEquals(self.jwt.get(MetaDataConstants.REF_P_END_DATE), self.metadata_store.ref_p_end_date.strftime('%Y-%m-%d'))
+            self.assertEquals(self.jwt.get(MetaDataConstants.REF_P_END_DATE.claim_id), self.metadata_store.ref_p_end_date.strftime('%Y-%m-%d'))
 
     def test_ru_ref(self):
         with self.application.test_request_context():
-            self.assertEquals(self.jwt.get(MetaDataConstants.REF_P_END_DATE), self.metadata_store.ref_p_end_date.strftime('%Y-%m-%d'))
+            self.assertEquals(self.jwt.get(MetaDataConstants.REF_P_END_DATE.claim_id), self.metadata_store.ref_p_end_date.strftime('%Y-%m-%d'))
 
     def test_is_valid(self):
         with self.application.test_request_context():
@@ -65,154 +65,154 @@ class TestMetadataStore(SurveyRunnerTestCase):
 
     def test_is_valid_fails_missing_user_id(self):
         jwt = {
-            MetaDataConstants.FORM_TYPE: "a",
-            MetaDataConstants.COLLECTION_EXERCISE_SID: "test-sid",
-            MetaDataConstants.EQ_ID: "2",
-            MetaDataConstants.PERIOD_ID: "3",
-            MetaDataConstants.PERIOD_STR: "2016-01-01",
-            MetaDataConstants.REF_P_START_DATE: "2016-02-02",
-            MetaDataConstants.REF_P_END_DATE: "2016-03-03",
-            MetaDataConstants.RU_REF: "2016-04-04",
-            MetaDataConstants.RU_NAME: "Apple",
-            MetaDataConstants.RETURN_BY: "2016-07-07"
+            MetaDataConstants.FORM_TYPE.claim_id: "a",
+            MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id: "test-sid",
+            MetaDataConstants.EQ_ID.claim_id: "2",
+            MetaDataConstants.PERIOD_ID.claim_id: "3",
+            MetaDataConstants.PERIOD_STR.claim_id: "2016-01-01",
+            MetaDataConstants.REF_P_START_DATE.claim_id: "2016-02-02",
+            MetaDataConstants.REF_P_END_DATE.claim_id: "2016-03-03",
+            MetaDataConstants.RU_REF.claim_id: "2016-04-04",
+            MetaDataConstants.RU_NAME.claim_id: "Apple",
+            MetaDataConstants.RETURN_BY.claim_id: "2016-07-07"
         }
         valid, reason = MetaDataStore.is_valid(jwt)
         self.assertFalse(valid)
-        self.assertEquals(MetaDataConstants.USER_ID, reason)
+        self.assertEquals(MetaDataConstants.USER_ID.claim_id, reason)
 
     def test_is_valid_fails_missing_form_type(self):
         jwt = {
-            MetaDataConstants.USER_ID: "1",
-            MetaDataConstants.FORM_TYPE: "a",
-            MetaDataConstants.COLLECTION_EXERCISE_SID: "test-sid",
-            MetaDataConstants.EQ_ID: "2",
-            MetaDataConstants.PERIOD_ID: "3",
-            MetaDataConstants.PERIOD_STR: "2016-01-01",
-            MetaDataConstants.REF_P_START_DATE: "2016-02-02",
-            MetaDataConstants.REF_P_END_DATE: "2016-03-03",
-            MetaDataConstants.RU_REF: "2016-04-04",
-            MetaDataConstants.RU_NAME: "Apple",
-            MetaDataConstants.RETURN_BY: "2016-07-07"
+            MetaDataConstants.USER_ID.claim_id: "1",
+            MetaDataConstants.FORM_TYPE.claim_id: "a",
+            MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id: "test-sid",
+            MetaDataConstants.EQ_ID.claim_id: "2",
+            MetaDataConstants.PERIOD_ID.claim_id: "3",
+            MetaDataConstants.PERIOD_STR.claim_id: "2016-01-01",
+            MetaDataConstants.REF_P_START_DATE.claim_id: "2016-02-02",
+            MetaDataConstants.REF_P_END_DATE.claim_id: "2016-03-03",
+            MetaDataConstants.RU_REF.claim_id: "2016-04-04",
+            MetaDataConstants.RU_NAME.claim_id: "Apple",
+            MetaDataConstants.RETURN_BY.claim_id: "2016-07-07"
         }
         valid, reason = MetaDataStore.is_valid(jwt)
         self.assertFalse(valid)
-        self.assertEquals(MetaDataConstants.FORM_TYPE, reason)
+        self.assertEquals(MetaDataConstants.FORM_TYPE.claim_id, reason)
 
     def test_is_valid_fails_missing_form_type(self):
         jwt = {
-            MetaDataConstants.USER_ID: "1",
-            MetaDataConstants.COLLECTION_EXERCISE_SID: "test-sid",
-            MetaDataConstants.EQ_ID: "2",
-            MetaDataConstants.PERIOD_ID: "3",
-            MetaDataConstants.PERIOD_STR: "2016-01-01",
-            MetaDataConstants.REF_P_START_DATE: "2016-02-02",
-            MetaDataConstants.REF_P_END_DATE: "2016-03-03",
-            MetaDataConstants.RU_REF: "2016-04-04",
-            MetaDataConstants.RU_NAME: "Apple",
-            MetaDataConstants.RETURN_BY: "2016-07-07"
+            MetaDataConstants.USER_ID.claim_id: "1",
+            MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id: "test-sid",
+            MetaDataConstants.EQ_ID.claim_id: "2",
+            MetaDataConstants.PERIOD_ID.claim_id: "3",
+            MetaDataConstants.PERIOD_STR.claim_id: "2016-01-01",
+            MetaDataConstants.REF_P_START_DATE.claim_id: "2016-02-02",
+            MetaDataConstants.REF_P_END_DATE.claim_id: "2016-03-03",
+            MetaDataConstants.RU_REF.claim_id: "2016-04-04",
+            MetaDataConstants.RU_NAME.claim_id: "Apple",
+            MetaDataConstants.RETURN_BY.claim_id: "2016-07-07"
         }
         valid, reason = MetaDataStore.is_valid(jwt)
         self.assertFalse(valid)
-        self.assertEquals(MetaDataConstants.FORM_TYPE, reason)
+        self.assertEquals(MetaDataConstants.FORM_TYPE.claim_id, reason)
 
     def test_is_valid_fails_missing_collection_exercise_sid(self):
         jwt = {
-            MetaDataConstants.USER_ID: "1",
-            MetaDataConstants.FORM_TYPE: "a",
-            MetaDataConstants.EQ_ID: "2",
-            MetaDataConstants.PERIOD_ID: "3",
-            MetaDataConstants.PERIOD_STR: "2016-01-01",
-            MetaDataConstants.REF_P_START_DATE: "2016-02-02",
-            MetaDataConstants.REF_P_END_DATE: "2016-03-03",
-            MetaDataConstants.RU_REF: "2016-04-04",
-            MetaDataConstants.RU_NAME: "Apple",
-            MetaDataConstants.RETURN_BY: "2016-07-07"
+            MetaDataConstants.USER_ID.claim_id: "1",
+            MetaDataConstants.FORM_TYPE.claim_id: "a",
+            MetaDataConstants.EQ_ID.claim_id: "2",
+            MetaDataConstants.PERIOD_ID.claim_id: "3",
+            MetaDataConstants.PERIOD_STR.claim_id: "2016-01-01",
+            MetaDataConstants.REF_P_START_DATE.claim_id: "2016-02-02",
+            MetaDataConstants.REF_P_END_DATE.claim_id: "2016-03-03",
+            MetaDataConstants.RU_REF.claim_id: "2016-04-04",
+            MetaDataConstants.RU_NAME.claim_id: "Apple",
+            MetaDataConstants.RETURN_BY.claim_id: "2016-07-07"
         }
         valid, reason = MetaDataStore.is_valid(jwt)
         self.assertFalse(valid)
-        self.assertEquals(MetaDataConstants.COLLECTION_EXERCISE_SID, reason)
+        self.assertEquals(MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id, reason)
 
     def test_is_valid_fails_missing_eq_id(self):
         jwt = {
-            MetaDataConstants.USER_ID: "1",
-            MetaDataConstants.FORM_TYPE: "a",
-            MetaDataConstants.COLLECTION_EXERCISE_SID: "test-sid",
-            MetaDataConstants.PERIOD_ID: "3",
-            MetaDataConstants.PERIOD_STR: "2016-01-01",
-            MetaDataConstants.REF_P_START_DATE: "2016-02-02",
-            MetaDataConstants.REF_P_END_DATE: "2016-03-03",
-            MetaDataConstants.RU_REF: "2016-04-04",
-            MetaDataConstants.RU_NAME: "Apple",
-            MetaDataConstants.RETURN_BY: "2016-07-07"
+            MetaDataConstants.USER_ID.claim_id: "1",
+            MetaDataConstants.FORM_TYPE.claim_id: "a",
+            MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id: "test-sid",
+            MetaDataConstants.PERIOD_ID.claim_id: "3",
+            MetaDataConstants.PERIOD_STR.claim_id: "2016-01-01",
+            MetaDataConstants.REF_P_START_DATE.claim_id: "2016-02-02",
+            MetaDataConstants.REF_P_END_DATE.claim_id: "2016-03-03",
+            MetaDataConstants.RU_REF.claim_id: "2016-04-04",
+            MetaDataConstants.RU_NAME.claim_id: "Apple",
+            MetaDataConstants.RETURN_BY.claim_id: "2016-07-07"
         }
         valid, reason = MetaDataStore.is_valid(jwt)
         self.assertFalse(valid)
-        self.assertEquals(MetaDataConstants.EQ_ID, reason)
+        self.assertEquals(MetaDataConstants.EQ_ID.claim_id, reason)
 
     def test_is_valid_fails_missing_period_id(self):
         jwt = {
-            MetaDataConstants.USER_ID: "1",
-            MetaDataConstants.FORM_TYPE: "a",
-            MetaDataConstants.COLLECTION_EXERCISE_SID: "test-sid",
-            MetaDataConstants.EQ_ID: "2",
-            MetaDataConstants.PERIOD_STR: "2016-01-01",
-            MetaDataConstants.REF_P_START_DATE: "2016-02-02",
-            MetaDataConstants.REF_P_END_DATE: "2016-03-03",
-            MetaDataConstants.RU_REF: "2016-04-04",
-            MetaDataConstants.RU_NAME: "Apple",
-            MetaDataConstants.RETURN_BY: "2016-07-07"
+            MetaDataConstants.USER_ID.claim_id: "1",
+            MetaDataConstants.FORM_TYPE.claim_id: "a",
+            MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id: "test-sid",
+            MetaDataConstants.EQ_ID.claim_id: "2",
+            MetaDataConstants.PERIOD_STR.claim_id: "2016-01-01",
+            MetaDataConstants.REF_P_START_DATE.claim_id: "2016-02-02",
+            MetaDataConstants.REF_P_END_DATE.claim_id: "2016-03-03",
+            MetaDataConstants.RU_REF.claim_id: "2016-04-04",
+            MetaDataConstants.RU_NAME.claim_id: "Apple",
+            MetaDataConstants.RETURN_BY.claim_id: "2016-07-07"
         }
         valid, reason = MetaDataStore.is_valid(jwt)
         self.assertFalse(valid)
-        self.assertEquals(MetaDataConstants.PERIOD_ID, reason)
+        self.assertEquals(MetaDataConstants.PERIOD_ID.claim_id, reason)
 
     def test_is_valid_fails_missing_period_str(self):
         jwt = {
-            MetaDataConstants.USER_ID: "1",
-            MetaDataConstants.FORM_TYPE: "a",
-            MetaDataConstants.COLLECTION_EXERCISE_SID: "test-sid",
-            MetaDataConstants.EQ_ID: "2",
-            MetaDataConstants.PERIOD_ID: "3",
-            MetaDataConstants.REF_P_START_DATE: "2016-02-02",
-            MetaDataConstants.REF_P_END_DATE: "2016-03-03",
-            MetaDataConstants.RU_REF: "2016-04-04",
-            MetaDataConstants.RU_NAME: "Apple",
-            MetaDataConstants.RETURN_BY: "2016-07-07"
+            MetaDataConstants.USER_ID.claim_id: "1",
+            MetaDataConstants.FORM_TYPE.claim_id: "a",
+            MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id: "test-sid",
+            MetaDataConstants.EQ_ID.claim_id: "2",
+            MetaDataConstants.PERIOD_ID.claim_id: "3",
+            MetaDataConstants.REF_P_START_DATE.claim_id: "2016-02-02",
+            MetaDataConstants.REF_P_END_DATE.claim_id: "2016-03-03",
+            MetaDataConstants.RU_REF.claim_id: "2016-04-04",
+            MetaDataConstants.RU_NAME.claim_id: "Apple",
+            MetaDataConstants.RETURN_BY.claim_id: "2016-07-07"
         }
         valid, reason = MetaDataStore.is_valid(jwt)
         self.assertFalse(valid)
-        self.assertEquals(MetaDataConstants.PERIOD_STR, reason)
+        self.assertEquals(MetaDataConstants.PERIOD_STR.claim_id, reason)
 
     def test_is_valid_fails_missing_ref_p_start_date(self):
         jwt = {
-            MetaDataConstants.USER_ID: "1",
-            MetaDataConstants.FORM_TYPE: "a",
-            MetaDataConstants.COLLECTION_EXERCISE_SID: "test-sid",
-            MetaDataConstants.EQ_ID: "2",
-            MetaDataConstants.PERIOD_ID: "3",
-            MetaDataConstants.PERIOD_STR: "2016-01-01",
-            MetaDataConstants.REF_P_END_DATE: "2016-03-03",
-            MetaDataConstants.RU_REF: "2016-04-04",
-            MetaDataConstants.RU_NAME: "Apple",
-            MetaDataConstants.RETURN_BY: "2016-07-07"
+            MetaDataConstants.USER_ID.claim_id: "1",
+            MetaDataConstants.FORM_TYPE.claim_id: "a",
+            MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id: "test-sid",
+            MetaDataConstants.EQ_ID.claim_id: "2",
+            MetaDataConstants.PERIOD_ID.claim_id: "3",
+            MetaDataConstants.PERIOD_STR.claim_id: "2016-01-01",
+            MetaDataConstants.REF_P_END_DATE.claim_id: "2016-03-03",
+            MetaDataConstants.RU_REF.claim_id: "2016-04-04",
+            MetaDataConstants.RU_NAME.claim_id: "Apple",
+            MetaDataConstants.RETURN_BY.claim_id: "2016-07-07"
         }
         valid, reason = MetaDataStore.is_valid(jwt)
         self.assertFalse(valid)
-        self.assertEquals(MetaDataConstants.REF_P_START_DATE, reason)
+        self.assertEquals(MetaDataConstants.REF_P_START_DATE.claim_id, reason)
 
     def test_is_valid_fails_invalid_ref_p_start_date(self):
         jwt = {
-            MetaDataConstants.USER_ID: "1",
-            MetaDataConstants.FORM_TYPE: "a",
-            MetaDataConstants.COLLECTION_EXERCISE_SID: "test-sid",
-            MetaDataConstants.EQ_ID: "2",
-            MetaDataConstants.PERIOD_ID: "3",
-            MetaDataConstants.PERIOD_STR: "2016-01-01",
-            MetaDataConstants.REF_P_START_DATE: "2016-13-31",
-            MetaDataConstants.REF_P_END_DATE: "2016-03-03",
-            MetaDataConstants.RU_REF: "2016-04-04",
-            MetaDataConstants.RU_NAME: "Apple",
-            MetaDataConstants.RETURN_BY: "2016-07-07"
+            MetaDataConstants.USER_ID.claim_id: "1",
+            MetaDataConstants.FORM_TYPE.claim_id: "a",
+            MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id: "test-sid",
+            MetaDataConstants.EQ_ID.claim_id: "2",
+            MetaDataConstants.PERIOD_ID.claim_id: "3",
+            MetaDataConstants.PERIOD_STR.claim_id: "2016-01-01",
+            MetaDataConstants.REF_P_START_DATE.claim_id: "2016-13-31",
+            MetaDataConstants.REF_P_END_DATE.claim_id: "2016-03-03",
+            MetaDataConstants.RU_REF.claim_id: "2016-04-04",
+            MetaDataConstants.RU_NAME.claim_id: "Apple",
+            MetaDataConstants.RETURN_BY.claim_id: "2016-07-07"
         }
         valid, reason = MetaDataStore.is_valid(jwt)
         self.assertTrue(valid)
@@ -222,17 +222,17 @@ class TestMetadataStore(SurveyRunnerTestCase):
 
     def test_is_valid_fails_invalid_ref_p_end_date(self):
         jwt = {
-            MetaDataConstants.USER_ID: "1",
-            MetaDataConstants.FORM_TYPE: "a",
-            MetaDataConstants.COLLECTION_EXERCISE_SID: "test-sid",
-            MetaDataConstants.EQ_ID: "2",
-            MetaDataConstants.PERIOD_ID: "3",
-            MetaDataConstants.PERIOD_STR: "2016-01-01",
-            MetaDataConstants.REF_P_START_DATE: "2016-12-31",
-            MetaDataConstants.REF_P_END_DATE: "2016-04-31",
-            MetaDataConstants.RU_REF: "2016-04-04",
-            MetaDataConstants.RU_NAME: "Apple",
-            MetaDataConstants.RETURN_BY: "2016-07-07"
+            MetaDataConstants.USER_ID.claim_id: "1",
+            MetaDataConstants.FORM_TYPE.claim_id: "a",
+            MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id: "test-sid",
+            MetaDataConstants.EQ_ID.claim_id: "2",
+            MetaDataConstants.PERIOD_ID.claim_id: "3",
+            MetaDataConstants.PERIOD_STR.claim_id: "2016-01-01",
+            MetaDataConstants.REF_P_START_DATE.claim_id: "2016-12-31",
+            MetaDataConstants.REF_P_END_DATE.claim_id: "2016-04-31",
+            MetaDataConstants.RU_REF.claim_id: "2016-04-04",
+            MetaDataConstants.RU_NAME.claim_id: "Apple",
+            MetaDataConstants.RETURN_BY.claim_id: "2016-07-07"
         }
         valid, reason = MetaDataStore.is_valid(jwt)
         self.assertTrue(valid)
@@ -242,17 +242,17 @@ class TestMetadataStore(SurveyRunnerTestCase):
 
     def test_is_valid_fails_invalid_return_by(self):
         jwt = {
-            MetaDataConstants.USER_ID: "1",
-            MetaDataConstants.FORM_TYPE: "a",
-            MetaDataConstants.COLLECTION_EXERCISE_SID: "test-sid",
-            MetaDataConstants.EQ_ID: "2",
-            MetaDataConstants.PERIOD_ID: "3",
-            MetaDataConstants.PERIOD_STR: "2016-01-01",
-            MetaDataConstants.REF_P_START_DATE: "2016-12-31",
-            MetaDataConstants.REF_P_END_DATE: "2016-03-31",
-            MetaDataConstants.RU_REF: "2016-04-04",
-            MetaDataConstants.RU_NAME: "Apple",
-            MetaDataConstants.RETURN_BY: "2016-09-31"
+            MetaDataConstants.USER_ID.claim_id: "1",
+            MetaDataConstants.FORM_TYPE.claim_id: "a",
+            MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id: "test-sid",
+            MetaDataConstants.EQ_ID.claim_id: "2",
+            MetaDataConstants.PERIOD_ID.claim_id: "3",
+            MetaDataConstants.PERIOD_STR.claim_id: "2016-01-01",
+            MetaDataConstants.REF_P_START_DATE.claim_id: "2016-12-31",
+            MetaDataConstants.REF_P_END_DATE.claim_id: "2016-03-31",
+            MetaDataConstants.RU_REF.claim_id: "2016-04-04",
+            MetaDataConstants.RU_NAME.claim_id: "Apple",
+            MetaDataConstants.RETURN_BY.claim_id: "2016-09-31"
         }
         valid, reason = MetaDataStore.is_valid(jwt)
         self.assertTrue(valid)
@@ -262,86 +262,86 @@ class TestMetadataStore(SurveyRunnerTestCase):
 
     def test_is_valid_fails_missing_ref_p_end_date(self):
         jwt = {
-            MetaDataConstants.USER_ID: "1",
-            MetaDataConstants.FORM_TYPE: "a",
-            MetaDataConstants.COLLECTION_EXERCISE_SID: "test-sid",
-            MetaDataConstants.EQ_ID: "2",
-            MetaDataConstants.PERIOD_ID: "3",
-            MetaDataConstants.PERIOD_STR: "2016-01-01",
-            MetaDataConstants.REF_P_START_DATE: "2016-02-02",
-            MetaDataConstants.RU_REF: "2016-04-04",
-            MetaDataConstants.RU_NAME: "Apple",
-            MetaDataConstants.RETURN_BY: "2016-07-07"
+            MetaDataConstants.USER_ID.claim_id: "1",
+            MetaDataConstants.FORM_TYPE.claim_id: "a",
+            MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id: "test-sid",
+            MetaDataConstants.EQ_ID.claim_id: "2",
+            MetaDataConstants.PERIOD_ID.claim_id: "3",
+            MetaDataConstants.PERIOD_STR.claim_id: "2016-01-01",
+            MetaDataConstants.REF_P_START_DATE.claim_id: "2016-02-02",
+            MetaDataConstants.RU_REF.claim_id: "2016-04-04",
+            MetaDataConstants.RU_NAME.claim_id: "Apple",
+            MetaDataConstants.RETURN_BY.claim_id: "2016-07-07"
         }
         valid, reason = MetaDataStore.is_valid(jwt)
         self.assertFalse(valid)
-        self.assertEquals(MetaDataConstants.REF_P_END_DATE, reason)
+        self.assertEquals(MetaDataConstants.REF_P_END_DATE.claim_id, reason)
 
     def test_is_valid_fails_missing_ru_ref(self):
         jwt = {
-            MetaDataConstants.USER_ID: "1",
-            MetaDataConstants.FORM_TYPE: "a",
-            MetaDataConstants.COLLECTION_EXERCISE_SID: "test-sid",
-            MetaDataConstants.EQ_ID: "2",
-            MetaDataConstants.PERIOD_ID: "3",
-            MetaDataConstants.PERIOD_STR: "2016-01-01",
-            MetaDataConstants.REF_P_START_DATE: "2016-02-02",
-            MetaDataConstants.REF_P_END_DATE: "2016-03-03",
-            MetaDataConstants.RU_NAME: "Apple",
-            MetaDataConstants.RETURN_BY: "2016-07-07"
+            MetaDataConstants.USER_ID.claim_id: "1",
+            MetaDataConstants.FORM_TYPE.claim_id: "a",
+            MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id: "test-sid",
+            MetaDataConstants.EQ_ID.claim_id: "2",
+            MetaDataConstants.PERIOD_ID.claim_id: "3",
+            MetaDataConstants.PERIOD_STR.claim_id: "2016-01-01",
+            MetaDataConstants.REF_P_START_DATE.claim_id: "2016-02-02",
+            MetaDataConstants.REF_P_END_DATE.claim_id: "2016-03-03",
+            MetaDataConstants.RU_NAME.claim_id: "Apple",
+            MetaDataConstants.RETURN_BY.claim_id: "2016-07-07"
         }
         valid, reason = MetaDataStore.is_valid(jwt)
         self.assertFalse(valid)
-        self.assertEquals(MetaDataConstants.RU_REF, reason)
+        self.assertEquals(MetaDataConstants.RU_REF.claim_id, reason)
 
     def test_is_valid_fails_missing_ru_name(self):
         jwt = {
-            MetaDataConstants.USER_ID: "1",
-            MetaDataConstants.FORM_TYPE: "a",
-            MetaDataConstants.COLLECTION_EXERCISE_SID: "test-sid",
-            MetaDataConstants.EQ_ID: "2",
-            MetaDataConstants.PERIOD_ID: "3",
-            MetaDataConstants.PERIOD_STR: "2016-01-01",
-            MetaDataConstants.REF_P_START_DATE: "2016-02-02",
-            MetaDataConstants.REF_P_END_DATE: "2016-03-03",
-            MetaDataConstants.RU_REF: "2016-04-04",
-            MetaDataConstants.RETURN_BY: "2016-07-07"
+            MetaDataConstants.USER_ID.claim_id: "1",
+            MetaDataConstants.FORM_TYPE.claim_id: "a",
+            MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id: "test-sid",
+            MetaDataConstants.EQ_ID.claim_id: "2",
+            MetaDataConstants.PERIOD_ID.claim_id: "3",
+            MetaDataConstants.PERIOD_STR.claim_id: "2016-01-01",
+            MetaDataConstants.REF_P_START_DATE.claim_id: "2016-02-02",
+            MetaDataConstants.REF_P_END_DATE.claim_id: "2016-03-03",
+            MetaDataConstants.RU_REF.claim_id: "2016-04-04",
+            MetaDataConstants.RETURN_BY.claim_id: "2016-07-07"
         }
         valid, reason = MetaDataStore.is_valid(jwt)
         self.assertFalse(valid)
-        self.assertEquals(MetaDataConstants.RU_NAME, reason)
+        self.assertEquals(MetaDataConstants.RU_NAME.claim_id, reason)
 
     def test_is_valid_fails_missing_return_by(self):
         jwt = {
-            MetaDataConstants.USER_ID: "1",
-            MetaDataConstants.FORM_TYPE: "a",
-            MetaDataConstants.COLLECTION_EXERCISE_SID: "test-sid",
-            MetaDataConstants.EQ_ID: "2",
-            MetaDataConstants.PERIOD_ID: "3",
-            MetaDataConstants.PERIOD_STR: "2016-01-01",
-            MetaDataConstants.REF_P_START_DATE: "2016-02-02",
-            MetaDataConstants.REF_P_END_DATE: "2016-03-03",
-            MetaDataConstants.RU_REF: "2016-04-04",
-            MetaDataConstants.RU_NAME: "Apple"
+            MetaDataConstants.USER_ID.claim_id: "1",
+            MetaDataConstants.FORM_TYPE.claim_id: "a",
+            MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id: "test-sid",
+            MetaDataConstants.EQ_ID.claim_id: "2",
+            MetaDataConstants.PERIOD_ID.claim_id: "3",
+            MetaDataConstants.PERIOD_STR.claim_id: "2016-01-01",
+            MetaDataConstants.REF_P_START_DATE.claim_id: "2016-02-02",
+            MetaDataConstants.REF_P_END_DATE.claim_id: "2016-03-03",
+            MetaDataConstants.RU_REF.claim_id: "2016-04-04",
+            MetaDataConstants.RU_NAME.claim_id: "Apple"
         }
         valid, reason = MetaDataStore.is_valid(jwt)
         self.assertFalse(valid)
-        self.assertEquals(MetaDataConstants.RETURN_BY, reason)
+        self.assertEquals(MetaDataConstants.RETURN_BY.claim_id, reason)
 
     def test_is_valid_does_not_fail_missing_optional_value_in_token(self):
         # Both trad_as and employment_date are optional and might not be in the token
         jwt = {
-            MetaDataConstants.USER_ID: "1",
-            MetaDataConstants.FORM_TYPE: "a",
-            MetaDataConstants.COLLECTION_EXERCISE_SID: "test-sid",
-            MetaDataConstants.EQ_ID: "2",
-            MetaDataConstants.PERIOD_ID: "3",
-            MetaDataConstants.PERIOD_STR: "2016-01-01",
-            MetaDataConstants.REF_P_START_DATE: "2016-02-02",
-            MetaDataConstants.REF_P_END_DATE: "2016-03-03",
-            MetaDataConstants.RU_REF: "2016-04-04",
-            MetaDataConstants.RU_NAME: "Apple",
-            MetaDataConstants.RETURN_BY: "2016-07-07"
+            MetaDataConstants.USER_ID.claim_id: "1",
+            MetaDataConstants.FORM_TYPE.claim_id: "a",
+            MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id: "test-sid",
+            MetaDataConstants.EQ_ID.claim_id: "2",
+            MetaDataConstants.PERIOD_ID.claim_id: "3",
+            MetaDataConstants.PERIOD_STR.claim_id: "2016-01-01",
+            MetaDataConstants.REF_P_START_DATE.claim_id: "2016-02-02",
+            MetaDataConstants.REF_P_END_DATE.claim_id: "2016-03-03",
+            MetaDataConstants.RU_REF.claim_id: "2016-04-04",
+            MetaDataConstants.RU_NAME.claim_id: "Apple",
+            MetaDataConstants.RETURN_BY.claim_id: "2016-07-07"
         }
         valid, reason = MetaDataStore.is_valid(jwt)
         self.assertTrue(valid)

--- a/tests/app/submitter/test_converter.py
+++ b/tests/app/submitter/test_converter.py
@@ -45,17 +45,17 @@ class TestConverter(SurveyRunnerTestCase):
             user = User("1", "2")
 
             jwt = {
-                MetaDataConstants.USER_ID: "789473423",
-                MetaDataConstants.FORM_TYPE: "0205",
-                MetaDataConstants.COLLECTION_EXERCISE_SID: "test-sid",
-                MetaDataConstants.EQ_ID: "1",
-                MetaDataConstants.PERIOD_ID: "2016-02-01",
-                MetaDataConstants.PERIOD_STR: "2016-01-01",
-                MetaDataConstants.REF_P_START_DATE: "2016-02-02",
-                MetaDataConstants.REF_P_END_DATE: "2016-03-03",
-                MetaDataConstants.RU_REF: "432423423423",
-                MetaDataConstants.RU_NAME: "Apple",
-                MetaDataConstants.RETURN_BY: "2016-07-07"
+                MetaDataConstants.USER_ID.claim_id: "789473423",
+                MetaDataConstants.FORM_TYPE.claim_id: "0205",
+                MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id: "test-sid",
+                MetaDataConstants.EQ_ID.claim_id: "1",
+                MetaDataConstants.PERIOD_ID.claim_id: "2016-02-01",
+                MetaDataConstants.PERIOD_STR.claim_id: "2016-01-01",
+                MetaDataConstants.REF_P_START_DATE.claim_id: "2016-02-02",
+                MetaDataConstants.REF_P_END_DATE.claim_id: "2016-03-03",
+                MetaDataConstants.RU_REF.claim_id: "432423423423",
+                MetaDataConstants.RU_NAME.claim_id: "Apple",
+                MetaDataConstants.RETURN_BY.claim_id: "2016-07-07"
             }
 
             metadata = MetaDataStore.save_instance(user, jwt)

--- a/tests/app/templating/test_template_pre_processor.py
+++ b/tests/app/templating/test_template_pre_processor.py
@@ -25,17 +25,17 @@ class TestTemplatePreProcessor(unittest.TestCase):
         self.navigator = MockNavigator()
         user = User("1", "2")
         jwt = {
-            MetaDataConstants.USER_ID: "1",
-            MetaDataConstants.FORM_TYPE: "a",
-            MetaDataConstants.COLLECTION_EXERCISE_SID: "test-sid",
-            MetaDataConstants.EQ_ID: "2",
-            MetaDataConstants.PERIOD_ID: "3",
-            MetaDataConstants.PERIOD_STR: "2016-01-01",
-            MetaDataConstants.REF_P_START_DATE: "2016-02-02",
-            MetaDataConstants.REF_P_END_DATE: "2016-03-03",
-            MetaDataConstants.RU_REF: "2016-04-04",
-            MetaDataConstants.RU_NAME: "Apple",
-            MetaDataConstants.RETURN_BY: "2016-07-07"
+            MetaDataConstants.USER_ID.claim_id: "1",
+            MetaDataConstants.FORM_TYPE.claim_id: "a",
+            MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id: "test-sid",
+            MetaDataConstants.EQ_ID.claim_id: "2",
+            MetaDataConstants.PERIOD_ID.claim_id: "3",
+            MetaDataConstants.PERIOD_STR.claim_id: "2016-01-01",
+            MetaDataConstants.REF_P_START_DATE.claim_id: "2016-02-02",
+            MetaDataConstants.REF_P_END_DATE.claim_id: "2016-03-03",
+            MetaDataConstants.RU_REF.claim_id: "2016-04-04",
+            MetaDataConstants.RU_NAME.claim_id: "Apple",
+            MetaDataConstants.RETURN_BY.claim_id: "2016-07-07"
         }
         self.metadata = MetaDataStore.save_instance(user, jwt)
 

--- a/tests/app/views/test_jwt_authentication.py
+++ b/tests/app/views/test_jwt_authentication.py
@@ -46,19 +46,19 @@ class FlaskClientAuthenticationTestCase(unittest.TestCase):
         iat = time.time()
         exp = time.time() + (5 * 60)
         return {
-                MetaDataConstants.USER_ID: 'jimmy',
+                MetaDataConstants.USER_ID.claim_id: 'jimmy',
                 'iat': str(int(iat)),
                 'exp': str(int(exp)),
-                MetaDataConstants.EQ_ID: '1',
-                MetaDataConstants.PERIOD_STR: '2016-01-01',
-                MetaDataConstants.PERIOD_ID: '12',
-                MetaDataConstants.FORM_TYPE: '0203',
-                MetaDataConstants.COLLECTION_EXERCISE_SID: "sid",
-                MetaDataConstants.REF_P_START_DATE: "2016-01-01",
-                MetaDataConstants.REF_P_END_DATE: "2016-09-01",
-                MetaDataConstants.RU_REF: "1234",
-                MetaDataConstants.RU_NAME: "Test",
-                MetaDataConstants.RETURN_BY: "2016-09-09"}
+                MetaDataConstants.EQ_ID.claim_id: '1',
+                MetaDataConstants.PERIOD_STR.claim_id: '2016-01-01',
+                MetaDataConstants.PERIOD_ID.claim_id: '12',
+                MetaDataConstants.FORM_TYPE.claim_id: '0203',
+                MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id: "sid",
+                MetaDataConstants.REF_P_START_DATE.claim_id: "2016-01-01",
+                MetaDataConstants.REF_P_END_DATE.claim_id: "2016-09-01",
+                MetaDataConstants.RU_REF.claim_id: "1234",
+                MetaDataConstants.RU_NAME.claim_id: "Test",
+                MetaDataConstants.RETURN_BY.claim_id: "2016-09-09"}
 
 if __name__ == '__main__':
     unittest.main()

--- a/token_generator.py
+++ b/token_generator.py
@@ -11,20 +11,20 @@ def create_payload(user):
     iat = time.time()
     exp = time.time() + EXPIRE_AFTER_SECONDS
     return {
-            MetaDataConstants.USER_ID: user,
+            MetaDataConstants.USER_ID.claim_id: user,
             'iat': str(int(iat)),
             'exp': str(int(exp)),
-            MetaDataConstants.EQ_ID: '1',
-            MetaDataConstants.PERIOD_STR: '2016-01-01',
-            MetaDataConstants.PERIOD_ID: '2016-01-01',
-            MetaDataConstants.FORM_TYPE: '0205',
-            MetaDataConstants.COLLECTION_EXERCISE_SID: "789",
-            MetaDataConstants.REF_P_START_DATE: "2016-01-01",
-            MetaDataConstants.REF_P_END_DATE: "2016-09-01",
-            MetaDataConstants.RU_REF: "12346789012A",
-            MetaDataConstants.RU_NAME: "Apple",
-            MetaDataConstants.RETURN_BY: "2016-04-30",
-            MetaDataConstants.EMPLOYMENT_DATE: "2016-06-10"}
+            MetaDataConstants.EQ_ID.claim_id: '1',
+            MetaDataConstants.PERIOD_STR.claim_id: '2016-01-01',
+            MetaDataConstants.PERIOD_ID.claim_id: '2016-01-01',
+            MetaDataConstants.FORM_TYPE.claim_id: '0205',
+            MetaDataConstants.COLLECTION_EXERCISE_SID.claim_id: "789",
+            MetaDataConstants.REF_P_START_DATE.claim_id: "2016-01-01",
+            MetaDataConstants.REF_P_END_DATE.claim_id: "2016-09-01",
+            MetaDataConstants.RU_REF.claim_id: "12346789012A",
+            MetaDataConstants.RU_NAME.claim_id: "Apple",
+            MetaDataConstants.RETURN_BY.claim_id: "2016-04-30",
+            MetaDataConstants.EMPLOYMENT_DATE.claim_id: "2016-06-10"}
 
 
 def generate_token():


### PR DESCRIPTION
### What is the context of this PR?

Refactoring MetaDataStore to use self describing items as discussed here: https://digitaleq.atlassian.net/wiki/display/EQ/Smelly+Code
### How to review
1. Complete a survey and check no functionality is broken 
- [x] Do all commits have sensible commit messages?
- [x] Is all new code unit tested?
- [x] Are there integration tests if needed?
- [x] Is there sufficient logging?
- [x] Is there documentation or is the code self-describing?
### Who worked on the PR

@warrenbailey
