### PR TITLE
Fixes #581 Underscores in answer Id submission failure.

### DIFF
--- a/app/questionnaire_state/state_repeating_answer_question.py
+++ b/app/questionnaire_state/state_repeating_answer_question.py
@@ -36,8 +36,8 @@ class RepeatingAnswerStateQuestion(StateQuestion):
         new_answer_state.parent = self
         self.answers.append(new_answer_state)
 
-    @classmethod
-    def iterate_over_instance_ids(cls, answer_instances):
+    @staticmethod
+    def iterate_over_instance_ids(answer_instances):
         """
         Iterates over a collection of answer instances yielding the answer Id and answer instance Id.
         :param answer_instances: A list of raw answer_instance_ids
@@ -47,11 +47,11 @@ class RepeatingAnswerStateQuestion(StateQuestion):
         answer_instance_ids = sorted(answer_instances, key=natural_order)
 
         for answer_instance_id in answer_instance_ids:
-            answer_id, answer_index = _extract_answer_instance_id(answer_instance_id)
+            answer_id, answer_index = extract_answer_instance_id(answer_instance_id)
             yield answer_id, answer_index
 
 
-def _extract_answer_instance_id(answer_instance_id):
+def extract_answer_instance_id(answer_instance_id):
     matches = re.match(r'^(.+?)_(\d+)$', answer_instance_id)
     if matches:
         answer_id, index = matches.groups()

--- a/app/questionnaire_state/state_repeating_answer_question.py
+++ b/app/questionnaire_state/state_repeating_answer_question.py
@@ -47,16 +47,16 @@ class RepeatingAnswerStateQuestion(StateQuestion):
         answer_instance_ids = sorted(answer_instances, key=natural_order)
 
         for answer_instance_id in answer_instance_ids:
-            answer_id, answer_index = cls._extract_answer_instance_id(answer_instance_id)
+            answer_id, answer_index = _extract_answer_instance_id(answer_instance_id)
             yield answer_id, answer_index
 
-    @staticmethod
-    def _extract_answer_instance_id(answer_instance_id):
-        matches = re.match(r'^(.+?)_(\d+)$', answer_instance_id)
-        if matches:
-            answer_id, index = matches.groups()
-        else:
-            answer_id = answer_instance_id
-            index = 0
 
-        return answer_id, int(index)
+def _extract_answer_instance_id(answer_instance_id):
+    matches = re.match(r'^(.+?)_(\d+)$', answer_instance_id)
+    if matches:
+        answer_id, index = matches.groups()
+    else:
+        answer_id = answer_instance_id
+        index = 0
+
+    return answer_id, int(index)

--- a/app/submitter/converter.py
+++ b/app/submitter/converter.py
@@ -4,7 +4,7 @@ import logging
 from datetime import datetime, timezone
 
 from app import settings
-from app.questionnaire_state.state_repeating_answer_question import _extract_answer_instance_id
+from app.questionnaire_state.state_repeating_answer_question import extract_answer_instance_id
 
 
 logger = logging.getLogger(__name__)
@@ -86,7 +86,7 @@ class Converter(object):
         data = {}
 
         for key in answers.keys():
-            answer_id, _ = _extract_answer_instance_id(key)
+            answer_id, _ = extract_answer_instance_id(key)
             item = questionnaire.get_item_by_id(answer_id)
             if item is not None:
                 value = answers[key]

--- a/app/submitter/converter.py
+++ b/app/submitter/converter.py
@@ -4,6 +4,8 @@ import logging
 from datetime import datetime, timezone
 
 from app import settings
+from app.questionnaire_state.state_repeating_answer_question import _extract_answer_instance_id
+
 
 logger = logging.getLogger(__name__)
 
@@ -84,8 +86,8 @@ class Converter(object):
         data = {}
 
         for key in answers.keys():
-            key_without_index = key.rsplit('_', 1)[0]
-            item = questionnaire.get_item_by_id(key_without_index)
+            answer_id, answer_index = _extract_answer_instance_id(key)
+            item = questionnaire.get_item_by_id(answer_id)
             if item is not None:
                 value = answers[key]
                 if value is not None:

--- a/app/submitter/converter.py
+++ b/app/submitter/converter.py
@@ -86,7 +86,7 @@ class Converter(object):
         data = {}
 
         for key in answers.keys():
-            answer_id, answer_index = _extract_answer_instance_id(key)
+            answer_id, _ = _extract_answer_instance_id(key)
             item = questionnaire.get_item_by_id(answer_id)
             if item is not None:
                 value = answers[key]

--- a/tests/app/questionnaire_state/test_repeating_answer_state_question.py
+++ b/tests/app/questionnaire_state/test_repeating_answer_state_question.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from mock import MagicMock
 
 from app.questionnaire_state.state_answer import StateAnswer
-from app.questionnaire_state.state_repeating_answer_question import RepeatingAnswerStateQuestion, _extract_answer_instance_id
+from app.questionnaire_state.state_repeating_answer_question import RepeatingAnswerStateQuestion, extract_answer_instance_id
 from app.schema.answer import Answer
 from app.schema.widgets.text_widget import TextWidget
 
@@ -112,38 +112,38 @@ class TestRepeatingAnswerStateQuestion(TestCase):
         self.assertEqual(len(question_state.answers), 6)
 
     def test_extract_answer_instance_id(self):
-        answer_id, answer_index = _extract_answer_instance_id('')
+        answer_id, answer_index = extract_answer_instance_id('')
         self.assertEqual(answer_id, '')
         self.assertEqual(answer_index, 0)
 
-        answer_id, answer_index = _extract_answer_instance_id('abcdefg')
+        answer_id, answer_index = extract_answer_instance_id('abcdefg')
         self.assertEqual(answer_id, 'abcdefg')
         self.assertEqual(answer_index, 0)
 
-        answer_id, answer_index = _extract_answer_instance_id('abcdefg_')
+        answer_id, answer_index = extract_answer_instance_id('abcdefg_')
         self.assertEqual(answer_id, 'abcdefg_')
         self.assertEqual(answer_index, 0)
 
-        answer_id, answer_index = _extract_answer_instance_id('abcdefg_0')
+        answer_id, answer_index = extract_answer_instance_id('abcdefg_0')
         self.assertEqual(answer_id, 'abcdefg')
         self.assertEqual(answer_index, 0)
 
-        answer_id, answer_index = _extract_answer_instance_id('abcdefg_1')
+        answer_id, answer_index = extract_answer_instance_id('abcdefg_1')
         self.assertEqual(answer_id, 'abcdefg')
         self.assertEqual(answer_index, 1)
 
-        answer_id, answer_index = _extract_answer_instance_id('abcdefg_1_2')
+        answer_id, answer_index = extract_answer_instance_id('abcdefg_1_2')
         self.assertEqual(answer_id, 'abcdefg_1')
         self.assertEqual(answer_index, 2)
 
-        answer_id, answer_index = _extract_answer_instance_id('_1')
+        answer_id, answer_index = extract_answer_instance_id('_1')
         self.assertEqual(answer_id, '_1')
         self.assertEqual(answer_index, 0)
 
-        answer_id, answer_index = _extract_answer_instance_id('1234_1')
+        answer_id, answer_index = extract_answer_instance_id('1234_1')
         self.assertEqual(answer_id, '1234')
         self.assertEqual(answer_index, 1)
 
-        answer_id, answer_index = _extract_answer_instance_id('abcdefg_12345')
+        answer_id, answer_index = extract_answer_instance_id('abcdefg_12345')
         self.assertEqual(answer_id, 'abcdefg')
         self.assertEqual(answer_index, 12345)

--- a/tests/app/questionnaire_state/test_repeating_answer_state_question.py
+++ b/tests/app/questionnaire_state/test_repeating_answer_state_question.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from mock import MagicMock
 
 from app.questionnaire_state.state_answer import StateAnswer
-from app.questionnaire_state.state_repeating_answer_question import RepeatingAnswerStateQuestion
+from app.questionnaire_state.state_repeating_answer_question import RepeatingAnswerStateQuestion, _extract_answer_instance_id
 from app.schema.answer import Answer
 from app.schema.widgets.text_widget import TextWidget
 
@@ -112,38 +112,38 @@ class TestRepeatingAnswerStateQuestion(TestCase):
         self.assertEqual(len(question_state.answers), 6)
 
     def test_extract_answer_instance_id(self):
-        answer_id, answer_index = RepeatingAnswerStateQuestion._extract_answer_instance_id('')
+        answer_id, answer_index = _extract_answer_instance_id('')
         self.assertEqual(answer_id, '')
         self.assertEqual(answer_index, 0)
 
-        answer_id, answer_index = RepeatingAnswerStateQuestion._extract_answer_instance_id('abcdefg')
+        answer_id, answer_index = _extract_answer_instance_id('abcdefg')
         self.assertEqual(answer_id, 'abcdefg')
         self.assertEqual(answer_index, 0)
 
-        answer_id, answer_index = RepeatingAnswerStateQuestion._extract_answer_instance_id('abcdefg_')
+        answer_id, answer_index = _extract_answer_instance_id('abcdefg_')
         self.assertEqual(answer_id, 'abcdefg_')
         self.assertEqual(answer_index, 0)
 
-        answer_id, answer_index = RepeatingAnswerStateQuestion._extract_answer_instance_id('abcdefg_0')
+        answer_id, answer_index = _extract_answer_instance_id('abcdefg_0')
         self.assertEqual(answer_id, 'abcdefg')
         self.assertEqual(answer_index, 0)
 
-        answer_id, answer_index = RepeatingAnswerStateQuestion._extract_answer_instance_id('abcdefg_1')
+        answer_id, answer_index = _extract_answer_instance_id('abcdefg_1')
         self.assertEqual(answer_id, 'abcdefg')
         self.assertEqual(answer_index, 1)
 
-        answer_id, answer_index = RepeatingAnswerStateQuestion._extract_answer_instance_id('abcdefg_1_2')
+        answer_id, answer_index = _extract_answer_instance_id('abcdefg_1_2')
         self.assertEqual(answer_id, 'abcdefg_1')
         self.assertEqual(answer_index, 2)
 
-        answer_id, answer_index = RepeatingAnswerStateQuestion._extract_answer_instance_id('_1')
+        answer_id, answer_index = _extract_answer_instance_id('_1')
         self.assertEqual(answer_id, '_1')
         self.assertEqual(answer_index, 0)
 
-        answer_id, answer_index = RepeatingAnswerStateQuestion._extract_answer_instance_id('1234_1')
+        answer_id, answer_index = _extract_answer_instance_id('1234_1')
         self.assertEqual(answer_id, '1234')
         self.assertEqual(answer_index, 1)
 
-        answer_id, answer_index = RepeatingAnswerStateQuestion._extract_answer_instance_id('abcdefg_12345')
+        answer_id, answer_index = _extract_answer_instance_id('abcdefg_12345')
         self.assertEqual(answer_id, 'abcdefg')
         self.assertEqual(answer_index, 12345)

--- a/tests/app/submitter/test_converter.py
+++ b/tests/app/submitter/test_converter.py
@@ -184,5 +184,48 @@ class TestConverter(SurveyRunnerTestCase):
             self.assertTrue('1' in answer_object["data"]["003"])
             self.assertTrue('2' in answer_object["data"]["003"])
 
+    def test_prepare_answers_for_answer_containing_underscore(self):
+        with self.application.test_request_context():
+            self.maxDiff = None
+
+            metadata = parse_metadata(JWT)
+
+            user_answer = {
+                "full_name": 0,
+                "full_name_1": 1,
+                "full_name_2": 2,
+            }
+
+            answer = Answer()
+            answer.id = "full_name"
+            answer.code = "003"
+
+            question = Question()
+            question.id = 'question-2'
+            question.add_answer(answer)
+
+            section = Section()
+            section.add_question(question)
+
+            block = Block()
+            block.id = 'block-1'
+            block.add_section(section)
+
+            group = Group()
+            group.id = 'group-1'
+            group.add_block(block)
+
+            questionnaire = Questionnaire()
+            questionnaire.survey_id = "021"
+            questionnaire.add_group(group)
+            questionnaire.register(question)
+            questionnaire.register(answer)
+
+            answer_object, submitted_at = Converter.prepare_answers(metadata, questionnaire, user_answer)
+            # Check the converter correctly
+            self.assertTrue('0' in answer_object["data"]["003"])
+            self.assertTrue('1' in answer_object["data"]["003"])
+            self.assertTrue('2' in answer_object["data"]["003"])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### What is the context of this PR?
Fixes #581 .

Submitter was doing too simplistic a match to determine the answer instance id.

### How to review 
Submission of answers containing _ should succeed.

