### PR TITLE
Add new date type(Month/Year) and update tests

### DIFF
--- a/app/data/test_dates.json
+++ b/app/data/test_dates.json
@@ -1,0 +1,124 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "questionnaire_id": "23",
+    "schema_version": "0.0.1",
+    "survey_id": "023",
+    "title": "Date formats",
+    "description": "A test schema for different date formats",
+    "theme": "default",
+    "introduction": {
+        "description": "",
+        "information_to_provide": [
+          "dates"
+        ]
+    },
+    "display": {
+        "properties": {}
+    },
+    "eq_id": "0",
+    "groups": [
+        {
+            "blocks": [
+                {
+                    "display": {
+                        "properties": {}
+                    },
+                    "id": "b10c8c7a-97fe-4bee-a4fb-e75f3a6f56c0",
+                    "sections": [
+                        {
+                            "description": "",
+                            "display": {
+                                "properties": {}
+                            },
+                            "id": "7352fd10-bb24-407a-9f13-23cc8b1cb51d",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "display": {},
+                                            "guidance": "",
+                                            "id": "5b12aea2-ae3b-467d-9291-4d803a444d25",
+                                            "label": "Period from",
+                                            "mandatory": true,
+                                            "options": [],
+                                            "q_code": "11",
+                                            "type": "Date",
+                                            "validation": {
+                                                "messages": {
+                                                    "INVALID_DATE": "The date entered is not valid.  Please correct your answer.",
+                                                    "MANDATORY": "Please answer before continuing."
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "display": {},
+                                            "guidance": "",
+                                            "id": "ce42c1f7-a32a-46d5-8183-f54e38616617",
+                                            "label": "Period to",
+                                            "mandatory": true,
+                                            "options": [],
+                                            "q_code": "12",
+                                            "type": "Date",
+                                            "validation": {
+                                                "messages": {
+                                                    "INVALID_DATE": "The date entered is not valid.  Please correct your answer.",
+                                                    "MANDATORY": "Please answer before continuing."
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "description": "",
+                                    "display": {
+                                        "properties": {}
+                                    },
+                                    "id": "e9130586-f72a-4b68-8373-885ad51d6cd5",
+                                    "title": "Date range",
+                                    "type": "DateRange",
+                                    "validation": []
+                                },
+                              {
+                                    "answers": [
+                                        {
+                                            "display": {},
+                                            "guidance": "",
+                                            "id": "eade17ef-3ec6-46c2-afc7-dffeb07e2e5e",
+                                            "label": "Date",
+                                            "mandatory": true,
+                                            "options": [],
+                                            "q_code": "11",
+                                            "type": "MonthYearDate",
+                                            "validation": {
+                                                "messages": {
+                                                    "INVALID_DATE": "The date entered is not valid.  Please correct your answer.",
+                                                    "MANDATORY": "Please answer before continuing."
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "description": "",
+                                    "display": {
+                                        "properties": {}
+                                    },
+                                    "id": "9858220e-0514-4868-984f-8bb2481fde8f",
+                                    "title": "Date with month and year",
+                                    "type": "General",
+                                    "validation": []
+                                }
+                            ],
+                            "title": "Date Examples",
+                            "validation": []
+                        }
+                    ],
+                    "title": "Date Examples",
+                    "validation": []
+                }
+            ],
+            "display": {
+                "properties": {}
+            },
+            "id": "a23d36db-6b07-4ce0-94b2-a843369511e3",
+            "title": "",
+            "validation": []
+        }
+    ]
+}

--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -39,3 +39,8 @@ def pretty_date_range(value):
     from_date = pretty_short_date(value['from'])
     to_date = pretty_short_date(value['to'])
     return '{from_date} to {to_date}'.format(from_date=from_date, to_date=to_date)
+
+
+@blueprint.app_template_filter()
+def pretty_month_year_date(value):
+    return datetime.strptime(value, "%m/%Y").strftime('%b %Y')

--- a/app/parser/v0_0_1/schema_parser.py
+++ b/app/parser/v0_0_1/schema_parser.py
@@ -16,6 +16,7 @@ from app.schema.answers.checkbox_answer import CheckboxAnswer
 from app.schema.answers.currency_answer import CurrencyAnswer
 from app.schema.answers.date_answer import DateAnswer
 from app.schema.answers.integer_answer import IntegerAnswer
+from app.schema.answers.month_year_date_answer import MonthYearDateAnswer
 from app.schema.answers.percentage_answer import PercentageAnswer
 from app.schema.answers.positiveinteger_answer import PositiveIntegerAnswer
 from app.schema.answers.radio_answer import RadioAnswer
@@ -60,6 +61,7 @@ class SchemaParser(AbstractSchemaParser):
             'CHECKBOX': CheckboxAnswer,
             'CURRENCY': CurrencyAnswer,
             'DATE': DateAnswer,
+            'MONTHYEARDATE': MonthYearDateAnswer,
             'INTEGER': IntegerAnswer,
             'PERCENTAGE': PercentageAnswer,
             'POSITIVEINTEGER': PositiveIntegerAnswer,

--- a/app/schema/answers/month_year_date_answer.py
+++ b/app/schema/answers/month_year_date_answer.py
@@ -1,0 +1,24 @@
+from app.schema.answer import Answer
+from app.schema.exceptions import TypeCheckingException
+from app.schema.widgets.month_year_date_widget import MonthYearDateWidget
+from app.validation.month_year_date_type_check import MonthYearDateTypeCheck
+
+
+class MonthYearDateAnswer(Answer):
+    def __init__(self, answer_id=None):
+        super().__init__(answer_id)
+        self.type_checkers.append(MonthYearDateTypeCheck())
+        self.widget = MonthYearDateWidget(self.id)
+
+    def get_typed_value(self, post_data):
+        user_input = self.get_user_input(post_data)
+
+        for checker in self.type_checkers:
+            result = checker.validate(user_input)
+            if not result.is_valid:
+                raise TypeCheckingException(result.errors[0])
+
+        return self._cast_user_input(user_input)
+
+    def get_user_input(self, post_vars):
+        return self.widget.get_user_input(post_vars)

--- a/app/schema/widgets/date_widget.py
+++ b/app/schema/widgets/date_widget.py
@@ -10,22 +10,77 @@ logger = logging.getLogger(__name__)
 
 
 class DateWidget(Widget):
-    def _get_days(self, selected_day):
-        if selected_day:
-            selected_day = int(selected_day)
 
-        days = []
-        for day in range(1, 32):
-            days.append(ObjectFromDict({
-                'type': 'text',
-                'value': day,
-                'text': day,
-                'selected': (selected_day == day),
-                'disabled': False,
-            }))
-        return days
+    def render(self, answer_state):
 
-    def _get_months(self, selected_month):
+        if answer_state.input:
+            parts = answer_state.input.split('/')
+        else:
+            parts = ['', None, '']
+
+        widget_params = {}
+        widget_params['legend'] = answer_state.schema_item.label
+        widget_params['fields'] = self._get_date_fields(parts)
+
+        return render_template('partials/widgets/date_widget.html', **widget_params)
+
+    def _get_date_fields(self, parts):
+
+        fields = {}
+        fields['day'] = self._get_day_field(parts[0])
+        fields['month'] = self._get_month_field(parts[1])
+        fields['year'] = self._get_year_field(parts[2])
+
+        return fields
+
+    def _get_day_field(self, day):
+
+        return {
+              'label': {
+                  'for': self.name + '-day',
+                  'text': 'Day',
+                  },
+              'input': {
+                  'type': 'text',
+                  'value': day,
+                  'placeholder': 'DD',
+                  'name': self.name + '-day',
+                  'id': self.name + '-day',
+                  },
+                }
+
+    def _get_month_field(self, month):
+
+        return {
+                'label': {
+                    'for': self.name + '-month',
+                    'text': 'Month',
+                },
+                'select': {
+                    'options': self._get_months(month),
+                    'name': self.name + '-month',
+                    'id': self.name + '-month',
+                  },
+                }
+
+    def _get_year_field(self, year):
+
+        return {
+                'label': {
+                    'for': self.name + '-year',
+                    'text': 'Year',
+                },
+                'input': {
+                    'value': year,
+                    'type': 'text',
+                    'placeholder': 'YYYY',
+                    'name': self.name + '-year',
+                    'id': self.name + '-year',
+                  },
+                }
+
+    @staticmethod
+    def _get_months(selected_month):
         if selected_month:
             selected_month = int(selected_month)
 
@@ -38,57 +93,6 @@ class DateWidget(Widget):
                 'disabled': False,
             }))
         return months
-
-    def render(self, answer_state):
-        if answer_state.input:
-            parts = answer_state.input.split('/')
-        else:
-            parts = [None, None, '']
-
-        widget_params = {
-            'legend': answer_state.schema_item.label,
-            'fields': {
-                'day': {
-                  'label': {
-                    'for': self.name + '-day',
-                    'text': 'Day',
-                  },
-                  'input': {
-                    'type': 'text',
-                    'value': parts[0],
-                    'placeholder': 'DD',
-                    'name': self.name + '-day',
-                    'id': self.name + '-day',
-                  },
-                },
-                'month': {
-                  'label': {
-                    'for': self.name + '-month',
-                    'text': 'Month',
-                  },
-                  'select': {
-                    'options': self._get_months(parts[1]),
-                    'name': self.name + '-month',
-                    'id': self.name + '-month',
-                  },
-                },
-                'year': {
-                  'label': {
-                    'for': self.name + '-year',
-                    'text': 'Year',
-                  },
-                  'input': {
-                    'type': 'text',
-                    'value': parts[2],
-                    'placeholder': 'YYYY',
-                    'name': self.name + '-year',
-                    'id': self.name + '-year',
-                  },
-                },
-            },
-        }
-
-        return render_template('partials/widgets/date_widget.html', **widget_params)
 
     def get_user_input(self, post_vars):
         # Todo, this needs a refactor, we currently have 3 types being passed in post_vars: datetime, string and dict

--- a/app/schema/widgets/month_year_date_widget.py
+++ b/app/schema/widgets/month_year_date_widget.py
@@ -1,0 +1,47 @@
+import logging
+
+from app.schema.widgets.date_widget import DateWidget
+
+from flask import render_template
+
+logger = logging.getLogger(__name__)
+
+
+class MonthYearDateWidget(DateWidget):
+
+    def render(self, answer_state):
+
+        if answer_state.input:
+            parts = answer_state.input.split('/')
+        else:
+            parts = [None, '']
+
+        widget_params = {}
+        widget_params['legend'] = answer_state.schema_item.label
+        widget_params['fields'] = self._get_date_fields(parts)
+
+        return render_template('partials/widgets/date_widget.html', **widget_params)
+
+    def _get_date_fields(self, parts):
+
+        fields = {}
+        fields['month'] = self._get_month_field(parts[0])
+        fields['year'] = self._get_year_field(parts[1])
+        return fields
+
+    def get_user_input(self, post_vars):
+
+        if isinstance(post_vars, dict):
+            if post_vars.get(self.name):
+                try:
+                    return post_vars.get(self.name).strftime('%m/%Y')
+                except AttributeError:
+                    return post_vars.get(self.name)
+            else:
+                month = post_vars.get(self.name + '-month', '')
+                year = post_vars.get(self.name + '-year', '')
+
+                return "{}/{}".format(month, year)
+
+        else:
+            return post_vars

--- a/app/templates/partials/answer.html
+++ b/app/templates/partials/answer.html
@@ -8,7 +8,7 @@
       {% include 'partials/guidance.html' %}
     {% endif %}
   {% endset -%}
-
+  
   {%- set answer_fields %}
     {% if answer.schema_item.display and answer.schema_item.display.properties %}
       {% set use_grid = answer.schema_item.display.properties.columns %}

--- a/app/templates/partials/answers/monthyeardate.html
+++ b/app/templates/partials/answers/monthyeardate.html
@@ -1,0 +1,1 @@
+{{ answer.schema_item.widget.render(answer)|safe}}

--- a/app/templates/partials/summary/monthyeardate.html
+++ b/app/templates/partials/summary/monthyeardate.html
@@ -1,0 +1,1 @@
+{{answer.value|pretty_month_year_date}}

--- a/app/templates/partials/widgets/date_widget.html
+++ b/app/templates/partials/widgets/date_widget.html
@@ -1,23 +1,29 @@
 {% set subfields %}
   <div class="fieldgroup__fields">
+    {% if fields['day'] %}
     <div class="field field--input field--day">
       {% set label = fields['day'].label %}
       <label class="label mercury" for="input-{{label.for}}" id="label-{{label.for}}" data-qa="label-day">{{label.text}}</label>
       {% set input = fields['day'].input %}
       {% include 'partials/forms/input.html' %}
     </div>
+    {% endif %}
+    {% if fields['month'] %}
     <div class="field field--select field--month">
       {% set label = fields['month'].label %}
       <label class="label mercury" for="input-{{label.for}}" id="label-{{label.for}}" data-qa="label-month">{{label.text}}</label>
       {% set select = fields['month'].select %}
       {% include 'partials/forms/select.html' %}
     </div>
+    {% endif %}
+    {% if fields['year'] %}
     <div class="field field--input field--year">
       {% set label = fields['year'].label %}
       <label class="label mercury" for="input-{{label.for}}" id="label-{{label.for}}" data-qa="label-year">{{label.text}}</label>
       {% set input = fields['year'].input %}
       {% include 'partials/forms/input.html' %}
     </div>
+    {% endif %}
   </div>
 {% endset %}
 

--- a/app/validation/month_year_date_type_check.py
+++ b/app/validation/month_year_date_type_check.py
@@ -1,0 +1,24 @@
+import time
+
+from app.validation.abstract_validator import AbstractValidator
+from app.validation.validation_result import ValidationResult
+
+
+class MonthYearDateTypeCheck(AbstractValidator):
+
+    """
+    Validate that the users answer is a valid date
+    :param user_answer: The answer the user provided for the response
+    :return: ValidationResult(): An object containing the result of the validation
+    """
+
+    def validate(self, user_answer):
+        result = ValidationResult(False)
+        try:
+            time.strptime(user_answer, "%m/%Y")
+            return ValidationResult(True)
+        except ValueError:
+            result.errors.append(AbstractValidator.INVALID_DATE)
+        except TypeError:
+            result.errors.append(AbstractValidator.INVALID_DATE)
+        return result

--- a/tests/app/schema/answers/test_month_year_date_answer.py
+++ b/tests/app/schema/answers/test_month_year_date_answer.py
@@ -1,0 +1,30 @@
+from unittest import TestCase
+
+from app.schema.answers.month_year_date_answer import MonthYearDateAnswer
+
+from app.schema.exceptions import TypeCheckingException
+
+
+class TestMonthYearDateAnswer(TestCase):
+
+    def test_month_year_date_answer(self):
+        month_year_date_answer = MonthYearDateAnswer('1234')
+        post_data = {'1234':'1/2000'}
+        result = month_year_date_answer.get_typed_value(post_data)
+        self.assertEquals(result, '1/2000')
+
+    def test_month_year_date_answer_incomplete_date(self):
+        month_year_date_answer = MonthYearDateAnswer('1234')
+        post_data = {'1234':'1/'}
+        self.assertRaises(TypeCheckingException, month_year_date_answer.get_typed_value, post_data)
+
+    def test_month_year_date_answer_text_empty(self):
+        month_year_date_answer = MonthYearDateAnswer('1234')
+        post_data = {}
+        self.assertRaises(TypeCheckingException, month_year_date_answer.get_typed_value, post_data)
+
+    def test_month_year_date_answer_non_dict(self):
+        month_year_date_answer = MonthYearDateAnswer('1234')
+        post_data = '1/2000'
+        result = month_year_date_answer.get_typed_value(post_data)
+        self.assertEquals(result, '1/2000')

--- a/tests/app/schema/widgets/test_month_year_date_widget.py
+++ b/tests/app/schema/widgets/test_month_year_date_widget.py
@@ -1,0 +1,43 @@
+from app.questionnaire_state.state_answer import StateAnswer
+from app.schema.answers.month_year_date_answer import MonthYearDateAnswer
+from app.schema.widgets.month_year_date_widget import MonthYearDateWidget
+
+from tests.integration.integration_test_case import IntegrationTestCase
+
+from app import create_app
+
+
+class TestMonthYearDateAnswer(IntegrationTestCase):
+
+    def setUp(self):
+        self.app = create_app("test")
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+
+    def tearDown(self):
+        self.app_context.pop()
+
+    def test_month_year_date_answer(self):
+        user_answer = '2/2016'
+        response = self.render_widget(user_answer)
+        self.assertRegexpMatches(response, 'February')
+        self.assertRegexpMatches(response, '2016')
+
+    def testmonth_year_date_answer_none_input(self):
+        user_answer = None
+        self.render_widget(user_answer)
+
+    def render_widget(self, user_answer):
+        month_year_date_widget = MonthYearDateWidget('1234')
+        month_year_date_answer = MonthYearDateAnswer()
+
+        answer_state = StateAnswer('1', month_year_date_answer)
+        answer_state.schema_item.label = 'Date month year Label'
+        answer_state.schema_item.type = "DateMonthYear"
+        answer_state.input = user_answer
+
+        response = month_year_date_widget.render(answer_state)
+        self.assertRegexpMatches(response, 'input-1234-month')
+        self.assertRegexpMatches(response, 'input-1234-year')
+        self.assertRegexpMatches(response, 'Date month year Label')
+        return response

--- a/tests/app/validation/test_date_month_year.py
+++ b/tests/app/validation/test_date_month_year.py
@@ -1,0 +1,61 @@
+import unittest
+from app.validation.month_year_date_type_check import MonthYearDateTypeCheck
+from app.validation.abstract_validator import AbstractValidator
+
+
+class DateMonthYearTest(unittest.TestCase):
+
+    def test_month_year_date_validator_none(self):
+
+        month_year_date_type = MonthYearDateTypeCheck()
+        result = month_year_date_type.validate(None)
+        self.assertFalse(result.is_valid)
+        self.assertEquals(len(result.errors), 1)
+        self.assertEquals(AbstractValidator.INVALID_DATE, result.errors[0])
+
+    def test_month_year_date_validator_empty_string(self):
+
+        month_year_date_type = MonthYearDateTypeCheck()
+        result = month_year_date_type.validate('')
+        self.assertFalse(result.is_valid)
+        self.assertEquals(len(result.errors), 1)
+        self.assertEquals(AbstractValidator.INVALID_DATE, result.errors[0])
+
+    def test_month_year_date_validator_missing_month(self):
+
+        month_year_date_type = MonthYearDateTypeCheck()
+        result = month_year_date_type.validate('/2017')
+        self.assertFalse(result.is_valid)
+        self.assertEquals(len(result.errors), 1)
+        self.assertEquals(AbstractValidator.INVALID_DATE, result.errors[0])
+
+    def test_month_year_date_validator_missing_year(self):
+
+        month_year_date_type = MonthYearDateTypeCheck()
+        result = month_year_date_type.validate('12/')
+        self.assertFalse(result.is_valid)
+        self.assertEquals(len(result.errors), 1)
+        self.assertEquals(AbstractValidator.INVALID_DATE, result.errors[0])
+
+    def test_month_year_date_validator_invalid_month(self):
+
+        month_year_date_type = MonthYearDateTypeCheck()
+        result = month_year_date_type.validate('13/2017')
+        self.assertFalse(result.is_valid)
+        self.assertEquals(len(result.errors), 1)
+        self.assertEquals(AbstractValidator.INVALID_DATE, result.errors[0])
+
+    def test_month_year_date_validator_invalid_year(self):
+
+        month_year_date_type = MonthYearDateTypeCheck()
+        result = month_year_date_type.validate('12/17')
+        self.assertFalse(result.is_valid)
+        self.assertEquals(len(result.errors), 1)
+        self.assertEquals(AbstractValidator.INVALID_DATE, result.errors[0])
+
+    def test_month_year_date_validator_valid(self):
+
+        month_year_date_type = MonthYearDateTypeCheck()
+        result = month_year_date_type.validate('01/2017')
+        self.assertTrue(result.is_valid)
+        self.assertEquals(len(result.errors), 0)

--- a/tests/functional/pages/surveys/dates/dates-answers.page.js
+++ b/tests/functional/pages/surveys/dates/dates-answers.page.js
@@ -1,0 +1,46 @@
+import QuestionPage from '../question.page'
+
+class DatesPage extends QuestionPage {
+
+  setFromReportingPeriodDay(day) {
+    browser.setValue('[name="5b12aea2-ae3b-467d-9291-4d803a444d25-day"]', day)
+    return this
+  }
+
+  setFromReportingPeriodMonth(month) {
+    browser.setValue('[name="5b12aea2-ae3b-467d-9291-4d803a444d25-month"]', month)
+  return this
+  }
+
+  setFromReportingPeriodYear(year) {
+    browser.setValue('[name="5b12aea2-ae3b-467d-9291-4d803a444d25-year"]', year)
+    return this
+  }
+
+  setToReportingPeriodDay(day) {
+    browser.setValue('[name="ce42c1f7-a32a-46d5-8183-f54e38616617-day"]', day)
+    return this
+  }
+
+  setToReportingPeriodMonth(month) {
+    browser.setValue('[name="ce42c1f7-a32a-46d5-8183-f54e38616617-month"]', month)
+    return this
+  }
+
+  setToReportingPeriodYear(year) {
+    browser.setValue('[name="ce42c1f7-a32a-46d5-8183-f54e38616617-year"]', year)
+    return this
+  }
+
+  setMonthYearMonth(month) {
+    browser.setValue('[name="eade17ef-3ec6-46c2-afc7-dffeb07e2e5e-month"]', month)
+    return this
+  }
+
+  setMonthYearYear(year) {
+    browser.setValue('[name="eade17ef-3ec6-46c2-afc7-dffeb07e2e5e-year"]', year)
+    return this
+  }
+}
+
+export default new DatesPage()

--- a/tests/functional/pages/surveys/dates/dates-summary.page.js
+++ b/tests/functional/pages/surveys/dates/dates-summary.page.js
@@ -1,0 +1,14 @@
+import SummaryPage from '../../summary.page'
+
+class RSISummaryPage extends SummaryPage {
+
+  getDateRangeSummary() {
+    return browser.element('[data-qa="5b12aea2-ae3b-467d-9291-4d803a444d25-answer"]').getText()
+  }
+
+  getMonthYearDateSummary() {
+    return browser.element('[data-qa="eade17ef-3ec6-46c2-afc7-dffeb07e2e5e-answer"]').getText()
+  }
+}
+
+export default new RSISummaryPage()

--- a/tests/functional/spec/dates.spec.js
+++ b/tests/functional/spec/dates.spec.js
@@ -1,0 +1,129 @@
+import chai from 'chai'
+import {startQuestionnaire} from '../helpers'
+
+import DatesPage from '../pages/surveys/dates/dates-answers.page'
+import SummaryPage from '../pages/surveys/dates/dates-summary.page'
+
+const expect = chai.expect
+
+describe('Date checks', function() {
+
+      it('Given the test_dates survey is selected when dates are entered then the summary screen shows the dates entered formatted', function() {
+
+            // Given the test_dates survey is selected
+            startQuestionnaire('test_dates.json')
+
+            // When dates are entered
+            DatesPage.setFromReportingPeriodDay(1)
+              .setFromReportingPeriodYear(2016)
+              .setToReportingPeriodDay(3)
+              .setToReportingPeriodYear(2017)
+              .setMonthYearYear(2018)
+              .submit()
+
+            // Then the summary screen shows the dates entered formatted
+            expect(SummaryPage.getDateRangeSummary()).to.contain('01 Jan 2016 to 03 Jan 2017')
+            expect(SummaryPage.getMonthYearDateSummary()).to.contain('Jan 2018')
+        })
+
+
+      it('Given the test_dates survey is selected when the from date is greater than the to date then an error message is shown', function() {
+
+            // Given the test_dates survey is selected
+             startQuestionnaire('test_dates.json')
+
+            // When the from date is greater than the to date
+            DatesPage.setFromReportingPeriodDay(1)
+              .setFromReportingPeriodYear(2016)
+              .setToReportingPeriodDay(1)
+              .setToReportingPeriodYear(2015)
+              .setMonthYearYear(2018)
+              .submit()
+
+            // Then an error message is shown
+            expect(DatesPage.getAlertText()).to.contain('The \'period to\' date cannot be before the \'period from\' date.')
+
+        })
+
+      it('Given the test_dates survey is selected when the from date and the to date are the same then an error message is shown', function() {
+
+            // Given the test_dates survey is selected
+             startQuestionnaire('test_dates.json')
+
+            // When the from date and the to date are the same
+            DatesPage.setFromReportingPeriodDay(1)
+              .setFromReportingPeriodYear(2016)
+              .setToReportingPeriodDay(1)
+              .setToReportingPeriodYear(2016)
+              .setMonthYearYear(2018)
+              .submit()
+
+            // Then an error message is shown
+            expect(DatesPage.getAlertText()).to.contain('The \'period to\' date must be different to the \'period from\' date.')
+
+        })
+
+      it('Given the test_dates survey is selected when an invalid date is entered in a date range then an error message is shown', function() {
+
+            // Given the test_dates survey is selected
+             startQuestionnaire('test_dates.json')
+
+            // When an invalid date is entered in a date range
+            DatesPage.setFromReportingPeriodDay(1)
+              .setFromReportingPeriodYear(2016)
+              .setToReportingPeriodDay(3)
+              .setToReportingPeriodYear('')
+              .setMonthYearYear(2018)
+              .submit()
+
+            // Then an error message is shown
+            expect(DatesPage.getAlertText()).to.contain('The date entered is not valid. Please correct your answer.')
+
+        })
+
+      it('Given the test_dates survey is selected when the year (month year type) is left empty then an error message is shown', function() {
+
+            // Given the test_dates survey is selected
+             startQuestionnaire('test_dates.json')
+
+            // When the year (month year type) is left empty
+            DatesPage.setFromReportingPeriodDay(1)
+              .setFromReportingPeriodYear(2016)
+              .setToReportingPeriodDay(3)
+              .setToReportingPeriodYear(2017)
+              .setMonthYearYear('')
+              .submit()
+
+            // Then an error message is shown
+            expect(DatesPage.getAlertText()).to.contain('The date entered is not valid. Please correct your answer.')
+
+        })
+
+      it('Given the test_dates survey is selected when an error message is shown then when it is corrected, it goes to the summary page and the information is correct', function() {
+
+            // Given the test_dates survey is selected
+             startQuestionnaire('test_dates.json')
+
+            // When an error message is shown
+            DatesPage.setFromReportingPeriodDay(1)
+              .setFromReportingPeriodYear(2016)
+              .setToReportingPeriodDay(3)
+              .setToReportingPeriodYear(2017)
+              .setMonthYearYear('')
+              .submit()
+
+            expect(DatesPage.getAlertText()).to.contain('The date entered is not valid. Please correct your answer.')
+
+
+            // Then when it is corrected, it goes to the summary page and the information is correct
+             DatesPage.setFromReportingPeriodDay(1)
+              .setFromReportingPeriodYear(2016)
+              .setToReportingPeriodDay(3)
+              .setToReportingPeriodYear(2017)
+              .setMonthYearYear('2018')
+              .submit()
+
+            expect(SummaryPage.getDateRangeSummary()).to.contain('01 Jan 2016 to 03 Jan 2017')
+            expect(SummaryPage.getMonthYearDateSummary()).to.contain('Jan 2018')
+      })
+})

--- a/tests/functional/spec/rsi-saverestore-0102.spec.js
+++ b/tests/functional/spec/rsi-saverestore-0102.spec.js
@@ -28,21 +28,6 @@ describe('RSI - Save and restore test', function() {
     expect(landingPage.isOpen()).to.be.true
   })
 
-  it('Given the rsi business survey 0102 is displayed when the same date period is reported then an error is displayed', function() {
-    // Given
-    startQuestionnaire('1_0102.json')
-
-    // When
-    reportingPeriod.setFromReportingPeriodDay('01')
-      .setFromReportingPeriodYear('2016')
-      .setToReportingPeriodDay('01')
-      .setToReportingPeriodYear('2016')
-      .submit()
-
-    // Then
-    expect(reportingPeriod.getAlertText()).to.contain('The \'period to\' date must be different to the \'period from\' date.')
-  })
-
   it('Given a rsi business survey 0102 previously had errors when I correct the errors then I can submit them', function() {
     // Given
     const collectionId = getRandomString(5)


### PR DESCRIPTION
### What is the context of this PR?
To add in the month/year answer type "mm/yyyy". A new widget has been introduced to deal with the alternative format and the summary . A test schema has also been set up to handle all dates 

### How to review 
Using dev, open up the test_dates.json and make sure it shows both the date range and the new format above. Add  invalid data into each and make sure the right messages are shown. Correct the errors and make sure the summary page is correct.

(N.B there is a malfunctioning test_date.json file as well and an associated selenium test already in master. This needs removing/fixing, but this is outside the scope of this story and will be done in EQ-718 date of birth)