### PR TITLE
HOTFIX eq-673 Add 'change of details' info to landing page

### DIFF
--- a/app/themes/basetheme/templates/landing-page.html
+++ b/app/themes/basetheme/templates/landing-page.html
@@ -13,7 +13,7 @@
 
   <div class="header">
     <h2 class="saturn">Your response is legally required</h2>
-      <div class="grid grid--align-mid">
+      <div class="grid">
         <div class="grid__col col-6@s">
           <dl>
             <dt class="mercury u-tt-u">Business name</dt>
@@ -22,6 +22,8 @@
               <dt class="mercury u-tt-u">Trading as</dt>
               <dd class="mars">{{ meta.respondent.address.trading_as }}</dd>
             {% endif %}
+            <dt class="dl__title mercury u-tt-u" id="details-changed-title">Change in details</dt>
+            <dd class="dl__data mars">Call <a href="tel:0300 1234 931" aria-describedby="details-changed-title">0300 1234 931</a> or email <a href="mailto:surveys@ons.gov.uk" aria-describedby="details-changed-title">surveys@ons.gov.uk</a> if there have been any changes to your business name, address or structure</dd>
           </dl>
         </div>
         <div class="grid__col col-6@s">


### PR DESCRIPTION
### What is the context of this PR?

[Trello](https://trello.com/c/wtRlpMK3/673-1-change-of-details-address-statement-hotfix)

This change adds the "change of details" info to the theme landing page.
### How to review
1. Start survey `1_0112.json`.
2. On landing page, confirm information is displayed:

<img width="769" alt="screenshot 2016-10-20 11 36 11" src="https://cloud.githubusercontent.com/assets/930398/19556524/70f287f0-96b9-11e6-8e32-42efe9035847.png">
