### PR TITLE
eq-582, eq-530 Input Widths & Numeric Date Entry

### DIFF
--- a/app/assets/styles/partials/base/_typography.scss
+++ b/app/assets/styles/partials/base/_typography.scss
@@ -59,12 +59,7 @@ h1,
 h2,
 h3,
 h4,
-h5,
-.h1,
-.h2,
-.h3,
-.h4,
-.h5 {
+h5 {
   font-size: 1rem;
   margin: 0 0 1rem;
   line-height: 1.2;
@@ -76,6 +71,7 @@ code {
 
 ul {
   margin-bottom: 1.5rem;
+  padding-left: 1.5rem;
 }
 
 li {

--- a/app/assets/styles/partials/base/_typography.scss
+++ b/app/assets/styles/partials/base/_typography.scss
@@ -46,12 +46,12 @@ p {
 }
 
 .mercury {
-  font-size: 0.7rem;
+  font-size: 0.8rem;
   font-weight: 700;
 }
 
 .pluto {
-  font-size: 0.7rem;
+  font-size: 0.8rem;
   font-weight: 400;
 }
 

--- a/app/assets/styles/partials/components/_field.scss
+++ b/app/assets/styles/partials/components/_field.scss
@@ -7,7 +7,7 @@
   margin-bottom: 0.5rem;
   position: relative;
   display: flex;
-  align-items: flex-start;;
+  align-items: flex-start;
 }
 
 .field--multi {
@@ -25,46 +25,23 @@
   }
 }
 
-.date {
-  $legend-width: 5rem;
+.fieldset--date {
   .legend {
     font-weight: 700;
     display: inline-block;
     width: 100%;
     margin: 0 0 0.5rem;
-
-    @include mq(s) {
-      margin: 2.2rem 0 0;
-      width: 5rem;
-    }
-
-    @include fixed {
-      width: 4rem;
-      float: left;
-      margin-top: 35px;
-    }
-
-    @include lt-ie8 {
-      position: absolute;
-      margin-top: 20px;
-    }
   }
-  .subfields {
+
+  .fieldset__fields {
     display: flex;
     width: 100%;
-
-    @include mq(s) {
-      width: calc(100% - #{$legend-width});
-    }
-
-    @include fixed {
-      width: 30rem;
-      float: right;
-    }
+    flex-direction: row;
   }
+
   .field {
+    margin: 0 0.5rem 0 0;
     flex: 1 1 0;
-    margin-right: 0.5rem;
 
     @include mq(s) {
       margin-right: 1rem;
@@ -81,16 +58,22 @@
       width: 7rem;
     }
   }
+
   .field--month {
     flex: 2;
     @include fixed {
       width: 14rem;
     }
   }
+
   .field--year {
     margin-right: 0;
     @include fixed {
       width: 7rem;
     }
+  }
+
+  .input {
+    width: 100%;
   }
 }

--- a/app/assets/styles/partials/components/_field.scss
+++ b/app/assets/styles/partials/components/_field.scss
@@ -54,6 +54,7 @@
   }
 
   .field--day {
+    max-width: 6rem;
     @include fixed {
       width: 7rem;
     }
@@ -61,6 +62,7 @@
 
   .field--month {
     flex: 2;
+    max-width: 10rem;
     @include fixed {
       width: 14rem;
     }
@@ -68,6 +70,7 @@
 
   .field--year {
     margin-right: 0;
+    max-width: 6rem;
     @include fixed {
       width: 7rem;
     }

--- a/app/assets/styles/partials/components/_input.scss
+++ b/app/assets/styles/partials/components/_input.scss
@@ -9,8 +9,6 @@ $input-padding: 0.6rem;
   font-size: 1rem;
   border: 1px solid $color-borders;
   border-radius: $input-radius;
-  width: 100%;
-  max-width: 40rem;
 }
 
 .input__helper {
@@ -25,13 +23,16 @@ $input-padding: 0.6rem;
   background: $color-white url("/s/img/icons/icons--chevron-down.svg") no-repeat center right 6px;
   background-size: 1.5rem;
   line-height: 1.4;
-  width: 100%;
   &::-ms-expand {
     display: none;
   }
   @include fixed() {
     padding-right: 0.5rem;
   }
+}
+
+.input--textarea {
+  width: 100%;
 }
 
 .input--radio,
@@ -89,7 +90,6 @@ $input-padding: 0.6rem;
   align-items: center;
   .input {
     border-radius: 0 3px 3px 0;
-    flex: 1;
     line-height: normal;
     position: relative;
     z-index: 1;

--- a/app/assets/styles/partials/components/_input.scss
+++ b/app/assets/styles/partials/components/_input.scss
@@ -9,6 +9,7 @@ $input-padding: 0.6rem;
   font-size: 1rem;
   border: 1px solid $color-borders;
   border-radius: $input-radius;
+  width: percentage(4 / 12);
 }
 
 .input__helper {

--- a/app/assets/styles/partials/components/_input.scss
+++ b/app/assets/styles/partials/components/_input.scss
@@ -1,4 +1,6 @@
 $input-padding: 0.6rem;
+$input-type-width: 2.4rem;
+$input-width: 15rem;
 
 .input {
   position: relative;
@@ -11,10 +13,7 @@ $input-padding: 0.6rem;
   border-radius: $input-radius;
   width: 100%;
   @include mq(s) {
-    width: percentage(6 / 12);
-  }
-  @include mq(l) {
-    width: percentage(4 / 12);
+    width: $input-width;
   }
 }
 
@@ -92,8 +91,6 @@ $input-padding: 0.6rem;
 }
 
 .input-type {
-  $input-type-width: 2.4rem;
-
   display: flex;
   position: relative;
   align-items: center;
@@ -102,15 +99,10 @@ $input-padding: 0.6rem;
     line-height: normal;
     position: relative;
     z-index: 1;
+    width: calc(#{$input-width} - #{$input-type-width});
     @include fixed {
       margin-left: 2.5rem;
       border-left: 0;
-    }
-    @include mq(s) {
-      width: calc(#{percentage(6 / 12)} - #{$input-type-width});
-    }
-    @include mq(l) {
-      width: calc(#{percentage(4 / 12)} - #{$input-type-width});
     }
   }
   &::before {

--- a/app/assets/styles/partials/components/_input.scss
+++ b/app/assets/styles/partials/components/_input.scss
@@ -9,7 +9,13 @@ $input-padding: 0.6rem;
   font-size: 1rem;
   border: 1px solid $color-borders;
   border-radius: $input-radius;
-  width: percentage(4 / 12);
+  width: 100%;
+  @include mq(s) {
+    width: percentage(6 / 12);
+  }
+  @include mq(l) {
+    width: percentage(4 / 12);
+  }
 }
 
 .input__helper {
@@ -86,6 +92,8 @@ $input-padding: 0.6rem;
 }
 
 .input-type {
+  $input-type-width: 2.4rem;
+
   display: flex;
   position: relative;
   align-items: center;
@@ -98,6 +106,12 @@ $input-padding: 0.6rem;
       margin-left: 2.5rem;
       border-left: 0;
     }
+    @include mq(s) {
+      width: calc(#{percentage(6 / 12)} - #{$input-type-width});
+    }
+    @include mq(l) {
+      width: calc(#{percentage(4 / 12)} - #{$input-type-width});
+    }
   }
   &::before {
     content: attr(data-type);
@@ -107,6 +121,7 @@ $input-padding: 0.6rem;
     border-right: none;
     border-radius: $input-radius 0 0 $input-radius;
     padding: $input-padding 0.9rem;
+    width: $input-type-width;
     font-weight: 600;
     font-size: 1rem;
     text-align: center;

--- a/app/assets/styles/partials/components/_label.scss
+++ b/app/assets/styles/partials/components/_label.scss
@@ -2,7 +2,6 @@
   display: block;
   margin-bottom: 0.4rem;
   font-weight: 600;
-  font-size: 1rem;
   color: inherit;
 }
 

--- a/app/assets/styles/partials/objects/_grid.scss
+++ b/app/assets/styles/partials/objects/_grid.scss
@@ -198,3 +198,18 @@
     background-color: rgba(0, 0, 0, 0.05);
   }
 }
+
+// WIP
+.u-grid-overlay {
+  $col: 62px;
+
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: -$grid-gutters;
+  max-width: $grid-max-width;
+  margin: 0 auto;
+  background-size: 86px;
+  background-image: linear-gradient(to left, rgba(255, 0, 0, 0.25), rgba(255, 0, 0, 0.25) $col, transparent $col);
+}

--- a/app/assets/styles/partials/vars/_typography.scss
+++ b/app/assets/styles/partials/vars/_typography.scss
@@ -4,12 +4,6 @@ $font-serif: Georgia, serif;
 $base-font-size: 1rem;
 $base-line-height: 1.5;
 
-$font-size-h1: 2rem;
-$font-size-h2: 1.7rem;
-$font-size-h3: 1.3rem;
-$font-size-h4: 0.9rem;
-$font-size-h5: 0.9rem;
-
 $font-weight-regular: 500;
 $font-weight-semibold: 600;
 $font-weight-bold: 700;

--- a/app/schema/widgets/date_widget.py
+++ b/app/schema/widgets/date_widget.py
@@ -52,8 +52,9 @@ class DateWidget(Widget):
                     'for': self.name + '-day',
                     'text': 'Day',
                   },
-                  'select': {
-                    'options': self._get_days(parts[0]),
+                  'input': {
+                    'value': parts[0],
+                    'placeholder': 'DD',
                     'name': self.name + '-day',
                     'id': self.name + '-day',
                   },

--- a/app/templates/partials/answer.html
+++ b/app/templates/partials/answer.html
@@ -1,6 +1,6 @@
 {% import 'macros/helpers.html' as helpers %}
 
-<div class="answer answer--{{answer.type|lower}}" id="{{answer.id}}">
+<div class="answer answer--{{answer.schema_item.type|lower}}" id="{{answer.id}}">
   {% set invalid = answer.is_valid == False %}
 
   {%- set answer_guidance %}
@@ -17,7 +17,7 @@
   {% endset -%}
 
   {% if invalid %}
-  
+
     <div class="alert alert--simple alert--error">
       <div class="alert__header">
         {% if answer.errors %}

--- a/app/templates/partials/answers/date.html
+++ b/app/templates/partials/answers/date.html
@@ -1,5 +1,1 @@
-<fieldset class="fieldset date">
-  <div class="field">
-    {{ answer.schema_item.widget.render(answer)|safe}}
-  </div>
-</fieldset>
+{{ answer.schema_item.widget.render(answer)|safe}}

--- a/app/templates/partials/forms/label.html
+++ b/app/templates/partials/forms/label.html
@@ -1,9 +1,9 @@
 {% set attr = {
-  "class": "label " ~ (" label--inline" if label.inline) ~ (" label--small" if label.small),
+  "class": "label venus " ~ (" label--inline" if label.inline) ~ (" label--small" if label.small),
   "for": label.for,
   "id": "label-" ~ label.for
 } %}
 
 <label {{attr|xmlattr}}>
-  <span class="label__inner venus">{{label.text}}</span>
+  <span class="label__inner">{{label.text}}</span>
 </label>

--- a/app/templates/partials/question.html
+++ b/app/templates/partials/question.html
@@ -4,10 +4,10 @@
 
 {% set question_titles %}
   {%- if question.schema_item.title -%}
-    <div class="question__title neptune">{{question.schema_item.title}}</div>
+    <span class="question__title neptune">{{question.schema_item.title}}</span>
   {%- endif %}
   {%- if question.schema_item.subtitle -%}
-    <div class="question__subtitle mars">{{question.schema_item.subtitle}}</div>
+    <span class="question__subtitle mars">{{question.schema_item.subtitle}}</span>
   {%- endif %}
 {% endset %}
 

--- a/app/templates/partials/widgets/date_widget.html
+++ b/app/templates/partials/widgets/date_widget.html
@@ -1,33 +1,23 @@
-{% set subfields %}
-  <div class="subfields">
-    <div class="field field--select">
+<fieldset class="fieldset  fieldset--date">
+  <legend class="legend venus">{{legend}}</legend>
+  <div class="fieldset__fields">
+    <div class="field field--input field--day">
       {% set label = fields['day'].label %}
-      {% include 'partials/forms/label.html' %}
-      {% set select = fields['day'].select %}
-      {% include 'partials/forms/select.html' %}
+      <label class="label mercury" for="{{label.for}}" id="label-{{label.for}}">{{label.text}}</label>
+      {% set input = fields['day'].input %}
+      {% include 'partials/forms/input.html' %}
     </div>
-    <div class="field field--select">
+    <div class="field field--select field--month">
       {% set label = fields['month'].label %}
-      {% include 'partials/forms/label.html' %}
+      <label class="label mercury" for="{{label.for}}" id="label-{{label.for}}">{{label.text}}</label>
       {% set select = fields['month'].select %}
       {% include 'partials/forms/select.html' %}
     </div>
-    <div class="field field--input">
+    <div class="field field--input field--year">
       {% set label = fields['year'].label %}
-      {% include 'partials/forms/label.html' %}
+      <label class="label mercury" for="{{label.for}}" id="label-{{label.for}}">{{label.text}}</label>
       {% set input = fields['year'].input %}
       {% include 'partials/forms/input.html' %}
     </div>
   </div>
-{% endset %}
-
-{% if legend %}
-  <fieldset class="fieldset date">
-    <legend class="legend">
-      <div class="venus">{{legend}}</div>
-    </legend>
-    {{subfields|safe}}
-  </fieldset>
-{% else %}
-  {{subfields|safe}}
-{% endif %}
+</fieldset>

--- a/app/templates/partials/widgets/date_widget.html
+++ b/app/templates/partials/widgets/date_widget.html
@@ -1,5 +1,4 @@
-<fieldset class="fieldset  fieldset--date">
-  <legend class="legend venus">{{legend}}</legend>
+{% set subfields %}
   <div class="fieldset__fields">
     <div class="field field--input field--day">
       {% set label = fields['day'].label %}
@@ -20,4 +19,13 @@
       {% include 'partials/forms/input.html' %}
     </div>
   </div>
-</fieldset>
+{% endset %}
+
+{% if legend %}
+  <fieldset class="fieldset fieldset--date">
+    <legend class="legend venus">{{legend}}</legend>
+    {{subfields|safe}}
+  </fieldset>
+{% else %}
+  {{subfields|safe}}
+{% endif %}

--- a/app/templates/summary.html
+++ b/app/templates/summary.html
@@ -31,7 +31,7 @@
 
             {% if item.type == 'date' %}
 
-              {% set date_format = '%w %b %Y' %}
+              {% set date_format = '%d %b %Y' %}
 
               {{item.answer[0].value.strftime(date_format)}} to {{item.answer[1].value.strftime(date_format)}}
 

--- a/app/templates/summary.html
+++ b/app/templates/summary.html
@@ -31,7 +31,9 @@
 
             {% if item.type == 'date' %}
 
-              {{item.answer[0].value.strftime('%d %b %Y')}} to {{item.answer[1].value.strftime('%d %b %Y')}}
+              {% set date_format = '%w %b %Y' %}
+
+              {{item.answer[0].value.strftime(date_format)}} to {{item.answer[1].value.strftime(date_format)}}
 
             {% elif item.type == 'checkbox' %}
 

--- a/tests/wdio/spec/error-message.spec.js
+++ b/tests/wdio/spec/error-message.spec.js
@@ -4,7 +4,7 @@ import {getRandomString} from '../helpers'
 const expect = chai.expect
 
 describe('Error messages', function() {
-  before('Progress from the developer page', function() {
+  before('Progress to tge correct page', function() {
     const userId = '.qa-user-id'
     const collectionSID = '.qa-collection-sid'
     const selectSchema = '.qa-select-schema'
@@ -14,34 +14,14 @@ describe('Error messages', function() {
     browser.waitForExist(collectionSID)
     browser.setValue(collectionSID, getRandomString(3))
     browser.waitForExist(selectSchema)
-    browser.selectByValue(selectSchema, '0_basetheme.json')
+    browser.selectByValue(selectSchema, '1_0205.json')
     browser.click('.qa-btn-submit-dev')
-  })
-
-  it('The landing page has been reached', function(done) {
-    const getStartedBtn = browser.element('.qa-btn-get-started')
-    getStartedBtn.waitForExist(10000)
-    const url = browser.url().value
-    expect(url).to.contain('introduction')
-    getStartedBtn.click()
-    browser.call(done)
-  })
-
-  it('The questionnaire page has been reached', function(done) {
-    const questionnaireElementExists = browser.isExisting('.qa-questionnaire-form')
-    expect(questionnaireElementExists).to.equal(true)
-    browser.call(done)
-  })
-
-  it('The form can be filled in and submitted to return error', function(done) {
-    const submitBtn = browser.element('.qa-btn-submit')
-    submitBtn.waitForExist(10000)
-    browser.setValue('#94f368e4-7c6c-4272-a780-8c46328626a2-year', '')
-    browser.setValue('#dc156715-3d48-4af3-afed-7a0a6bb65583-year', '')
-    submitBtn.click()
-    const url = browser.url().value
-    expect(url).to.contain('5bce8d8f-0af8-4d35-b77d-744e6179b406')
-    browser.call(done)
+    browser.click('.qa-btn-get-started')
+    browser.setValue('[id="6fd644b0-798e-4a58-a393-a438b32fe637-day"]', '01')
+    browser.setValue('[id="6fd644b0-798e-4a58-a393-a438b32fe637-year"]', '2016')
+    browser.setValue('[id="06a6a4b7-6ce4-4687-879d-3443cd8e2ff0-day"]', '01')
+    browser.setValue('[id="06a6a4b7-6ce4-4687-879d-3443cd8e2ff0-year"]', '2016')
+    browser.click('.qa-btn-submit')
   })
 
   it('Error link is clicked to take focus to day input', function(done) {
@@ -51,7 +31,7 @@ describe('Error messages', function() {
     browser.timeoutsImplicitWait(10000)
     const activeElementValueNumber = browser.elementActive().value.ELEMENT
     const activeElementValue = browser.elementIdAttribute(activeElementValueNumber, "id").value
-    expect(activeElementValue).to.contain('94f368e4-7c6c-4272-a780-8c46328626a2-day')
+    expect(activeElementValue).to.contain('6fd644b0-798e-4a58-a393-a438b32fe637-day')
     browser.call(done)
   })
 

--- a/tests/wdio/spec/mci.spec.js
+++ b/tests/wdio/spec/mci.spec.js
@@ -36,9 +36,10 @@ describe('MCI test', function() {
   it('The form can be filled in and submitted', function(done) {
     const submitBtn = browser.element('.qa-btn-submit')
     submitBtn.waitForExist(10000)
-    browser.setValue('[id = 6fd644b0-798e-4a58-a393-a438b32fe637-year]', '2016')
-    browser.debug()
-    browser.setValue('#06a6a4b7-6ce4-4687-879d-3443cd8e2ff0-year', '2017')
+    browser.setValue('[id="6fd644b0-798e-4a58-a393-a438b32fe637-day"]', '01')
+    browser.setValue('[id="6fd644b0-798e-4a58-a393-a438b32fe637-year"]', '2016')
+    browser.setValue('[id="06a6a4b7-6ce4-4687-879d-3443cd8e2ff0-day"]', '01')
+    browser.setValue('[id="06a6a4b7-6ce4-4687-879d-3443cd8e2ff0-year"]', '2017')
     browser.setValue('.input-type--currency .input', 2000)
     submitBtn.click()
     const url = browser.url().value

--- a/tests/wdio/spec/rsi-saverestore.spec.js
+++ b/tests/wdio/spec/rsi-saverestore.spec.js
@@ -39,8 +39,10 @@ describe('RSI - Save and restore test', function() {
     expect(questionnaireElementExists).to.equal(true)
     const submitBtn = browser.element('.qa-btn-submit')
     submitBtn.waitForExist(10000)
-    browser.setValue('[id = "94f368e4-7c6c-4272-a780-8c46328626a2-year"]', '2016')
-    browser.setValue('#dc156715-3d48-4af3-afed-7a0a6bb65583-year', '2016')
+    browser.setValue('[id="94f368e4-7c6c-4272-a780-8c46328626a2-day"]', '01')
+    browser.setValue('[id="94f368e4-7c6c-4272-a780-8c46328626a2-year"]', '2016')
+    browser.setValue('[id="dc156715-3d48-4af3-afed-7a0a6bb65583-day"]', '01')
+    browser.setValue('[id="dc156715-3d48-4af3-afed-7a0a6bb65583-year"]', '2016')
     const saveandcontinueBtn2 = browser.element('.qa-btn-submit')
     saveandcontinueBtn2.click();
     const erroralert = browser.element('.alert__body')
@@ -86,7 +88,9 @@ describe('RSI - Save and restore test', function() {
     expect(questionnaireElementExists).to.equal(true)
     const submitBtn = browser.element('.qa-btn-submit')
     submitBtn.waitForExist(10000)
+    browser.setValue('#fad63234-1083-4f6a-826a-20b5df6e4baa-day', '01')
     browser.setValue('#fad63234-1083-4f6a-826a-20b5df6e4baa-year', '2016')
+    browser.setValue('#c8c4bd92-fd45-4fd1-83b6-18c813de2df2-day', '01')
     browser.setValue('#c8c4bd92-fd45-4fd1-83b6-18c813de2df2-year', '2017')
     const saveandcontinueBtn2 = browser.element('.qa-btn-submit')
     saveandcontinueBtn2.click();
@@ -138,7 +142,9 @@ describe('RSI - Save and restore test', function() {
     expect(questionnaireElementExists).to.equal(true)
     const submitBtn = browser.element('.qa-btn-submit')
     submitBtn.waitForExist(10000)
-    browser.setValue('[id = "94f368e4-7c6c-4272-a780-8c46328626a2-year"]', '2016')
+    browser.setValue('[id="94f368e4-7c6c-4272-a780-8c46328626a2-day"]', '01')
+    browser.setValue('[id="94f368e4-7c6c-4272-a780-8c46328626a2-year"]', '2016')
+    browser.setValue('#dc156715-3d48-4af3-afed-7a0a6bb65583-day', '01')
     browser.setValue('#dc156715-3d48-4af3-afed-7a0a6bb65583-year', '2017')
     const saveandcontinueBtn2 = browser.element('.qa-btn-submit')
     saveandcontinueBtn2.click();


### PR DESCRIPTION
### What is the context of this PR?

The width of inputs have been changed to span three columns instead of being full-width as per [EQ-582](https://trello.com/c/g5dCsCh2/582-1-base-theme-input-fields-are-displaying-full-width-and-should-be-indicative-of-the-data-required)

![screenshot 2016-09-29 13 21 34](https://cloud.githubusercontent.com/assets/930398/18953750/d68fa9e4-8647-11e6-84f3-2bb21f8ce7f8.png)

The date input has also been altered to take less space, as well as moving to a numeric input for the date as per [EQ-530](https://trello.com/c/Hkz8aHER/530-1-rsi-change-day-entry-input-to-numeric-p2b)

![screenshot 2016-09-29 13 21 20](https://cloud.githubusercontent.com/assets/930398/18953925/a254f6e2-8648-11e6-8050-150aa9020e02.png)
### How to review
1. Start any survey
2. Check date input is as above screenshot and that it behaves sensibly as the viewport reduces to mobile (320px)
3. Check other inputs width is sensible down to mobile
4. Confirm dates are still working as expected on summary screen.
