### PR TITLE
added a fix so other text is only used when other option is selected

### DIFF
--- a/app/schema/widgets/multiple_choice_widget.py
+++ b/app/schema/widgets/multiple_choice_widget.py
@@ -42,6 +42,8 @@ class MultipleChoiceWidget(Widget):
 
         has_multiple_values = isinstance(posted_data, list) and len(posted_data) > 1
 
-        other_value = str(posted_data[-1:][0]).strip() if has_multiple_values else None
+        is_other_selected = str(posted_data[:1][0]).strip().lower() == 'other' if has_multiple_values else False
+
+        other_value = str(posted_data[-1:][0]).strip() if is_other_selected else None
 
         return other_value if other_value is not None and len(other_value) > 0 else None

--- a/tests/app/schema/widgets/test_multiple_choice_widget.py
+++ b/tests/app/schema/widgets/test_multiple_choice_widget.py
@@ -52,3 +52,9 @@ class TestMultipleChoiceWidget(TestCase):
     def test_get_other_value_when_single_value_called_other_returns_none(self):
         post_vars = {'multiple_choice_widget': ['Other']}
         assert self.widget.get_other_input(post_vars) is None
+
+    def test_get_other_input_with_multi_dict_other_not_selected(self):
+        post_vars = MultiDict()
+        post_vars.add('multiple_choice_widget', 'Another Option')
+        post_vars.add('multiple_choice_widget', 'Other value')
+        assert self.widget.get_other_input(post_vars) is None


### PR DESCRIPTION
### What is the context of this PR?
Fixes https://github.com/ONSdigital/eq-survey-runner/issues/565 and https://github.com/ONSdigital/eq-survey-runner/issues/566

### How to review 
Open a survey with an other option on a radio or checkbox. Enter an other option. Navigate back to the page and select a different value. 
On the summary page the new value should be shown and not the previously entered other value
