### PR TITLE
Fix issue with proceeding zeros

### DIFF
--- a/app/questionnaire/questionnaire_manager.py
+++ b/app/questionnaire/questionnaire_manager.py
@@ -195,7 +195,7 @@ class QuestionnaireManager(object):
             node = node.next
 
         for answer in answers:
-            answers_dict[answer.id] = answer.input
+            answers_dict[answer.id] = answer.value
         return answers_dict
 
     def find_answer(self, id):

--- a/app/schema/widgets/currency_widget.py
+++ b/app/schema/widgets/currency_widget.py
@@ -12,7 +12,7 @@ class CurrencyWidget(Widget):
                 'name': self.name,
                 'id': state.schema_item.id,
                 'label': state.schema_item.label,
-                'value': state.input,
+                'value': state.value or state.input or '',
                 'placeholder': ''
             },
             'debug': {

--- a/app/schema/widgets/text_widget.py
+++ b/app/schema/widgets/text_widget.py
@@ -12,7 +12,7 @@ class TextWidget(Widget):
                 'name': self.name,
                 'id': state.schema_item.id,
                 'label': state.schema_item.label or '',
-                'value': state.input or '',
+                'value': state.value or state.input or '',
                 'placeholder': ''
             }
         }

--- a/app/settings.py
+++ b/app/settings.py
@@ -100,9 +100,12 @@ for password_name, dev_default in _PASSWORDS.items():
 
 
 # non configurable settings
-
+# date format when displayed to the user
 DISPLAY_DATETIME_FORMAT = '%A %d %B %Y at %H:%M'
+# Date Format for the submitted at date
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+# Date Format expected by SDX
+SDX_DATE_FORMAT = "%d/%m/%Y"
 EUROPE_LONDON = pytz.timezone("Europe/London")
 
 # JWT configurations

--- a/app/submitter/converter.py
+++ b/app/submitter/converter.py
@@ -47,11 +47,6 @@ class SubmitterConstants(object):
 
 class Converter(object):
 
-    """
-    Date Format expected by SDX
-    """
-    SDX_DATE_FORMAT = "%d/%m/%Y"
-
     @staticmethod
     def prepare_answers(user, metadata_store, questionnaire, answers):
         """
@@ -122,6 +117,6 @@ class Converter(object):
         if isinstance(value, int):
             return str(value)
         elif isinstance(value, datetime):
-            return value.strftime(Converter.SDX_DATE_FORMAT)
+            return value.strftime(settings.SDX_DATE_FORMAT)
         else:
             return value

--- a/app/submitter/converter.py
+++ b/app/submitter/converter.py
@@ -47,6 +47,11 @@ class SubmitterConstants(object):
 
 class Converter(object):
 
+    """
+    Date Format expected by SDX
+    """
+    SDX_DATE_FORMAT = "%d/%m/%Y"
+
     @staticmethod
     def prepare_answers(user, metadata_store, questionnaire, answers):
         """
@@ -73,8 +78,8 @@ class Converter(object):
             },
             "paradata": {},
             "data": {
-              "001": "2016-01-01",
-              "002": "2016-03-30"
+              "001": "01-01-2016",
+              "002": "30-03-2016"
             }
           }
         """
@@ -86,7 +91,7 @@ class Converter(object):
             if item is not None:
                 value = answers[key]
                 if value:
-                    data[item.code] = value
+                    data[item.code] = Converter._encode_value(value)
 
         metadata = {SubmitterConstants.USER_ID_KEY: metadata_store.user_id,
                     SubmitterConstants.RU_REF_KEY: metadata_store.ru_ref}
@@ -111,3 +116,12 @@ class Converter(object):
 
         logging.debug("Converted answer ready for submission %s", json.dumps(payload))
         return payload, submitted_at
+
+    @staticmethod
+    def _encode_value(value):
+        if isinstance(value, int):
+            return str(value)
+        elif isinstance(value, datetime):
+            return value.strftime(Converter.SDX_DATE_FORMAT)
+        else:
+            return value

--- a/tests/integration/downstream/test_downstream_data_typing.py
+++ b/tests/integration/downstream/test_downstream_data_typing.py
@@ -20,7 +20,7 @@ class TestDownstreamDataTyping(DownstreamTestCase, StarWarsTestCase):
         form_data = MultiDict()
         # Start Date
         form_data.add("6cf5c72a-c1bf-4d0c-af6c-d0f07bc5b65b", "234")
-        form_data.add("92e49d93-cbdc-4bcb-adb2-0e0af6c9a07c", "40")
+        form_data.add("92e49d93-cbdc-4bcb-adb2-0e0af6c9a07c", "00000000000000000000000000000000040")        # 40
         form_data.add("pre49d93-cbdc-4bcb-adb2-0e0af6c9a07c", "1370")
 
         form_data.add("a5dc09e8-36f2-4bf4-97be-c9e6ca8cbe0d", "Elephant")
@@ -122,6 +122,7 @@ class TestDownstreamDataTyping(DownstreamTestCase, StarWarsTestCase):
         for key, value in expected.items():
             self.assertIn(key, data.keys())
             self.assertTrue(type(expected[key]) == type(data[key]))  # NOQA
+            self.assertEquals(expected[key], data[key])
             if isinstance(expected[key], list):
                 for item in expected[key]:
                     self.assertIn(item, data[key])


### PR DESCRIPTION
### What is the context of this PR?

Fixes issue #263.  Updates the converter, questionnaire manager and widgets to use typed values rather than input values.  Modifies the downstream data test to check the proceeding zeros case.
### How to review

1) Checkout the branch
2) Run the tests
3) Go to the dev console and select a survey that allows you to enter integer/currency values
4) Fill an input box with a load of proceeeding zeros and a valid integer
5) Cause a validation error elsewhere on the page and submit, causing the page to be redisplayed
6) Verify that the proceeding zeros for your valid integer answer have been removed
7) Complete the survey and verify the proceeding zeros are not present
- [ ] Do all commits have sensible commit messages?
- [ ] Is all new code unit tested?
- [ ] Are there integration tests if needed?
- [ ] Is there sufficient logging?
- [ ] Is there documentation or is the code self-describing?
### Who worked on the PR

@weapdiv-david worked on this
