### PR TITLE
issue-463 Comment field layout breaks on summary screen

### DIFF
--- a/app/assets/styles/partials/components/_summary.scss
+++ b/app/assets/styles/partials/components/_summary.scss
@@ -88,6 +88,7 @@
 .summary__answer-text {
   align-items: center;
   flex: 1 1 auto;
+  word-break: break-all;
 }
 
 .summary__edit {


### PR DESCRIPTION
### What is the context of this PR?

Fixes #463 by adding explicit `word-break` CSS to force wrapping of link text.
### How to review

As per steps to reproduce in bug report. Here's an example of a link that would previously break the layout:

```
https://www.browserstack.com/start?utm_source=chrome&amp;utm_medium=extension&amp;utm_campaign=quick-launch×tamp=1475760724302#os=Windows&amp;os_version=7&amp;browser=IE&amp;browser_version=9.0&amp;zoom_to_fit=true&amp;full_screen=true&amp;resolution=responsive-mode&amp;url=http%3A%2F%2Flocalhost%3A3000%2Fquestionnaire%2F1%2F0205%2F201605%2F789%2Fsummary%23215015b1-f87c-4740-9fd4-f01f707ef558&amp;speed=1&amp;host_ports=google.com%2C80%2C0
```

This should look like this:

<img width="1044" alt="screenshot 2016-10-06 14 40 23" src="https://cloud.githubusercontent.com/assets/930398/19154699/87679124-8bd3-11e6-8ff4-6811111f8797.png">
