### PR TITLE
EQ-315 Updated question css with 'responses' renamed to 'answers'.

### DIFF
--- a/app/assets/styles/partials/components/forms/_question.scss
+++ b/app/assets/styles/partials/components/forms/_question.scss
@@ -53,11 +53,11 @@
   clear: both;
 }
 
-.question__responses {
+.question__answers {
   clear: both;
 }
 
-.question__response {
+.question__answer {
   margin: 0 0 2rem;
   &:last-of-type {
     margin-bottom: 0;

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,4 +1,5 @@
 import gulp from 'gulp'
+import gutil from 'gulp-util'
 import del from 'del'
 import plumber from 'gulp-plumber'
 import yargs from 'yargs'
@@ -25,6 +26,7 @@ gulp.task('test:a11ym', (done) => {
 
 // Process, lint, and minify Sass files
 gulp.task('build:styles', () => {
+  gutil.log('build:styles')
   styles()
 })
 
@@ -86,6 +88,7 @@ gulp.task('listen', () => {
     files: paths.styles.output
   })
   gulp.watch(paths.images.input, ['build:images'])
+  gutil.log(paths.styles.input)
   gulp.watch(paths.styles.input, ['build:styles'])
   gulp.watch([paths.scripts.input, `!${paths.scripts.dir}app/**/*`], ['copy:scripts'])
   gulp.watch(paths.templates.input).on('change', browserSync.reload)


### PR DESCRIPTION
### What is the context of this PR?
- Renaming a class in the templates had not been reflected in the CSS causing a visual regression (Fixes #315).
### How to review
- Run the app
- Check legends/labels wrap as expected
### Who worked on the PR

@hamishtaplin
