### PR TITLE
Fixing dict conversion bug

### DIFF
--- a/app/data/test_skip_condition.json
+++ b/app/data/test_skip_condition.json
@@ -1,0 +1,184 @@
+{
+   "mime_type":"application/json/ons/eq",
+   "questionnaire_id":"0",
+   "schema_version":"0.0.1",
+   "survey_id":"0",
+   "title":"Test skip condition",
+   "theme":"default",
+   "description":"A questionnaire to test skip condition.",
+   "introduction":{
+      "description":"",
+      "information_to_provide":[
+         "Breakfast foods",
+         "Other info"
+      ]
+   },
+   "display":{
+      "properties":{
+
+      }
+   },
+   "eq_id":"0",
+   "messages":{},
+   "groups":[
+      {
+         "blocks":[
+            {
+               "display":{
+                  "properties":{
+
+                  }
+               },
+               "id":"food-block",
+               "sections":[
+                  {
+                     "description":"",
+                     "display":{
+                        "properties":{
+
+                        }
+                     },
+                     "id":"food-section",
+                     "questions":[
+                        {
+                           "answers":[
+                              {
+                                 "display":{
+                                    "properties":{
+                                       "columns":false
+                                    }
+                                 },
+                                 "guidance":"",
+                                 "id":"food-answer",
+                                 "label":"What is your favourite breakfast food",
+                                 "mandatory":true,
+                                 "options":[
+                                    {
+                                       "label":"Bacon",
+                                       "value":"Bacon"
+                                    },
+                                    {
+                                       "label":"Eggs",
+                                       "value":"Eggs"
+                                    }
+                                 ],
+                                 "q_code":"20",
+                                 "type":"Radio",
+                                 "validation":{
+                                    "messages":{
+
+                                    }
+                                 }
+                              }
+                           ],
+                           "description":"",
+                           "display":{
+                              "properties":{
+
+                              }
+                           },
+                           "id":"food-question",
+                           "title":"",
+                           "type":"General",
+                           "validation":[
+
+                           ]
+                        }
+                     ],
+                     "title":"What is your favourite breakfast food",
+                     "validation":[
+
+                     ]
+                  }
+               ],
+               "routing_rules":[
+
+               ],
+               "title":"",
+               "validation":[
+
+               ]
+            },
+            {
+               "display":{
+                  "properties":{
+
+                  }
+               },
+               "id":"drink-block",
+               "sections":[
+                  {
+                     "description":"",
+                     "display":{
+                        "properties":{
+
+                        }
+                     },
+                     "id":"drink-question",
+                     "questions":[
+                        {
+                           "answers":[
+                              {
+                                 "alias":"",
+                                 "display":{
+                                    "properties":{
+                                       "columns":false
+                                    }
+                                 },
+                                 "guidance":"",
+                                 "id":"drink-answer",
+                                 "label":"What is your favourite breakfast beverage",
+                                 "mandatory":true,
+                                 "options":[
+                                    {
+                                       "label":"Tea",
+                                       "value":"Tea"
+                                    },
+                                    {
+                                       "label":"Coffee",
+                                       "value":"Coffee"
+                                    }
+                                 ],
+                                 "q_code":"20",
+                                 "type":"Radio",
+                                 "validation":{
+                                    "messages":{
+
+                                    }
+                                 }
+                              }
+                           ],
+                           "description":"",
+                           "display":{
+                              "properties":{
+
+                              }
+                           },
+                           "id":"drink-section",
+                           "title":"What beverage would you like to accompany your choice of breakfast?",
+                           "type":"General",
+                           "skip_condition": {
+                               "when": {
+                                   "id" : "food-answer",
+                                   "condition": "equals",
+                                   "value": "Eggs"
+                               }
+                           }
+                        }
+                     ],
+                     "title":""
+                  }
+               ],
+               "title":""
+            }
+         ],
+         "display":{
+            "properties":{
+
+            }
+         },
+         "id":"breakfast",
+         "title":""
+      }
+   ]
+}

--- a/app/questionnaire/questionnaire_manager.py
+++ b/app/questionnaire/questionnaire_manager.py
@@ -130,8 +130,7 @@ class QuestionnaireManager(object):
             item.skipped = False
 
             if hasattr(item.schema_item, 'skip_condition') and item.schema_item.skip_condition:
-                rule = item.schema_item.skip_condition.__dict__
-                rule['when'] = rule['when'].__dict__
+                rule = item.schema_item.skip_condition.as_dict()
                 answer = get_answers(current_user).get(rule['when']['id'])
 
                 item.skipped = evaluate_rule(rule, answer)

--- a/app/schema/skip_condition.py
+++ b/app/schema/skip_condition.py
@@ -1,5 +1,11 @@
+import copy
 
 
 class SkipCondition(object):
     def __init__(self):
         self.when = None
+
+    def as_dict(self):
+        self_copy = copy.deepcopy(self.__dict__)
+        self_copy['when'] = self_copy['when'].__dict__ if self.when else None
+        return self_copy

