### PR TITLE
issue-469 Fix "ga is not defined" error

### DIFF
--- a/app/assets/js/app/modules/analytics.js
+++ b/app/assets/js/app/modules/analytics.js
@@ -2,6 +2,10 @@ import forEach from 'lodash/forEach'
 import domready from './domready'
 
 export default function initAnalytics() {
+  if (typeof ga === 'undefined') {
+    return false
+  }
+
   const errors = document.querySelectorAll('[data-error=true]')
   const guidances = document.querySelectorAll('[data-guidance]')
 


### PR DESCRIPTION
### What is the context of this PR?

Fixes #469. 

Analytics event tracking now checks if the global `ga` object is defined before attempting to execute code. This fixes an issue whereby an environment that does not have Google Analytics JS loaded (eg. Sauce Labs) will cause all further JS execution to halt.
### How to review

As per reproduction steps in the bug.

Also, we need to check that the event tracking _does_ still work as expected when the environment variable is set.
