### PR TITLE
Fixing previous link issue on first page

### DIFF
--- a/app/questionnaire/questionnaire_manager.py
+++ b/app/questionnaire/questionnaire_manager.py
@@ -282,10 +282,8 @@ class QuestionnaireManager(object):
         self.go_to_state(location)
 
     def is_known_state(self, location):
-        if self._tail.item_id == location:
-            return True
         node = self._tail
-        while node.previous:
+        while node:
             if node.item_id == location:
                 return True
             node = node.previous

--- a/tests/integration/star_wars/test_previous_link.py
+++ b/tests/integration/star_wars/test_previous_link.py
@@ -63,3 +63,29 @@ class TestPreviousLink(StarWarsTestCase):
         # now go back to the second page
         self.check_second_quiz_page(second_page)
 
+    def test_previous_link_to_introduction(self):
+
+        self.login_and_check_introduction_text()
+        first_page = "http://localhost/questionnaire/0/789/f22b1ba4-d15f-48b8-a1f3-db62b6f34cc0"
+
+        post_data = {
+            'action[start_questionnaire]': 'Start Questionnaire'
+        }
+
+        # first start the survey
+        resp = self.client.post('/questionnaire/0/789/introduction', data=post_data, follow_redirects=False)
+        self.assertEquals(resp.status_code, 302)
+        self.assertEquals(resp.headers['Location'], first_page)
+
+        # then click previous
+        resp = self.client.get('/questionnaire/0/789/previous', follow_redirects=False)
+        self.assertEquals(resp.status_code, 302)
+        self.assertEquals(resp.headers['Location'], "http://localhost/questionnaire/0/789/introduction")
+
+        # then try to start the survey again
+        resp = self.client.post('/questionnaire/0/789/introduction', data=post_data, follow_redirects=False)
+        self.assertEquals(resp.status_code, 302)
+        self.assertEquals(resp.headers['Location'], first_page)
+
+
+


### PR DESCRIPTION
### What is the context of this PR?

Fixes #402 - Clicking start questionnaire and then immediately clicking the previous link resulted in the user not being able to start the questionnaire.

The problem was introduced by the is_known_state method not checking the entire list.
### How to review
1. Start a survey
2. Click the previous link
3. Click start a survey
### Who worked on the PR

@warrenbailey