--- a/app/schema/test_skip_condition.py
+++ b/app/schema/test_skip_condition.py
@@ -1,0 +1,24 @@
+from unittest import TestCase
+
+from app.schema.skip_condition import SkipCondition
+from app.schema.when import When
+
+
+class TestSkipCondition(TestCase):
+    def test_as_dict(self):
+        skip = SkipCondition()
+        skip.when = When()
+
+        copy = skip.as_dict()
+
+        self.assertIsNot(copy, skip.__dict__)
+        self.assertIsNot(copy['when'], skip.when.__dict__)
+        self.assertEqual(copy['when'], skip.when.__dict__)
+
+    def test_as_dict_no_when(self):
+        skip = SkipCondition()
+
+        copy = skip.as_dict()
+
+        self.assertIsNot(copy, skip.__dict__)
+        self.assertEqual(copy, skip.__dict__)

--- a/tests/app/routing/test_conditional_display.py
+++ b/tests/app/routing/test_conditional_display.py
@@ -15,39 +15,33 @@ class TestConditionalDisplay(SurveyRunnerTestCase):
         answer = "Bothans"
         # find the question with the 'not equals' skip condition
         question = self.questionnaire.get_item_by_id("048e40da-bca4-48e5-9885-0bb6413bef62")
-        rule = question.skip_condition.__dict__
-        rule['when'] = rule['when'].__dict__
 
         # check the parse has set up the skip condition
-        self.assertIsNotNone(question.skip_condition)
+        self.assertIsNotNone(question.skip_condition.as_dict())
 
         # the condition will fire now as we have answer the question correctly, so we won't skip the question
-        self.assertFalse(evaluate_rule(rule, answer))
+        self.assertFalse(evaluate_rule(question.skip_condition.as_dict(), answer))
 
     def test_skip_condition_true(self):
         answer = "Some other answer"
 
         # find the question with the 'not equals' skip condition
         question = self.questionnaire.get_item_by_id("048e40da-bca4-48e5-9885-0bb6413bef62")
-        rule = question.skip_condition.__dict__
-        rule['when'] = rule['when'].__dict__
 
         # check the parse has set up the skip condition
-        self.assertIsNotNone(question.skip_condition)
+        self.assertIsNotNone(question.skip_condition.as_dict())
 
         # the condition won't fire as we haven't answered any questions, so we will skip the question
-        self.assertTrue(evaluate_rule(rule, answer))
+        self.assertTrue(evaluate_rule(question.skip_condition.as_dict(), answer))
 
     def test_skip_condition_blank(self):
         answer = ""
 
         # find the question with the 'not equals' skip condition
         question = self.questionnaire.get_item_by_id("048e40da-bca4-48e5-9885-0bb6413bef62")
-        rule = question.skip_condition.__dict__
-        rule['when'] = rule['when'].__dict__
 
         # check the parse has set up the skip condition
         self.assertIsNotNone(question.skip_condition)
 
         # the condition won't fire as we haven't answered any questions, so we will skip the question
-        self.assertTrue(evaluate_rule(rule, answer))
+        self.assertTrue(evaluate_rule(question.skip_condition.as_dict(), answer))

--- a/tests/integration/star_wars/test_errors.py
+++ b/tests/integration/star_wars/test_errors.py
@@ -1,3 +1,4 @@
+from tests.integration.create_token import create_token
 from tests.integration.star_wars.star_wars_tests import StarWarsTestCase
 from werkzeug.datastructures import MultiDict
 
@@ -80,3 +81,20 @@ class TestPageErrors(StarWarsTestCase):
         self.assertRegex(content, 'href="#a5dc09e8-36f2-4bf4-97be-c9e6ca8cbe0d"')
         # We DO NOT have the error from page two
         self.assertNotRegex(content, 'href="215015b1-f87c-4740-9fd4-f01f707ef558"')
+
+    def test_skip_question_errors(self):
+        # Given on the page with skip question with skip condition
+        self.token = create_token('skip_condition', 'test')
+        self.client.get('/session?token=' + self.token.decode(), follow_redirects=True)
+        post_data = {'action[start_questionnaire]': 'Start Questionnaire'}
+        self.client.post('/questionnaire/test/skip_condition/201604/789/introduction', data=post_data, follow_redirects=True)
+        post_data = {'food-answer': 'Bacon', 'action[save_continue]': 'Save &amp; Continue'}
+        self.client.post('/questionnaire/test/skip_condition/201604/789/food-block', data=post_data, follow_redirects=True)
+
+        # When submit no answers which is invalid
+        post_data = {'action[save_continue]': 'Save &amp; Continue'}
+        resp = self.client.post('/questionnaire/test/skip_condition/201604/789/drink-block', data=post_data)
+
+        # Then errors exists on page
+        self.assertEqual(resp.status_code, 200)
+        self.assertRegex(resp.get_data(True), 'This page has 1 errors')


### PR DESCRIPTION
### What is the context of this PR?
Describe what you have changed and why, link to other PRs or Issues as appropriate.

When posting invalid answers that contain questions with skip_conditions
state modification causes a error to be raised which redirects the user
to a server error page when they should see the errors.
We now create a deep copy of the object so when we change state it
doesn't affect the state item.

### How to review 
Describe the steps required to test the changes (include screenshots if appropriate).
See steps to replicated in #538 