### PR TITLE
WIP: Household Member Repeating Details

### DIFF
--- a/app/data/test_repeating_household.json
+++ b/app/data/test_repeating_household.json
@@ -1,0 +1,135 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "questionnaire_id": "23",
+    "schema_version": "0.0.1",
+    "survey_id": "023",
+    "title": "Test Repeating",
+    "description": "",
+    "theme": "default",
+    "eq_id": "1",
+    "introduction": {
+        "description": ""
+    },
+    "groups": [{
+        "blocks": [{
+            "id": "980b148e-0856-4e50-9afe-67a4fa6ae13b",
+            "title": "Block 1",
+            "sections": [{
+                "title": "Dummy Question",
+                "description": "",
+                "id": "b3c2e966-77ec-4373-b3dd-fdafb5a05cbd",
+                "questions": [{
+                    "id": "df9e9a50-912b-4c9e-9a75-1e7b78b2d87f",
+                    "title": "First Question",
+                    "description": "",
+                    "type": "General",
+                    "answers": [{
+                        "q_code": "1",
+                        "guidance": "",
+                        "id": "fad63234-1083-4f6a-826a-20b5df6e4baa",
+                        "label": "First input",
+                        "mandatory": true,
+                        "type": "PositiveInteger",
+                        "validation": {
+                            "messages": {
+                                "MANDATORY": "Please answer before continuing."
+                            }
+                        }
+                    }]
+                }]
+            }]
+        }, {
+            "id": "0c7c8876-6a63-4251-ac29-b821b3e9b1bc",
+            "title": "Block 2",
+            "sections": [{
+                "title": "No of Iterations",
+                "description": "",
+                "id": "5355deab-0b1e-495d-b4ab-f3e1f7c0c6f1",
+                "questions": [{
+                    "id": "269e6c4a-4e27-4469-b4db-91537fae4629",
+                    "title": "Second Question",
+                    "description": "",
+                    "type": "General",
+                    "answers": [{
+                        "q_code": "2",
+                        "guidance": "",
+                        "id": "78774493-5b64-45c4-8072-22f1a9638095",
+                        "label": "How many time are we going to repeat?",
+                        "mandatory": true,
+                        "type": "PositiveInteger",
+                        "validation": {
+                            "messages": {
+                                "MANDATORY": "Please answer before continuing."
+                            }
+                        }
+                    }]
+                }]
+            }]
+        }],
+        "id": "f74d1147-673c-497a-9616-763829d944ac",
+        "title": "Group 1"
+    }, {
+        "blocks": [{
+            "id": "96682325-47ab-41e4-a56e-8315a19ffe2a",
+            "title": "Block 3",
+            "sections": [{
+                "title": "Repeating Block",
+                "description": "",
+                "id": "91631df0-4356-4e9f-a9d9-ce8b08d26eb3",
+                "questions": [{
+                    "id": "c1d9976e-d031-4fab-96fc-1d37d4a8b86b",
+                    "title": "First Question, Second Group",
+                    "description": "",
+                    "type": "General",
+                    "answers": [{
+                        "q_code": "3",
+                        "guidance": "",
+                        "id": "680f2ff9-d5a5-4057-b1cd-9fde2660b244",
+                        "label": "First input",
+                        "mandatory": true,
+                        "type": "PositiveInteger",
+                        "validation": {
+                            "messages": {
+                                "MANDATORY": "Please answer before continuing."
+                            }
+                        }
+                    }]
+                }]
+            }]
+        }, {
+            "id": "a7dcbb30-1187-4276-a49c-9284730ba4ed",
+            "title": "Block 4",
+            "sections": [{
+                "title": "",
+                "description": "",
+                "id": "2e0989b8-5185-4ba6-b73f-c126e3a06ba7",
+                "questions": [{
+                    "id": "31ec5b0a-094b-44ca-9807-9090c1b849f5",
+                    "title": "Second Question, Second Group",
+                    "description": "",
+                    "type": "General",
+                    "answers": [{
+                        "q_code": "4",
+                        "guidance": "",
+                        "id": "5667e5eb-f9d3-4482-9257-edf752000708",
+                        "label": "Second input",
+                        "mandatory": true,
+                        "type": "PositiveInteger",
+                        "validation": {
+                            "messages": {
+                                "MANDATORY": "Please answer before continuing."
+                            }
+                        }
+                    }]
+                }]
+            }]
+        }],
+        "id": "f22b1ba4-d15f-48b8-a1f3-db62b6f34cc0",
+        "title": "Group 2",
+        "routing_rules": [{
+            "repeat": {
+                "answer_id": "78774493-5b64-45c4-8072-22f1a9638095"
+            }
+        }]
+    }]
+}

