### PR TITLE
eq-532 Telephone numbers accessibility & various design snags

### DIFF
--- a/app/assets/styles/partials/base/_typography.scss
+++ b/app/assets/styles/partials/base/_typography.scss
@@ -33,6 +33,7 @@ p {
 .neptune {
   font-size: 1.2rem;
   font-weight: 600;
+  line-height: 1.3;
 }
 
 .venus {

--- a/app/assets/styles/partials/components/_alert.scss
+++ b/app/assets/styles/partials/components/_alert.scss
@@ -1,5 +1,8 @@
 .alert {
   border-radius: 0;
+  a {
+    color: $color-blue;
+  }
 }
 
 .alert__header {

--- a/app/assets/styles/partials/components/_buttons.scss
+++ b/app/assets/styles/partials/components/_buttons.scss
@@ -2,8 +2,9 @@
   background-color: $bg;
   color: $color;
   border: none;
-  padding: 9px 18px;
-  margin: 0 0 18px 0;
+  padding: 0.75rem 2.5rem;
+  margin: 0 0 1rem;
+  font-size: 1rem;
   border-radius: 3px;
   display: inline-block;
   text-rendering: optimizeLegibility;
@@ -26,6 +27,11 @@
 
 .btn--neutral {
   @include btn($color-dark-grey, $color-white);
+}
+
+.btn--lg {
+  font-weight: $font-weight-semibold;
+  padding: 0.9rem 5rem;
 }
 
 .btn-group {

--- a/app/assets/styles/partials/components/_info.scss
+++ b/app/assets/styles/partials/components/_info.scss
@@ -22,9 +22,15 @@
     display: inline-block;
     vertical-align: middle;
     @include icon('phone');
+
     width: 1.5em;
     height: 1.5em;
     background-size: 2.5em;
+  }
+
+  a {
+    text-decoration: none;
+    color: $color-text;
   }
 }
 
@@ -32,7 +38,7 @@
   display: flex;
   border-top: 1px solid $color-borders;
   padding-top: 0.5em;
-  margin: 0.1em 0 0 0;
+  margin: 0.1em 0 0;
   @include mq(m) {
     display: inline-flex;
   }

--- a/app/assets/styles/partials/objects/_footer.scss
+++ b/app/assets/styles/partials/objects/_footer.scss
@@ -1,0 +1,10 @@
+.footer {
+  padding: 2rem 0;
+  margin-top: 3rem;
+  background-color: $color-light-grey;
+  color: $color-very-dark-grey;
+
+  a {
+    color: $color-very-dark-grey;
+  }
+}

--- a/app/assets/styles/partials/objects/_section.scss
+++ b/app/assets/styles/partials/objects/_section.scss
@@ -1,6 +1,10 @@
 .section {
   padding: 1rem 0;
   border-bottom: 1px solid $color-light-grey;
+  &:last-of-type {
+    border: none;
+    padding-bottom: 0;
+  }
   @include mq(s) {
     padding: 2rem 0;
   }
@@ -9,10 +13,6 @@
     padding-top: 0;
     margin-top: 0;
   }
-}
-
-.section__title {
-
 }
 
 .section__description {

--- a/app/assets/styles/partials/vars/_colors.scss
+++ b/app/assets/styles/partials/vars/_colors.scss
@@ -24,12 +24,12 @@ $color-amber: #fe781f;
 
 $color-text: $color-black;
 $color-text-light: $color-very-dark-grey;
-$color-links: $color-blue;
+$color-links: #385bba;
 $color-borders: $color-grey;
 $color-placeholder: lighten($color-text-light, 40%);
 
 $color-errors: $color-red;
 
-$color-dark-blue: #033E58;
-$color-lighter-blue: #4263C2;
-$color-dark-highlight: #4361AA;
+$color-dark-blue: #033e58;
+$color-lighter-blue: #4263c2;
+$color-dark-highlight: #4361aa;

--- a/app/templates/landing-page.html
+++ b/app/templates/landing-page.html
@@ -29,7 +29,7 @@
         <div class="grid__col col-6@s">
           <dl class="dl">
             <dt class="dl__title mercury">PERIOD</dt>
-            <dd class="dl__data">
+            <dd class="dl__data mars">
               <span class="">{{ meta.survey.start_date }} to {{ meta.survey.end_date}}
             </dd>
             <dt class="dl__title mercury">PLEASE SUBMIT BY</dt>
@@ -54,7 +54,7 @@
     </div>
 
     <form class="form" method="POST" novalidate>
-      <button class="btn btn--secondary qa-btn-get-started venus" type="submit" name="action[start_questionnaire]">Get Started</button>
+      <button class="btn btn--secondary btn--lg qa-btn-get-started" type="submit" name="action[start_questionnaire]">Start survey</button>
     </form>
     <div class="lock u-mb-s u-mb-m@s">
       <div class="venus lock__text">We will treat your data securely and confidentially</div>

--- a/app/templates/layouts/_base.html
+++ b/app/templates/layouts/_base.html
@@ -41,6 +41,12 @@
 
     {% block content %}{% endblock %}
 
+    <footer class="footer">
+      <div class="container">
+        <div class="pluto">&copy; <a href="https://www.ons.gov.uk/" target="_blank">Office for National Statistics 2016</a></div>
+      </div>
+    </footer>
+
     <!-- jQuery 1 -->
   	<!--[if lt IE 9]>
   	<script src="//ajax.googleapis.com/ajax/libs/jquery/1.12.0/jquery.min.js"></script>

--- a/app/templates/partials/section.html
+++ b/app/templates/partials/section.html
@@ -1,6 +1,6 @@
 <div class="section" id="{{section.id}}">
   {% if section.schema_item.title %}
-    <h2 class="section__title saturn">{{section.schema_item.title}}</h2>
+    <h1 class="section__title saturn">{{section.schema_item.title}}</h1>
   {% endif %}
   {% if section.schema_item.description %}
     <div class="section__description mars">{{section.schema_item.description|safe}}</div>

--- a/app/templates/partials/survey-header.html
+++ b/app/templates/partials/survey-header.html
@@ -6,10 +6,8 @@
       {% endblock logo %}
     </div>
     <div class="info survey-header__info" role="contentinfo">
-      <div class="info__title venus">Survey Help</div>
-      <div class="info__tel">
-        0300 1234 931
-      </div>
+      <div class="info__title venus" id="survey-help">Survey Help</div>
+      <div class="info__tel" aria-describedby="survey-help">0300 1234 931</div>
       {% if meta %}
       <dl class="info__list">
         <dt class="info__dt first">ID:</dt>

--- a/app/templates/partials/survey-header.html
+++ b/app/templates/partials/survey-header.html
@@ -6,8 +6,10 @@
       {% endblock logo %}
     </div>
     <div class="info survey-header__info" role="contentinfo">
-      <div class="info__title venus" id="survey-help">Survey Help</div>
-      <div class="info__tel" aria-describedby="survey-help">0300 1234 931</div>
+      <h3 class="info__title venus" id="survey-help">Survey Help</h3>
+      <div class="info__tel">
+        <a href="tel:03001234931" aria-describedby="survey-help">0300 1234 931</a>
+      </div>
       {% if meta %}
       <dl class="info__list">
         <dt class="info__dt first">ID:</dt>

--- a/app/templates/partials/topbar.html
+++ b/app/templates/partials/topbar.html
@@ -8,7 +8,7 @@
       <h1 class="bar__title jupiter">{% if meta %}{{ meta.survey.title }}{% endif %}</h1>
       <h2 class="venus">Notice is given under section 1 of the Statistics of Trade Act 1947</h2>
     {% else %}
-      <h1 class="bar__title venus">{% if meta %}{{ meta.survey.title }}{% endif %}</h1>
-    {% endif %}  
+      <div class="bar__title venus">{% if meta %}{{ meta.survey.title }}{% endif %}</div>
+    {% endif %}
   </div>
 </div>

--- a/tests/integration/mci/test_change_answers.py
+++ b/tests/integration/mci/test_change_answers.py
@@ -20,7 +20,7 @@ class TestHappyPath(IntegrationTestCase):
         content = resp.get_data(True)
 
         self.assertRegexpMatches(content, '<title>Introduction</title>')
-        self.assertRegexpMatches(content, '>Get Started<')
+        self.assertRegexpMatches(content, '>Start survey<')
         self.assertRegexpMatches(content, 'Monthly Business Survey - Retail Sales Index')
 
         # We proceed to the questionnaire

--- a/tests/integration/mci/test_clear_error.py
+++ b/tests/integration/mci/test_clear_error.py
@@ -19,7 +19,7 @@ class TestClearError(IntegrationTestCase):
         content = resp.get_data(True)
 
         self.assertRegexpMatches(content, '<title>Introduction</title>')
-        self.assertRegexpMatches(content, '>Get Started<')
+        self.assertRegexpMatches(content, '>Start survey<')
         self.assertRegexpMatches(content, 'Monthly Business Survey - Retail Sales Index')
 
         # We proceed to the questionnaire

--- a/tests/integration/mci/test_clear_value.py
+++ b/tests/integration/mci/test_clear_value.py
@@ -19,7 +19,7 @@ class TestClearValue(IntegrationTestCase):
         content = resp.get_data(True)
 
         self.assertRegexpMatches(content, '<title>Introduction</title>')
-        self.assertRegexpMatches(content, '>Get Started<')
+        self.assertRegexpMatches(content, '>Start survey<')
         self.assertRegexpMatches(content, 'Monthly Business Survey - Retail Sales Index')
 
         # We proceed to the questionnaire

--- a/tests/integration/mci/test_empty_comments.py
+++ b/tests/integration/mci/test_empty_comments.py
@@ -15,7 +15,7 @@ class TestEmptyComments(IntegrationTestCase):
         content = resp.get_data(True)
 
         self.assertRegexpMatches(content, '<title>Introduction</title>')
-        self.assertRegexpMatches(content, '>Get Started<')
+        self.assertRegexpMatches(content, '>Start survey<')
         self.assertRegexpMatches(content, 'Monthly Business Survey - Retail Sales Index')
 
         # We proceed to the questionnaire

--- a/tests/integration/mci/test_empty_questionnaire.py
+++ b/tests/integration/mci/test_empty_questionnaire.py
@@ -18,7 +18,7 @@ class TestEmptyQuestionnaire(IntegrationTestCase):
 
         # We are on the landing page
         content = resp.get_data(True)
-        self.assertRegexpMatches(content, '>Get Started<')
+        self.assertRegexpMatches(content, '>Start survey<')
 
         # We try to access the submission page without entering anything
         resp = self.client.get(mci_test_urls.MCI_0205_SUMMARY, follow_redirects=False)

--- a/tests/integration/mci/test_empty_submission.py
+++ b/tests/integration/mci/test_empty_submission.py
@@ -17,7 +17,7 @@ class TestEmptySubmission(IntegrationTestCase):
         # We are on the landing page
         content = resp.get_data(True)
         self.assertRegexpMatches(content, '<title>Introduction</title>')
-        self.assertRegexpMatches(content, '>Get Started<')
+        self.assertRegexpMatches(content, '>Start survey<')
         self.assertRegexpMatches(content, 'Monthly Business Survey - Retail Sales Index')
 
         # We proceed to the questionnaire

--- a/tests/integration/mci/test_happy_path.py
+++ b/tests/integration/mci/test_happy_path.py
@@ -20,7 +20,7 @@ class TestHappyPath(IntegrationTestCase):
         content = resp.get_data(True)
 
         self.assertRegexpMatches(content, '<title>Introduction</title>')
-        self.assertRegexpMatches(content, '>Get Started<')
+        self.assertRegexpMatches(content, '>Start survey<')
         self.assertRegexpMatches(content, 'Monthly Business Survey - Retail Sales Index')
 
         # We proceed to the questionnaire

--- a/tests/integration/mci/test_information_page.py
+++ b/tests/integration/mci/test_information_page.py
@@ -27,7 +27,7 @@ class TestInformationPage(IntegrationTestCase):
         content1 = response1.get_data(True)
 
         self.assertRegexpMatches(content1, '<title>Introduction</title>')
-        self.assertRegexpMatches(content1, '>Get Started<')
+        self.assertRegexpMatches(content1, '>Start survey<')
         self.assertRegexpMatches(content1, 'Monthly Business Survey - Retail Sales Index')
 
         # Open up a second questionnaire
@@ -38,7 +38,7 @@ class TestInformationPage(IntegrationTestCase):
         content2 = response2.get_data(True)
 
         self.assertRegexpMatches(content2, '<title>Introduction</title>')
-        self.assertRegexpMatches(content2, '>Get Started<')
+        self.assertRegexpMatches(content2, '>Start survey<')
         self.assertRegexpMatches(content2, 'Star Wars')
 
         # We try to post to the wrong questionnaire

--- a/tests/integration/mci/test_invalid_dates_numbers.py
+++ b/tests/integration/mci/test_invalid_dates_numbers.py
@@ -17,7 +17,7 @@ class TestInvalidDateNumber(IntegrationTestCase):
         # We are on the landing page
         content = resp.get_data(True)
         self.assertRegexpMatches(content, '<title>Introduction</title>')
-        self.assertRegexpMatches(content, '>Get Started<')
+        self.assertRegexpMatches(content, '>Start survey<')
         self.assertRegexpMatches(content, 'Monthly Business Survey - Retail Sales Index')
 
         # We proceed to the questionnaire

--- a/tests/integration/mci/test_submission_with_errors.py
+++ b/tests/integration/mci/test_submission_with_errors.py
@@ -15,7 +15,7 @@ class TestSubmissionWithErrors(IntegrationTestCase):
         content = resp.get_data(True)
 
         self.assertRegexpMatches(content, '<title>Introduction</title>')
-        self.assertRegexpMatches(content, '>Get Started<')
+        self.assertRegexpMatches(content, '>Start survey<')
         self.assertRegexpMatches(content, 'Monthly Business Survey - Retail Sales Index')
 
         # We proceed to the questionnaire

--- a/tests/integration/star_wars/star_wars_tests.py
+++ b/tests/integration/star_wars/star_wars_tests.py
@@ -18,7 +18,7 @@ class StarWarsTestCase(IntegrationTestCase):
         self.assertRegexpMatches(content, 'Star Wars')
         self.assertRegexpMatches(content, 'If actual figures are not available, please provide informed estimates.')
         self.assertRegexpMatches(content, 'Legal Information')
-        self.assertRegexpMatches(content, '>Get Started<')
+        self.assertRegexpMatches(content, '>Start survey<')
         self.assertRegexpMatches(content, '(?s)Trading as.*?Integration Tests')
         self.assertRegexpMatches(content, '(?s)Business name.*?MCI Integration Testing')
         self.assertRegexpMatches(content, '(?s)PLEASE SUBMIT BY.*?6 May 2016')


### PR DESCRIPTION
### What is the context of this PR?

Trello card: [eq-532 Telephone numbers with screen-readers](https://trello.com/c/WyhEjZa4/532-1-telephone-number-with-screen-readers)

`aria-describedby` has been added to the telephone number markup to make screen-readers read the "survey help" text to add context to the telephone number. I haven't added a `tel:` link as desktop browsers don't know what to do with this an mobile browsers add it automatically.

I've also fixed some design issues as per [Wills list of issues](https://docs.google.com/presentation/d/1rRbDA4ONUm_Cr_cEf4rtLlrz-p7Soagw8OkZmPtlZUQ/edit#slide=id.g1703d0d653_0_49)
1. New button size/whitespace.
2. Added a `btn--lg` modifier for an extra button size used for the "start survey" button.
3. Added a footer with copyright link.
4. Changed default colour of links to a richer blue.
5. Removed erroneous key line from sections.
### How to review
1. Start any survey.
2. Confirm telephone number uses "Survey help" description on a screenreader.
3. Compare design changes with those outlines in the document above.
