### PR TITLE
Remove coveralls (no longer used) and redundant test packages

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,0 @@
-service_name: travis-ci
-parallel: true

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,13 +1,5 @@
 pytest==2.8.2
 pep8==1.6.2
-nose==1.3.4
 mock==1.0.1
-requests-mock==0.6.0
-lxml==3.4.4
-cssselect==0.9.1
-watchdog==0.8.3
-python-coveralls==2.7.0
-PyYAML==3.11
-sh==1.11
 coverage==4.2b1
 pytest-cov==2.3.0


### PR DESCRIPTION
### What is the context of this PR?

Removed coveralls config file (we are using codecov now instead) and redundant pip requirements for testing.
### How to review

Ensure that ./scripts/run_tests.sh still works with a clean virtual env (remember to install requirements_for_test.txt).
