### PR TITLE
eq-526 Save and continue button

### DIFF
--- a/app/templates/questionnaire.html
+++ b/app/templates/questionnaire.html
@@ -61,7 +61,7 @@
 
           </div>
 
-      <button class="btn btn--secondary qa-btn-submit venus" type="submit" name="action[save_continue]">Save &amp; Continue</button>
+      <button class="btn btn--secondary qa-btn-submit venus" type="submit" name="action[save_continue]">Save and continue</button>
       <br/>
       <div class="u-mt-xs">
         <a class="mars" href="previous">Previous</a>

--- a/tests/integration/mci/test_change_answers.py
+++ b/tests/integration/mci/test_change_answers.py
@@ -40,7 +40,7 @@ class TestHappyPath(IntegrationTestCase):
         self.assertRegexpMatches(content, '<title>Survey</title>')
         self.assertRegexpMatches(content, '>Monthly Business Survey - Retail Sales Index</')
         self.assertRegexpMatches(content, "What are the dates of the sales period you are reporting for\?")
-        self.assertRegexpMatches(content, ">Save &amp; Continue<")
+        self.assertRegexpMatches(content, ">Save and continue<")
 
         # We fill in our answers
         form_data = {

--- a/tests/integration/mci/test_clear_error.py
+++ b/tests/integration/mci/test_clear_error.py
@@ -39,7 +39,7 @@ class TestClearError(IntegrationTestCase):
         self.assertRegexpMatches(content, '<title>Survey</title>')
         self.assertRegexpMatches(content, '>Monthly Business Survey - Retail Sales Index</')
         self.assertRegexpMatches(content, "What are the dates of the sales period you are reporting for\?")
-        self.assertRegexpMatches(content, ">Save &amp; Continue<")
+        self.assertRegexpMatches(content, ">Save and continue<")
         # check with have some guidance
         self.assertRegexpMatches(content, "alcoholic drink")
 

--- a/tests/integration/mci/test_clear_value.py
+++ b/tests/integration/mci/test_clear_value.py
@@ -39,7 +39,7 @@ class TestClearValue(IntegrationTestCase):
         self.assertRegexpMatches(content, '<title>Survey</title>')
         self.assertRegexpMatches(content, '>Monthly Business Survey - Retail Sales Index</')
         self.assertRegexpMatches(content, "What are the dates of the sales period you are reporting for\?")
-        self.assertRegexpMatches(content, ">Save &amp; Continue<")
+        self.assertRegexpMatches(content, ">Save and continue<")
         # check with have some guidance
         self.assertRegexpMatches(content, "alcoholic drink")
 

--- a/tests/integration/mci/test_empty_comments.py
+++ b/tests/integration/mci/test_empty_comments.py
@@ -35,7 +35,7 @@ class TestEmptyComments(IntegrationTestCase):
         self.assertRegexpMatches(content, '<title>Survey</title>')
         self.assertRegexpMatches(content, '>Monthly Business Survey - Retail Sales Index</')
         self.assertRegexpMatches(content, "What are the dates of the sales period you are reporting for\?")
-        self.assertRegexpMatches(content, ">Save &amp; Continue<")
+        self.assertRegexpMatches(content, ">Save and continue<")
 
         # We fill in our answers
         form_data = {

--- a/tests/integration/mci/test_empty_submission.py
+++ b/tests/integration/mci/test_empty_submission.py
@@ -34,7 +34,7 @@ class TestEmptySubmission(IntegrationTestCase):
         # We are in the Questionnaire
         content = resp.get_data(True)
         self.assertRegexpMatches(content, "What are the dates of the sales period you are reporting for\?")
-        self.assertRegexpMatches(content, ">Save &amp; Continue<")
+        self.assertRegexpMatches(content, ">Save and continue<")
 
         form_data = {
             # Start Date

--- a/tests/integration/mci/test_happy_path.py
+++ b/tests/integration/mci/test_happy_path.py
@@ -40,7 +40,7 @@ class TestHappyPath(IntegrationTestCase):
         self.assertRegexpMatches(content, '<title>Survey</title>')
         self.assertRegexpMatches(content, '>Monthly Business Survey - Retail Sales Index</')
         self.assertRegexpMatches(content, "What are the dates of the sales period you are reporting for\?")
-        self.assertRegexpMatches(content, ">Save &amp; Continue<")
+        self.assertRegexpMatches(content, ">Save and continue<")
         # check with have some guidance
         self.assertRegexpMatches(content, "alcoholic drink")
 

--- a/tests/integration/mci/test_invalid_dates_numbers.py
+++ b/tests/integration/mci/test_invalid_dates_numbers.py
@@ -34,7 +34,7 @@ class TestInvalidDateNumber(IntegrationTestCase):
         # We are in the Questionnaire
         content = resp.get_data(True)
         self.assertRegexpMatches(content, "What are the dates of the sales period you are reporting for\?")
-        self.assertRegexpMatches(content, ">Save &amp; Continue<")
+        self.assertRegexpMatches(content, ">Save and continue<")
 
         form_data = {
             # Start Date

--- a/tests/integration/mci/test_submission_with_errors.py
+++ b/tests/integration/mci/test_submission_with_errors.py
@@ -35,7 +35,7 @@ class TestSubmissionWithErrors(IntegrationTestCase):
         self.assertRegexpMatches(content, '<title>Survey</title>')
         self.assertRegexpMatches(content, '>Monthly Business Survey - Retail Sales Index</')
         self.assertRegexpMatches(content, "What are the dates of the sales period you are reporting for\?")
-        self.assertRegexpMatches(content, ">Save &amp; Continue<")
+        self.assertRegexpMatches(content, ">Save and continue<")
 
         # We fill in our answers
         form_data = {

--- a/tests/integration/star_wars/star_wars_tests.py
+++ b/tests/integration/star_wars/star_wars_tests.py
@@ -155,7 +155,7 @@ class StarWarsTestCase(IntegrationTestCase):
 
     def check_quiz_first_page(self, page):
         content = self.retrieve_content(page)
-        self.assertRegexpMatches(content, ">Save &amp; Continue<")
+        self.assertRegexpMatches(content, ">Save and continue<")
         self.assertRegexpMatches(content, 'Star Wars Quiz')
         self.assertRegexpMatches(content, 'May the force be with you young EQ developer')
 

--- a/tests/integration/star_wars/test_previous_link.py
+++ b/tests/integration/star_wars/test_previous_link.py
@@ -56,7 +56,7 @@ class TestPreviousLink(StarWarsTestCase):
         resp = self.client.get(resp.headers['Location'])
 
         content = resp.get_data(True)
-        self.assertRegexpMatches(content, ">Save &amp; Continue<")
+        self.assertRegexpMatches(content, ">Save and continue<")
         self.assertRegexpMatches(content, 'Star Wars Quiz')
         self.assertRegexpMatches(content, 'May the force be with you young EQ developer')
 


### PR DESCRIPTION
### What is the context of this PR?

Fixes #526 by changing the label on the 'Save & Continue' button to 'Save and continue' as per design changes. Also updates tests accordingly.
### How to review
1. Start and survey.
2. Confirm label change.
