### PR TITLE
Add survey JSON to demo radio description text

### DIFF
--- a/app/data/test_radio_descriptions.json
+++ b/app/data/test_radio_descriptions.json
@@ -1,0 +1,90 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "questionnaire_id": "23",
+  "schema_version": "0.0.1",
+  "survey_id": "023",
+  "title": "Test Survey - Radio option descriptions",
+  "description": "Radio option descriptions",
+  "theme": "default",
+  "introduction": {
+    "description": "<p>Some description text</p>",
+    "information_to_provide": [
+      "information to provide one",
+      "information to provide two"
+    ]
+  },
+  "display": {
+    "properties": {}
+  },
+  "eq_id": "1",
+  "groups": [
+    {
+      "id": "14ba4707-321d-441d-8d21-b8367366e766",
+      "blocks": [
+        {
+          "display": {
+            "properties": {}
+          },
+          "id": "f22b1ba4-d15f-48b8-a1f3-db62b6f34cc0",
+          "sections": [
+            {
+              "description": "",
+              "display": {
+                "properties": {}
+              },
+              "id": "ed3e200a-0735-4e8d-9eea-627c1d908697",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "guidance": "",
+                      "id": "ca3ce3a3-ae44-4e30-8f85-5b6a7a2fb23c",
+                      "label": "Did this business make major changes in the following areas?",
+                      "mandatory": true,
+                      "options": [
+                        {
+                          "label": "New business practices for organising procedures",
+                          "value": "New business practices for organising procedures",
+                          "description": "For example supply chain management, business re-engineering, knowledge management, lean production, quality management"
+                        },
+                        {
+                          "label": "New methods of organising work responsibilities and decision making",
+                          "value": "New methods of organising work responsibilities and decision making",
+                          "description": "For example first use of a new system of employee responsibilities, team work, decentralisation, integration or de-integration of departments, education / training systems"
+                        },
+                        {
+                          "label": "New methods of organising external relationships with other firms or public institutions",
+                          "value": "New methods of organising external relationships with other firms or public institutions",
+                          "description": "For example first use of alliances, partnerships, outsourcing or sub-contracting"
+                        },
+                        {
+                          "label": "Implementation of changes to marketing concepts or strategies",
+                          "value": "Implementation of changes to marketing concepts or strategies"
+                        }
+                      ],
+                      "q_code": "20",
+                      "type": "Checkbox",
+                      "validation": {
+                        "messages": {}
+                      }
+                    }
+                  ],
+                  "description": "Did this business make major changes in the following areas?",
+                  "display": {
+                    "properties": {}
+                  },
+                  "id": "4bfa0229-0ce8-4190-817b-535f55ad2817",
+                  "title": "",
+                  "type": "General",
+                  "validation": []
+                }
+              ],
+              "title": "Business Strategy and Practices",
+              "validation": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### What is the context of this PR?

Adds a new survey JSON to demo the feature implemented in https://github.com/ONSdigital/eq-survey-runner/pull/471
### How to review
- Go to the dev page
- Select the test_radio_descriptions.json schema
- Complete survey and verify the appropriate radio option labels appear on the summary page (not the description text)
