### PR TITLE
Recover State by replaying post data

### DIFF
--- a/app/main/views/questionnaire.py
+++ b/app/main/views/questionnaire.py
@@ -4,8 +4,8 @@ from app.main.errors import internal_server_error
 from app.main.errors import page_not_found
 from app.main.errors import service_unavailable
 from app.metadata.metadata_store import MetaDataStore
-from app.questionnaire.create_questionnaire_manager import create_questionnaire_manager
 from app.questionnaire.questionnaire_manager import InvalidLocationException
+from app.questionnaire.questionnaire_manager_factory import QuestionnaireManagerFactory
 from app.schema.questionnaire import QuestionnaireException
 from app.submitter.submission_failed import SubmissionFailedException
 
@@ -28,7 +28,7 @@ def survey(eq_id, collection_id, location):
 
     logger.debug("Requesting location : /questionnaire/%s/%s/%s", eq_id, collection_id, location)
     try:
-        questionnaire_manager = create_questionnaire_manager()
+        questionnaire_manager = QuestionnaireManagerFactory.get_instance()
         # Redirect to thank you page if the questionnaire has already been submitted
         if questionnaire_manager.submitted and location != 'thank-you':
             return do_redirect(eq_id, collection_id, 'thank-you')

--- a/app/main/views/root.py
+++ b/app/main/views/root.py
@@ -5,7 +5,7 @@ from app.authentication.invalid_token_exception import InvalidTokenException
 from app.authentication.no_token_exception import NoTokenException
 from app.main import errors
 from app.metadata.metadata_store import MetaDataStore
-from app.questionnaire.create_questionnaire_manager import create_questionnaire_manager
+from app.questionnaire.questionnaire_manager_factory import QuestionnaireManagerFactory
 
 from flask import abort
 from flask import redirect
@@ -53,7 +53,7 @@ def login():
             logger.error("Missing EQ id %s or form type %s in JWT", eq_id, form_type)
             abort(404)
 
-        questionnaire_manager = create_questionnaire_manager()
+        questionnaire_manager = QuestionnaireManagerFactory.get_instance()
 
         # get the current location of the user
         current_location = questionnaire_manager.get_current_location()

--- a/app/questionnaire/create_questionnaire_manager.py
+++ b/app/questionnaire/create_questionnaire_manager.py
@@ -1,6 +1,6 @@
 import logging
 
-from app.main import errors
+
 from app.metadata.metadata_store import MetaDataStore
 from app.parser.schema_parser_factory import SchemaParserFactory
 from app.questionnaire.questionnaire_manager import QuestionnaireManager
@@ -15,17 +15,7 @@ def create_questionnaire_manager():
 
     questionnaire_manager = QuestionnaireManager.get_instance()
     if not questionnaire_manager:
-        metadata = MetaDataStore.get_instance(current_user)
-
-        eq_id = metadata.eq_id
-        form_type = metadata.form_type
-
-        logger.debug("Requested questionnaire %s for form type %s", eq_id, form_type)
-
-        schema = load_and_parse_schema(eq_id, form_type)
-        if not schema:
-            return errors.page_not_found()
-        logger.debug("Constructing brand new User Journey Manager")
+        schema = get_schema()
         questionnaire_manager = QuestionnaireManager.new_instance(schema)
 
     return questionnaire_manager
@@ -47,3 +37,17 @@ def load_and_parse_schema(eq_id, form_type):
         return schema
     else:
         return None
+
+
+def get_schema():
+    metadata = MetaDataStore.get_instance(current_user)
+
+    eq_id = metadata.eq_id
+    form_type = metadata.form_type
+    logger.debug("Requested questionnaire %s for form type %s", eq_id, form_type)
+
+    schema = load_and_parse_schema(eq_id, form_type)
+    if not schema:
+        raise ValueError("No schema available")
+    logger.debug("Constructing brand new User Journey Manager")
+    return schema

--- a/app/questionnaire/questionnaire_manager.py
+++ b/app/questionnaire/questionnaire_manager.py
@@ -3,7 +3,9 @@ import logging
 from app.authentication.session_management import session_manager
 from app.metadata.metadata_store import MetaDataStore
 from app.piping.plumbing_preprocessor import PlumbingPreprocessor
+from app.questionnaire.state import State
 from app.questionnaire.state_manager import StateManager
+from app.questionnaire.state_recovery import StateRecovery
 from app.questionnaire.user_action_processor import UserActionProcessor, UserActionProcessorException
 from app.questionnaire_state.confirmation import Confirmation as StateConfirmation
 from app.questionnaire_state.introduction import Introduction as StateIntroduction
