### PR TITLE
Fixes issue #288 - Pipe an answer on summary page

### DIFF
--- a/app/templating/template_pre_processor.py
+++ b/app/templating/template_pre_processor.py
@@ -46,7 +46,17 @@ class TemplatePreProcessor(object):
             return 'questionnaire.html'
 
     def build_view_data(self):
-        self._augment_questionnaire()
+        # Always plumb the questionnaire
+        self._plumb_questionnaire()
+
+        # Collect the answers for all pages except the intro and thank you pages
+        current_location = self._navigator.get_current_location()
+        if current_location != 'introduction' and current_location != 'thank-you':
+            self._collect_answers()
+
+            # We only need to augment the questionnaire if we are still inside it
+            if current_location != 'summary':
+                self._augment_questionnaire()
 
         render_data = {
             "meta": {
@@ -139,31 +149,41 @@ class TemplatePreProcessor(object):
         for group in self._schema.groups:
             # We only do this for the current group...
             if self._current_group.id == group.id:
-                self._augment_item(group, errors, warnings)
+                self._collect_errors(group, errors, warnings)
                 for block in group.blocks:
                     # ...and the current block
                     if self._current_block.id == block.id:
-                        self._augment_item(block, errors, warnings)
+                        self._collect_errors(block, errors, warnings)
                         for section in block.sections:
-                            self._augment_item(section, errors, warnings)
+                            self._collect_errors(section, errors, warnings)
                             for question in section.questions:
-                                self._augment_item(question, errors, warnings)
+                                self._collect_errors(question, errors, warnings)
                                 for answer in question.answers:
-                                    self._augment_item(answer, errors, warnings)
-
-        # We need to augment all the answer objects, regardless of the current
-        # group/block as the summary page will otherwise fail
-        for answer_id in self._answer_store.get_answers().keys():
-            answer = self._schema.get_item_by_id(answer_id)
-            self._augment_answer(answer)
+                                    self._collect_errors(answer, errors, warnings)
 
         self._schema.errors = errors
         self._schema.warnings = warnings
 
-    def _augment_item(self, item, global_errors, global_warnings):
-        # Perform any plumbing of variables into displayed text
-        self._plumber.plumb_item(item)
+    def _plumb_questionnaire(self):
+        # loops through the Schema and plumbs each item it finds
+        for group in self._schema.groups:
+            self._plumber.plumb_item(group)
+            for block in group.blocks:
+                self._plumber.plumb_item(block)
+                for section in block.sections:
+                    self._plumber.plumb_item(section)
+                    for question in section.questions:
+                        self._plumber.plumb_item(question)
+                        for answer in question.answers:
+                            self._plumber.plumb_item(answer)
 
+    def _collect_answers(self):
+        # Collect all the answers and add them to the schema
+        for answer_id in self._answer_store.get_answers().keys():
+            answer = self._schema.get_item_by_id(answer_id)
+            self._augment_answer(answer)
+
+    def _collect_errors(self, item, global_errors, global_warnings):
         item.is_valid = None
         item.errors = []
         item.warnings = []

--- a/tests/app/templating/test_template_pre_processor.py
+++ b/tests/app/templating/test_template_pre_processor.py
@@ -83,7 +83,7 @@ class TestTemplatePreProcessor(unittest.TestCase):
 
         self.assertIsNone(answer_3.value)
 
-    def test_augment_item(self):
+    def test_collect_errors(self):
         # Instantiate the pre_proc using the pre-populated mock objects
         pre_proc = TemplatePreProcessor(self.schema, self.answer_store, self.validation_store, self.navigator, self.metadata)
 
@@ -99,9 +99,9 @@ class TestTemplatePreProcessor(unittest.TestCase):
             value = answer_1.is_valid
 
         # Augment the items
-        pre_proc._augment_item(answer_1, errors, warnings)
-        pre_proc._augment_item(answer_2, errors, warnings)
-        pre_proc._augment_item(answer_3, errors, warnings)
+        pre_proc._collect_errors(answer_1, errors, warnings)
+        pre_proc._collect_errors(answer_2, errors, warnings)
+        pre_proc._collect_errors(answer_3, errors, warnings)
 
         # Check the model has been augmented correctly
         self.assertTrue(answer_1.is_valid)

--- a/tests/integration/star_wars/test_piping.py
+++ b/tests/integration/star_wars/test_piping.py
@@ -207,6 +207,47 @@ class TestPiping(IntegrationTestCase):
         # Check Cheewies Age has been correctly piped into the question text
         self.assertRegexpMatches(content, "Do you really think that Chewbacca is 234 years old?")
 
+        # Our answers
+        form_data = {
+            # People in household
+            "215015b1-f87c-4740-9fd4-f01f707ef558": "Wookiees don’t place value in material rewards and refused the medal initially", # NOQA
+            "7587qe9b-f24e-4dc0-ac94-66118b896c10": "Yes",  # Yes, Chewbacca is really 234 years old
+            # User Action
+            "action[save_continue]": "Save &amp; Continue"
+        }
+
+        resp = self.client.post(second_page, data=form_data, follow_redirects=False)
+        self.assertEquals(resp.status_code, 302)
+
+        # There are no validation errors
+        self.assertRegexpMatches(resp.headers['Location'], r'\/questionnaire\/0\/789\/summary$')
+
+        summary_url = resp.headers['Location']
+
+        resp = self.client.get(summary_url, follow_redirects=False)
+        self.assertEquals(resp.status_code, 200)
+
+        # We are on the review answers page
+        content = resp.get_data(True)
+        self.check_headings(content)
+        self.assertRegexpMatches(content, '<title>Summary</title>')
+        self.assertRegexpMatches(content, '>Star Wars</')
+        self.assertRegexpMatches(content, '>Your responses<')
+        self.assertRegexpMatches(content, '(?s)How old is Chewy?.*?234')
+        self.assertRegexpMatches(content, '(?s)How many Octillions do Nasa reckon it would cost to build a death star?.*?£40')
+        self.assertRegexpMatches(content, '(?s)How hot is a lightsaver in degrees C?.*?1370')
+        self.assertRegexpMatches(content, '(?s)What animal was used to create the engine sound of the Empire\'s TIE fighters?.*?Elephant') # NOQA
+        self.assertRegexpMatches(content, '(?s)Which of these Darth Vader quotes is wrong?.*?Luke, I am your father')
+        self.assertRegexpMatches(content, '(?s)Which 3 have wielded a green lightsaber?.*?<li class="list__item">Y.*?o.*?d.*?a') # NOQA
+        self.assertRegexpMatches(content, '(?s)Which 3 appear in any of the opening crawlers?')
+        self.assertRegexpMatches(content, '(?s)When was The Empire Strikes Back released?.*?From: 28/05/1983.*?To: 29/05/1983') # NOQA
+        self.assertRegexpMatches(content, '(?s)What was the total number of Ewokes?.*?')
+        self.assertRegexpMatches(content, '(?s)Why doesn\'t Chewbacca receive a medal at the end of A New Hope?.*?Wookiees don’t place value in material rewards and refused the medal initially') # NOQA
+        # Check that the piped value appear on the summary page also
+        self.assertRegexpMatches(content, '(?s)Do you really think that Chewbacca is 234 years old?.*') # NOQA
+        self.assertRegexpMatches(content, '>Please check carefully before submission<')
+        self.assertRegexpMatches(content, '>Submit answers<')
+
     def check_headings(self, content):
         self.assertRegexpMatches(content, 'BETA')
         self.assertRegexpMatches(content, 'Survey Help')


### PR DESCRIPTION
### What is the context of this PR?

This change splits out the multiple roles of the TemplatePreProcessor into discrete functions and ensures those functions are called at the correct points in the users journey through a questionnaire.  This PR solves the issue #228 which showed that piped values were not being passed into questions when being displayed on the summary page.
### How to review

1) Checkout the branch and run the unit tests
2) Run the app and use the dev console to select the star wars survey
3) Fill in the survey and verify that Chewbaccas age is correctly displayed in the question text
4) Go to the summary page, and confirm that Chewbaccas age is _also_ displayed on the summary page
- [x] Do all commits have sensible commit messages?
- [x] Is all new code unit tested?
- [x] Are there integration tests if needed?
- [ ] Is there sufficient logging?
- [x] Is there documentation or is the code self-describing?
### Who worked on the PR

@weapdiv-david worked on this PR
