### PR TITLE
captures issue with None employment date and correctly logs exception

### DIFF
--- a/app/piping/plumber.py
+++ b/app/piping/plumber.py
@@ -1,4 +1,8 @@
 import re
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 class Plumber(object):
@@ -36,10 +40,16 @@ class Plumber(object):
         Perform the string replacement directly on the object
         '''
         if hasattr(item, templatable_property):
+            logger.debug('Piping property "{}" of item "{}"'.format(templatable_property, item.id))
             try:
                 template = getattr(item, templatable_property)
                 formatting_data = self._context
                 plumbed_value = template.format(**formatting_data)
                 setattr(item, templatable_property, plumbed_value)
             except KeyError:
+                logger.warn('Property "{}" cannot be piped'.format(templatable_property))
                 pass    # Do nothing, leave the propery as is
+            except Exception as e:
+                logger.error("An exception has been thrown")
+                logger.exception(e)
+                raise e

--- a/app/piping/plumber.py
+++ b/app/piping/plumber.py
@@ -41,15 +41,15 @@ class Plumber(object):
         '''
         if hasattr(item, templatable_property):
             logger.debug('Piping property "{}" of item "{}"'.format(templatable_property, item.id))
+            template = getattr(item, templatable_property)
             try:
-                template = getattr(item, templatable_property)
                 formatting_data = self._context
                 plumbed_value = template.format(**formatting_data)
                 setattr(item, templatable_property, plumbed_value)
             except KeyError:
-                logger.warn('Property "{}" cannot be piped'.format(templatable_property))
+                logger.warn('Property "{}" of item "{}" cannot be piped'.format(templatable_property, item.id))
                 pass    # Do nothing, leave the propery as is
             except Exception as e:
-                logger.error("An exception has been thrown")
+                logger.error('Data required to pip property "{}" of item "{}" is invalid.  The template is "{}"'.format(templatable_property, item.id, template))  # NOQA
                 logger.exception(e)
                 raise e

--- a/tests/app/piping/test_plumber.py
+++ b/tests/app/piping/test_plumber.py
@@ -12,7 +12,8 @@ class TestPlumber(unittest.TestCase):
                 "property_two": "value two"
             }),
             'dates': ObjectFromDict({
-                "first_april_2016": datetime.strptime('01-04-2016', "%d-%m-%Y")
+                "first_april_2016": datetime.strptime('01-04-2016', "%d-%m-%Y"),
+                'none_date': None
             })
         }
 
@@ -20,6 +21,7 @@ class TestPlumber(unittest.TestCase):
 
     def test_plumb_item(self):
         item = ObjectFromDict({
+            "id": "item1",
             "templatable_properties": ['description'],
             "description": "Property One is {simple.property_one}, while Property Two is {simple.property_two}"
         })
@@ -31,6 +33,7 @@ class TestPlumber(unittest.TestCase):
         self.assertEquals(item.description, "Property One is value one, while Property Two is value two")
 
         item2 = ObjectFromDict({
+            "id": "item2",
             "templatable_properties": ['property_one', 'property_two', 'property_three'],
             "property_one": "Date is {dates.first_april_2016:%-d %B %Y}",
             "property_two": "Date is {dates.first_april_2016:%Y/%m/%d}",
@@ -51,6 +54,7 @@ class TestPlumber(unittest.TestCase):
         self.assertEquals(item2.property_four, "Not plumbed {dates.first_april_2016}")
 
         item3 = ObjectFromDict({
+            "id": "item3",
             'templatable_properties': ['funky_formatting', 'random_brace', 'mixing_it_up'],
             'funky_formatting': 'This is an opening brace {{ and this is a closing brace }}',
             'random_brace': 'This will not throw an error {',
@@ -68,6 +72,7 @@ class TestPlumber(unittest.TestCase):
         self.assertEquals(item3.mixing_it_up, '{ value one value two }')
 
         item4 = ObjectFromDict({
+            "id": "item4",
             'templatable_properties': ['unknown_parameter'],
             'unknown_parameter': 'This expansion is {unknown}'
         })
@@ -77,3 +82,15 @@ class TestPlumber(unittest.TestCase):
         self.plumber.plumb_item(item4)
 
         self.assertEquals(item4.unknown_parameter, 'This expansion is {unknown}')
+
+        item5 = ObjectFromDict({
+            "id": "item5",
+            'templatable_properties': ['none_date'],
+            'none_date': 'This date is {dates.none_date:%Y/%m/%d}'
+        })
+
+        self.assertEquals(item5.none_date, 'This date is {dates.none_date:%Y/%m/%d}')
+
+        self.assertRaises(Exception, self.plumber.plumb_item, item5)
+
+        self.assertEquals(item5.none_date, 'This date is {dates.none_date:%Y/%m/%d}')


### PR DESCRIPTION
### What is the context of this PR?

During the course of testing we discovered that if RRM did not send the employment date and the schema required it, then the runner would crash.

This PR increased the logging around the piping component and it nows correctly throws an exception under these circumstances.
### How to review

1) Checkout the branch
2) Run the tests and ensure they all pass
- [ ] Do all commits have sensible commit messages?
- [ ] Is all new code unit tested?
- [ ] Are there integration tests if needed?
- [ ] Is there sufficient logging?
- [ ] Is there documentation or is the code self-describing?
### Who worked on the PR

@weapdiv-david worked on this