--- a/app/data/test_routing_and_repeating_household.json
+++ b/app/data/test_routing_and_repeating_household.json
@@ -1,0 +1,198 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "questionnaire_id": "23",
+    "schema_version": "0.0.1",
+    "survey_id": "023",
+    "title": "Test Repeating",
+    "description": "",
+    "theme": "default",
+    "eq_id": "1",
+    "introduction": {
+        "description": ""
+    },
+    "groups": [{
+        "blocks": [{
+            "id": "980b148e-0856-4e50-9afe-67a4fa6ae13b",
+            "title": "Block 1",
+            "sections": [{
+                "title": "Dummy Question",
+                "description": "",
+                "id": "b3c2e966-77ec-4373-b3dd-fdafb5a05cbd",
+                "questions": [{
+                    "id": "df9e9a50-912b-4c9e-9a75-1e7b78b2d87f",
+                    "title": "First Question",
+                    "description": "",
+                    "type": "General",
+                    "answers": [{
+                        "q_code": "1",
+                        "guidance": "",
+                        "id": "fad63234-1083-4f6a-826a-20b5df6e4baa",
+                        "label": "First input",
+                        "mandatory": true,
+                        "type": "PositiveInteger",
+                        "validation": {
+                            "messages": {
+                                "MANDATORY": "Please answer before continuing."
+                            }
+                        }
+                    }]
+                }]
+            }]
+        }, {
+            "id": "0c7c8876-6a63-4251-ac29-b821b3e9b1bc",
+            "title": "Block 2",
+            "sections": [{
+                "title": "No of Iterations",
+                "description": "",
+                "id": "5355deab-0b1e-495d-b4ab-f3e1f7c0c6f1",
+                "questions": [{
+                    "id": "269e6c4a-4e27-4469-b4db-91537fae4629",
+                    "title": "Second Question",
+                    "description": "",
+                    "type": "General",
+                    "answers": [{
+                        "q_code": "2",
+                        "guidance": "",
+                        "id": "78774493-5b64-45c4-8072-22f1a9638095",
+                        "label": "How many time are we going to repeat?",
+                        "mandatory": true,
+                        "type": "PositiveInteger",
+                        "validation": {
+                            "messages": {
+                                "MANDATORY": "Please answer before continuing."
+                            }
+                        }
+                    }]
+                }]
+            }]
+        }],
+        "id": "f74d1147-673c-497a-9616-763829d944ac",
+        "title": "Group 1"
+    }, {
+        "blocks": [{
+            "id": "96682325-47ab-41e4-a56e-8315a19ffe2a",
+            "title": "Block 3",
+            "sections": [{
+                "title": "Repeating Block",
+                "description": "",
+                "id": "91631df0-4356-4e9f-a9d9-ce8b08d26eb3",
+                "questions": [{
+                    "id": "c1d9976e-d031-4fab-96fc-1d37d4a8b86b",
+                    "title": "First Question, Second Group",
+                    "description": "",
+                    "type": "General",
+                    "answers": [{
+                        "options": [
+                            {
+                                "label": "Question 2",
+                                "value": "Question 2",
+                                "description": ""
+                            },
+                            {
+                                "label": "Question 3",
+                                "value": "Question 3",
+                                "description": ""
+                            }
+                        ],
+                        "q_code": "3",
+                        "guidance": "",
+                        "id": "680f2ff9-d5a5-4057-b1cd-9fde2660b244",
+                        "label": "First input",
+                        "mandatory": true,
+                        "type": "Radio",
+                        "validation": {
+                            "messages": {
+                                "MANDATORY": "Please answer before continuing."
+                            }
+                        }
+                    }]
+                }]
+            }],
+            "routing_rules":[
+                {
+                    "goto": {
+                        "id" : "a7dcbb30-1187-4276-a49c-9284730ba4ed",
+                        "when": {
+                            "id" : "680f2ff9-d5a5-4057-b1cd-9fde2660b244",
+                            "condition": "equals",
+                            "value":"Question 2"
+                        }
+                    }
+
+                },
+                {
+                    "goto": {
+                        "id": "b6a470c7-f9cd-46dd-91fe-ee3c820dae71",
+                        "when": {
+                            "id" : "680f2ff9-d5a5-4057-b1cd-9fde2660b244",
+                            "condition": "equals",
+                            "value":"Question 3"
+                        }
+                    }
+
+                }
+            ]
+        }, {
+            "id": "a7dcbb30-1187-4276-a49c-9284730ba4ed",
+            "title": "Block 4",
+            "sections": [{
+                "title": "",
+                "description": "",
+                "id": "2e0989b8-5185-4ba6-b73f-c126e3a06ba7",
+                "questions": [{
+                    "id": "31ec5b0a-094b-44ca-9807-9090c1b849f5",
+                    "title": "Second Question, Second Group",
+                    "description": "",
+                    "type": "General",
+                    "answers": [{
+                        "q_code": "4",
+                        "guidance": "",
+                        "id": "5667e5eb-f9d3-4482-9257-edf752000708",
+                        "label": "Second input",
+                        "mandatory": true,
+                        "type": "PositiveInteger",
+                        "validation": {
+                            "messages": {
+                                "MANDATORY": "Please answer before continuing."
+                            }
+                        }
+                    }]
+                }]
+            }]
+        }, {
+            "id": "b6a470c7-f9cd-46dd-91fe-ee3c820dae71",
+            "title": "Block 5",
+            "sections": [{
+                "title": "",
+                "description": "",
+                "id": "9b9d5386-5e2f-46cb-9456-92f35254d7b1",
+                "questions": [{
+                    "id": "e4407328-e5ab-4d5d-afe0-12c9b33d5e21",
+                    "title": "Third Question, Second Group",
+                    "description": "",
+                    "type": "General",
+                    "answers": [{
+                        "q_code": "5",
+                        "guidance": "",
+                        "id": "eccada31-f214-4bf2-9239-11487914c9d3",
+                        "label": "Second input",
+                        "mandatory": true,
+                        "type": "PositiveInteger",
+                        "validation": {
+                            "messages": {
+                                "MANDATORY": "Please answer before continuing."
+                            }
+                        }
+                    }]
+                }]
+            }]
+        }],
+        "id": "f22b1ba4-d15f-48b8-a1f3-db62b6f34cc0",
+        "title": "Group 2",
+        "routing_rules": [{
+            "repeat": {
+                "answer_id": "78774493-5b64-45c4-8072-22f1a9638095"
+            }
+        }]
+    }]
+}

