### PR TITLE
Add JSON to demo radio and checkbox description text

### DIFF
--- a/app/data/test_radio_checkbox_descriptions.json
+++ b/app/data/test_radio_checkbox_descriptions.json
@@ -1,0 +1,126 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "questionnaire_id": "0",
+  "schema_version": "0.0.1",
+  "survey_id": "0",
+  "title": "Test Survey - Checkbox and Radio option descriptions",
+  "description": "",
+  "theme": "default",
+  "eq_id": "0",
+  "groups": [
+    {
+      "id": "14ba4707-321d-441d-8d21-b8367366e766",
+      "blocks": [
+        {
+          "id": "f22b1ba4-d15f-48b8-a1f3-db62b6f34cc0",
+          "sections": [
+            {
+              "description": "",
+              "id": "ed3e200a-0735-4e8d-9eea-627c1d908697",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "guidance": "",
+                      "id": "ca3ce3a3-ae44-4e30-8f85-5b6a7a2fb23c",
+                      "label": "Did this business make major changes in the following areas?",
+                      "mandatory": true,
+                      "options": [
+                        {
+                          "label": "New business practices for organising procedures",
+                          "value": "New business practices for organising procedures",
+                          "description": "For example supply chain management, business re-engineering, knowledge management, lean production, quality management"
+                        },
+                        {
+                          "label": "New methods of organising work responsibilities and decision making",
+                          "value": "New methods of organising work responsibilities and decision making",
+                          "description": "For example first use of a new system of employee responsibilities, team work, decentralisation, integration or de-integration of departments, education / training systems"
+                        },
+                        {
+                          "label": "New methods of organising external relationships with other firms or public institutions",
+                          "value": "New methods of organising external relationships with other firms or public institutions",
+                          "description": "For example first use of alliances, partnerships, outsourcing or sub-contracting"
+                        },
+                        {
+                          "label": "Implementation of changes to marketing concepts or strategies",
+                          "value": "Implementation of changes to marketing concepts or strategies"
+                        }
+                      ],
+                      "q_code": "10",
+                      "type": "Checkbox",
+                      "validation": {
+                        "messages": {}
+                      }
+                    }
+                  ],
+                  "description": "Select all that apply",
+                  "id": "4bfa0229-0ce8-4190-817b-535f55ad2817",
+                  "title": "Did this business make major changes in the following areas?",
+                  "type": "General",
+                  "validation": []
+                }
+              ],
+              "title": "Business Strategy and Practices",
+              "description": "<p>Include all <strong>new</strong> and <strong>significantly improved</strong> forms of organisation, business structures or practices aimed at raising internal efficiency or the effectiveness of approaching markets and customers.</p>",
+              "validation": []
+            }
+          ]
+        },
+        {
+          "id": "a78fcaa4-dd82-4208-97dd-2d48dfeded80",
+          "sections": [
+            {
+              "description": "",
+              "id": "be4735f3-00f6-468e-946a-d854c2ad6d66",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "guidance": "",
+                      "id": "f368b115-5ab5-4cac-934e-113b8eb1cbcc",
+                      "label": "Did this business make major changes in the following areas?",
+                      "mandatory": true,
+                      "options": [
+                        {
+                          "label": "New business practices for organising procedures",
+                          "value": "New business practices for organising procedures",
+                          "description": "For example supply chain management, business re-engineering, knowledge management, lean production, quality management"
+                        },
+                        {
+                          "label": "New methods of organising work responsibilities and decision making",
+                          "value": "New methods of organising work responsibilities and decision making",
+                          "description": "For example first use of a new system of employee responsibilities, team work, decentralisation, integration or de-integration of departments, education / training systems"
+                        },
+                        {
+                          "label": "New methods of organising external relationships with other firms or public institutions",
+                          "value": "New methods of organising external relationships with other firms or public institutions",
+                          "description": "For example first use of alliances, partnerships, outsourcing or sub-contracting"
+                        },
+                        {
+                          "label": "Implementation of changes to marketing concepts or strategies",
+                          "value": "Implementation of changes to marketing concepts or strategies"
+                        }
+                      ],
+                      "q_code": "20",
+                      "type": "Radio",
+                      "validation": {
+                        "messages": {}
+                      }
+                    }
+                  ],
+                  "description": "",
+                  "id": "f9cc4d5c-1f47-4c50-b125-a46da98a310c",
+                  "title": "Did this business make major changes in the following areas?",
+                  "type": "General",
+                  "validation": []
+                }
+              ],
+              "title": "Business Strategy and Practices Part Two",
+              "validation": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### What is the context of this PR?

Adds a new survey JSON to demo the feature implemented in https://github.com/ONSdigital/eq-survey-runner/pull/471
### How to review
- Go to the dev page
- Select the test_radio_checkbox_descriptions.json schema
- Complete survey and verify the appropriate checkbox and radio option labels appear on the summary page (not the description text)
