### PR TITLE
Update JWT token to accept region_code

### DIFF
--- a/app/dev_mode/templates/dev-page.html
+++ b/app/dev_mode/templates/dev-page.html
@@ -61,6 +61,15 @@
           EMPLOYMENT_DATE:
           <input name="employment_date" type="text" value="2016-06-10" class="qa-employment-date">
         </p>
+        <p>
+          REGION_CODE:
+          <select name="region_code" class="qa-region-code">
+            <option name="GB-ENG" value="GB-ENG">GB-ENG</option>
+            <option name="GB-GBN" value="GB-GBN">GB-GBN</option>
+            <option name="GB-NI" value="GB-NI">GB-NI</option>
+            <option name="GB-WLS" value="GB-WLS">GB-WLS</option>
+          </select>
+        </p>
         <input type="submit" value="submit" class="qa-btn-submit-dev"/>
       </form>
     </div>

--- a/app/dev_mode/views.py
+++ b/app/dev_mode/views.py
@@ -34,8 +34,9 @@ def dev_mode():
         trad_as = form.get("trad_as")
         return_by = form.get("return_by")
         employment_date = form.get("employment_date")
+        region_code = form.get("region_code")
         payload = create_payload(user, exp_time, eq_id, period_str, period_id, form_type, collection_exercise_sid,
-                                 ref_p_start_date, ref_p_end_date, ru_ref, ru_name, trad_as, return_by, employment_date)
+                                 ref_p_start_date, ref_p_end_date, ru_ref, ru_name, trad_as, return_by, employment_date, region_code)
         return redirect("/session?token=" + generate_token(payload).decode())
 
     return render_template("dev-page.html", user=os.getenv('USER', 'UNKNOWN'), available_schemas=available_schemas())
@@ -67,7 +68,7 @@ def extract_eq_id_and_form_type(schema_name):
 
 
 def create_payload(user, exp_time, eq_id, period_str, period_id, form_type, collection_exercise_sid, ref_p_start_date,
-                   ref_p_end_date, ru_ref, ru_name, trad_as, return_by, employment_date):
+                   ref_p_end_date, ru_ref, ru_name, trad_as, return_by, employment_date, region_code):
     iat = time.time()
     exp = time.time() + float(exp_time)
     return {
@@ -85,7 +86,8 @@ def create_payload(user, exp_time, eq_id, period_str, period_id, form_type, coll
             "ru_name": ru_name,
             "return_by": return_by,
             "trad_as": trad_as,
-            "employment_date": employment_date}
+            "employment_date": employment_date,
+            "region_code": region_code}
 
 
 def generate_token(payload):

--- a/app/parser/metadata_parser.py
+++ b/app/parser/metadata_parser.py
@@ -55,6 +55,7 @@ metadata_fields = {
     "return_by": MetadataField(validator=iso_8601_data_parser),
     "trad_as": MetadataField(mandatory=False),
     "employment_date": MetadataField(mandatory=False, validator=iso_8601_data_parser),
+    "region_code": MetadataField(mandatory=False),
     "tx_id": MetadataField(mandatory=False, validator=uuid_4_parser, generator=id_generator),
 }
 
@@ -77,7 +78,6 @@ def parse_metadata(metadata_to_check):
         logger.error("parse_metadata: Unable to parse")
         logger.exception(e)
         raise InvalidTokenException("Incorrect data in token")
-
     return parsed
 
 

--- a/app/piping/plumbing_preprocessor.py
+++ b/app/piping/plumbing_preprocessor.py
@@ -34,6 +34,7 @@ def _build_exercise():
         "end_date": to_date(metadata["ref_p_end_date"]),
         "employment_date": to_date(metadata["employment_date"]),
         "return_by": to_date(metadata["return_by"]),
+        "region_code": metadata["region_code"],
     }
 
 

--- a/app/templating/metadata_template_preprocessor.py
+++ b/app/templating/metadata_template_preprocessor.py
@@ -55,6 +55,7 @@ class MetaDataTemplatePreprocessor(object):
             "start_date":  self._format_date(metadata["ref_p_start_date"]),
             "end_date": self._format_date(metadata["ref_p_end_date"]),
             "employment_date": self._format_date(metadata["employment_date"]),
