### PR TITLE
EQ 494 Allow the user to use a confirmation page rather then a summar…

### DIFF
--- a/app/data/0_rouge_one.json
+++ b/app/data/0_rouge_one.json
@@ -1,0 +1,466 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "questionnaire_id": "23",
+    "schema_version": "0.0.1",
+    "submission_page" : "confirmation",
+    "survey_id": "023",
+    "title": "Rouge One ",
+    "description": "Test with a confirmation page instead of a summary",
+    "theme": "starwars",
+    "introduction": {
+        "description": "Good luck in stealing the plans to the Death Star"
+    },
+    "display": {
+        "properties": {}
+    },
+    "eq_id": "1",
+    "groups": [
+        {
+            "blocks": [
+                {
+                    "display": {
+                        "properties": {}
+                    },
+                    "id": "f22b1ba4-d15f-48b8-a1f3-db62b6f34cc0",
+                    "sections": [
+                        {
+                            "description": "",
+                            "display": {
+                                "properties": {}
+                            },
+                            "id": "ed3e200a-0735-4e8d-9eea-627c1d908697",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "alias": "character",
+                                            "display": {
+                                                "properties": {
+                                                    "columns": true
+                                                }
+                                            },
+                                            "guidance": "",
+                                            "id": "ca3ce3a3-ae44-4e30-8f85-5b6a7a2fb23c",
+                                            "label": "Who do you want to know more about?",
+                                            "mandatory": true,
+                                            "options": [
+                                                {
+                                                    "label": "Jyn Erso",
+                                                    "value": "Jyn Erso"
+                                                },
+                                                {
+                                                    "label": "Cassian Andor",
+                                                    "value": "Cassian Andor"
+                                                },
+                                                {
+                                                    "label": "Bodhi Rook",
+                                                    "value": "Bodhi Rook"
+                                                },
+                                                  {
+                                                    "label": "Orson Krennic",
+                                                    "value": "Orson Krennic"
+                                                }
+
+                                            ],
+                                            "q_code": "1",
+                                            "type": "Radio",
+                                            "validation": {
+                                                "messages": {}
+                                            }
+                                        }
+                                    ],
+                                    "description": "",
+                                    "display": {
+                                        "properties": {}
+                                    },
+                                    "id": "4bfa0229-0ce8-4190-817b-535f55ad2817",
+                                    "title": "",
+                                    "type": "General",
+                                    "validation": []
+                                }
+                            ],
+                            "title": "Who do you want to know more about?",
+                            "validation": []
+                        }
+                    ],
+                    "routing_rules":[
+                        {
+                            "goto": {
+                                "id" : "26f2c4b3-28ac-4072-9f18-a6a6c6f660db",
+                                "when": {
+                                    "id" : "ca3ce3a3-ae44-4e30-8f85-5b6a7a2fb23c",
+                                    "condition": "equals",
+                                    "value":"Jyn Erso"
+                                }
+                            }
+
+                        },
+                        {
+                            "goto": {
+                                "id": "cbb1f973-7fbc-4e96-bd7b-47a8d8056a46",
+                                "when": {
+                                    "id" : "ca3ce3a3-ae44-4e30-8f85-5b6a7a2fb23c",
+                                    "condition": "equals",
+                                    "value":"Cassian Andor"
+                                }
+                            }
+
+                        },
+                        {
+                            "goto": {
+                                "id": "9b091307-e14c-4211-9104-91e3975d6910",
+                                "when": {
+                                    "id" : "ca3ce3a3-ae44-4e30-8f85-5b6a7a2fb23c",
+                                    "condition": "equals",
+                                    "value":"Bodhi Rook"
+                                }
+                            }
+
+                        },
+                        {
+                            "goto": {
+                                "id": "b4f8e11a-dac9-4554-ba44-55fc5c5aebcb",
+                                "when": {
+                                    "id" : "ca3ce3a3-ae44-4e30-8f85-5b6a7a2fb23c",
+                                    "condition": "equals",
+                                    "value":"Orson Krennic"
+                                }
+                            }
+
+                        }
+                    ],
+                    "title": "",
+                    "validation": []
+                },
+                {
+                    "display": {
+                        "properties": {}
+                    },
+                    "id": "26f2c4b3-28ac-4072-9f18-a6a6c6f660db",
+                    "sections": [
+                        {
+                            "description": "Putting behind a checkered past by lending her skills to a greater cause, Jyn is impetuous, defiant, and eager to bring the battle to the Empire. Used to operating alone, she finds higher purpose by taking on a desperate mission for the Rebel Alliance.",
+                            "display": {
+                                "properties": {}
+                            },
+                            "id": "b2b1eb6d-400f-452a-854f-be028600f862",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "display": {
+                                                "properties": {
+                                                    "columns": true
+                                                }
+                                            },
+                                            "guidance": "",
+                                            "id": "a2c2649a-85ff-4a26-ba3c-e1880f7c807b",
+                                            "label": "",
+                                            "mandatory": true,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "2",
+                                            "type": "Radio",
+                                            "validation": {
+                                                "messages": {}
+                                            }
+                                        }
+                                    ],
+                                    "description": "",
+                                    "display": {
+                                        "properties": {}
+                                    },
+                                    "id": "574e5d5e-36b4-44ea-b8f6-09d744552241",
+                                    "title": "Do you like this page?",
+                                    "type": "General",
+                                    "validation": []
+                                }
+                            ],
+                            "title": "{answers.character}",
+                            "validation": []
+                        }
+                    ],
+                    "routing_rules":[
+                        {
+                            "goto": {
+                                "location": "block",
+                                "id" : "5e633f04-073a-44c0-a9da-a7cc2116b937"
+                            }
+                        }
+                    ],
+                    "title": "",
+                    "validation": []
+                },
+                {
+                    "display": {
+                        "properties": {}
+                    },
+                    "id": "cbb1f973-7fbc-4e96-bd7b-47a8d8056a46",
+                    "sections": [
+                        {
+                            "description": "An accomplished Rebel Alliance Intelligence Officer with combat field experience, Captain Andor commands respect from his Rebel troops with his ability to keep a cool head under fire and complete his missions with minimal resources",
+                            "display": {
+                                "properties": {}
+                            },
+                            "id": "bcd67e48-7eec-4766-ab0c-acbaa3a3af01",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "display": {
+                                                "properties": {
+                                                    "columns": true
+                                                }
+                                            },
+                                            "guidance": "",
+                                            "id": "3f1f1bb7-2452-4f8d-ac7a-735ea5d4517f",
+                                            "label": "",
+                                            "mandatory": true,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "3",
+                                            "type": "Radio",
+                                            "validation": {
+                                                "messages": {}
+                                            }
+                                        }
+                                    ],
+                                    "description": "",
+                                    "display": {
+                                        "properties": {}
+                                    },
+                                    "id": "b5c0c1fd-578c-436e-86a8-7d3b1786cb5f",
+                                    "title": "Do you like this page?",
+                                    "type": "General",
+                                    "validation": []
+                                }
+                            ],
+                            "title": "{answers.character}",
+                            "validation": []
+                        }
+                    ],
+                    "routing_rules":[
+                        {
+                            "goto": {
+                                "location": "block",
+                                "id" : "5e633f04-073a-44c0-a9da-a7cc2116b937"
+                            }
+                        }
+                    ],
+                    "title": "",
+                    "validation": []
+                },
+                {
+                    "display": {
+                        "properties": {}
+                    },
+                    "id": "9b091307-e14c-4211-9104-91e3975d6910",
+                    "sections": [
+                        {
+                            "description": "A former Imperial pilot, Bodhi has strong piloting and technical skills to use as the pilot of the Rebel squad. Ever practical, but highly anxious, Rook must gather his courage to bring the battle to the Empire.",
+                            "display": {
+                                "properties": {}
+                            },
+                            "id": "95d5abef-d2c4-4a27-a89b-43f8bfe8f404",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "display": {
+                                                "properties": {
+                                                    "columns": true
+                                                }
+                                            },
+                                            "guidance": "",
+                                            "id": "57ff0b3a-d66e-4f06-b6f8-00a4474e4ade",
+                                            "label": "",
+                                            "mandatory": true,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "4",
+                                            "type": "Radio",
+                                            "validation": {
+                                                "messages": {}
+                                            }
+                                        }
+                                    ],
+                                    "description": "",
+                                    "display": {
+                                        "properties": {}
+                                    },
+                                    "id": "ff1d8559-d5f7-4ba8-95fa-bf76178f4433",
+                                    "title": "Do you like this page?",
+                                    "type": "General",
+                                    "validation": []
+                                }
+                            ],
+                            "title": "{answers.character}",
+                            "validation": []
+                        }
+                    ],
+                    "routing_rules":[
+                        {
+                            "goto": {
+                                "location": "block",
+                                "id" : "5e633f04-073a-44c0-a9da-a7cc2116b937"
+                            }
+                        }
+                    ],
+                    "title": "",
+                    "validation": []
+                },
+                {
+                    "display": {
+                        "properties": {}
+                    },
+                    "id": "b4f8e11a-dac9-4554-ba44-55fc5c5aebcb",
+                    "sections": [
+                        {
+                            "description": "An Imperial Military Director who is obsessed with the completion of the long-delayed Death Star project. A cruel but brilliant man, Krennic has staked his reputation on the delivery of the functional battle station to the Emperor.",
+                            "display": {
+                                "properties": {}
+                            },
+                            "id": "c37363d8-5a2d-479c-8b88-31c23e3f4d44",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "display": {
+                                                "properties": {
+                                                    "columns": true
+                                                }
+                                            },
+                                            "guidance": "",
+                                            "id": "216d7f5b-e908-42d4-84b6-036a9f76512e",
+                                            "label": "",
+                                            "mandatory": true,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "5",
+                                            "type": "Radio",
+                                            "validation": {
+                                                "messages": {}
+                                            }
+                                        }
+                                    ],
+                                    "description": "",
+                                    "display": {
+                                        "properties": {}
+                                    },
+                                    "id": "15beab29-e3b3-42c5-a8ea-ce299504ce66",
+                                    "title": "Do you like this page?",
+                                    "type": "General",
+                                    "validation": []
+                                }
+                            ],
+                            "title": "{answers.character}",
+                            "validation": []
+                        }
+                    ],
+                    "routing_rules":[
+                        {
+                            "goto": {
+                                "location": "block",
+                                "id" : "5e633f04-073a-44c0-a9da-a7cc2116b937"
+                            }
+                        }
+                    ],
+                    "title": "",
+                    "validation": []
+                },
+                {
+                    "display": {
+                        "properties": {}
+                    },
+                    "id": "5e633f04-073a-44c0-a9da-a7cc2116b937",
+                    "sections": [
+                        {
+                            "description": "",
+                            "display": {
+                                "properties": {}
+                            },
+                            "id": "c50124ac-79f5-40c9-8dc4-af8bef649981",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "display": {
+                                            "properties": {
+                                                "columns": true
+                                            }
+                                        },
+                                        "guidance": "",
+                                        "id": "a04a516d-502d-4068-bbed-a43427c68cd9",
+                                        "label": "",
+                                        "mandatory": true,
+                                        "options": [],
+                                        "q_code": "2",
+                                        "type": "Currency",
+                                        "validation": {
+                                            "messages": {
+                                                "INTEGER_TOO_LARGE": "How much, fool you must be",
+                                                "NEGATIVE_INTEGER": "How can it be negative?",
+                                                "NOT_INTEGER": "Please only enter whole numbers into the field."
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "description": "",
+                                    "display": {
+                                        "properties": {}
+                                    },
+                                    "id": "0ae9664b-601d-4428-8cd4-4738df48b685",
+                                    "title": "In millions, how much do you think this film will take?",
+                                    "type": "General",
+                                    "validation": []
+                                }
+                            ],
+                            "title": "",
+                            "validation": []
+                        }
+                    ],
+                    "title": "",
+                    "validation": []
+                }
+            ],
+            "display": {
+                "properties": {}
+            },
+            "id": "82504ab4-de5d-41fd-9a86-9ad5ea483296",
+            "title": "",
+            "validation": []
+        }
+    ]
+}

