### PR TITLE
eq-529 Make currency symbol available to screenreaders

### DIFF
--- a/app/assets/styles/partials/components/_input.scss
+++ b/app/assets/styles/partials/components/_input.scss
@@ -94,37 +94,39 @@ $input-width: 15rem;
   display: flex;
   position: relative;
   align-items: center;
-  .input {
-    border-radius: 0 3px 3px 0;
-    line-height: normal;
-    position: relative;
-    z-index: 1;
-    width: calc(#{$input-width} - #{$input-type-width});
-    @include fixed {
-      margin-left: 2.5rem;
-      border-left: 0;
-    }
+}
+
+.input-type__input {
+  border-radius: 0 3px 3px 0;
+  line-height: normal;
+  position: relative;
+  z-index: 1;
+  width: calc(#{$input-width} - #{$input-type-width});
+  @include fixed {
+    margin-left: 2.5rem;
+    border-left: 0;
   }
-  &::before {
-    content: attr(data-type);
-    display: inline-block;
-    background-color: $color-lighter-grey;
+}
+
+.input-type__type {
+  content: attr(data-type);
+  display: inline-block;
+  background-color: $color-lighter-grey;
+  border: 1px solid $color-borders;
+  border-right: none;
+  border-radius: $input-radius 0 0 $input-radius;
+  padding: $input-padding 0.9rem;
+  width: $input-type-width;
+  font-weight: 600;
+  font-size: 1rem;
+  text-align: center;
+  line-height: normal;
+  @include fixed {
+    position: absolute;
+    left: 0;
+    width: 2.5rem;
+    height: 100%;
     border: 1px solid $color-borders;
-    border-right: none;
-    border-radius: $input-radius 0 0 $input-radius;
-    padding: $input-padding 0.9rem;
-    width: $input-type-width;
-    font-weight: 600;
-    font-size: 1rem;
-    text-align: center;
-    line-height: normal;
-    @include fixed {
-      position: absolute;
-      left: 0;
-      width: 2.5rem;
-      height: 100%;
-      border: 1px solid $color-borders;
-      z-index: 2;
-    }
+    z-index: 2;
   }
 }

--- a/app/templates/partials/forms/input.html
+++ b/app/templates/partials/forms/input.html
@@ -1,5 +1,5 @@
 {% set attr = {
-  "class": "input input--" ~ (input.valueType if input.valueType|length > 0 else input.type),
+  "class": "input " ~ input.classes,
   "type": input.type,
   "value": input.value,
   "name": input.name,

--- a/app/templates/partials/widgets/currency_widget.html
+++ b/app/templates/partials/widgets/currency_widget.html
@@ -3,17 +3,24 @@
   'for': answer.id,
   'text': answer.label
 } %}
+
 {% include 'partials/forms/label.html' %}
 
-<div class="input-type input-type--currency" data-type="£">
+<div class="input-type input-type--currency">
+
+  <span class="input-type__type" id="{{answer.id}}-type">£</span>
+
   {% set input = {
     'type': 'text',
-    'valueType': 'currency',
+    'classes': 'input-type__input',
+    'hasType': true,
     'value': (answer.value or "")|e,
     'name': answer.name,
     'id': answer.id,
     'placeholder': answer.placeholder
   } %}
+
   {% include 'partials/forms/input.html' %}
+
 </div>
 <!-- END CurrencyWidget -->


### PR DESCRIPTION
### What is the context of this PR?

[Trello card](https://trello.com/c/S5EfydGO/529-0-5-fix-sign-not-being-read-by-screen-readers)

Previously, the symbol associated with "typed" inputs (eg. currency) were not being read by all screenreaders. This PR fixes this by moving the symbol itself from a CSS "pseudo-element" into the markup where a screenreader will pick it up.
### How to review
1. Visit any survey that uses the currency inputs.
2. Test with voiceover to confirm £ is being read aloud.