@@ -32,33 +34,20 @@ class QuestionnaireManager(object):
     The doubly linked list approach allows us to maintain the path the user has taken through the question. If that path
     changes we archive off the nodes in case the user revisits that path.
     '''
-    def __init__(self, schema):
-        self.submitted_at = None
+    def __init__(self, schema, current=None, first=None, tail=None, archive={}, valid_locations=None, submitted_at=None):
+        self.submitted_at = submitted_at
         self._schema = schema
-        self._current = None  # the latest node
-        self._first = None  # the first node in the doubly linked list
-        self._tail = None
-        self._archive = {}  # a dict of discarded nodes for later use (if needed)
-        self._valid_locations = self._build_valid_locations()
-
-    @staticmethod
-    def new_instance(schema):
-        questionnaire_manager = QuestionnaireManager(schema)
-        # immediately save it to the database
-        StateManager.save_state(questionnaire_manager)
-        questionnaire_manager.go_to(questionnaire_manager.get_first_location())
-        logger.debug("Constructing new state")
-        return questionnaire_manager
-
-    @staticmethod
-    def get_instance():
-        logger.error("get instance")
-        if StateManager.has_state():
-            logger.error("StateManager loading state")
-            return StateManager.get_state()
+        self._current = current  # the latest node
+        self._first = first  # the first node in the doubly linked list
+        self._tail = tail  # the last node in the doubly linked list
+        self._archive = archive  # a dict of discarded nodes for later use (if needed)
+        if valid_locations:
+            self._valid_locations = valid_locations
         else:
-            logger.error("Get instance returning None")
-            return None
+            self._valid_locations = self._build_valid_locations()
+
+    def construct_state(self):
+        return State(self._schema, self._current, self._first, self._tail, self._archive, self.submitted_at, self._valid_locations)
 
     def resolve_location(self, location):
         if location == 'first':
@@ -103,7 +92,7 @@ class QuestionnaireManager(object):
         else:
             logger.debug("creating new state for %s", item_id)
             self._create_new_state(item_id)
-        StateManager.save_state(self)
+        StateManager.save_state(self.construct_state())
 
     def _create_new_state(self, item_id):
 
@@ -140,7 +129,7 @@ class QuestionnaireManager(object):
             if node.next:
                 self._truncate(node.next)
 
-            StateManager.save_state(self)
+            StateManager.save_state(self.construct_state())
         else:
             raise TypeError("Can only handle blocks")
 
@@ -302,7 +291,7 @@ class QuestionnaireManager(object):
         if self.is_known_state(location):
             if not replay:
                 # if we're not on replay then save the post data for state recovery
-                StateManager.save_post_date(location, post_data)
+                StateRecovery.save_post_date(location, post_data)
             self.go_to_state(location)
 
             # apply any conditional display rules

--- a/app/questionnaire/questionnaire_manager_factory.py
+++ b/app/questionnaire/questionnaire_manager_factory.py
@@ -16,7 +16,7 @@ class QuestionnaireManagerFactory(object):
     def get_instance():
         logger.debug("QuestionManagerFactory - get instance")
         if StateManager.has_state():
-            logger.error("StateManager loading state")
+            logger.debug("StateManager loading state")
             state = StateManager.get_state()
             if state.revision == settings.EQ_GIT_REF:
                 questionnaire_manager = QuestionnaireManager(state.schema,
@@ -27,13 +27,19 @@ class QuestionnaireManagerFactory(object):
                                                              valid_locations=state.valid_locations,
                                                              submitted_at=state.submitted_at)
             else:
-                questionnaire_manager = QuestionnaireManager(get_schema())
+                questionnaire_manager = QuestionnaireManager(QuestionnaireManagerFactory._get_schema())
                 StateRecovery.recover_from_post_data(questionnaire_manager)
         else:
             logger.debug("QuestionnaireManagerFactory - constructing new instance")
-            questionnaire_manager = QuestionnaireManager(get_schema())
+            questionnaire_manager = QuestionnaireManager(QuestionnaireManagerFactory._get_schema())
             questionnaire_manager.go_to(questionnaire_manager.get_first_location())
+
         # immediately save it to the database
         StateManager.save_state(questionnaire_manager.construct_state())
         logger.debug("QuestionnaireManagerFactory savingstate")
         return questionnaire_manager
+
+    @staticmethod
+    def _get_schema():
+        # exists to facilitate testing
+        return get_schema()

--- a/app/questionnaire/questionnaire_manager_factory.py
+++ b/app/questionnaire/questionnaire_manager_factory.py
@@ -7,6 +7,7 @@ from app.questionnaire.state_manager import StateManager
 from app.questionnaire.state_recovery import StateRecovery
 from app.utilities.schema import get_schema
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -18,17 +19,23 @@ class QuestionnaireManagerFactory(object):
         if StateManager.has_state():
             logger.debug("StateManager loading state")
             state = StateManager.get_state()
-            if state.revision == settings.EQ_GIT_REF:
-                questionnaire_manager = QuestionnaireManager(state.schema,
-                                                             current=state.current,
-                                                             first=state.first,
-                                                             tail=state.tail,
-                                                             archive=state.archive,
-                                                             valid_locations=state.valid_locations,
-                                                             submitted_at=state.submitted_at)
+
+            # TODO remove attribute check. This is for data migration in production and can be removed at a later date
+            if hasattr(state, 'revision'):
+                if state.revision == settings.EQ_GIT_REF:
+                    questionnaire_manager = QuestionnaireManager(state.schema,
+                                                                 current=state.current,
+                                                                 first=state.first,
+                                                                 tail=state.tail,
+                                                                 archive=state.archive,
+                                                                 valid_locations=state.valid_locations,
+                                                                 submitted_at=state.submitted_at)
+                else:
+                    questionnaire_manager = QuestionnaireManager(QuestionnaireManagerFactory._get_schema())
+                    StateRecovery.recover_from_post_data(questionnaire_manager)
             else:
+                logger.error("Data not recoverable, old version of state without revision attribute")
                 questionnaire_manager = QuestionnaireManager(QuestionnaireManagerFactory._get_schema())
-                StateRecovery.recover_from_post_data(questionnaire_manager)
         else:
             logger.debug("QuestionnaireManagerFactory - constructing new instance")
             questionnaire_manager = QuestionnaireManager(QuestionnaireManagerFactory._get_schema())

--- a/app/questionnaire/questionnaire_manager_factory.py
+++ b/app/questionnaire/questionnaire_manager_factory.py
@@ -1,0 +1,39 @@
+import logging
+
+from app import settings
+
+from app.questionnaire.questionnaire_manager import QuestionnaireManager
+from app.questionnaire.state_manager import StateManager
+from app.questionnaire.state_recovery import StateRecovery
+from app.utilities.schema import get_schema
+
+logger = logging.getLogger(__name__)
+
+
+class QuestionnaireManagerFactory(object):
+
+    @staticmethod
+    def get_instance():
+        logger.debug("QuestionManagerFactory - get instance")
+        if StateManager.has_state():
+            logger.error("StateManager loading state")
+            state = StateManager.get_state()
+            if state.revision == settings.EQ_GIT_REF:
+                questionnaire_manager = QuestionnaireManager(state.schema,
+                                                             current=state.current,
+                                                             first=state.first,
+                                                             tail=state.tail,
+                                                             archive=state.archive,
+                                                             valid_locations=state.valid_locations,
+                                                             submitted_at=state.submitted_at)
+            else:
+                questionnaire_manager = QuestionnaireManager(get_schema())
+                StateRecovery.recover_from_post_data(questionnaire_manager)
+        else:
+            logger.debug("QuestionnaireManagerFactory - constructing new instance")
+            questionnaire_manager = QuestionnaireManager(get_schema())
+            questionnaire_manager.go_to(questionnaire_manager.get_first_location())
+        # immediately save it to the database
+        StateManager.save_state(questionnaire_manager.construct_state())
+        logger.debug("QuestionnaireManagerFactory savingstate")
+        return questionnaire_manager

--- a/app/questionnaire/questionnaire_manager_factory.py
+++ b/app/questionnaire/questionnaire_manager_factory.py
@@ -31,6 +31,7 @@ class QuestionnaireManagerFactory(object):
                                                                  valid_locations=state.valid_locations,
                                                                  submitted_at=state.submitted_at)
                 else:
+                    logger.info("Recovering from post data - revision=%s git_ref=%s", state.revision, settings.EQ_GIT_REF)
                     questionnaire_manager = QuestionnaireManager(QuestionnaireManagerFactory._get_schema())
                     StateRecovery.recover_from_post_data(questionnaire_manager)
             else:

--- a/app/questionnaire/state.py
+++ b/app/questionnaire/state.py
@@ -1,0 +1,26 @@
+from app import settings
+
+'''
+  Everything in this class and the following packages is potentially serialized to the database and
+  therefore can cause issues if the code changes between deployments and sessions remain in the database.
+  Hence we check the git revision that created it, and if that has changed we replay the post data to
+  get back to the same state
+
+
+  schema - the entire schema (once it's parsed) this is needed as repeated elements modifies the schema, so the modified
+  version needs to be recovered
+  questionnaire_state - the doubly linked listed, i.e. the Node object, its associated Block State and all the child
+  states
+'''
+
+
+class State(object):
+    def __init__(self, schema, current_node, first_node, tail_node, archive, submitted_at, valid_locations):
+        self.schema = schema
+        self.current = current_node
+        self.first = first_node
+        self.tail = tail_node
+        self.archive = archive
+        self.submitted_at = submitted_at
+        self.valid_locations = valid_locations
+        self.revision = settings.EQ_GIT_REF

--- a/app/questionnaire/state_manager.py
+++ b/app/questionnaire/state_manager.py
@@ -14,9 +14,9 @@ STATE = "state"
 class StateManager(object):
     '''
     This class is responsible for saving the state of the User Journey Manager into the database.
-    It does this by pickling the Python object graph into JSON and storing that. Thi means that code
+    It does this by pickling the Python object graph into JSON and storing that. This means that code
     changes between deployments can cause odd behaviour if the database isn't wipe, as when it deserializes
-    state from old python code to new python code attributes can be missing.
+    state from old python code to new python code attributes can be missing. Hence why we have the StateRecovery class
     '''
     @staticmethod
     def has_state():

--- a/app/questionnaire/state_manager.py
+++ b/app/questionnaire/state_manager.py
@@ -129,8 +129,8 @@ class DatabaseStateManager(StateManager):
             logger.debug("Replaying post data %s", post_data)
             location = post_data['location']
             data_to_replay = DatabaseStateManager._convert_to_multi_dict(post_data['post_data'])
-            questionnaire_manager.go_to(location)
             location = questionnaire_manager.process_incoming_answers(location, data_to_replay, replay=True)
+            questionnaire_manager.go_to(location)
             logger.debug("Location %s", location)
         logger.debug("Post data replayed")
 

--- a/app/questionnaire/state_manager.py
+++ b/app/questionnaire/state_manager.py
@@ -6,18 +6,15 @@ from flask_login import current_user
 
 import jsonpickle
 
-from werkzeug.datastructures import ImmutableMultiDict, MultiDict
-
 logger = logging.getLogger(__name__)
 
 STATE = "state"
-POST_DATA = "post_data"
 
 
 class StateManager(object):
     '''
     This class is responsible for saving the state of the User Journey Manager into the database.
-    It does this by pickling the Python object graph into JSON and storing that. This means that code
+    It does this by pickling the Python object graph into JSON and storing that. Thi means that code
     changes between deployments can cause odd behaviour if the database isn't wipe, as when it deserializes
     state from old python code to new python code attributes can be missing.
     '''
@@ -71,77 +68,17 @@ class DatabaseStateManager(StateManager):
     @staticmethod
     def has_state():
         questionnaire_data = current_user.get_questionnaire_data()
-        # return STATE in questionnaire_data.keys()
-        return POST_DATA in questionnaire_data.keys()
+        return STATE in questionnaire_data.keys()
 
     @staticmethod
     def get_state():
         questionnaire_data = current_user.get_questionnaire_data()
         logger.debug("Returning questionnaire data %s", questionnaire_data)
-        # TODO
-        # state = questionnaire_data[STATE]
-        # return jsonpickle.decode(state)
-
-        return DatabaseStateManager.recover_from_post_data()
+        state = questionnaire_data[STATE]
+        return jsonpickle.decode(state)
 
     @staticmethod
     def save_state(questionnaire_state):
-        # questionnaire_data = current_user.get_questionnaire_data()
-        # questionnaire_data[STATE] = jsonpickle.encode(questionnaire_state)
-        # current_user.save()
-        pass
-
-    @staticmethod
-    def save_post_date(location, post_data):
-        logger.error("Saving Post Data %s", post_data)
         questionnaire_data = current_user.get_questionnaire_data()
-        if POST_DATA not in questionnaire_data:
-            questionnaire_data[POST_DATA] = []
-
-        questionnaire_data[POST_DATA].append({'location': location, 'post_data': DatabaseStateManager._convert_to_dict(post_data)})
+        questionnaire_data[STATE] = jsonpickle.encode(questionnaire_state)
         current_user.save()
-
-    @staticmethod
-    def _convert_to_dict(post_data):
-        logger.error("Multi dict is %s", post_data)
-        return post_data.to_dict(flat=False)
-
-    @staticmethod
-    def recover_from_post_data():
-        logger.debug("Recovering from post data")
-        from app.questionnaire.questionnaire_manager import QuestionnaireManager
-        from app.questionnaire.create_questionnaire_manager import get_schema
-
-        logger.debug("Creating questionnaire manager")
-        questionnaire_manager = QuestionnaireManager.new_instance(get_schema())
-
-        logger.debug("Retrieving questionnaire data")
-        questionnaire_data = current_user.get_questionnaire_data()
-        if POST_DATA not in questionnaire_data:
-            questionnaire_data[POST_DATA] = []
-
-        all_post_data = questionnaire_data[POST_DATA]
-        logger.debug("All post data %s", all_post_data)
-        questionnaire_manager.go_to(questionnaire_manager.get_first_location())
-
-        # basically this replays the post data in order
-        for post_data in all_post_data:
-            logger.debug("Replaying post data %s", post_data)
-            location = post_data['location']
-            data_to_replay = DatabaseStateManager._convert_to_multi_dict(post_data['post_data'])
-            location = questionnaire_manager.process_incoming_answers(location, data_to_replay, replay=True)
-            questionnaire_manager.go_to(location)
-            logger.debug("Location %s", location)
-        logger.debug("Post data replayed")
-
-        return questionnaire_manager
-
-    @staticmethod
-    def _convert_to_multi_dict(post_data):
-        multi_dict = MultiDict()
-        for key in post_data.keys():
-            for value in post_data[key]:
-                multi_dict.add(key, value)
-
-        logger.error("Recovered multi dict is %s", multi_dict)
-        return ImmutableMultiDict(multi_dict)

--- a/app/questionnaire/state_manager.py
+++ b/app/questionnaire/state_manager.py
@@ -6,9 +6,12 @@ from flask_login import current_user
 
 import jsonpickle
 
+from werkzeug.datastructures import ImmutableMultiDict, MultiDict
+
 logger = logging.getLogger(__name__)
 
 STATE = "state"
+POST_DATA = "post_data"
 
 
 class StateManager(object):
@@ -39,6 +42,13 @@ class StateManager(object):
         else:
             InMemoryStateManager.save_state(questionnaire_state)
 
+    @staticmethod
+    def save_post_date(location, post_data):
+        if settings.EQ_SERVER_SIDE_STORAGE_TYPE == 'DATABASE':
+            DatabaseStateManager.save_post_date(location, post_data)
+        else:
+            InMemoryStateManager.save_post_date(location, post_data)
+
 
 class InMemoryStateManager(StateManager):
     IN_MEMORY_STATE = {}
@@ -61,17 +71,77 @@ class DatabaseStateManager(StateManager):
     @staticmethod
     def has_state():
         questionnaire_data = current_user.get_questionnaire_data()
-        return STATE in questionnaire_data.keys()
+        # return STATE in questionnaire_data.keys()
+        return POST_DATA in questionnaire_data.keys()
 
     @staticmethod
     def get_state():
         questionnaire_data = current_user.get_questionnaire_data()
         logger.debug("Returning questionnaire data %s", questionnaire_data)
-        state = questionnaire_data[STATE]
-        return jsonpickle.decode(state)
+        # TODO
+        # state = questionnaire_data[STATE]
+        # return jsonpickle.decode(state)
+
+        return DatabaseStateManager.recover_from_post_data()
 
     @staticmethod
     def save_state(questionnaire_state):
+        # questionnaire_data = current_user.get_questionnaire_data()
+        # questionnaire_data[STATE] = jsonpickle.encode(questionnaire_state)
+        # current_user.save()
+        pass
+
+    @staticmethod
+    def save_post_date(location, post_data):
+        logger.error("Saving Post Data %s", post_data)
         questionnaire_data = current_user.get_questionnaire_data()
-        questionnaire_data[STATE] = jsonpickle.encode(questionnaire_state)
+        if POST_DATA not in questionnaire_data:
+            questionnaire_data[POST_DATA] = []
+
+        questionnaire_data[POST_DATA].append({'location': location, 'post_data': DatabaseStateManager._convert_to_dict(post_data)})
         current_user.save()
+
+    @staticmethod
+    def _convert_to_dict(post_data):
+        logger.error("Multi dict is %s", post_data)
+        return post_data.to_dict(flat=False)
+
+    @staticmethod
+    def recover_from_post_data():
+        logger.debug("Recovering from post data")
+        from app.questionnaire.questionnaire_manager import QuestionnaireManager
+        from app.questionnaire.create_questionnaire_manager import get_schema
+
+        logger.debug("Creating questionnaire manager")
+        questionnaire_manager = QuestionnaireManager.new_instance(get_schema())
+
+        logger.debug("Retrieving questionnaire data")
+        questionnaire_data = current_user.get_questionnaire_data()
+        if POST_DATA not in questionnaire_data:
+            questionnaire_data[POST_DATA] = []
+
+        all_post_data = questionnaire_data[POST_DATA]
+        logger.debug("All post data %s", all_post_data)
+        questionnaire_manager.go_to(questionnaire_manager.get_first_location())
+
+        # basically this replays the post data in order
+        for post_data in all_post_data:
+            logger.debug("Replaying post data %s", post_data)
+            location = post_data['location']
+            data_to_replay = DatabaseStateManager._convert_to_multi_dict(post_data['post_data'])
+            questionnaire_manager.go_to(location)
+            location = questionnaire_manager.process_incoming_answers(location, data_to_replay, replay=True)
+            logger.debug("Location %s", location)
+        logger.debug("Post data replayed")
+
+        return questionnaire_manager
+
+    @staticmethod
+    def _convert_to_multi_dict(post_data):
+        multi_dict = MultiDict()
+        for key in post_data.keys():
+            for value in post_data[key]:
+                multi_dict.add(key, value)
+
+        logger.error("Recovered multi dict is %s", multi_dict)
+        return ImmutableMultiDict(multi_dict)

--- a/app/questionnaire/state_recovery.py
+++ b/app/questionnaire/state_recovery.py
@@ -1,0 +1,64 @@
+import logging
+
+
+from flask_login import current_user
+
+
+from werkzeug.datastructures import ImmutableMultiDict, MultiDict
+
+logger = logging.getLogger(__name__)
+
+POST_DATA = "post_data"
+
+
+class StateRecovery(object):
+
+    @staticmethod
+    def save_post_date(location, post_data):
+        logger.debug("Saving Post Data %s", post_data)
+        questionnaire_data = current_user.get_questionnaire_data()
+        if POST_DATA not in questionnaire_data:
+            questionnaire_data[POST_DATA] = []
+
+        questionnaire_data[POST_DATA].append({'location': location, 'post_data': StateRecovery._convert_to_dict(post_data)})
+        current_user.save()
+
+    @staticmethod
+    def _convert_to_dict(post_data):
+        logger.error("Multi dict is %s", post_data)
+        return post_data.to_dict(flat=False)
+
+    @staticmethod
+    def recover_from_post_data(questionnaire_manager):
+        logger.debug("Recovering from post data")
+
+        logger.debug("Retrieving questionnaire data")
+        questionnaire_data = current_user.get_questionnaire_data()
+        if POST_DATA not in questionnaire_data:
+            questionnaire_data[POST_DATA] = []
+
+        all_post_data = questionnaire_data[POST_DATA]
+        logger.debug("All post data %s", all_post_data)
+        questionnaire_manager.go_to(questionnaire_manager.get_first_location())
+
+        # basically this replays the post data in order
+        for post_data in all_post_data:
+            logger.debug("Replaying post data %s", post_data)
+            location = post_data['location']
+            data_to_replay = StateRecovery._convert_to_multi_dict(post_data['post_data'])
+            location = questionnaire_manager.process_incoming_answers(location, data_to_replay, replay=True)
+            questionnaire_manager.go_to(location)
+            logger.debug("Location %s", location)
+        logger.debug("Post data replayed")
+
+        return questionnaire_manager
+
+    @staticmethod
+    def _convert_to_multi_dict(post_data):
+        multi_dict = MultiDict()
+        for key in post_data.keys():
+            for value in post_data[key]:
+                multi_dict.add(key, value)
+
+        logger.debug("Recovered multi dict is %s", multi_dict)
+        return ImmutableMultiDict(multi_dict)

--- a/app/questionnaire_state/node.py
+++ b/app/questionnaire_state/node.py
@@ -9,3 +9,6 @@ class Node(object):
 
         # the state of the node, this is always a Block object
         self.state = state
+
+    def __str__(self):
+        return self.item_id

--- a/app/settings.py
+++ b/app/settings.py
@@ -53,6 +53,7 @@ EQ_SESSION_TIMEOUT = int(os.getenv('EQ_SESSION_TIMEOUT', '28800'))
 EQ_SECRET_KEY = os.getenv('EQ_SECRET_KEY', os.urandom(24))
 EQ_UA_ID = os.getenv('EQ_UA_ID', '')
 EQ_SCHEMA_BUCKET = os.getenv('EQ_SCHEMA_BUCKET', "eq-schema-files-" + os.getenv('USER', 'UNKNOWN'))
+EQ_MAX_REPLAY_COUNT = os.getenv('EQ_REPLAY_COUNT', 50)
 
 
 EQ_SERVER_SIDE_STORAGE_TYPE = os.getenv('EQ_SERVER_SIDE_STORAGE_TYPE', 'DATABASE')

--- a/app/utilities/schema.py
+++ b/app/utilities/schema.py
@@ -1,9 +1,7 @@
 import logging
 
-
 from app.metadata.metadata_store import MetaDataStore
 from app.parser.schema_parser_factory import SchemaParserFactory
-from app.questionnaire.questionnaire_manager import QuestionnaireManager
 from app.schema_loader.schema_loader import load_schema
 
 from flask_login import current_user
@@ -11,14 +9,18 @@ from flask_login import current_user
 logger = logging.getLogger(__name__)
 
 
-def create_questionnaire_manager():
+def get_schema():
+    metadata = MetaDataStore.get_instance(current_user)
 
-    questionnaire_manager = QuestionnaireManager.get_instance()
-    if not questionnaire_manager:
-        schema = get_schema()
-        questionnaire_manager = QuestionnaireManager.new_instance(schema)
+    eq_id = metadata.eq_id
+    form_type = metadata.form_type
+    logger.debug("Requested questionnaire %s for form type %s", eq_id, form_type)
 
-    return questionnaire_manager
+    schema = load_and_parse_schema(eq_id, form_type)
+    if not schema:
+        raise ValueError("No schema available")
+    logger.debug("Constructing brand new User Journey Manager")
+    return schema
 
 
 def load_and_parse_schema(eq_id, form_type):
@@ -37,17 +39,3 @@ def load_and_parse_schema(eq_id, form_type):
         return schema
     else:
         return None
-
-
-def get_schema():
-    metadata = MetaDataStore.get_instance(current_user)
-
-    eq_id = metadata.eq_id
-    form_type = metadata.form_type
-    logger.debug("Requested questionnaire %s for form type %s", eq_id, form_type)
-
-    schema = load_and_parse_schema(eq_id, form_type)
-    if not schema:
-        raise ValueError("No schema available")
-    logger.debug("Constructing brand new User Journey Manager")
-    return schema

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -35,7 +35,7 @@ function display_result {
 flake8 --max-complexity 10 --count
 display_result $? 1 "Code style check"
 
-py.test --cov=app $@
+py.test --cov=app $@ $1
 display_result $? 2 "Unit tests"
 
 # Run front end tests

--- a/tests/app/questionnaire/test_questionnaire_manager.py
+++ b/tests/app/questionnaire/test_questionnaire_manager.py
@@ -3,7 +3,6 @@ import os
 
 from app import settings
 from app.parser.schema_parser_factory import SchemaParserFactory
-from app.questionnaire.state_manager import InMemoryStateManager
 from app.questionnaire_state.node import Node
 from app.questionnaire.questionnaire_manager import QuestionnaireManager
 from app.schema.block import Block
@@ -22,21 +21,6 @@ class TestQuestionnaireManager(SurveyRunnerTestCase):
         parser = SchemaParserFactory.create_parser(json.loads(schema))
         self.questionnaire = parser.parse()
         settings.EQ_SERVER_SIDE_STORAGE_TYPE = "IN_MEMORY"
-
-    def test_new_and_get_instance(self):
-        # clear any state
-        InMemoryStateManager.IN_MEMORY_STATE = {}
-
-        # test there is no instance
-        questionnaire_manager = QuestionnaireManager.get_instance()
-        self.assertIsNone(questionnaire_manager)
-
-        # test we can construct an instance
-        questionnaire_manager = QuestionnaireManager.new_instance(self.questionnaire)
-        self.assertIsNotNone(questionnaire_manager)
-
-        # check get now returns one
-        self.assertIsNotNone(QuestionnaireManager.get_instance())
 
     def test_get_state_is_none(self):
         questionnaire_manager = QuestionnaireManager(self.questionnaire)

--- a/tests/app/questionnaire/test_questionnaire_manager_factory.py
+++ b/tests/app/questionnaire/test_questionnaire_manager_factory.py
@@ -1,0 +1,42 @@
+from app.questionnaire.questionnaire_manager_factory import QuestionnaireManagerFactory
+from app.questionnaire_state.node import Node
+from app.questionnaire.state import State
+from app.questionnaire.state_recovery import StateRecovery
+from app.questionnaire.state_manager import StateManager
+from tests.app.framework.sr_unittest import SurveyRunnerTestCase
+
+from unittest.mock import MagicMock
+
+
+class TestQuestionnaireManagerFactory(SurveyRunnerTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.has_state = StateManager.has_state
+        self.get_state = StateManager.get_state
+        self.recover_from_post_data = StateRecovery.recover_from_post_data
+        self.get_schema = QuestionnaireManagerFactory._get_schema
+        QuestionnaireManagerFactory._get_schema = lambda: self.questionnaire
+
+    def tearDown(self):
+        super().tearDown()
+        StateManager.has_state = self.has_state
+        StateManager.get_state = self.get_state
+        StateRecovery.recover_from_post_data = self.recover_from_post_data
+        QuestionnaireManagerFactory._get_schema = self.get_schema
+
+    def test_get_instance(self):
+        with self.application.test_request_context():
+            self.assertIsNotNone(QuestionnaireManagerFactory.get_instance())
+
+    def test_get_instance_git_revision_change(self):
+        with self.application.test_request_context():
+            StateManager.has_state = MagicMock(return_value="True")
+            node = Node("1", None)
+            state = State(self.questionnaire, current_node=node, first_node=node, tail_node=node, valid_locations=[], archive={}, submitted_at=None)
+            state.revision = "1"
+            StateManager.get_state = MagicMock(return_value=state)
+            StateRecovery.recover_from_post_data = MagicMock()
+            questionnaire_manager = QuestionnaireManagerFactory.get_instance()
+            StateRecovery.recover_from_post_data.assert_called_with(questionnaire_manager)
+

--- a/tests/app/questionnaire/test_questionnaire_manager_factory.py
+++ b/tests/app/questionnaire/test_questionnaire_manager_factory.py
@@ -1,3 +1,5 @@
+import logging
+
 from app.questionnaire.questionnaire_manager_factory import QuestionnaireManagerFactory
 from app.questionnaire_state.node import Node
 from app.questionnaire.state import State
@@ -31,12 +33,26 @@ class TestQuestionnaireManagerFactory(SurveyRunnerTestCase):
 
     def test_get_instance_git_revision_change(self):
         with self.application.test_request_context():
-            StateManager.has_state = MagicMock(return_value="True")
-            node = Node("1", None)
-            state = State(self.questionnaire, current_node=node, first_node=node, tail_node=node, valid_locations=[], archive={}, submitted_at=None)
+            state = self.mock_state()
             state.revision = "1"
             StateManager.get_state = MagicMock(return_value=state)
             StateRecovery.recover_from_post_data = MagicMock()
             questionnaire_manager = QuestionnaireManagerFactory.get_instance()
             StateRecovery.recover_from_post_data.assert_called_with(questionnaire_manager)
 
+    def test_missing_revision_attribute(self):
+        with self.application.test_request_context():
+            state = self.mock_state()
+            del state.revision
+            StateManager.get_state = MagicMock(return_value=state)
+            logger_name = 'app.questionnaire.questionnaire_manager_factory'
+            logging.getLogger(logger_name).error = MagicMock()
+            QuestionnaireManagerFactory.get_instance()
+            logging.getLogger(logger_name).error.assert_called_with('Data not recoverable, old version of state without revision attribute')
+
+    def mock_state(self):
+        StateManager.has_state = MagicMock(return_value="True")
+        node = Node("1", None)
+        state = State(self.questionnaire, current_node=node, first_node=node, tail_node=node, valid_locations=[],
+                    archive={}, submitted_at=None)
+        return state

--- a/tests/app/questionnaire/test_state_recovery.py
+++ b/tests/app/questionnaire/test_state_recovery.py
@@ -1,0 +1,58 @@
+from app import settings
+from app.questionnaire import state_recovery
+from app.questionnaire.state_recovery import StateRecovery, POST_DATA, MAX_NO_OF_REPLAYS
+from app.questionnaire.questionnaire_manager import QuestionnaireManager
+from tests.app.framework.sr_unittest import SurveyRunnerTestCase
+from unittest.mock import MagicMock
+
+from flask_login import current_user
+from werkzeug.datastructures import MultiDict, ImmutableMultiDict
+
+
+class TestStateRecovery(SurveyRunnerTestCase):
+
+    def test_save_post_data(self):
+        with self.application.test_request_context():
+            post_data = MultiDict()
+            post_data.add("1", "test")
+            location = "page1"
+
+            StateRecovery.save_post_date(location, post_data)
+
+            self.assertIsNotNone(current_user.get_questionnaire_data())
+            self.assertEqual(post_data, current_user.get_questionnaire_data()[POST_DATA][0]["post_data"])
+            self.assertEqual(location, current_user.get_questionnaire_data()[POST_DATA][0]["location"])
+
+    def test_recover_from_post_data(self):
+        with self.application.test_request_context():
+            questionnaire_manager = QuestionnaireManager(self.questionnaire)
+            questionnaire_manager.process_incoming_answers = MagicMock(return_value="page_2")
+            questionnaire_manager.go_to = MagicMock()
+            post_data = MultiDict()
+            post_data.add("1", "test")
+            post_data = ImmutableMultiDict(post_data)
+            location = "page_1"
+
+            StateRecovery.save_post_date(location, post_data)
+
+            StateRecovery.recover_from_post_data(questionnaire_manager)
+            questionnaire_manager.process_incoming_answers.assert_called_with(location, post_data, replay=True)
+            questionnaire_manager.go_to.assert_called_with("page_2")
+
+    def test_recover_from_post_data_replay_count(self):
+        with self.application.test_request_context():
+            setattr(state_recovery, "MAX_NO_OF_REPLAYS", 0)
+            questionnaire_manager = QuestionnaireManager(self.questionnaire)
+            questionnaire_manager.process_incoming_answers = MagicMock(return_value="page_2")
+            questionnaire_manager.go_to = MagicMock()
+            post_data = MultiDict()
+            post_data.add("1", "test")
+            post_data = ImmutableMultiDict(post_data)
+            location = "page_1"
+
+            StateRecovery.save_post_date(location, post_data)
+
+            StateRecovery.recover_from_post_data(questionnaire_manager)
+            questionnaire_manager.process_incoming_answers.assert_not_called()
+            questionnaire_manager.go_to.assert_called_with("introduction")
+            setattr(state_recovery, "MAX_NO_OF_REPLAYS", settings.EQ_MAX_REPLAY_COUNT)

--- a/tests/integration/mci/test_empty_submission.py
+++ b/tests/integration/mci/test_empty_submission.py
@@ -15,7 +15,16 @@ class TestEmptySubmission(IntegrationTestCase):
 
         # We are on the landing page
         content = resp.get_data(True)
+        self.assertRegexpMatches(content, '<title>Introduction</title>')
         self.assertRegexpMatches(content, '>Get Started<')
+        self.assertRegexpMatches(content, '(?s)Monthly Business Survey - Retail Sales Index.*?Monthly Business Survey - Retail Sales Index')
+
+        # We proceed to the questionnaire
+        post_data = {
+            'action[start_questionnaire]': 'Start Questionnaire'
+        }
+        resp = self.client.post('/questionnaire/' + eq_id + '/789/introduction', data=post_data, follow_redirects=False)
+        self.assertEquals(resp.status_code, 302)
 
         # We proceed to the questionnaire
         resp = self.client.get('/questionnaire/' + eq_id + '/789/cd3b74d1-b687-4051-9634-a8f9ce10a27d', follow_redirects=True)

--- a/tests/integration/mci/test_invalid_dates_numbers.py
+++ b/tests/integration/mci/test_invalid_dates_numbers.py
@@ -15,7 +15,16 @@ class TestInvalidDateNumber(IntegrationTestCase):
 
         # We are on the landing page
         content = resp.get_data(True)
+        self.assertRegexpMatches(content, '<title>Introduction</title>')
         self.assertRegexpMatches(content, '>Get Started<')
+        self.assertRegexpMatches(content, '(?s)Monthly Business Survey - Retail Sales Index.*?Monthly Business Survey - Retail Sales Index')
+
+        # We proceed to the questionnaire
+        post_data = {
+            'action[start_questionnaire]': 'Start Questionnaire'
+        }
+        resp = self.client.post('/questionnaire/' + eq_id + '/789/introduction', data=post_data, follow_redirects=False)
+        self.assertEquals(resp.status_code, 302)
 
         # We proceed to the questionnaire
         resp = self.client.get('/questionnaire/' + eq_id + '/789/cd3b74d1-b687-4051-9634-a8f9ce10a27d', follow_redirects=True)


### PR DESCRIPTION
### What is the context of this PR?

Fixes #364 

Questionnaire state is serialization via jsonpickle to the database. In most case that is used to restore questionnaire state. However if a deployment happens and the GIT revision changes then we replay post data, which we are now also saving, to recover the state. This solves the issue when the python classes can get out of sync between deployments.
### How to review
1. Start a survey
2. Submit at least a single page
3. Manually set the EQ_GIT_REVISION to a value other than the git head revision
4. Restart and the survey and check that the state is recovered.

Part 2 - Safe prod/pre-prod migration
1. Using master and not this branch, start a questionnaire, completing a couple of pages
2. Checkout this branch and try to restore the same session with the same questionnaire
3. It should not be able to restore the state but take you to the first page
4. A record should be included in the logs
- [ ] Do all commits have sensible commit messages?
- [ ] Is all new code unit tested?
- [ ] Are there integration tests if needed?
- [ ] Is there sufficient logging?
- [ ] Is there documentation or is the code self-describing?
### Who worked on the PR

@warrenbailey and @LJBabbage