+            "region_code": metadata["region_code"] if 'region_code' in metadata else None,
             "period_str": metadata["period_str"],
         }
         return survey_meta

--- a/tests/app/templating/test_metadata_template_preprocessor.py
+++ b/tests/app/templating/test_metadata_template_preprocessor.py
@@ -45,6 +45,7 @@ class TestMetadataTemplatePreprocessor(SurveyRunnerTestCase):
         self.assertEqual('2 February 2016', survey_data['start_date'])
         self.assertEqual('3 March 2016', survey_data['end_date'])
         self.assertIsNone(survey_data['employment_date'])
+        self.assertIsNone(survey_data['region_code'])
         self.assertEqual(self.jwt["period_str"], survey_data['period_str'])
 
         respondent = render_data['respondent']

--- a/tests/app/templating/test_model_builder.py
+++ b/tests/app/templating/test_model_builder.py
@@ -23,7 +23,8 @@ class TestBuildModel(unittest.TestCase):
                 'trad_as': 'Apple',
                 'tx_id': '12345678-1234-5678-1234-567812345678',
                 'period_str': '201610',
-                'employment_date': '2016-10-10'}
+                'employment_date': '2016-10-10',
+                }
 
     def setUp(self):
         schema_file = open(os.path.join(settings.EQ_SCHEMA_DIRECTORY, "0_star_wars.json"))

--- a/tests/app/views/test_dev_mode.py
+++ b/tests/app/views/test_dev_mode.py
@@ -18,6 +18,7 @@ def test_dev_mode_submission(survey_runner):
       ref_p_end_date="2016-05-31",
       return_by="2016-06-12",
       employment_date="2016-06-10",
+      region_code="GB-GBN",
       user_id="test"
     ), follow_redirects=True)
     assert response.status_code == 200

--- a/tests/integration/create_token.py
+++ b/tests/integration/create_token.py
@@ -13,7 +13,8 @@ RETURN_BY = "2016-05-06"
 TRAD_AS = "Integration Tests"
 EMPLOYMENT_P_DATE = "1983-06-02"
 
-def create_token(form_type_id, eq_id, start_date=None, end_date=None, employment_date=None):
+
+def create_token(form_type_id, eq_id, start_date=None, end_date=None, employment_date=None, region_code=None):
         user = USER
         exp_time = 3600                         # one hour from now
         eq_id = eq_id
@@ -37,6 +38,7 @@ def create_token(form_type_id, eq_id, start_date=None, end_date=None, employment
         else:
             ref_p_employment_date = employment_date
 
+
         ru_ref = RU_REF
         ru_name = RU_NAME
         trad_as = TRAD_AS
@@ -44,6 +46,6 @@ def create_token(form_type_id, eq_id, start_date=None, end_date=None, employment
 
         payload = create_payload(user, exp_time, eq_id, period_str, period_id,
                                  form_type, collection_exercise_sid, ref_p_start_date,
-                                 ref_p_end_date, ru_ref, ru_name, trad_as, return_by, ref_p_employment_date)
+                                 ref_p_end_date, ru_ref, ru_name, trad_as, return_by, ref_p_employment_date, region_code)
 
         return generate_token(payload)

--- a/token_generator.py
+++ b/token_generator.py
@@ -23,7 +23,8 @@ def create_payload(user):
             "ru_ref": "12346789012A",
             "ru_name": "Apple",
             "return_by": "2016-04-30",
-            "employment_date": "2016-06-10"}
+            "employment_date": "2016-06-10",
+            "region_code": "GB-GBN"}
 
 
 def generate_token():


### PR DESCRIPTION
### What is the context of this PR?
To include region_code in the JWT and store the result in metadata["region_code"]. It has been agreed that it will be optional to begin with and then mandatory at a later date. If it is not passed in the JWT it will be stored as None. Surveys which are currently inflight, which don't have region_codes have been protected against and will still work.  
This functionality will be used in the future so front end tests are not possible at this time.

### How to review 
We currently don't use this functionality so the best way is to add {{ meta.survey.region_code}} somewhere on the landing page(can be any page) and use /dev to make sure it changes when the dev page region code drop down changes.

