### PR TITLE
Allow zeros to be entered in a currency field

### DIFF
--- a/app/schema/answer.py
+++ b/app/schema/answer.py
@@ -51,7 +51,7 @@ class Answer(Item):
 
     @staticmethod
     def check_user_input(user_input):
-        if user_input and not str(user_input).isspace() and user_input != '':
+        if user_input is not None and not str(user_input).isspace() and user_input != '':
             return user_input
         else:
             return None

--- a/app/schema/widgets/currency_widget.py
+++ b/app/schema/widgets/currency_widget.py
@@ -14,8 +14,8 @@ class CurrencyWidget(Widget):
                 'name': self.name,
                 'id': state.schema_item.id,
                 'label': state.schema_item.label,
-                'value': state.value or state.input or '',
-                'placeholder': ''
+                'value': state.value if state.value is not None else '',
+                'placeholder': '',
             },
             'debug': {
                 'schema': state.schema_item,

--- a/app/schema/widgets/text_widget.py
+++ b/app/schema/widgets/text_widget.py
@@ -14,7 +14,7 @@ class TextWidget(Widget):
                 'name': self.name,
                 'id': state.schema_item.id,
                 'label': state.schema_item.label or '',
-                'value': state.value or state.input or '',
+                'value': state.value if state.value is not None else '',
             },
         }
         return render_template('partials/widgets/text_widget.html', **widget_params)

--- a/app/templates/partials/widgets/currency_widget.html
+++ b/app/templates/partials/widgets/currency_widget.html
@@ -14,7 +14,7 @@
     'type': 'text',
     'classes': 'input-type__input',
     'hasType': true,
-    'value': (answer.value or "")|e,
+    'value': answer.value|e,
     'name': answer.name,
     'id': answer.id,
     'placeholder': answer.placeholder

--- a/app/templates/partials/widgets/text_widget.html
+++ b/app/templates/partials/widgets/text_widget.html
@@ -7,7 +7,7 @@
 
 {% set input = {
   'type': 'text',
-  'value': (answer.value or "")|e,
+  'value': answer.value|e,
   'name': answer.name,
   'id': 'input-' ~ answer.id,
   'placeholder': answer.placeholder

--- a/tests/functional/helpers.js
+++ b/tests/functional/helpers.js
@@ -18,3 +18,7 @@ export const startQuestionnaire = (schema, userId = getRandomString(10), collect
   openQuestionnaire(schema, userId, collectionId)
   landingPage.getStarted()
 }
+
+export function getElementId(element) {
+    return browser.elementIdAttribute(element.value.ELEMENT, "id").value
+  }

--- a/tests/functional/pages/dev.page.js
+++ b/tests/functional/pages/dev.page.js
@@ -20,7 +20,7 @@ class DevPage {
     return this
   }
 
-  submit = function() {
+  submit() {
     browser.click('.qa-btn-submit-dev')
     return this
   }

--- a/tests/functional/pages/surveys/rsi/0102/internet-sales.page.js
+++ b/tests/functional/pages/surveys/rsi/0102/internet-sales.page.js
@@ -6,7 +6,9 @@ class InternetSalesPage extends QuestionPage {
     browser.setValue('[name="66612bbb-bc06-4d38-b32c-e2a113641c8a"]', sales)
     return this
   }
-
+   getInternetSales() {
+    return browser.element('[name="66612bbb-bc06-4d38-b32c-e2a113641c8a"]').getValue()
+   }
 }
 
 export default new InternetSalesPage()

--- a/tests/functional/pages/surveys/rsi/0102/rsi-summary.page.js
+++ b/tests/functional/pages/surveys/rsi/0102/rsi-summary.page.js
@@ -22,6 +22,10 @@ class RSISummaryPage extends SummaryPage {
     browser.click('[aria-describedby="summary-3-0-0 summary-3-0-0-answer"]')
   }
 
+  editLinkChangeInternetSales(){
+    browser.click('[aria-describedby="summary-2-0-0 summary-2-0-0-answer"]')
+  }
+
 }
 
 export default new RSISummaryPage()

--- a/tests/functional/spec/error-message.spec.js
+++ b/tests/functional/spec/error-message.spec.js
@@ -1,5 +1,5 @@
 import chai from 'chai'
-import {getRandomString, startQuestionnaire} from '../helpers'
+import {getRandomString, startQuestionnaire, getElementId} from '../helpers'
 import monthlyBusinessSurveyPage from '../pages/surveys/mci/monthly-business-survey.page'
 
 const expect = chai.expect
@@ -21,9 +21,4 @@ describe('Error messages', function() {
     // Then
     expect(getElementId(browser.elementActive())).to.equal(getElementId(monthlyBusinessSurveyPage.getFromReportingPeriodDay()))
   })
-
-  function getElementId(element) {
-    return browser.elementIdAttribute(element.value.ELEMENT, "id").value
-  }
-
 })

--- a/tests/functional/spec/summary-screen.spec.js
+++ b/tests/functional/spec/summary-screen.spec.js
@@ -63,4 +63,29 @@ describe('RSI - summary screen edit test', function() {
     expect(rsiSummaryPage.getChangeInRetailTurnoverSummary()).to.contain('This is to test edit links on summary screen - edited')
 
   })
+  it('Given the RSI survery 0102 when a 0 is entered in a currency field then the summary screen should show £0 and the original page should show 0', function(done) {
+
+    //Given the RSI business survey 0102 is started
+    startQuestionnaire('1_0102.json')
+
+    // when data is entered for the survey
+    reportingPeriod.setFromReportingPeriodDay(2)
+      .setToReportingPeriodDay(2)
+      .setFromReportingPeriodYear(2016)
+      .setToReportingPeriodYear(2017)
+      .submit()
+    retailTurnoverPage.setRetailTurnover(1000)
+      .submit()
+    internetSalesPage.setInternetSales(0)
+      .submit()
+    changeInRetailTurnover.setChangesInRetailTurnover('')
+      .submit()
+
+    // Then summary screen and the original page shows the data entered
+    expect(rsiSummaryPage.getRetailTurnoverSummary()).to.contain('£1,000')
+    expect(rsiSummaryPage.getInternetSalesSummary()).to.contain('£' + 0)
+    rsiSummaryPage.editLinkChangeInternetSales()
+    expect(internetSalesPage.getInternetSales()).to.contain('0')
+
+      })
 })


### PR DESCRIPTION
### What is the context of this PR?

Fixes #511 . Python sees integer 0 as false therefore our current code is returning None or empty string for currency questions, this therefore means the frontend shows the data wrong, a None check is better in this situation. The state input and the state value don't need both checking, so I have removed one
### How to review

Open any survey and start entering the data making sure you enter '0' into a currency question, submit the survey and make sure '0' appears on the summary page and on the original page when you navigate back to it