--- a/app/helpers/schema_helper.py
+++ b/app/helpers/schema_helper.py
@@ -1,0 +1,16 @@
+class SchemaHelper(object):
+
+    @staticmethod
+    def get_first_block_id(survey_json):
+        return survey_json['groups'][0]['blocks'][0]['id']
+
+    @staticmethod
+    def get_blocks(survey_json):
+        blocks = []
+        for group in survey_json['groups']:
+            blocks.extend([block for block in group['blocks']])
+        return blocks
+
+    @classmethod
+    def get_block(cls, survey_json, block_id):
+        return next(b for b in cls.get_blocks(survey_json) if b["id"] == block_id)

--- a/app/main/views/questionnaire.py
+++ b/app/main/views/questionnaire.py
@@ -103,7 +103,7 @@ def post_block_iteration(eq_id, form_type, collection_id, block_id, iteration):
 
     logger.info("Redirecting user to next location %s with tx_id=%s", next_block_id, metadata["tx_id"])
 
-    return redirect_to_block(eq_id, form_type, collection_id, next_block_id)
+    return redirect_to_block(eq_id, form_type, collection_id, next_block_id, next_iteration)
 
 
 @questionnaire_blueprint.route('summary', methods=["GET"])

--- a/app/questionnaire/navigator.py
+++ b/app/questionnaire/navigator.py
@@ -238,13 +238,11 @@ class Navigator:
         :param completed_blocks:
         :return:
         """
-        latest_location = self.get_first_location()
-
         if completed_blocks:
             answers = answers or {}
             incomplete_blocks = [item for item in self.get_location_path(answers) if item not in completed_blocks]
 
             if incomplete_blocks:
-                latest_location = incomplete_blocks[0]
+                return incomplete_blocks[0]
 
-        return latest_location
+        return self.get_first_location()

--- a/app/questionnaire/navigator.py
+++ b/app/questionnaire/navigator.py
@@ -76,7 +76,7 @@ class Navigator:
         :param path: The known path as a list which has been visited already
         :return: A list of block ids followed through the survey
         """
