### PR TITLE
moved skip link to top of page

### DIFF
--- a/app/assets/styles/partials/components/_skip.scss
+++ b/app/assets/styles/partials/components/_skip.scss
@@ -3,6 +3,7 @@
   top: 0;
   left: 0;
   right: 0;
+  z-index: 999999;
 }
 
 .skip__link {

--- a/app/templates/layouts/_base.html
+++ b/app/templates/layouts/_base.html
@@ -37,6 +37,11 @@
     {{ analytics }}
   </head>
   <body>
+
+    <div class="skip">
+      <a class="skip__link" href="#main">Skip to content</a>
+    </div>
+    
     {% block top_bar %}{% endblock %}
 
     {% block content %}{% endblock %}

--- a/app/templates/partials/topbar.html
+++ b/app/templates/partials/topbar.html
@@ -1,7 +1,4 @@
 <div class="bar {{'bar--hero' if is_hero}}" role="banner">
-  <div class="skip">
-    <a class="skip__link" href="#main">Skip to content</a>
-  </div>
   <div class="bar__inner container">
     <div class="badge badge--amber u-mr-xs">BETA</div>
     {% if is_hero %}


### PR DESCRIPTION
### What is the context of this PR?

Fixes #501.

<img width="762" alt="screenshot 2016-10-19 09 25 17" src="https://cloud.githubusercontent.com/assets/930398/19511171/098d98ce-95de-11e6-99b8-76963bdc5911.png">

"Skip to content" should be the first link to be focused when a user tabs into the page to allow screen reader users to get to page content quicker.
### How to review

Check "Skip to content" is the first link to receive focus as per reproduction steps on issue #501.
