### PR TITLE
Remove employees from info to provide

### DIFF
--- a/app/data/1_0102.json
+++ b/app/data/1_0102.json
@@ -11,7 +11,6 @@
         "information_to_provide": [
           "value of total retail turnover",
           "value of internet sales",
-          "numbers of employees",
           "reasons for changes to figures"
         ]
     },

--- a/app/data/1_0203.json
+++ b/app/data/1_0203.json
@@ -11,7 +11,6 @@
         "information_to_provide": [
           "value of total retail turnover",
           "value of internet sales",
-          "numbers of employees",
           "reasons for changes to figures"
         ]
     },

--- a/app/data/1_0205.json
+++ b/app/data/1_0205.json
@@ -9,12 +9,11 @@
 	"theme": "basetheme",
 	"introduction": {
 		"description": "<p>The information supplied is used to produce monthly estimates of the total retail sales in Great Britain where retailing is defined as the sale of goods to the general public for household consumption. The Retail Sales Index is a key indicator of the progress of the economy. It is also used to help estimate consumer spending on retail goods and the output of the retail sector, both of which feed into the compilation of the National Accounts. The results are also used by the Bank of England and HM Treasury to inform decision making by government and in formulating financial policies. The results <a href=\"http://www.ons.gov.uk/businessindustryandtrade/retailindustry\">are published on our website</a>.</p>",
-    "information_to_provide": [
-      "value of total retail turnover",
-      "value of internet sales",
-      "numbers of employees",
-      "reasons for changes to figures"
-    ]
+		"information_to_provide": [
+			"value of total retail turnover",
+			"value of internet sales",
+			"reasons for changes to figures"
+		]
 	},
 	"messages": {
 		"MANDATORY": "Please answer before continuing.",


### PR DESCRIPTION
### What is the context of this PR?

Remove "employees" from information to provide in schema if the survey doesn't require employees. Fixes #450. 
### How to review

Open one of 102, 203 or 205 surveys and observe the statement "numbers of employees" doesn't appear in the information to provide statement on landing page. Open one of 112, 213, or 215 surveys and observe the statement does appear.
### Who worked on the PR

@iwootten