-        if block_id in Navigator.CLOSING_INTERSTITIAL_PATH:
+        if block_id in cls.CLOSING_INTERSTITIAL_PATH:
             return path
 
         path.append(block_id)

--- a/app/questionnaire/navigator.py
+++ b/app/questionnaire/navigator.py
@@ -22,41 +22,38 @@ def evaluate_rule(rule, answer):
     return False
 
 
-def build_path(blocks, block_id, answers, path):
+def evaluate_goto(goto_rule, answers):
     """
-    Recursive method which visits all the blocks and returns path taken
-    given a list of answers
-
-    :param blocks: A list containing all blocks in the survey
-    :param block_id: The block id to visit
-    :param answers: The answers to use on evaluating rules
-    :param path: The known path as a list which has been visited already
-    :return: A list of block ids followed through the survey
+    Determine whether a goto rule will be satisfied based on a given answer
+    :param goto_rule:
+    :param answers:
+    :return:
     """
-    if block_id in Navigator.CLOSING_INTERSTITIAL_PATH:
-        return path
+    if 'when' in goto_rule.keys():
+        answer_index = goto_rule['when']['id']
+        if answer_index in answers:
+            answer = answers[answer_index]
+            if evaluate_rule(goto_rule, answer):
+                return True
+        else:
+            return False
+    elif 'id' in goto_rule.keys():
+        return True
+    return None
 
-    path.append(block_id)
-    # Return the index of the block id to be visited
-    block_id_index = next(index for (index, b) in enumerate(blocks) if b["id"] == block_id)
 
-    if 'routing_rules' in blocks[block_id_index] and len(blocks[block_id_index]['routing_rules']) > 0:
-        for rule in blocks[block_id_index]['routing_rules']:
-            goto_rule = rule['goto']
-            if 'when' in goto_rule.keys():
-                answer_index = goto_rule['when']['id']
-                if answer_index in answers:
-                    answer = answers[answer_index]
-                    if evaluate_rule(goto_rule, answer):
-                        return build_path(blocks, goto_rule['id'], answers, path)
-                else:
-                    return path
-            elif 'id' in goto_rule.keys():
-                return build_path(blocks, goto_rule['id'], answers, path)
-    elif block_id_index != len(blocks) - 1:
-        next_block_id = blocks[block_id_index + 1]['id']
-        return build_path(blocks, next_block_id, answers, path)
-    return path
+def evaluate_repeat(repeat_rule, answers):
+    """
+    Returns the number of times repetition should occur based on answers
+    :param repeat_rule:
+    :param answers:
+    :return: The number of times to repeat
+    """
+    if 'answer_id' in repeat_rule:
+        repeat_index = repeat_rule['answer_id']
+        if repeat_index in answers:
+            return int(answers[repeat_index])
+    return 1
 
 
 class Navigator:
