### PR TITLE
Use ISO 8601 for submitted_at

### DIFF
--- a/app/questionnaire/user_action_processor.py
+++ b/app/questionnaire/user_action_processor.py
@@ -97,7 +97,8 @@ class SubmitAnswers(UserAction):
         if is_valid:
             submitter = SubmitterFactory.get_submitter()
             submitted_at = submitter.send_answers(current_user, self._metadata, self._schema, answers)
-            logger.debug("setting submitted at %s", submitted_at)
-            self._questionnaire_manager.submitted_at = submitted_at.strftime(settings.DISPLAY_DATETIME_FORMAT)
+            local_submitted_at = submitted_at.astimezone(settings.EUROPE_LONDON)
+            logger.debug("setting submitted at %s", local_submitted_at)
+            self._questionnaire_manager.submitted_at = local_submitted_at.strftime(settings.DISPLAY_DATETIME_FORMAT)
         else:
             raise UserActionProcessorException("Unable to submit - answers are not valid")

--- a/app/settings.py
+++ b/app/settings.py
@@ -104,8 +104,7 @@ for password_name, dev_default in _PASSWORDS.items():
 # non configurable settings
 # date format when displayed to the user
 DISPLAY_DATETIME_FORMAT = '%A %d %B %Y at %H:%M'
-# Date Format for the submitted at date
-DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
 # Date Format expected by SDX
 SDX_DATE_FORMAT = "%d/%m/%Y"
 EUROPE_LONDON = pytz.timezone("Europe/London")

--- a/app/submitter/converter.py
+++ b/app/submitter/converter.py
@@ -1,7 +1,7 @@
 import json
 import logging
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from app import settings
 
@@ -98,14 +98,14 @@ class Converter(object):
                       SubmitterConstants.PERIOD_KEY: metadata_store.period_id}
 
         paradata = {}
-        submitted_at = datetime.now(settings.EUROPE_LONDON)
+        submitted_at = datetime.now(timezone.utc)
 
         payload = {SubmitterConstants.TX_ID: metadata_store.tx_id,
                    SubmitterConstants.TYPE_KEY: SubmitterConstants.TYPE,
                    SubmitterConstants.VERSION_KEY: SubmitterConstants.VERSION,
                    SubmitterConstants.ORIGIN_KEY: SubmitterConstants.ORIGIN,
                    SubmitterConstants.SURVEY_ID_KEY: survey_id,
-                   SubmitterConstants.SUBMITTED_AT_KEY: submitted_at.strftime(settings.DATETIME_FORMAT),
+                   SubmitterConstants.SUBMITTED_AT_KEY: submitted_at.isoformat(),
                    SubmitterConstants.COLLECTION_KEY: collection,
                    SubmitterConstants.METADATA_KEY: metadata,
                    SubmitterConstants.PARADATA_KEY: paradata,


### PR DESCRIPTION
### What is the context of this PR?

Dropped the use of DATETIME_FORMAT setting. This was only used for submitted_at within survey-runner and incorrectly specified UTC. Instead use datetimes isoformat method to set a ISO 8601 formatted version of the the submission time, as specified in the ons sdx-eq schema docs.
### How to review

Given this time is based on the time the test is run, unsure how we'd modify current integration tests to check this.
### Who worked on the PR

@iwootten
