### PR TITLE
The schema files in s3 do not include form type in the file name

### DIFF
--- a/app/dev_mode/views.py
+++ b/app/dev_mode/views.py
@@ -53,7 +53,7 @@ def extract_eq_id_and_form_type(schema_name):
         else:
             # No form type associated with
             eq_id = schema_name.split(".", 1)[0]
-            form_type = "0"
+            form_type = "-1"
         logger.debug("eq-id: %s", eq_id)
         logger.debug("form_type: " + form_type)
         return eq_id, form_type

--- a/app/schema_loader/schema_loader.py
+++ b/app/schema_loader/schema_loader.py
@@ -21,7 +21,12 @@ def load_schema(eq_id, form_type):
     :return: The Schema representing in a dict
     """
     logging.debug("About to load schema for eq-id %s and form type %s", eq_id, form_type)
-    schema_key = ("{}_{}.json").format(eq_id, form_type)
+    # form type is mandatory JWT claim, but it isn't needed when getting schemas from the schema bucket
+    # in that case default it to -1 and ignore it
+    if form_type and form_type != "-1":
+        schema_key = "{}_{}.json".format(eq_id, form_type)
+    else:
+        schema_key = "{}.json".format(eq_id)
     try:
         schema_file = open(os.path.join(settings.EQ_SCHEMA_DIRECTORY, schema_key), encoding="utf8")
         return json.load(schema_file)


### PR DESCRIPTION
### What is the context of this PR?

Fixes #308 by ignore the form type when it's submitted from the dev page.
### How to review

Check you can load a schema hosted in the S3 bucket
- [ ] Do all commits have sensible commit messages?
- [ ] Is all new code unit tested?
- [ ] Are there integration tests if needed?
- [ ] Is there sufficient logging?
- [ ] Is there documentation or is the code self-describing?
### Who worked on the PR

@warrenbailey