@@ -65,8 +62,44 @@ class Navigator:
 
     def __init__(self, survey_json):
         self.survey_json = survey_json
-        self.blocks = self.get_blocks()
-        self.first_block_id = self.blocks[0]['id']
+        self.first_block_id = self.get_first_block_id()
+
+    @classmethod
+    def build_path(cls, blocks, block_id, answers, path):
+        """
+        Recursive method which visits all the blocks and returns path taken
+        given a list of answers
+
+        :param blocks: A list containing all blocks in the survey
+        :param block_id: The block id to visit
+        :param answers: The answers to use on evaluating rules
+        :param path: The known path as a list which has been visited already
+        :return: A list of block ids followed through the survey
+        """
+        if block_id in Navigator.CLOSING_INTERSTITIAL_PATH:
+            return path
+
+        path.append(block_id)
+
+        # Get blocks to be visited and a count of previous visits to this block in path
+        block_ids = [index for (index, b) in enumerate(blocks) if b["id"] == block_id]
+        no_of_previous_visits = path.count(block_id)
+
+        # Return the index of the block id to be visited
+        block_id_index = block_ids[no_of_previous_visits - 1]
+
+        if 'routing_rules' in blocks[block_id_index] and len(blocks[block_id_index]['routing_rules']) > 0:
+            for rule in blocks[block_id_index]['routing_rules']:
+                if 'goto' in rule:
+                    should_go = evaluate_goto(rule['goto'], answers)
+                    if should_go is True:
+                        return cls.build_path(blocks, rule['goto']['id'], answers, path)
+                    elif should_go is False:
+                        return path
+        elif block_id_index != len(blocks) - 1:
+            next_block_id = blocks[block_id_index + 1]['id']
+            return cls.build_path(blocks, next_block_id, answers, path)
+        return path
 
     def get_routing_path(self, answers=None):
         """
@@ -75,8 +108,9 @@ class Navigator:
         """
         answers = answers or {}
         routing_path = []
+        blocks = self.get_blocks(answers)
 
-        return build_path(self.blocks, self.first_block_id, answers, routing_path)
+        return self.build_path(blocks, self.first_block_id, answers, routing_path)
 
     def can_reach_summary(self, answers=None, routing_path=None):
         """
@@ -86,29 +120,23 @@ class Navigator:
         :param answers:
         :return:
         """
+        blocks = self.get_blocks(answers)
         answers = answers or {}
-        routing_path = routing_path or build_path(self.blocks, self.first_block_id, answers, [])
+        routing_path = routing_path or self.build_path(blocks, self.first_block_id, answers, [])
         last_routing_block_id = routing_path[-1]
 
-        if self.blocks[-1]['id'] == last_routing_block_id:
+        if blocks[-1]['id'] == last_routing_block_id:
             return True
 
-        routing_block_id_index = next(index for (index, b) in enumerate(self.blocks) if b["id"] == last_routing_block_id)
+        routing_block_id_index = next(index for (index, b) in enumerate(blocks) if b["id"] == last_routing_block_id)
 
-        last_routing_block = self.blocks[routing_block_id_index]
+        last_routing_block = blocks[routing_block_id_index]
 
         if 'routing_rules' in last_routing_block:
             for rule in last_routing_block['routing_rules']:
                 goto_rule = rule['goto']
                 if 'id' in goto_rule.keys() and goto_rule['id'] == 'summary':
-                    if 'when' in goto_rule.keys():
-                        answer_index = goto_rule['when']['id']
-                        if answer_index in answers:
-                            answer = answers[answer_index]
-                            if evaluate_rule(goto_rule, answer):
-                                return True
-                    else:
-                        return True
+                    return evaluate_goto(goto_rule, answers)
         return False
 
     def get_location_path(self, answers=None):
