### PR TITLE
Enabled config of werkzeug log level and reduce TRAVIS CI logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 # Repo for newer Node.js versions
 - curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
 # Repo for Yarn
-- sudo apt-key adv --keyserver pgp.mit.edu --recv D101F7899D41F3C3
+- sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
 - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 - sudo apt-get update -qq
 - sudo apt-get install -y -qq yarn

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ EQ_CLOUDWATCH_LOGGING - feature flag to enable AWS cloudwatch logging
 EQ_GIT_REF - the latest git ref of HEAD on master
 EQ_SR_LOG_GROUP - The name of the log group to create (defaults to `username-local` for local development)
 EQ_LOG_LEVEL - The default logging level (defaults to 'INFO' for local development)
+EQ_WERKZEUG_LOG_LEVEL - The default logging level for werkzeug (defaults to 'INFO' for local development)
 EQ_SCHEMA_DIRECTORY - The directory that contains the schema files
 EQ_SESSION_TIMEOUT - The duration of the flask session, defaults to 30 minutes
 EQ_SECRET_KEY - The Flask secret key for signing cookies

--- a/app/settings.py
+++ b/app/settings.py
@@ -48,6 +48,7 @@ EQ_NEW_RELIC_CONFIG_FILE = os.getenv('EQ_NEW_RELIC_CONFIG_FILE', './newrelic.ini
 EQ_SR_LOG_GROUP = os.getenv('EQ_SR_LOG_GROUP', os.getenv('USER', 'UNKNOWN') + '-local')
 EQ_LOG_LEVEL = os.getenv('EQ_LOG_LEVEL', 'INFO')
 EQ_CLOUDWATCH_LOGGING = parse_mode(os.getenv("EQ_CLOUDWATCH_LOGGING", 'True'))
+EQ_WERKZEUG_LOG_LEVEL = os.getenv('EQ_WERKZEUG_LOG_LEVEL', 'INFO')
 EQ_SCHEMA_DIRECTORY = os.getenv('EQ_SCHEMA_DIRECTORY', 'app/data')
 EQ_SESSION_TIMEOUT = int(os.getenv('EQ_SESSION_TIMEOUT', '28800'))
 EQ_SECRET_KEY = os.getenv('EQ_SECRET_KEY', os.urandom(24))

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -17,6 +17,12 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 echo $DIR
 
 
+if [ "${TRAVIS}" ]; then
+  # Reduce logging on TRAVIS builds
+  export EQ_LOG_LEVEL=WARNING
+  export EQ_WERKZEUG_LOG_LEVEL=WARNING
+fi
+
 # Output the current git revision
 if [ -z "$EQ_GIT_REF" ]; then
   export EQ_GIT_REF=`git rev-parse HEAD`

--- a/tests/functional/config.js
+++ b/tests/functional/config.js
@@ -42,7 +42,7 @@ const sauceLabsConfig = {
 if (process.env.TRAVIS === 'true') {
   config = {
     ...config,
-    logLevel: 'debug',
+    logLevel: 'silent',
     capabilities: [chrome]
   }
 } else {


### PR DESCRIPTION
### What is the context of this PR?
Travis builds logs are full of INFO logging from the app and werkzeug making it hard to see errors and test output. This change enables config of the "werkzeug" logging level (which was logging every GET) and sets both it and the normal app logging to WARNING for TRAVIS builds as well as reducing the selenium log output slightly.

I also moved login init outside of logging setup function as it looks to have been put there by mistake (logging/login??)

### How to review 
- Check Travis build log for this PR and confirm only WARNING/ERROR messages are displayed.
- Confirm if we're happy to not log INFO on TRAVIS before merging.