--- a/app/data/1_0205.json
+++ b/app/data/1_0205.json
@@ -3,7 +3,7 @@
 	"schema_version": "0.0.1",
 	"questionnaire_id": "23",
 	"eq_id": "1",
-	"survey_id": "023",
+  "survey_id": "023",
 	"title": "Monthly Business Survey - Retail Sales Index",
 	"description": "MCI Description",
 	"theme": "default",

--- a/app/main/views/questionnaire.py
+++ b/app/main/views/questionnaire.py
@@ -22,7 +22,6 @@ def survey(eq_id, collection_id, location):
     logger.debug("Requesting location : /questionnaire/%s/%s/%s", eq_id, collection_id, location)
     try:
         questionnaire_manager = create_questionnaire_manager()
-
         # Redirect to thank you page if the questionnaire has already been submitted
         if questionnaire_manager.submitted and location != 'thank-you':
             return do_redirect(eq_id, collection_id, 'thank-you')

--- a/app/parser/parser_utils.py
+++ b/app/parser/parser_utils.py
@@ -142,16 +142,16 @@ class ParserUtils(object):
         else:
             return None
 
-    def get_optional_string(obj, key):
+    def get_optional_string(obj, key, default_value=None):
         """Get an optional string property from the dict
 
         Gets the optional string value associated with the key in the dict, or returns
-        None if the key is not found.
+        the default value if the key is not found.
 
         :param obj: A dict on json object
         :param key: The name of the property to retrieve
 
-        :returns: The value if found, otherwise returns None
+        :returns: The value if found, otherwise returns default_value
 
         :raises: A SchemaParserException is raised if the value exists and is not a string
 
@@ -160,7 +160,7 @@ class ParserUtils(object):
         if isinstance(value, str):
             return value
         elif value is None:
-            return None
+            return default_value
         else:
             raise SchemaParserException("Expected string '{field}' is not a string".format(field=key))
 

--- a/app/parser/v0_0_1/schema_parser.py
+++ b/app/parser/v0_0_1/schema_parser.py
@@ -101,6 +101,7 @@ class SchemaParser(AbstractSchemaParser):
             logger.debug("title: " + questionnaire.title)
             questionnaire.description = ParserUtils.get_required_string(self._schema, "description")
             questionnaire.theme = ParserUtils.get_required_string(self._schema, "theme")
+            questionnaire.submission_page = ParserUtils.get_optional_string(self._schema, "submission_page", questionnaire.submission_page)
 
         except Exception as e:
             logging.error('Error parsing schema')

--- a/app/questionnaire/questionnaire_manager.py
+++ b/app/questionnaire/questionnaire_manager.py
@@ -2,6 +2,7 @@ from app.questionnaire.state_manager import StateManager
 from app.questionnaire_state.introduction import Introduction as StateIntroduction
 from app.questionnaire_state.page import Page
 from app.questionnaire_state.summary import Summary as StateSummary
+from app.questionnaire_state.confirmation import Confirmation as StateConfirmation
 from app.questionnaire_state.thank_you import ThankYou as StateThankYou
 from app.schema.questionnaire import QuestionnaireException
 from app.templating.template_pre_processor import TemplatePreProcessor
@@ -51,7 +52,11 @@ class QuestionnaireManager(object):
             return None
 
     def _build_valid_locations(self):
-        validate_location = ['thank-you', 'summary']
+        validate_location = ['thank-you']
+
+        # Add the submission page (default is summary)
+        validate_location.append(self._schema.submission_page)
+
         if self._schema.introduction:
             validate_location.append('introduction')
         for group in self._schema.children:
@@ -95,6 +100,8 @@ class QuestionnaireManager(object):
                 state = StateThankYou(item_id)
             elif item_id == 'summary':
                 state = StateSummary(item_id)
+            elif item_id == 'confirmation':
+                state = StateConfirmation(item_id)
             else:
                 item = self._schema.get_item_by_id(item_id)
                 state = item.construct_state()

--- a/app/questionnaire_state/confirmation.py
+++ b/app/questionnaire_state/confirmation.py
@@ -1,0 +1,7 @@
+from app.questionnaire_state.item import Item
+
+
+class Confirmation(Item):
+
+    def __init__(self, id):
+        super().__init__(id=id)

--- a/app/routing/routing_engine.py
+++ b/app/routing/routing_engine.py
@@ -18,7 +18,7 @@ class RoutingEngine(object):
     def get_next_location(self, current_location):
         if current_location == 'introduction':
             next_location = self._schema.groups[0].blocks[0].id
-        elif current_location == 'summary':
+        elif current_location == self._schema.submission_page:
             next_location = 'thank-you'
         else:
             current_block = self._schema.get_item_by_id(current_location)
@@ -50,8 +50,9 @@ class RoutingEngine(object):
                     if index + 1 < len(self._schema.groups):
                         # return the first block in the next group
                         return self._schema.groups[index + 1].blocks[0].id
-        # There are no more blocks or groups, go to summary
-        return 'summary'
+
+        # There are no more blocks or groups, go to submission page (Default is summary)
+        return self._schema.submission_page
 
     def _process_routing_rules(self, routing_rules):
 

--- a/app/schema/questionnaire.py
+++ b/app/schema/questionnaire.py
@@ -19,6 +19,7 @@ class Questionnaire(object):
         self.display = Display()
         self.aliases = {}
         self.theme = None
+        self.submission_page = 'summary'
         self.messages = {}
 
     def add_group(self, group):
@@ -27,8 +28,10 @@ class Questionnaire(object):
             group.container = self
 
     def get_item_by_id(self, item_id):
+
         if item_id == self.id:
             return self
+
         elif item_id in self.items_by_id.keys():
             return self.items_by_id[item_id]
         else:

--- a/app/templates/confirmation.html
+++ b/app/templates/confirmation.html
@@ -1,0 +1,18 @@
+{% extends 'layouts/_survey.html' -%}
+
+{% block page_title -%}Summary{% endblock -%}
+
+{% block survey -%}
+  <div class="header">
+    <h1 class="header__title h1">Confirmation</h1>
+    <h2 class="header__subtitle">Thank you for your answers, do you wish to submit</h2>
+  </div>
+
+<div>
+  <form action="" method="POST" novalidate>
+    <button class="btn btn--secondary u-mr-s qa-btn-submit-answers" type="submit" name="action[submit_answers]">Submit answers</button>
+    <a class="u-dib" href="first">Change your answers</a>
+  </form>
+</div>
+
+{% endblock -%}

--- a/app/templating/template_pre_processor.py
+++ b/app/templating/template_pre_processor.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 KNOWN_TEMPLATES = {
             'introduction': "landing-page.html",
             'summary': "submission.html",
+            'confirmation': "confirmation.html",
             'thank-you': 'thank-you.html'
 }
 
@@ -121,9 +122,10 @@ class TemplatePreProcessor(object):
     def _augment_questionnaire(self):
         current_location = self.questionnaire_manager.get_current_location()
 
-        # @TODO: This needs to be revisited when we reimplement the rendering
-        if current_location == 'summary':
+        # Check to see if we are on the submission page set by the JSON (default is summary)
+        if current_location == self._schema.submission_page:
             location = self.questionnaire_manager._first
+
             while location.next_page:
                 if self._schema.item_exists(location.item_id):
                     location_state = location.page_state

--- a/tests/app/confirmation_page/test_confirmation_page.py
+++ b/tests/app/confirmation_page/test_confirmation_page.py
@@ -1,0 +1,22 @@
+from app.routing.routing_engine import RoutingEngine
+from app.parser.schema_parser_factory import SchemaParserFactory
+from app.questionnaire.questionnaire_manager import QuestionnaireManager
+import json
+from app import settings
+import unittest
+import os
+
+
+class TestConfirmationPage(unittest.TestCase):
+
+    def setUp(self):
+        schema_file = open(os.path.join(settings.EQ_SCHEMA_DIRECTORY, "0_rouge_one.json"))
+        schema = schema_file.read()
+        parser = SchemaParserFactory.create_parser(json.loads(schema))
+        self.questionnaire = parser.parse()
+        self.questionnaire_manager = QuestionnaireManager(self.questionnaire)
+        self.routing_engine = RoutingEngine(self.questionnaire, self.questionnaire_manager)
+
+    def test_get_next_location_confirmation(self):
+        next_location = self.routing_engine.get_next_location('5e633f04-073a-44c0-a9da-a7cc2116b937')
+        self.assertEqual('confirmation', next_location)

--- a/tests/integration/star_wars/star_wars_tests.py
+++ b/tests/integration/star_wars/star_wars_tests.py
@@ -4,11 +4,11 @@ from tests.integration.integration_test_case import IntegrationTestCase
 class StarWarsTestCase(IntegrationTestCase):
     def setUp(self):
         super().setUp()
-        self.token = create_token('star_wars', '0')
+
 
     def login_and_check_introduction_text(self):
-        resp = self.client.get('/session?token=' + self.token.decode(), follow_redirects=True)
-        self.assertEquals(resp.status_code, 200)
+        self.token = create_token('star_wars', '0')
+        resp = self.get_first_page()
         self.check_introduction_text(resp)
 
     def check_introduction_text(self, response):
@@ -28,6 +28,11 @@ class StarWarsTestCase(IntegrationTestCase):
         self.assertRegexpMatches(content, 'Notice is given under section 1 of the Statistics of Trade Act 1947')
         self.assertRegexpMatches(content, 'You are required by law to complete this questionnaire')
         self.assertRegexpMatches(content, 'NB: Your response is legally required')
+
+    def get_first_page(self):
+      resp = self.client.get('/session?token=' + self.token.decode(), follow_redirects=True)
+      self.assertEquals(resp.status_code, 200)
+      return resp
 
     def start_questionnaire(self):
         # Go to questionnaire
@@ -85,68 +90,52 @@ class StarWarsTestCase(IntegrationTestCase):
 
         return current_page
 
-    def check_choose_your_side(self, start_page):
-        resp = self.client.get(start_page, follow_redirects=False)
-        self.assertEquals(resp.status_code, 200)
-        content = resp.get_data(True)
-
+    def check_choose_your_side(self, page):
+        content = self.retrieve_content(page)
         self.assertRegexpMatches(content, 'Choose your side')
         self.assertRegexpMatches(content, 'ca3ce3a3-ae44-4e30-8f85-5b6a7a2fb23c')
-        return start_page
+        return page
 
-    def routing_pick_your_character_light_side(self, routing_page):
+    def retrieve_content(self, page):
+      response = self.client.get(page, follow_redirects=False)
+      self.assertEquals(response.status_code, 200)
+      content = response.get_data(True)
+      return content
 
-        resp = self.client.get(routing_page, follow_redirects=False)
-        self.assertEquals(resp.status_code, 200)
-        content = resp.get_data(True)
-
+    def routing_pick_your_character_light_side(self,page):
+        content = self.retrieve_content(page)
         self.assertRegexpMatches(content, 'A wise choice young Yedi. Pick your hero')
         self.assertRegexpMatches(content, '91631df0-4356-4e9f-a9d9-ce8b08d26eb3')
         self.assertRegexpMatches(content, 'Do you want to pick a ship?')
         self.assertRegexpMatches(content, '2e0989b8-5185-4ba6-b73f-c126e3a06ba7')
-        return routing_page
+        return page
 
-    def routing_pick_your_character_dark_side(self, routing_page):
-
-        resp = self.client.get(routing_page, follow_redirects=False)
-        self.assertEquals(resp.status_code, 200)
-        content = resp.get_data(True)
-
+    def routing_pick_your_character_dark_side(self,page):
+        content = self.retrieve_content(page)
         self.assertRegexpMatches(content, 'Good! Your hate has made you powerful. Pick your baddie')
         self.assertRegexpMatches(content, '653e6407-43d6-4dfc-8b11-a673a73d602d')
         self.assertRegexpMatches(content, 'Do you want to pick a ship?')
         self.assertRegexpMatches(content, 'pel989b8-5185-4ba6-b73f-c126e3a06ba7')
-        return routing_page
+        return page
 
-    def routing_select_your_ship_light_side(self, routing_page):
-        resp = self.client.get(routing_page, follow_redirects=False)
-        self.assertEquals(resp.status_code, 200)
-        content = resp.get_data(True)
-
+    def routing_select_your_ship_light_side(self, page):
+        content = self.retrieve_content(page)
         self.assertRegexpMatches(content, 'Which ship do you want?')
         self.assertRegexpMatches(content, 'Millennium Falcon')
         self.assertRegexpMatches(content, 'X-wing')
         self.assertRegexpMatches(content, 'a2c2649a-85ff-4a26-ba3c-e1880f7c807b')
-        return routing_page
+        return page
 
-    def routing_select_your_ship_dark_side(self, routing_page):
-
-        resp = self.client.get(routing_page, follow_redirects=False)
-        self.assertEquals(resp.status_code, 200)
-        content = resp.get_data(True)
-
+    def routing_select_your_ship_dark_side(self, page):
+        content = self.retrieve_content(page)
         self.assertRegexpMatches(content, 'Which ship do you want?')
         self.assertRegexpMatches(content, 'TIE Fighter')
         self.assertRegexpMatches(content, 'Death Star')
         self.assertRegexpMatches(content, 'a5d5ca1a-cf58-4626-be35-dce81297688b')
-        return routing_page
+        return page
 
-    def check_quiz_first_page(self, first_page):
-        resp = self.client.get(first_page, follow_redirects=False)
-        self.assertEquals(resp.status_code, 200)
-
-        # Questionnaire tests
-        content = resp.get_data(True)
+    def check_quiz_first_page(self, page):
+        content = self.retrieve_content(page)
         self.assertRegexpMatches(content, ">Save &amp; Continue<")
         self.assertRegexpMatches(content, 'Star Wars Quiz')
         self.assertRegexpMatches(content, 'May the force be with you young EQ developer')
@@ -190,10 +179,10 @@ class StarWarsTestCase(IntegrationTestCase):
         # Pipe Test for question description
         self.assertRegexpMatches(content, 'It could be between 1 April 2016 and 30 April 2016. But that might just be a test')  # NOQA
 
-        return first_page
+        return page
 
-    def check_second_quiz_page(self, second_page):
-        resp = self.client.get(second_page, follow_redirects=False)
+    def check_second_quiz_page(self, page):
+        resp = self.client.get(page, follow_redirects=False)
         self.assertEquals(resp.status_code, 200)
 
         content = resp.get_data(True)
@@ -230,5 +219,38 @@ class StarWarsTestCase(IntegrationTestCase):
         # Thank you page
         content = resp.get_data(True)
         self.assertRegexpMatches(content, '<title>Thank You</title>')
-        self.assertRegexpMatches(content, '(?s)Star Wars.*?Star Wars')
         self.assertRegexpMatches(content, '>Successfully Received<')
+
+    def rouge_one_login_and_check_introduction_text(self):
+        self.token = create_token('rouge_one', '0')
+        response = self.get_first_page()
+        self.rouge_one_check_introduction_text(response)
+
+    def rouge_one_check_introduction_text(self, response):
+        content = response.get_data(True)
+        self.assertRegexpMatches(content, '<title>Introduction</title>')
+        self.assertRegexpMatches(content, '(?s)Rouge One.*?Rouge One')
+        self.assertRegexpMatches(content, 'Good luck in stealing the plans to the Death Star')
+
+    def rouge_one_check_character_page(self, page):
+        content = self.retrieve_content(page)
+        self.assertRegexpMatches(content, 'Who do you want to know more about?')
+        self.assertRegexpMatches(content, 'Jyn Erso')
+        self.assertRegexpMatches(content, 'ca3ce3a3-ae44-4e30-8f85-5b6a7a2fb23c-3')
+
+    def rouge_one_check_description_page(self, page):
+        content = self.retrieve_content(page)
+        self.assertRegexpMatches(content, 'An accomplished Rebel Alliance Intelligence Officer')
+        self.assertRegexpMatches(content, 'Do you like this page?')
+        self.assertRegexpMatches(content, '3f1f1bb7-2452-4f8d-ac7a-735ea5d4517f-2')
+
+    def rouge_one_check_takings_page(self, page):
+        content = self.retrieve_content(page)
+        self.assertRegexpMatches(content, 'In millions, how much do you think this film will take?')
+        self.assertRegexpMatches(content, 'a04a516d-502d-4068-bbed-a43427c68cd9')
+
+    def rouge_one_check_confirmation_page(self, page):
+        content = self.retrieve_content(page)
+        self.assertRegexpMatches(content, 'Confirmation')
+        self.assertRegexpMatches(content, 'Thank you for your answers, do you wish to submit')
+

--- a/tests/integration/star_wars/test_confirmation_page.py
+++ b/tests/integration/star_wars/test_confirmation_page.py
@@ -1,0 +1,74 @@
+from tests.integration.star_wars.star_wars_tests import StarWarsTestCase
+from werkzeug.datastructures import MultiDict
+
+
+class TestConfirmationPage(StarWarsTestCase):
+
+    def test_confirmation_page(self):
+        self.rouge_one_login_and_check_introduction_text()
+        post_data = {
+            'action[start_questionnaire]': 'Start Questionnaire'
+        }
+        response = self.client.post('/questionnaire/0/789/introduction', data=post_data, follow_redirects=False)
+        self.assertEquals(response.status_code, 302)
+
+        character_page = response.headers['Location']
+
+        self.rouge_one_check_character_page(character_page)
+
+        # Our answers
+        form_data = MultiDict()
+        # Start Date
+        form_data.add("ca3ce3a3-ae44-4e30-8f85-5b6a7a2fb23c", "Cassian Andor")
+        # User Action
+        form_data.add("action[save_continue]", "Save &amp; Continue")
+
+        # Form submission with no errors
+        resp = self.submit_page(character_page, form_data)
+        self.assertNotEquals(resp.headers['Location'], character_page)
+
+        # Like page
+        description_page = resp.headers['Location']
+
+        self.rouge_one_check_description_page(description_page)
+
+        # Our answers
+        form_data = MultiDict()
+        # Start Date
+        form_data.add("3f1f1bb7-2452-4f8d-ac7a-735ea5d4517f", "Yes")
+        # User Action
+        form_data.add("action[save_continue]", "Save &amp; Continue")
+
+        # Form submission with no errors
+        resp = self.submit_page(description_page, form_data)
+        self.assertNotEquals(resp.headers['Location'], description_page)
+
+        # Takings page
+        takings_page = resp.headers['Location']
+
+        self.rouge_one_check_takings_page(takings_page)
+
+        # Our answers
+        form_data = MultiDict()
+        # Start Date
+        form_data.add("a04a516d-502d-4068-bbed-a43427c68cd9", "900")
+        # User Action
+        form_data.add("action[save_continue]", "Save &amp; Continue")
+
+        # Form submission with no errors
+        resp = self.submit_page(takings_page, form_data)
+        self.assertNotEquals(resp.headers['Location'], takings_page)
+
+        # Confirmation page
+        confirmation_page = resp.headers['Location']
+
+        self.rouge_one_check_confirmation_page(confirmation_page)
+
+        # User Action
+        form_data.add("action[save_continue]", "Save &amp; Continue")
+
+        # Form submission with no errors
+        resp = self.submit_page(confirmation_page, form_data)
+        self.assertNotEquals(resp.headers['Location'], confirmation_page)
+
+        self.complete_survey(confirmation_page)


### PR DESCRIPTION
### What is the context of this PR?

Allow the user to choose if they want a summary page or a confirmation page
### How to review
1. Make sure Star Wars and MCI all still have a functioning summary page
2. Make sure 0_rouge_one.json, works and has a confirmation page
3. Using 1_0203 (easier then Star Wars as it has routing to summary) add "submission_page" : "confirmation" to the JSON and notice it has a confirmation page, take it away and see it has a summary page 
- [ ] Do all commits have sensible commit messages?
- [ ] Is all new code unit tested?
- [ ] Are there integration tests if needed?
- [ ] Is there sufficient logging?
- [ ] Is there documentation or is the code self-describing?
### Who worked on the PR

@LJBabbage
