### PR TITLE
Alter connection logic to rabbitmq to handle failover

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -37,6 +37,7 @@ EQ_MINIMIZE_ASSETS = parse_mode(os.getenv('EQ_MINIMIZE_ASSETS', 'False'))
 EQ_PROFILING = parse_mode(os.getenv('EQ_PROFILING', 'False'))
 
 EQ_RABBITMQ_URL = os.getenv('EQ_RABBITMQ_URL', 'amqp://localhost:5672/%2F')
+EQ_RABBITMQ_URL_SECONDARY = os.getenv('EQ_RABBITMQ_URL_SECONDARY', 'amqp://localhost:5672/%2F')
 EQ_RABBITMQ_QUEUE_NAME = os.getenv('EQ_RABBITMQ_QUEUE_NAME', 'eq-submissions')
 EQ_RABBITMQ_TEST_QUEUE_NAME = os.getenv('EQ_RABBITMQ_TEST_QUEUE_NAME', 'eq-test')
 EQ_RABBITMQ_ENABLED = parse_mode(os.getenv('EQ_RABBITMQ_ENABLED', 'True'))

--- a/app/submitter/submitter.py
+++ b/app/submitter/submitter.py
@@ -84,8 +84,6 @@ class RabbitMQSubmitter(Submitter):
                 logger.error("Attempting failover to secondary")
                 raise err
 
-
-
     def _disconnect(self):
         try:
             if self.connection:

--- a/app/submitter/submitter.py
+++ b/app/submitter/submitter.py
@@ -73,9 +73,18 @@ class RabbitMQSubmitter(Submitter):
         try:
             self.connection = pika.BlockingConnection(pika.URLParameters(settings.EQ_RABBITMQ_URL))
         except pika.exceptions.AMQPError as e:
-            logger.error('Unable to connect to Message Server')
+            logger.error('Unable to connect to Prime Message Server')
             logger.info("Unable to open Rabbit MQ connection to  " + settings.EQ_RABBITMQ_URL + " " + repr(e))
-            raise e
+            logger.error("Attempting failover to secondary")
+            try:
+                self.connection = pika.BlockingConnection(pika.URLParameters(settings.EQ_RABBITMQ_URL_SECONDARY))
+            except pika.exceptions.AMQPError as err:
+                logger.error('Unable to connect to Prime Message Server')
+                logger.info("Unable to open Secondary Rabbit MQ connection to %s, ERROR: %s ".format(settings.EQ_RABBITMQ_URL_SECONDARY, repr(e)))
+                logger.error("Attempting failover to secondary")
+                raise err
+
+
 
     def _disconnect(self):
         try:


### PR DESCRIPTION
### What is the context of this PR?

As part of the removal of the ELB in our architecture, we've changed how we connect and handle rabbitmq clusters. This PR changes how we connect, adding the failover to a secondary backup RabbitMQ server in the event of not being able to connect to the prime.

In the event that the secondary fails, we generate a 5XX server error and log to the error logger.
### How to review
1. Deploy a local RabbitMQ server (brew install rabbitmq if on mac - this allows local anom access by default.) 
2. Set the following env variables:

```
export EQ_RABBITMQ_ENABLED=True
export EQ_RABBITMQ_URL=''
export EQ_RABBITMQ_URL_SECONDARY=amqp://localhost:5672/%2F

```
1. Run the app
2. Complete a survey
3. Check the terminal output for logging messages explaining the failover to secondary.

This scenario replicates not being able to connect to the prime and failing over to the secondary without notifying the user. You may choose to run other scenarios by setting secondary to null as well.
- [ ] Do all commits have sensible commit messages?
- [ ] Is all new code unit tested?
- [ ] Are there integration tests if needed?
- [ ] Is there sufficient logging?
- [ ] Is there documentation or is the code self-describing?
### Who worked on the PR

@dhilton
