### PR TITLE
Stop empty Submissions

### DIFF
--- a/app/main/views/questionnaire.py
+++ b/app/main/views/questionnaire.py
@@ -5,6 +5,7 @@ from app.main.errors import page_not_found
 from app.main.errors import service_unavailable
 from app.metadata.metadata_store import MetaDataStore
 from app.questionnaire.create_questionnaire_manager import create_questionnaire_manager
+from app.questionnaire.questionnaire_manager import InvalidLocationException
 from app.schema.questionnaire import QuestionnaireException
 from app.submitter.submission_failed import SubmissionFailedException
 
@@ -45,6 +46,8 @@ def survey(eq_id, collection_id, location):
 
     except QuestionnaireException as e:
         return page_not_found(e)
+    except InvalidLocationException as e:
+        return do_redirect(eq_id, collection_id, questionnaire_manager.get_current_location())
     except SubmissionFailedException as e:
         # Rabbit MQ connection issue
         return service_unavailable(e)

--- a/tests/integration/star_wars/test_empty_submission_fails.py
+++ b/tests/integration/star_wars/test_empty_submission_fails.py
@@ -1,0 +1,125 @@
+from tests.integration.star_wars.star_wars_tests import StarWarsTestCase
+from werkzeug.datastructures import MultiDict
+
+
+class TestEmptySubmissionFails(StarWarsTestCase):
+
+    def test_empty_submission_fails(self):
+
+        self.login_and_check_introduction_text()
+
+        # go to the first page
+        self.start_questionnaire_and_navigate_routing()
+
+        # now issue a request to the summary page
+        resp = self.client.get('/questionnaire/0/789/summary', follow_redirects=False)
+        self.assertEquals(resp.status_code, 302)
+
+        # check that we're redirected to the first block as its an empty submission
+        self.assertRegexpMatches(resp.headers['Location'], r'\/questionnaire\/0\/789\/cd3b74d1-b687-4051-9634-a8f9ce10a27d')
+
+        # go to the first page
+        first_page = resp.headers['Location']
+        self.navigate_to_page(first_page)
+
+        # now check we can complete the survey
+        # Our answers
+        form_data = MultiDict()
+        # Start Date
+        form_data.add("6cf5c72a-c1bf-4d0c-af6c-d0f07bc5b65b", "234")
+        form_data.add("92e49d93-cbdc-4bcb-adb2-0e0af6c9a07c", "40")
+        form_data.add("pre49d93-cbdc-4bcb-adb2-0e0af6c9a07c", "1370")
+
+        form_data.add("a5dc09e8-36f2-4bf4-97be-c9e6ca8cbe0d", "Elephant")
+        form_data.add("7587eb9b-f24e-4dc0-ac94-66118b896c10", "Luke, I am your father")
+
+        # Check three boxes
+        form_data.add("9587eb9b-f24e-4dc0-ac94-66117b896c10", 'Luke Skywalker')
+        form_data.add("9587eb9b-f24e-4dc0-ac94-66117b896c10", 'Yoda')
+        form_data.add("9587eb9b-f24e-4dc0-ac94-66117b896c10", 'Qui-Gon Jinn')
+
+        form_data.add("6fd644b0-798e-4a58-a393-a438b32fe637-day", "28")
+        form_data.add("6fd644b0-798e-4a58-a393-a438b32fe637-month", "05")
+        form_data.add("6fd644b0-798e-4a58-a393-a438b32fe637-year", "1983")
+        # End Date
+        form_data.add("06a6a4b7-6ce4-4687-879d-3443cd8e2ff0-day", "29")
+        form_data.add("06a6a4b7-6ce4-4687-879d-3443cd8e2ff0-month", "05")
+        form_data.add("06a6a4b7-6ce4-4687-879d-3443cd8e2ff0-year", "1983")
+        # Total Turnover
+        form_data.add("215015b1-f87c-4740-9fd4-f01f707ef558", "Wookiees don’t place value in material rewards and refused the medal initially")
+        form_data.add("7587qe9b-f24e-4dc0-ac94-66118b896c10", "Yes")
+        # User Action
+        form_data.add("action[save_continue]", "Save &amp; Continue")
+
+        # Form submission with no errors
+        resp = self.submit_page(first_page, form_data)
+        self.assertNotEquals(resp.headers['Location'], first_page)
+
+        # Second page
+        second_page = resp.headers['Location']
+        resp = self.navigate_to_page(second_page)
+        content = resp.get_data(True)
+
+        # Pipe Test for section title
+        self.assertRegexpMatches(content, 'On 2 June 1983 how many were employed?')
+
+        # Textarea question
+        self.assertRegexpMatches(content, 'Why doesn&#39;t Chewbacca receive a medal at the end of A New Hope?')
+        self.assertRegexpMatches(content, '215015b1-f87c-4740-9fd4-f01f707ef558')
+
+        # Our answers
+        form_data = {
+            # People in household
+            "215015b1-f87c-4740-9fd4-f01f707ef558": "Wookiees don’t place value in material rewards and refused the medal initially",  # NOQA
+            "7587qe9b-f24e-4dc0-ac94-66118b896c10": "Yes",
+            # User Action
+            "action[save_continue]": "Save &amp; Continue"
+        }
+
+        resp = self.submit_page(second_page, form_data)
+
+        # third page
+        third_page = resp.headers['Location']
+        resp = self.navigate_to_page(third_page)
+        content = resp.get_data(True)
+
+        self.assertRegexpMatches(content, "Thanks for participating in the survey")
+
+        form_data = {
+          # final answers
+          "fcf636ff-7b3d-47b6-aaff-9a4b00aa888b": "Naboo",
+          "4a085fe5-6830-4ef6-96e6-2ea2b3caf0c1": "5",
+          # User Action
+          "action[save_continue]": "Save &amp; Continue"
+        }
+
+        resp = self.submit_page(third_page, form_data)
+
+        # There are no validation errors
+        self.assertRegexpMatches(resp.headers['Location'], r'\/questionnaire\/0\/789\/summary$')
+
+        summary_url = resp.headers['Location']
+
+        resp = self.navigate_to_page(summary_url)
+
+        # We are on the review answers page
+        content = resp.get_data(True)
+        self.assertRegexpMatches(content, '<title>Summary</title>')
+        self.assertRegexpMatches(content, '>Star Wars</')
+        self.assertRegexpMatches(content, '>Your responses<')
+        self.assertRegexpMatches(content, '(?s)How old is Chewy?.*?234')
+        self.assertRegexpMatches(content, '(?s)How many Octillions do Nasa reckon it would cost to build a death star?.*?£40')
+        self.assertRegexpMatches(content, '(?s)How hot is a lightsaber in degrees C?.*?1370')
+        self.assertRegexpMatches(content, '(?s)What animal was used to create the engine sound of the Empire\'s TIE fighters?.*?Elephant')  # NOQA
+        self.assertRegexpMatches(content, '(?s)Which of these Darth Vader quotes is wrong?.*?Luke, I am your father')
+        self.assertRegexpMatches(content, '(?s)Which 3 have wielded a green lightsaber?.*?<li class="list__item">Yoda')  # NOQA
+        self.assertRegexpMatches(content, '(?s)Which 3 have wielded a green lightsaber?.*?<li class="list__item">Luke Skywalker')  # NOQA
+        self.assertRegexpMatches(content, '(?s)Which 3 have wielded a green lightsaber?.*?<li class="list__item">Qui-Gon Jinn')  # NOQA
+        self.assertRegexpMatches(content, '(?s)Which 3 appear in any of the opening crawlers?')
+        self.assertRegexpMatches(content, '(?s)When was The Empire Strikes Back released?.*?From: 28/05/1983.*?To: 29/05/1983')  # NOQA
+        self.assertRegexpMatches(content, '(?s)What was the total number of Ewokes?.*?')
+        self.assertRegexpMatches(content, '(?s)Why doesn\'t Chewbacca receive a medal at the end of A New Hope?.*?Wookiees don’t place value in material rewards and refused the medal initially')  # NOQA
+        self.assertRegexpMatches(content, '>Please check carefully before submission<')
+        self.assertRegexpMatches(content, '>Submit answers<')
+
+        self.complete_survey(summary_url)


### PR DESCRIPTION
### What is the context of this PR?

Fixes #384 

Adding a check to ensure you can only visit the summary page if that's where the questionnaire manager thinks you should be. This should stop the user submitting an empty survey (i.e. by clicking change your answers and then the back button)
### How to review
1. Complete the RSI survey (1_0102)
2. On the summary page click change your answers
3. Now click back
4. Confirm you remain on the first page
- [ ] Do all commits have sensible commit messages?
- [ ] Is all new code unit tested?
- [ ] Are there integration tests if needed?
- [ ] Is there sufficient logging?
- [ ] Is there documentation or is the code self-describing?
### Who worked on the PR

@warrenbailey