@@ -118,7 +146,8 @@ class Navigator:
         :return:
         """
         answers = answers or {}
-        routing_path = build_path(self.blocks, self.first_block_id, answers, [])
+        blocks = self.get_blocks(answers)
+        routing_path = self.build_path(blocks, self.first_block_id, answers, [])
 
         can_reach_summary = self.can_reach_summary(answers, routing_path)
 
@@ -134,41 +163,70 @@ class Navigator:
     def get_first_block_id(self):
         return self.survey_json['groups'][0]['blocks'][0]['id']
 
-    def get_blocks(self):
+    def get_blocks(self, answers=None):
         blocks = []
+        answers = answers or {}
         for group in self.survey_json['groups']:
-            blocks.extend([block for block in group['blocks']])
+            group_blocks = [block for block in group['blocks']]
+            blocks.extend(group_blocks)
+            if 'routing_rules' in group:
+                for rule in group['routing_rules']:
+                    if 'repeat' in rule.keys():
+                        no_of_times = evaluate_repeat(rule['repeat'], answers)
+                        for i in range(no_of_times - 1):
+                            blocks.extend(group_blocks)
         return blocks
 
-    def get_first_location(self):
-        return Navigator.PRECEEDING_INTERSTITIAL_PATH[0]
+    def block_in_path_count(self, answers, block_id):
+        blocks = [b['id'] for b in self.get_blocks(answers)]
 
-    def get_next_location(self, answers=None, current_location_id=None):
+        return blocks.count(block_id)
+
+    @classmethod
+    def get_first_location(cls):
+        return cls.PRECEEDING_INTERSTITIAL_PATH[0]
+
+    def get_next_location(self, answers=None, current_location_id=None, current_iteration=None):
         """
         Returns the next 'location' to visit given a set of user answers
         :param answers:
         :param current_location_id:
+        :param current_iteration:
         :return:
         """
+        current_iteration = current_iteration or 0
         answers = answers or {}
         location_path = self.get_location_path(answers)
+
         if current_location_id in location_path:
-            current_location_index = location_path.index(current_location_id)
+
+            # Get blocks to be visited
+            block_ids = [index for (index, bid) in enumerate(location_path) if bid == current_location_id]
+
+            # Return the index of the block id to be visited
+            current_location_index = block_ids[current_iteration]
 
             if current_location_index < len(location_path) - 1:
                 return location_path[current_location_index + 1]
 
-    def get_previous_location(self, answers=None, current_location_id=None):
+    def get_previous_location(self, answers=None, current_location_id=None, current_iteration=None):
         """
         Returns the next 'location' to visit given a set of user answers
         :param answers:
         :param current_location_id:
