### PR TITLE
Legal date is wrong on landing page

### DIFF
--- a/app/themes/basetheme/templates/landing-page.html
+++ b/app/themes/basetheme/templates/landing-page.html
@@ -58,7 +58,7 @@
       <div class="venus lock__text">We will treat your data securely and confidentially</div>
     </div>
     <h2 class="saturn">Legal Information</h2>
-    <p class="mars">You are required to complete this questionnaire. If you do not complete and return this questionnaire by 9 July 2016, penalties may be incurred (under section 4 of the Statistics of Trade Act 1947).</p>
+    <p class="mars">You are required to complete this questionnaire. If you do not complete and return this questionnaire by {{ meta.survey.return_by }}, penalties may be incurred (under section 4 of the Statistics of Trade Act 1947).</p>
   </div>
 
 

--- a/tests/integration/star_wars/star_wars_tests.py
+++ b/tests/integration/star_wars/star_wars_tests.py
@@ -24,6 +24,7 @@ class StarWarsTestCase(IntegrationTestCase):
         self.assertRegexpMatches(content, '(?s)To be completed by.*?MCI Integration Testing')
         self.assertRegexpMatches(content, '(?s)PLEASE SUBMIT BY.*?6 May 2016')
         self.assertRegexpMatches(content, '(?s)PERIOD.*?1 April 2016.*?30 April 2016')
+        self.assertRegexpMatches(content, 'questionnaire by 6 May 2016, penalties may be incurred')
 
         # Legal checks
         self.assertRegexpMatches(content, 'Notice is given under section 1 of the Statistics of Trade Act 1947')


### PR DESCRIPTION
### What is the context of this PR?

Fixes #459. The date is currently hardcoded on the landing page to be 6 July 2016, this should be whatever is sent in the return by date on the JWT. Code updated to call from the metadata store
### How to review

Open up any survey in dev, change the return by date and make sure it changes in the legal documentation at the bottom to be the same
