### PR TITLE
Add support for piping based on current group_instance Id.

### DIFF
--- a/app/data/census_household.json
+++ b/app/data/census_household.json
@@ -179,6 +179,7 @@
                                     "answers": [
                                         {
                                             "id": "household-composition-answer",
+                                            "alias": "person_full_name",
                                             "mandatory": false,
                                             "q_code": "20",
                                             "type": "TextField"
@@ -819,10 +820,10 @@
                 {
                     "type": "interstitial",
                     "id": "household-member-begin",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "id": "household-member-begin-section",
                             "questions": [
                                 {
@@ -837,11 +838,11 @@
                 },
                 {
                     "id": "details-correct",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "details-correct-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "details-correct-display-name",
@@ -890,11 +891,11 @@
                 },
                 {
                     "id": "correct-name",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "correct-name-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "correct-name-question",
@@ -915,11 +916,11 @@
                 },
                 {
                     "id": "sex",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "sex-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "sex-question",
@@ -950,11 +951,11 @@
                 },
                 {
                     "id": "date-of-birth",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "date-of-birth-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "date-of-birth-question",
@@ -976,11 +977,11 @@
                 },
                 {
                     "id": "over-16",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "over-16-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "over-16-question",
@@ -1011,11 +1012,11 @@
                 },
                 {
                     "id": "marital-status",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "marital-status-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "marital-status-question",
@@ -1074,11 +1075,11 @@
                 },
                 {
                     "id": "another-address",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "another-address-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "another-address-question",
@@ -1153,11 +1154,11 @@
                 },
                 {
                     "id": "other-address",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "other-address-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "other-address-question",
@@ -1207,11 +1208,11 @@
                 },
                 {
                     "id": "address-type",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "address-type-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "address-type-question",
@@ -1265,11 +1266,11 @@
                 },
                 {
                     "id": "in-education",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "in-education-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "in-education-question",
@@ -1312,11 +1313,11 @@
                 },
                 {
                     "id": "term-time-location",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "term-time-location-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "term-time-location-question",
@@ -1359,11 +1360,11 @@
                 },
                 {
                     "id": "country-of-birth",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "country-of-birth-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "country-of-birth-england-question",
@@ -1551,11 +1552,11 @@
                 },
                 {
                     "id": "arrive-in-uk",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "arrive-in-uk-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "arrive-in-uk-question",
@@ -1581,11 +1582,11 @@
                 },
                 {
                     "id": "length-of-stay",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "length-of-stay-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "length-of-stay-question",
@@ -1620,11 +1621,11 @@
                 },
                 {
                     "id": "carer",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "carer-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "carer-question",
@@ -1669,11 +1670,11 @@
                 },
                 {
                     "id": "national-identity",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "national-identity-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "national-identity-question",
@@ -1724,11 +1725,11 @@
                 },
                 {
                     "id": "ethnic-group",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "ethnic-group-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "ethnic-group-question",
@@ -1828,11 +1829,11 @@
                 },
                 {
                     "id": "white-ethnic-group",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "white-ethnic-group-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "white-ethnic-group-question",
@@ -1891,11 +1892,11 @@
                 },
                 {
                     "id": "mixed-ethnic-group",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "mixed-ethnic-group-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "mixed-ethnic-group-question",
@@ -1954,11 +1955,11 @@
                 },
                 {
                     "id": "asian-ethnic-group",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "asian-ethnic-group-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "asian-ethnic-group-question",
@@ -2021,11 +2022,11 @@
                 },
                 {
                     "id": "black-ethnic-group",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "black-ethnic-group-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "black-ethnic-group-question",
@@ -2080,11 +2081,11 @@
                 },
                 {
                     "id": "other-ethnic-group",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "other-ethnic-group-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "other-ethnic-group-question",
@@ -2135,11 +2136,11 @@
                 },
                 {
                     "id": "sexual-identity",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "sexual-identity-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "sexual-identity-question",
@@ -2182,11 +2183,11 @@
                 },
                 {
                     "id": "understand-welsh",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "understand-welsh-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "understand-welsh-question",
@@ -2230,11 +2231,11 @@
                 },
                 {
                     "id": "language",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "language-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "language-question",
@@ -2332,11 +2333,11 @@
                 },
                 {
                     "id": "english",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "english-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "english-question",
@@ -2375,11 +2376,11 @@
                 },
                 {
                     "id": "religion",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "religion-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "religion-question",
@@ -2501,11 +2502,11 @@
                 },
                 {
                     "id": "past-usual-address",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "past-usual-address-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "past-usual-address-question",
@@ -2574,11 +2575,11 @@
                 },
                 {
                     "id": "last-year-address",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "last-year-address-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "last-year-address-question",
@@ -2628,11 +2629,11 @@
                 },
                 {
                     "id": "passports",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "passports-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "passports-question",
@@ -2674,11 +2675,11 @@
                 },
                 {
                     "id": "disability",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "disability-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "disability-question",
@@ -2718,11 +2719,11 @@
                 },
                 {
                     "id": "qualifications",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "qualifications-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "qualifications-question",
@@ -2904,11 +2905,11 @@
                 },
                 {
                     "id": "volunteering",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "volunteering-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "volunteering-question",
@@ -2952,11 +2953,11 @@
                 },
                 {
                     "id": "employment-type",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "employment-type-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "employment-type-question",
@@ -3030,11 +3031,11 @@
                 },
                 {
                     "id": "jobseeker",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "jobseeker-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "jobseeker-question",
@@ -3065,11 +3066,11 @@
                 },
                 {
                     "id": "job-availability",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "job-availability-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "job-availability-question",
@@ -3100,11 +3101,11 @@
                 },
                 {
                     "id": "job-pending",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "job-pending-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "job-pending-question",
@@ -3135,11 +3136,11 @@
                 },
                 {
                     "id": "occupation",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "occupation-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "occupation-question",
@@ -3183,11 +3184,11 @@
                 },
                 {
                     "id": "ever-worked",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "ever-worked-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "ever-worked-question",
@@ -3218,11 +3219,11 @@
                 },
                 {
                     "id": "main-job",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "main-job-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "main-job-question",
@@ -3262,11 +3263,11 @@
                 },
                 {
                     "id": "job-title",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "job-title-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "job-title-question",
@@ -3293,11 +3294,11 @@
                 },
                 {
                     "id": "job-description",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "job-description-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "job-description-question",
@@ -3319,11 +3320,11 @@
                 },
                 {
                     "id": "employers-business",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "employers-business-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "employers-business-question",
@@ -3354,11 +3355,11 @@
                 },
                 {
                     "id": "main-job-type",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "main-job-type-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "main-job-type-question",
@@ -3406,11 +3407,11 @@
                 },
                 {
                     "id": "business-name",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "business-name-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "business-name-question",
@@ -3525,11 +3526,11 @@
                 },
                 {
                     "id": "visitor-sex",
-                    "title": "John Doe",
+                    "title": "{{ answers.person_full_name[group_instance] }}",
                     "sections": [
                         {
                             "id": "visitor-sex-section",
-                            "title": "John Doe",
+                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "questions": [
                                 {
                                     "id": "visitor-sex-question",

--- a/app/data/test_repeating_household.json
+++ b/app/data/test_repeating_household.json
@@ -30,13 +30,14 @@
                                   "display": {
                                       "properties": {}
                                   },
-                                  "id": "question",
+                                  "id": "household-composition-question",
                                   "title": "Who usually lives here?",
                                   "description": "<br> <div> <h3>Include:</h3> <ul> <li>Yourself, if this is your permanent or family home </li> <li>Family members including partners, children and babies born on or before 9 April 2017</li> <li>Students and/or school children who live away from home during term time</li> <li>Housemates, tenants or lodgers</li> </ul> </div>",
                                   "type": "RepeatingAnswer",
                                   "validation": [],
                                   "answers": [
                                     {
+                                        "alias": "person_full_name",
                                         "display": {},
                                         "id": "household-full-name",
                                         "label": "Full Name",
@@ -44,7 +45,8 @@
                                         "options": [],
                                         "q_code": "1",
                                         "type": "Textfield",
-                                        "validation": {}
+                                        "validation": {},
+                                        "repeats": true
                                     }
                                   ]
 
@@ -69,7 +71,7 @@
             "id": "repeating-block-1",
             "title": "Block 2",
             "sections": [{
-                "title": "Repeating Section",
+                "title": "{{answers.person_full_name[group_instance]}}",
                 "description": "",
                 "id": "91631df0-4356-4e9f-a9d9-ce8b08d26eb3",
                 "questions": [{
@@ -80,7 +82,7 @@
                     "answers": [{
                         "q_code": "3",
                         "guidance": "",
-                        "id": "680f2ff9-d5a5-4057-b1cd-9fde2660b244",
+                        "id": "what-is-your-age",
                         "label": "What is their age?",
                         "mandatory": true,
                         "type": "PositiveInteger",
@@ -96,7 +98,7 @@
             "id": "repeating-block-2",
             "title": "Block 3",
             "sections": [{
-                "title": "Repeating Section",
+                "title": "{{answers.person_full_name[group_instance]}}",
                 "description": "",
                 "id": "2e0989b8-5185-4ba6-b73f-c126e3a06ba7",
                 "questions": [{
@@ -107,7 +109,7 @@
                     "answers": [{
                         "q_code": "4",
                         "guidance": "",
-                        "id": "5667e5eb-f9d3-4482-9257-edf752000708",
+                        "id": "what-is-your-shoe-size",
                         "label": "What is their shoe size?",
                         "mandatory": true,
                         "type": "PositiveInteger",

--- a/app/main/views/questionnaire.py
+++ b/app/main/views/questionnaire.py
@@ -57,7 +57,7 @@ def get_block(eq_id, form_type, collection_id, group_id, group_instance, block_i
     answers = answer_store.map(group_id=group_id, group_instance=group_instance, block_id=block_id)
 
     q_manager = get_questionnaire_manager(g.schema, g.schema_json)
-    q_manager.build_state(block_id, answers)
+    q_manager.build_state(block_id, answers, group_instance)
 
     block = g.schema.get_item_by_id(block_id)
     template = block.type if block and block.type else 'questionnaire'
@@ -152,7 +152,7 @@ def get_summary(eq_id, form_type, collection_id):
 
     if latest_location['block_id'] is 'summary':
         metadata = get_metadata(current_user)
-        answers = get_answers(current_user)
+        answers = get_answer_store(current_user)
         schema_context = build_schema_context(metadata, g.schema.aliases, answers)
         rendered_schema_json = renderer.render(g.schema_json, **schema_context)
         summary_context = build_summary_rendering_context(rendered_schema_json, answer_store, metadata)

--- a/app/main/views/questionnaire.py
+++ b/app/main/views/questionnaire.py
@@ -218,15 +218,15 @@ def submit_answers(eq_id, form_type, collection_id):
                                   block_id=invalid_location['block_id']))
 
 
-@questionnaire_blueprint.route('multiple-questions-group/0/household-composition', methods=["POST"])
+@questionnaire_blueprint.route('<group_id>/0/household-composition', methods=["POST"])
 @login_required
-def post_household_composition(eq_id, form_type, collection_id):
+def post_household_composition(eq_id, form_type, collection_id, group_id):
     questionnaire_manager = get_questionnaire_manager(g.schema, g.schema_json)
     answer_store = get_answer_store(current_user)
 
     this_block = {
         'block_id': 'household-composition',
-        'group_id': 'multiple-questions-group',
+        'group_id': group_id,
         'group_instance': 0,
     }
 
@@ -234,15 +234,15 @@ def post_household_composition(eq_id, form_type, collection_id):
 
     if 'action[add_answer]' in request.form:
         questionnaire_manager.add_answer(this_block, 'household-composition-question', answer_store)
-        return get_block(eq_id, form_type, collection_id, 'multiple-questions-group', 0, 'household-composition')
+        return get_block(eq_id, form_type, collection_id, group_id, 0, 'household-composition')
 
     elif 'action[remove_answer]' in request.form:
         index_to_remove = request.form.get('action[remove_answer]')
         questionnaire_manager.remove_answer(this_block, answer_store, index_to_remove)
-        return get_block(eq_id, form_type, collection_id, 'multiple-questions-group', 0, 'household-composition')
+        return get_block(eq_id, form_type, collection_id, group_id, 0, 'household-composition')
 
     if not valid:
-        return _render_template(questionnaire_manager.state, 'multiple-questions-group', 0, 'household-composition', template='questionnaire')
+        return _render_template(questionnaire_manager.state, group_id, 0, 'household-composition', template='questionnaire')
 
     return _go_to_next_block(current_block_id=this_block, eq_id=eq_id,
                              form_type=form_type, collection_id=collection_id)

--- a/app/parser/v0_0_1/schema_parser.py
+++ b/app/parser/v0_0_1/schema_parser.py
@@ -124,6 +124,8 @@ class SchemaParser(AbstractSchemaParser):
             # re-use the parse validation method
             self._parse_validation(questionnaire, self._schema)
 
+        questionnaire.register_aliases()
+
         return questionnaire
 
     @staticmethod

--- a/app/questionnaire/questionnaire_manager.py
+++ b/app/questionnaire/questionnaire_manager.py
@@ -79,19 +79,19 @@ class QuestionnaireManager(object):
 
         return is_valid
 
-    def build_state(self, item_id, answers):
+    def build_state(self, item_id, answers, group_instance=0):
         # Build the state from the answers
         self.state = None
         if self._schema.item_exists(item_id):
             metadata = get_metadata(current_user)
-            all_answers = get_answers(current_user)
+            answer_store = get_answer_store(current_user)
             schema_item = self._schema.get_item_by_id(item_id)
 
             self.state = schema_item.construct_state()
             self.state.update_state(answers)
             self._conditional_display(self.state)
 
-            context = build_schema_context(metadata, self._schema.aliases, all_answers)
+            context = build_schema_context(metadata, self._schema.aliases, answer_store, group_instance)
             renderer.render_state(self.state, context)
 
     def get_state_answers(self, item_id):

--- a/app/questionnaire_state/state_repeating_answer_question.py
+++ b/app/questionnaire_state/state_repeating_answer_question.py
@@ -16,7 +16,7 @@ class RepeatingAnswerStateQuestion(StateQuestion):
             state_answer.update_state(user_input)
 
     def build_repeating_state(self, user_input):
-        for answer_id, answer_index in self.iterate_over_instance_ids(user_input.keys()):
+        for answer_id, answer_index in iterate_over_instance_ids(user_input.keys()):
             for answer_schema in self.schema_item.answers:
                 if answer_schema.id == answer_id:
                     self.create_new_answer_state(answer_schema, answer_index)
@@ -36,19 +36,19 @@ class RepeatingAnswerStateQuestion(StateQuestion):
         new_answer_state.parent = self
         self.answers.append(new_answer_state)
 
-    @staticmethod
-    def iterate_over_instance_ids(answer_instances):
-        """
-        Iterates over a collection of answer instances yielding the answer Id and answer instance Id.
-        :param answer_instances: A list of raw answer_instance_ids
-        :return: Tuple containing the answer Id and answer instance Id.
-        """
 
-        answer_instance_ids = sorted(answer_instances, key=natural_order)
+def iterate_over_instance_ids(answer_instances):
+    """
+    Iterates over a collection of answer instances yielding the answer Id and answer instance Id.
+    :param answer_instances: A list of raw answer_instance_ids
+    :return: Tuple containing the answer Id and answer instance Id.
+    """
 
-        for answer_instance_id in answer_instance_ids:
-            answer_id, answer_index = extract_answer_instance_id(answer_instance_id)
-            yield answer_id, answer_index
+    answer_instance_ids = sorted(answer_instances, key=natural_order)
+
+    for answer_instance_id in answer_instance_ids:
+        answer_id, answer_index = extract_answer_instance_id(answer_instance_id)
+        yield answer_id, answer_index
 
 
 def extract_answer_instance_id(answer_instance_id):

--- a/app/schema/questionnaire.py
+++ b/app/schema/questionnaire.py
@@ -43,16 +43,22 @@ class Questionnaire(object):
             raise QuestionnaireException('{} is a duplicate id'.format(item.id))
 
         self.items_by_id[item.id] = item
-        self._register_alias(item)
 
         # Build the two-way relationship
         item.questionnaire = self
+
+    def register_aliases(self):
+        for item in self.items_by_id.values():
+            self._register_alias(item)
 
     def _register_alias(self, item):
         # Register the alias if the item has one
         if isinstance(item, Answer) and item.alias is not None:
             if item.alias not in self.aliases.keys():
-                self.aliases[item.alias] = item.id
+                self.aliases[item.alias] = {
+                    "answer_id": item.id,
+                    "repeats": item.type == 'Checkbox' or item.container.type == 'RepeatingAnswer',
+                }
             elif self.aliases[item.alias] != item.id:
                 raise QuestionnaireException('{} is not a unique alias'.format(item.alias))
 

--- a/app/templating/schema_context.py
+++ b/app/templating/schema_context.py
@@ -1,25 +1,39 @@
 from app.utilities.date_utils import to_date
 
 
-def build_schema_context(metadata, aliases, answers):
+def build_schema_context(metadata, aliases, answer_store, group_instance=0):
     """
     Build questionnaire schema context containing exercise and answers
     :param metadata: user metadata
     :param aliases: alias mapping of friendly names to answer ids
-    :param answers: all the answers for the given questionnaire
+    :param answer_store: all the answers for the given questionnaire
+    :param group_instance: The group instance Id passed into the url route
     :return: questionnaire schema context
     """
     return {
         "exercise": _build_exercise(metadata),
-        "answers": _map_alias_to_answers(aliases, answers),
+        "answers": _map_alias_to_answers(aliases, answer_store),
+        "group_instance": group_instance,
     }
 
 
-def _map_alias_to_answers(aliases, answers):
+def _map_alias_to_answers(aliases, answer_store):
     values = {}
-    for alias, item_id in aliases.items():
-        value = answers.get(item_id)
-        values[alias] = value if value else ""
+    for alias, answer_info in aliases.items():
+        matching_answers = []
+
+        answers = answer_store.filter(answer_id=answer_info['answer_id'])
+        matching_answers.extend([answer['value'] for answer in answers])
+
+        number_of_matches = len(matching_answers)
+
+        if number_of_matches >= 1 and answer_info['repeats']:
+            values[alias] = matching_answers
+        elif number_of_matches == 1 and not answer_info['repeats']:
+            values[alias] = matching_answers[0]
+        else:
+            values[alias] = ''
+
     return values
 
 

--- a/app/templating/summary/question.py
+++ b/app/templating/summary/question.py
@@ -1,5 +1,5 @@
 from app.questionnaire.navigator import evaluate_rule
-from app.questionnaire_state.state_repeating_answer_question import RepeatingAnswerStateQuestion
+from app.questionnaire_state.state_repeating_answer_question import iterate_over_instance_ids
 from app.templating.summary.answer import Answer
 
 
@@ -26,7 +26,7 @@ class Question:
         answers_iterator = iter(answer_schema)
         for answer_schema in answers_iterator:
             if question_schema['type'] == 'RepeatingAnswer':
-                for answer_id, answer_index in RepeatingAnswerStateQuestion.iterate_over_instance_ids(answers.keys()):
+                for answer_id, answer_index in iterate_over_instance_ids(answers.keys()):
                     if answer_schema['id'] == answer_id:
                         key = answer_id if answer_index == 0 else '_'.join([answer_id, str(answer_index)])
                         answer = cls._build_answer(question_schema, answer_schema, answers, answers_iterator, key)

--- a/tests/app/templating/test_schema_context.py
+++ b/tests/app/templating/test_schema_context.py
@@ -1,4 +1,4 @@
-from mock import Mock
+from unittest.mock import MagicMock
 
 from app.templating.schema_context import build_schema_context
 from tests.app.framework.sr_unittest import SurveyRunnerTestCase
@@ -18,20 +18,38 @@ class TestMetadataContext(SurveyRunnerTestCase):
                 'region_code': 'GB-GBN',
                 }
 
-    def test_build_schema_context(self):
-        aliases = {'first_name': 'answer_id'}
-        answers = Mock()
+    def setUp(self):
+        super().setUp()
+        self.answer_store = MagicMock()
 
-        schema_context = build_schema_context(self.metadata, aliases, answers)
+    def test_build_schema_context(self):
+        aliases = {
+            'first_name': {
+                'answer_id': 'answer_id',
+                'repeats': False,
+            },
+        }
+        answers = []
+
+        self.answer_store.filter = MagicMock(return_value=answers)
+
+        schema_context = build_schema_context(self.metadata, aliases, self.answer_store)
 
         self.assertTrue('exercise' in schema_context)
         self.assertTrue('answers' in schema_context)
 
     def test_build_exercise(self):
-        aliases = {'first_name': 'answer_id'}
-        answers = Mock()
+        aliases = {
+            'first_name': {
+                'answer_id': 'answer_id',
+                'repeats': False,
+            },
+        }
+        answers = []
 
-        schema_context = build_schema_context(self.metadata, aliases, answers)
+        self.answer_store.filter = MagicMock(return_value=answers)
+
+        schema_context = build_schema_context(self.metadata, aliases, self.answer_store)
 
         exercise = schema_context['exercise']
         self.assertEqual('2016-10-11', exercise['start_date'].date().isoformat())
@@ -41,11 +59,135 @@ class TestMetadataContext(SurveyRunnerTestCase):
         self.assertEqual('GB-GBN', exercise['region_code'])
 
     def test_build_answers(self):
-        aliases = {'first_name': 'answer_id'}
-        answers = {'answer_id': 'Joe Bloggs'}
+        aliases = {
+            'first_name': {
+                'answer_id': 'answer_id',
+                'repeats': False,
+            },
+        }
+        answers = [{
+            'answer_id': 'answer_id',
+            'answer_instance': 0,
+            'value': 'Joe Bloggs',
+        }]
 
-        schema_context = build_schema_context(self.metadata, aliases, answers)
+        self.answer_store.filter = MagicMock(return_value=answers)
+
+        schema_context = build_schema_context(self.metadata, aliases, self.answer_store)
 
         answers = schema_context['answers']
         self.assertEqual(len(answers), 1)
         self.assertEqual(answers['first_name'], 'Joe Bloggs')
+
+    def test_build_schema_context_repeating_answers(self):
+        aliases = {
+            '_full_name': {
+                'answer_id': 'full_name_answer',
+                'repeats': True,
+            },
+        }
+        answers = [
+            {
+                'answer_id': 'full_name_answer',
+                'answer_instance': 0,
+                'value': 'Person One',
+            },
+            {
+                'answer_id': 'full_name_answer',
+                'answer_instance': 1,
+                'value': 'Person Two',
+            },
+            {
+                'answer_id': 'full_name_answer',
+                'answer_instance': 2,
+                'value': 'Person Three',
+            }
+        ]
+
+        self.answer_store.filter = MagicMock(return_value=answers)
+
+        schema_context = build_schema_context(self.metadata, aliases, self.answer_store)
+
+        answers = schema_context['answers']
+        self.assertIsInstance(answers['_full_name'], list)
+        self.assertEqual(len(answers['_full_name']), 3)
+        self.assertEqual(len(answers), 1)
+
+    def test_build_schema_context_single_answer_should_not_return_list(self):
+        aliases = {
+            'full_name': {
+                'answer_id': 'full_name_answer',
+                'repeats': False,
+            },
+        }
+        answers = [{
+            'answer_id': 'full_name_answer',
+            'answer_instance': 0,
+            'value': 'Person One',
+        }]
+
+        self.answer_store.filter = MagicMock(return_value=answers)
+
+        schema_context = build_schema_context(self.metadata, aliases, self.answer_store)
+
+        answers = schema_context['answers']
+        self.assertEqual(len(answers), 1)
+        self.assertEqual(answers['full_name'], 'Person One')
+
+    def test_build_schema_context_no_answers_should_return_empty_alias_value(self):
+        aliases = {
+            'alias_with_no_matching_answer': {
+                'answer_id': 'answer_not_provided',
+                'repeats': False,
+            },
+        }
+        answers = []
+
+        self.answer_store.filter = MagicMock(return_value=answers)
+
+        schema_context = build_schema_context(self.metadata, aliases, self.answer_store)
+
+        answers = schema_context['answers']
+        self.assertEqual(len(answers), 1)
+        self.assertEqual(answers['alias_with_no_matching_answer'], '')
+
+    def test_alias_for_repeating_answer_returns_list(self):
+        aliases = {
+            'repeating_answer_alias': {
+                'answer_id': 'answer_id',
+                'repeats': True,
+            },
+        }
+        answers = [{
+            'answer_id': 'answer_id',
+            'answer_instance': 0,
+            'value': 'Some Value',
+        }]
+
+        self.answer_store.filter = MagicMock(return_value=answers)
+
+        schema_context = build_schema_context(self.metadata, aliases, self.answer_store)
+
+        answers = schema_context['answers']
+        self.assertIsInstance(answers['repeating_answer_alias'], list)
+
+    def test_alias_for_non_repeating_answer_returns_string(self):
+        aliases = {
+            'non_repeating_answer_alias': {
+                'answer_id': 'answer_id',
+                'repeats': False,
+            },
+        }
+        answers = [{
+            'answer_id': 'answer_id',
+            'answer_instance': 0,
+            'value': 'Some Value',
+        }]
+
+        self.answer_store.filter = MagicMock(return_value=answers)
+
+        schema_context = build_schema_context(self.metadata, aliases, self.answer_store)
+
+        answers = schema_context['answers']
+        self.assertIsInstance(answers['non_repeating_answer_alias'], str)
+        self.assertEqual(answers['non_repeating_answer_alias'], 'Some Value')

--- a/tests/functional/pages/surveys/question.page.js
+++ b/tests/functional/pages/surveys/question.page.js
@@ -17,6 +17,10 @@ class QuestionPage {
     return browser.click('a[id="top-previous"]')
   }
 
+  getDisplayedName() {
+    return browser.getText('h1[class="section__title saturn"]')
+  }
+
 }
 
 export default QuestionPage

--- a/tests/functional/pages/surveys/repeating_household/repeating-household.page.js
+++ b/tests/functional/pages/surveys/repeating_household/repeating-household.page.js
@@ -1,0 +1,11 @@
+import QuestionPage from '../question.page'
+
+class RepeatingHouseholdPage extends QuestionPage {
+
+  getDisplayedName() {
+    return browser.getText('h1[class="section__title saturn"]')
+  }
+
+}
+
+export default new RepeatingHouseholdPage()

--- a/tests/functional/spec/census-household.spec.js
+++ b/tests/functional/spec/census-household.spec.js
@@ -260,5 +260,88 @@ describe('Census Household', function () {
         expect(ThankYou.isOpen()).to.be.true
     })
 
+    it('Given a census household survey, When one person in household, Then persons name should appear on member details pages.', function () {
+        openAndStartCensusQuestionnaire('census_household.json', false, 'GB-WLS')
+
+        // who-lives-here
+        var person = 'John Smith'
+
+        PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
+        HouseholdComposition.setPersonName(0, person).submit()
+        EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
+        OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
+        HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
+        WhoLivesHereCompleted.submit()
+
+        // household-and-accommodation
+        TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
+        TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
+        SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
+        NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
+        CentralHeating.clickCentralHeatingAnswerGas().submit()
+        OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
+        NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
+        HouseholdAndAccommodationCompleted.submit()
+
+        // household-member
+        HouseholdMemberBegin.submit()
+        expect(HouseholdMemberBegin.getDisplayedName()).to.equal(person)
+        DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
+        expect(DetailsCorrect.getDisplayedName()).to.equal(person)
+        Sex.clickSexAnswerMale().submit()
+        expect(Sex.getDisplayedName()).to.equal(person)
+        DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(4).setDateOfBirthAnswerYear(1980).submit()
+        expect(DateOfBirth.getDisplayedName()).to.equal(person)
+        Over16.clickOver16AnswerYes().submit()
+        expect(Over16.getDisplayedName()).to.equal(person)
+        MaritalStatus.clickMaritalStatusAnswerMarried().submit()
+        expect(MaritalStatus.getDisplayedName()).to.equal(person)
+        AnotherAddress.clickAnotherAddressAnswerNo().submit()
+        expect(AnotherAddress.getDisplayedName()).to.equal(person)
+        InEducation.clickInEducationAnswerNo().submit()
+        expect(InEducation.getDisplayedName()).to.equal(person)
+        CountryOfBirth.clickCountryOfBirthWalesAnswerWales().submit()
+        expect(CountryOfBirth.getDisplayedName()).to.equal(person)
+        Carer.clickCarerAnswerNo().submit()
+        expect(Carer.getDisplayedName()).to.equal(person)
+        NationalIdentity.clickNationalIdentityAnswerBritish().submit()
+        expect(NationalIdentity.getDisplayedName()).to.equal(person)
+        EthnicGroup.clickEthnicGroupAnswerWhite().submit()
+        expect(EthnicGroup.getDisplayedName()).to.equal(person)
+        WhiteEthnicGroup.clickWhiteEthnicGroupAnswerEnglishWelshScottishNorthernIrishBritish().submit()
+        expect(WhiteEthnicGroup.getDisplayedName()).to.equal(person)
+        UnderstandWelsh.clickUnderstandWelshAnswerNoneOfTheAbove().submit()
+        expect(UnderstandWelsh.getDisplayedName()).to.equal(person)
+        Language.clickLanguageWelshAnswerEnglishOrWelsh().submit()
+        expect(Language.getDisplayedName()).to.equal(person)
+        Religion.clickReligionWelshAnswerNoReligion().submit()
+        expect(Religion.getDisplayedName()).to.equal(person)
+        PastUsualAddress.clickPastUsualAddressAnswerThisAddress().submit()
+        expect(PastUsualAddress.getDisplayedName()).to.equal(person)
+        Passports.clickPassportsAnswerUnitedKingdom().submit()
+        expect(Passports.getDisplayedName()).to.equal(person)
+        Disability.clickDisabilityAnswerNo().submit()
+        expect(Disability.getDisplayedName()).to.equal(person)
+        Qualifications.clickQualificationsWelshAnswerUndergraduateDegree().submit()
+        expect(Qualifications.getDisplayedName()).to.equal(person)
+        Volunteering.clickVolunteeringAnswerNo().submit()
+        expect(Volunteering.getDisplayedName()).to.equal(person)
+        EmploymentType.clickEmploymentTypeAnswerWorkingAsAnEmployee().submit()
+        HouseholdMemberCompleted.submit()
+
+        // visitors
+        NumberOfVisitors.setNumberOfVisitorsAnswer(1).submit()
+        VisitorName.setVisitorNameAnswer("Jane Doe").submit()
+        VisitorSex.clickVisitorSexAnswerFemale().submit()
+        VisitorDateOfBirth.setVisitorDateOfBirthAnswerDay(10).setVisitorDateOfBirthAnswerMonth(7).setVisitorDateOfBirthAnswerYear(1990).submit()
+        VisitorUkResident.clickVisitorUkResidentAnswerYes().submit()
+        VisitorAddress.setVisitorAddressAnswerBuilding(50).setVisitorAddressAnswerStreet("My Road").setVisitorAddressAnswerCity("Newport").setVisitorAddressAnswerPostcode("AB123CD").submit()
+
+        Confirmation.submit()
+
+        // Thank You
+        expect(ThankYou.isOpen()).to.be.true
+    })
+
 })
 

--- a/tests/functional/spec/repeating-household.spec.js
+++ b/tests/functional/spec/repeating-household.spec.js
@@ -1,0 +1,64 @@
+import chai from 'chai'
+import {startQuestionnaire, getBlockId, getRepeatedGroup} from '../helpers'
+import AgePage from '../pages/surveys/repeating_groups/age.page.js'
+import ShoeSizePage from '../pages/surveys/repeating_groups/shoe-size.page.js'
+import HouseholdCompositionPage from '../pages/surveys/household_composition/household-composition.page.js'
+import RepeatingHouseholdPage from '../pages/surveys/repeating_household/repeating-household.page.js'
+import SummaryPage from '../pages/summary.page.js'
+
+const expect = chai.expect
+
+describe('Populating household names on subsequent repeating groups.', function() {
+
+  var repeating_household_schema = 'test_repeating_household.json';
+
+  it('Given I enter one name, when I navigate through the subsequent group, I should see the name on each block.', function() {
+    // Given
+    startQuestionnaire(repeating_household_schema)
+    var name = 'Person One'
+
+    // When
+    HouseholdCompositionPage.setPersonName(0, name).submit()
+
+    expect(RepeatingHouseholdPage.getDisplayedName()).to.equal(name)
+    AgePage.setAge(99).submit()
+    expect(RepeatingHouseholdPage.getDisplayedName()).to.equal(name)
+  })
+
+  it('Given I enter multiple names, when I navigate through the subsequent groups, I should the names on their respective blocks.', function() {
+    // Given
+    startQuestionnaire(repeating_household_schema)
+    var name1 = 'Person One'
+    var name2 = 'Person Two'
+    var name3 = 'Person Three'
+
+    // When
+    HouseholdCompositionPage
+        .setPersonName(0, name1)
+        .addPerson()
+        .setPersonName(1, name2)
+        .addPerson()
+        .setPersonName(2, name3)
+        .submit()
+
+    // Person One
+    expect(RepeatingHouseholdPage.getDisplayedName()).to.equal(name1)
+    AgePage.setAge(99).submit()
+    expect(RepeatingHouseholdPage.getDisplayedName()).to.equal(name1)
+    ShoeSizePage.setShoeSize(10).submit()
+
+    // Person Two
+    expect(RepeatingHouseholdPage.getDisplayedName()).to.equal(name2)
+    AgePage.setAge(99).submit()
+    expect(RepeatingHouseholdPage.getDisplayedName()).to.equal(name2)
+    ShoeSizePage.setShoeSize(10).submit()
+
+    // Person Three
+    expect(RepeatingHouseholdPage.getDisplayedName()).to.equal(name3)
+    AgePage.setAge(99).submit()
+    expect(RepeatingHouseholdPage.getDisplayedName()).to.equal(name3)
+    ShoeSizePage.setShoeSize(10).submit()
+
+  })
+
+})


### PR DESCRIPTION
### What is the context of this PR?
Added support for piping based on group instance Id.

### How to review 
Start the household repeating questionnaire.
Enter some names for people in the household.
Observe that the names are displayed in the titles of the subsequent repeated groups.