+        :param current_iteration:
         :return:
         """
+        current_iteration = current_iteration or 0
         answers = answers or {}
         location_path = self.get_location_path(answers)
+
         if current_location_id in location_path:
-            current_location_index = location_path.index(current_location_id)
+            # Get blocks to be visited
+            block_ids = [index for (index, bid) in enumerate(location_path) if bid == current_location_id]
+
+            # Return the index of the block id to be visited
+            current_location_index = block_ids[current_iteration]
 
             if current_location_index != 0:
                 return location_path[current_location_index - 1]

--- a/tests/app/questionnaire/test_navigator.py
+++ b/tests/app/questionnaire/test_navigator.py
@@ -269,7 +269,7 @@ class TestNavigator(unittest.TestCase):
         navigator = Navigator(survey)
 
         # Force some empty routing rules
-        navigator.blocks[0]['routing_rules'] = []
+        navigator.survey_json['groups'][0]['blocks'][0]['routing_rules'] = []
 
         expected_path = [
           'introduction',
@@ -299,3 +299,72 @@ class TestNavigator(unittest.TestCase):
         }
 
         self.assertFalse('summary' in navigator.get_location_path(answers))
+
+    def test_repeating_groups(self):
+        survey = load_schema_file("test_repeating_household.json")
+        navigator = Navigator(survey)
+
+        expected_path = [
+            '980b148e-0856-4e50-9afe-67a4fa6ae13b',
+            '0c7c8876-6a63-4251-ac29-b821b3e9b1bc',
+            '96682325-47ab-41e4-a56e-8315a19ffe2a',
+            'a7dcbb30-1187-4276-a49c-9284730ba4ed',
+            '96682325-47ab-41e4-a56e-8315a19ffe2a',
+            'a7dcbb30-1187-4276-a49c-9284730ba4ed'
+        ]
+
+        answers = {
+            "78774493-5b64-45c4-8072-22f1a9638095": "2"
+        }
+
+        self.assertEqual(expected_path, navigator.get_routing_path(answers))
+
+    def test_repeating_groups_previous_location(self):
+        survey = load_schema_file("test_repeating_household.json")
+        navigator = Navigator(survey)
+
+        expected_path = [
+            '980b148e-0856-4e50-9afe-67a4fa6ae13b',
+            '0c7c8876-6a63-4251-ac29-b821b3e9b1bc',
+            '96682325-47ab-41e4-a56e-8315a19ffe2a',
+            'a7dcbb30-1187-4276-a49c-9284730ba4ed',
+            '96682325-47ab-41e4-a56e-8315a19ffe2a',
+            'a7dcbb30-1187-4276-a49c-9284730ba4ed',
+            '96682325-47ab-41e4-a56e-8315a19ffe2a',
+            'a7dcbb30-1187-4276-a49c-9284730ba4ed'
+        ]
+
+        current_location = expected_path[4]
+        current_iteration = 2
+
+        expected_previous_location = expected_path[3]
+
+        answers = {
+            "78774493-5b64-45c4-8072-22f1a9638095": "3"
+        }
+
+        self.assertEqual(expected_previous_location, navigator.get_previous_location(answers, current_location, current_iteration))
+
+    def test_repeating_groups_next_location(self):
+        survey = load_schema_file("test_repeating_household.json")
+        navigator = Navigator(survey)
+
+        expected_path = [
+            '980b148e-0856-4e50-9afe-67a4fa6ae13b',
+            '0c7c8876-6a63-4251-ac29-b821b3e9b1bc',
+            '96682325-47ab-41e4-a56e-8315a19ffe2a',
+            'a7dcbb30-1187-4276-a49c-9284730ba4ed',
+            '96682325-47ab-41e4-a56e-8315a19ffe2a',
+            'a7dcbb30-1187-4276-a49c-9284730ba4ed',
+            '96682325-47ab-41e4-a56e-8315a19ffe2a',
+            'a7dcbb30-1187-4276-a49c-9284730ba4ed'
+        ]
+
+        current_location = expected_path[-1]
+        current_iteration = 2
+
+        answers = {
+            "78774493-5b64-45c4-8072-22f1a9638095": "3"
+        }
+
+        self.assertEqual('summary', navigator.get_next_location(answers, current_location, current_iteration))


### PR DESCRIPTION
### What is the context of this PR?

WIP for implementation of repeating groups of blocks within survey-runner. Currently builds a flat list of blocks based on a answer given earlier on in the survey. Currently doesn't actually save answers, only determines and follows a route.

I've checked the questions on the [original card](https://trello.com/c/jG7jljQF/688-8-spike-household-member-personal-details) which I believe are currently answered and there's a [confluence page](https://digitaleq.atlassian.net/wiki/display/EQ/Spike%3A+Household+Member+Repeating+Details) detailing findings.

- [x] How does it affect navigation?
- [x] How does repeating of blocks, groups etc. fit in with architecture?
- [x] How can the implementation be broken down?
- [ ] How is piping affected/enabled (i.e. show the names in the next screen)?
- [ ] Any implications of add/removing individuals?
- [x] How hard is to use existing system patterns to achieve this functionality?

### How to review?

Tests have been added to cover new behaviour, so run them. There is a new schema "test_repeating_household.json" that demonstrates the work from the spike.

