### PR TITLE
Adds support for question guidance

### DIFF
--- a/app/assets/styles/partials/components/_alert.scss
+++ b/app/assets/styles/partials/components/_alert.scss
@@ -23,9 +23,9 @@
   padding: 1rem;
 }
 
-@mixin alert_type($name, $color) {
+@mixin alert_type($name, $color, $color-tint:tint($color, 90%)) {
   .alert--#{$name} {
-    background: tint($color, 90%);
+    background: $color-tint;
     .alert__header {
       background: $color;
     }
@@ -40,7 +40,7 @@
 @include alert_type(error, $color-red);
 @include alert_type(warn, $color-amber);
 @include alert_type(success, $color-primary-dark);
-@include alert_type(neutral, $color-secondary);
+@include alert_type(neutral, $color-secondary, #f5f6ff);
 
 .alert--simple {
   border: none;

--- a/app/assets/styles/partials/components/_question.scss
+++ b/app/assets/styles/partials/components/_question.scss
@@ -49,6 +49,11 @@
   clear: both;
 }
 
+.question__guidance {
+  margin-bottom: 1rem;
+  clear: both;
+}
+
 .question__actions {
   margin-top: 1rem;
   @include mq(s) {

--- a/app/data/1_0102.json
+++ b/app/data/1_0102.json
@@ -120,7 +120,26 @@
                                             }
                                         }
                                     ],
-                                    "description": "Round your figures to the nearest whole pound (£). Even if your figures are zero, please still complete.<div><br/> <h4>Include</h4> <ul> <li>VAT</li> <li>internet sales</li></ul> </div> <div> <h4>Exclude</h4> <ul> <li>revenue from mobile phone network commission and top up </li> <li>sales from catering facilities used by customers</li>  <li>lottery sales and commission from lottery sales</li> <li>sales of car accessories and motor vehicles</li> <li>NHS receipts</li> </ul> </div>",
+                                    "description": "<p>Round your figures to the nearest whole pound (£). Even if your figures are zero, please still complete.</p>",
+                                    "guidance": [
+                                        {
+                                            "title": "Include",
+                                            "list": [
+                                                "VAT",
+                                                "internet sales"
+                                            ]
+                                        },
+                                        {
+                                            "title": "Exclude",
+                                            "list": [
+                                                "revenue from mobile phone network commission and top up ",
+                                                "sales from catering facilities used by customers",
+                                                "lottery sales and commission from lottery sales",
+                                                "sales of car accessories and motor vehicles",
+                                                "NHS receipts"
+                                            ]
+                                        }
+                                    ],
                                     "display": {
                                         "properties": {}
                                     },
@@ -171,7 +190,13 @@
                                             }
                                         }
                                     ],
-                                    "description": "Round your figures to the nearest whole pound (£). Even if your figures are zero, please still complete.<div><br/> <h4>Include</h4><ul> <li>VAT</li></ul></div>",
+                                    "description": "<p>Round your figures to the nearest whole pound (£). Even if your figures are zero, please still complete.</p>",
+                                    "guidance": [
+                                        {
+                                            "title": "Include",
+                                            "list": [ "VAT" ]
+                                        }
+                                    ],
                                     "display": {
                                         "properties": {}
                                     },
@@ -221,7 +246,16 @@
                                             }
                                         }
                                     ],
-                                    "description": "<div><p>We rely on your commentary to 'tell the story' behind changes to the business's figures. By commenting here it will reduce the need for us to call you. Comment on significant changes to the business's total retail turnover figures  from:<ul><li>the previous reporting period</li> <li>the same reporting period last year</li></ul></div>",
+                                    "description": "<p>We rely on your commentary to 'tell the story' behind changes to the business's figures.</p><p>By commenting here it will reduce the need for us to call you.</p>",
+                                    "guidance": [
+                                        {
+                                            "description": "<p>Comment on significant changes to the business's total retail turnover figures from:</p>",
+                                            "list": [
+                                                "the previous reporting period",
+                                                "the same reporting period last year"
+                                            ]
+                                        }
+                                    ],
                                     "display": {
                                         "properties": {}
                                     },

--- a/app/data/1_0112.json
+++ b/app/data/1_0112.json
@@ -121,7 +121,26 @@
                                             }
                                         }
                                     ],
-                                    "description": "Round your figures to the nearest whole pound (£). Even if your figures are zero, please still complete.<div><br/> <h4>Include</h4> <ul> <li>VAT</li> <li>internet sales</li></ul> </div> <div> <h4>Exclude</h4> <ul> <li>revenue from mobile phone network commission and top up </li> <li>sales from catering facilities used by customers</li>  <li>lottery sales and commission from lottery sales</li> <li>sales of car accessories and motor vehicles</li> <li>NHS receipts</li> </ul> </div>",
+                                    "description": "<p>Round your figures to the nearest whole pound (£). Even if your figures are zero, please still complete.</p>",
+                                    "guidance": [
+                                        {
+                                            "title": "Include",
+                                            "list": [
+                                                "VAT",
+                                                "internet sales"
+                                            ]
+                                        },
+                                        {
+                                            "title": "Exclude",
+                                            "list": [
+                                                "revenue from mobile phone network commission and top up",
+                                                "sales from catering facilities used by customers",
+                                                "lottery sales and commission from lottery sales",
+                                                "sales of car accessories and motor vehicles",
+                                                "NHS receipts"
+                                            ]
+                                        }
+                                    ],
                                     "display": {
                                         "properties": {}
                                     },
@@ -172,7 +191,13 @@
                                             }
                                         }
                                     ],
-                                    "description": "Round your figures to the nearest whole pound (£). Even if your figures are zero, please still complete.<div><br/> <h4>Include</h4><ul> <li>VAT</li></ul></div>",
+                                    "description": "<p>Round your figures to the nearest whole pound (£). Even if your figures are zero, please still complete.</p>",
+                                    "guidance": [
+                                        {
+                                            "title": "Include",
+                                            "list": [ "VAT" ]
+                                        }
+                                    ],
                                     "display": {
                                         "properties": {}
                                     },
@@ -222,7 +247,16 @@
                                             }
                                         }
                                     ],
-                                    "description": "<div><p>We rely on your commentary to 'tell the story' behind changes to the business's figures. By commenting here it will reduce the need for us to call you. Comment on significant changes to the business's total retail turnover figures  from:<ul><li>the previous reporting period</li> <li>the same reporting period last year</li></ul></div>",
+                                    "description": "<p>We rely on your commentary to 'tell the story' behind changes to the business's figures.</p><p>By commenting here it will reduce the need for us to call you.</p>",
+                                    "guidance": [
+                                        {
+                                            "description": "<p>Comment on significant changes to the business's total retail turnover figures from:</p>",
+                                            "list": [
+                                                "the previous reporting period",
+                                                "the same reporting period last year"
+                                            ]
+                                        }
+                                    ],
                                     "display": {
                                         "properties": {}
                                     },
@@ -340,13 +374,31 @@
                                           }
                                       }
                                     ],
-                                    "description": "",
                                     "display": {
                                         "properties": {}
                                     },
                                     "id": "17136377-f52e-4a00-a1d6-039972fc26ab",
                                     "title": "On {{exercise.employment_date|format_date}} what was the number of employees?",
-                                    "description" : "<p>An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.</p><div> <h4>Include:</h4> <ul> <li>all workers paid directly from this business\u2019s payroll(s)</li> <li>those temporarily absent but still being paid, for example on maternity leave</li></ul> <br/><h4>Exclude:</h4> <ul> <li>agency workers paid directly from the agency payroll</li><li>voluntary workers</li><li>former employees only receiving pension</li><li>self-employed workers</li><li>working owners who are not paid via PAYE</li></ul> </div>",
+                                    "description": "<p>An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.</p>",
+                                    "guidance": [
+                                        {
+                                            "title": "Include",
+                                            "list": [
+                                                "all workers paid directly from this business's payroll(s)",
+                                                "those temporarily absent but still being paid, for example on maternity leave"
+                                            ]
+                                        },
+                                        {
+                                            "title": "Exclude",
+                                            "list": [
+                                                "agency workers paid directly from the agency payroll",
+                                                "voluntary workers",
+                                                "former employees only receiving pension",
+                                                "self-employed workers",
+                                                "working owners who are not paid via PAYE"
+                                            ]
+                                        }
+                                    ],
                                     "type": "General",
                                     "validation": []
                                 }
@@ -390,7 +442,16 @@
                                             }
                                         }
                                     ],
-                                    "description": "<div><p>Comment on significant changes in the number of employees from: <ul><li>the previous reporting period</li> <li>the same reporting period last year</li></ul></p></div>",
+                                    "description": "",
+                                    "guidance": [
+                                        {
+                                            "description": "<p>Comment on significant changes in the number of employees from:</p>",
+                                            "list": [
+                                                "the previous reporting period",
+                                                "the same reporting period last year"
+                                            ]
+                                        }
+                                    ],
                                     "display": {
                                         "properties": {}
                                     },

--- a/app/data/1_0203.json
+++ b/app/data/1_0203.json
@@ -83,13 +83,22 @@
                             "validation": []
                         },
                         {
-                            "description": "<p>- You should enter figures for the reporting period stated above<br>- You should round your figures to the nearest (\u00a3) pound</p><h4>Include</h4><ul><li>VAT</li><li>Internet Sales</li></ul>",
+                            "description": "<p>- You should enter figures for the reporting period stated above<br>- You should round your figures to the nearest (\u00a3) pound</p>",
                             "display": {
                                 "properties": {}
                             },
                             "id": "d9d25a21-41b8-42b2-ac7b-fb21b1036d71",
                             "questions": [
                                 {
+                                    "guidance": [
+                                        {
+                                            "title": "Include",
+                                            "list": [
+                                                "VAT",
+                                                "Internet Sales"
+                                            ]
+                                        }
+                                    ],
                                     "answers": [
                                         {
                                             "display": {},

--- a/app/data/1_0205.json
+++ b/app/data/1_0205.json
@@ -58,8 +58,17 @@
 				}, {
 					"id": "d9d25a21-41b8-42b2-ac7b-fb21b1036d71",
 					"title": "Commodities - Retail Turnover",
-					"description": "<p>- You should enter figures for the reporting period stated above<br>- You should round your figures to the nearest (£) pound</p><h4>Include</h4><ul><li>VAT</li><li>Internet Sales</li></ul>",
+					"description": "<p>- You should enter figures for the reporting period stated above<br>- You should round your figures to the nearest (£) pound</p>",
 					"questions": [{
+                        "guidance": [
+                            {
+                                "title": "Include",
+                                "list": [
+                                    "VAT",
+                                    "Internet Sales"
+                                ]
+                            }
+                        ],
 						"id": "eedb9f9f-2f2e-41f4-9186-ba7110d9e6a4",
 						"title": "",
 						"description": "",

--- a/app/data/1_0213.json
+++ b/app/data/1_0213.json
@@ -84,13 +84,22 @@
                             "validation": []
                         },
                         {
-                            "description": "<p>- You should enter figures for the reporting period stated above<br>- You should round your figures to the nearest (\u00a3) pound</p><h4>Include</h4><ul><li>VAT</li><li>Internet Sales</li></ul>",
+                            "description": "<p>- You should enter figures for the reporting period stated above<br>- You should round your figures to the nearest (\u00a3) pound</p>",
                             "display": {
                                 "properties": {}
                             },
                             "id": "d9d25a21-41b8-42b2-ac7b-fb21b1036d71",
                             "questions": [
                                 {
+                                    "guidance": [
+                                        {
+                                            "title": "Include",
+                                            "list": [
+                                                "VAT",
+                                                "Internet Sales"
+                                            ]
+                                        }
+                                    ],
                                     "answers": [
                                         {
                                             "display": {},
@@ -349,13 +358,32 @@
                     "id": "2d24cb72-5598-4c3e-bd53-1d21bb12455f",
                     "sections": [
                         {
-                            "description": "<p>An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.</p><div> <h4>Include:</h4> <ul> <li>all workers paid directly from this business\u2019s payroll(s)</li> <li>those temporarily absent but still being paid, for example on maternity leave</li></ul> </div> <div> <h4>Exclude:</h4> <ul> <li>agency workers paid directly from the agency payroll</li><li>voluntary workers</li><li>former employees only receiving pension</li><li>self-employed workers</li><li><b>working</b> owners who are not paid via PAYE</li></ul> </div>",
+                            "description": "<p>An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.</p>",
                             "display": {
                                 "properties": {}
                             },
                             "id": "c528d24b-d0dd-45cd-91af-380b61a5725d",
                             "questions": [
                                 {
+                                    "guidance": [
+                                        {
+                                            "title": "Include",
+                                            "list": [
+                                                "all workers paid directly from this business\u2019s payroll(s)",
+                                                "those temporarily absent but still being paid, for example on maternity leave"
+                                            ]
+                                        },
+                                        {
+                                            "title": "Exclude",
+                                            "list": [
+                                                "agency workers paid directly from the agency payroll",
+                                                "voluntary workers",
+                                                "former employees only receiving pension",
+                                                "self-employed workers",
+                                                "<b>working</b> owners who are not paid via PAYE"
+                                            ]
+                                        }
+                                    ],
                                     "answers": [
                                         {
                                             "display": {},

--- a/app/data/1_0215.json
+++ b/app/data/1_0215.json
@@ -84,13 +84,22 @@
                             "validation": []
                         },
                         {
-                            "description": "<p>- You should enter figures for the reporting period stated above<br>- You should round your figures to the nearest (\u00a3) pound</p><h4>Include</h4><ul><li>VAT</li><li>Internet Sales</li></ul>",
+                            "description": "<p>- You should enter figures for the reporting period stated above<br>- You should round your figures to the nearest (\u00a3) pound</p>",
                             "display": {
                                 "properties": {}
                             },
                             "id": "d9d25a21-41b8-42b2-ac7b-fb21b1036d71",
                             "questions": [
                                 {
+                                    "guidance": [
+                                        {
+                                            "title": "Include",
+                                            "list": [
+                                                "VAT",
+                                                "Internet Sales"
+                                            ]
+                                        }
+                                    ],
                                     "answers": [
                                         {
                                             "display": {},
@@ -378,13 +387,32 @@
                     "id": "2d24cb72-5598-4c3e-bd53-1d21bb12455f",
                     "sections": [
                         {
-                            "description": "<p>An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.</p><div> <h4>Include:</h4> <ul> <li>all workers paid directly from this business\u2019s payroll(s)</li> <li>those temporarily absent but still being paid, for example on maternity leave</li></ul> </div> <div> <h4>Exclude:</h4> <ul> <li>agency workers paid directly from the agency payroll</li><li>voluntary workers</li><li>former employees only receiving pension</li><li>self-employed workers</li><li><b>working</b> owners who are not paid via PAYE</li></ul> </div>",
+                            "description": "<p>An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.</p>",
                             "display": {
                                 "properties": {}
                             },
                             "id": "c528d24b-d0dd-45cd-91af-380b61a5725d",
                             "questions": [
                                 {
+                                    "guidance": [
+                                        {
+                                            "title": "Include",
+                                            "list": [
+                                                "all workers paid directly from this business\u2019s payroll(s)",
+                                                "those temporarily absent but still being paid, for example on maternity leave"
+                                            ]
+                                        },
+                                        {
+                                            "title": "Exclude",
+                                            "list": [
+                                                "agency workers paid directly from the agency payroll",
+                                                "voluntary workers",
+                                                "former employees only receiving pension",
+                                                "self-employed workers",
+                                                "<b>working</b> owners who are not paid via PAYE"
+                                            ]
+                                        }
+                                    ],
                                     "answers": [
                                         {
                                             "display": {},

--- a/app/data/census_household.json
+++ b/app/data/census_household.json
@@ -25,7 +25,17 @@
                                 {
                                     "id": "permanent-or-family-home-question",
                                     "title": "1. Does anyone live here as their permanent or family home?",
-                                    "description": "<div> <h4>Include</h4> <ul> <li>Yourself, if this is your permanent or family home </li> <li>Family members including partners, children and babies born on or before 9 April  2017</li> <li>Students and, or school children who live away from home during term time</li> <li>Housemates tenants or lodgers</li></ul> </div>",
+                                    "guidance": [
+                                        {
+                                             "title": "Include",
+                                             "list": [
+                                                 "Yourself, if this is your permanent or family home",
+                                                 "Family members including partners, children and babies born on or before 9 April 2017",
+                                                 "Students and, or school children who live away from home during term time",
+                                                 "Housemates tenants or lodgers"
+                                             ]
+                                        }
+                                    ],
                                     "type": "General",
                                     "answers": [
                                         {
@@ -84,7 +94,19 @@
                                 {
                                     "id": "else-permanent-or-family-home-question",
                                     "title": "1a. Is there anyone else who lives here as their permanent or family home?",
-                                    "description": "<div> <h4>Include</h4> <ul> <li>People who usually live outside the UK who are staying in the UK for three months or more</li> <li>People who work away from home within the UK  if this is their permanent or family home</li> <li>Members of the Armed Forces if this is their permanent or family home</li> <li>People who are temporarily outside the UK for less than 12 months</li> <li>People staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends</li> <li>Other people who usually live here, including anyone temporarily away from home</li></ul> </div>",
+                                    "guidance": [
+                                        {
+                                             "title": "Include",
+                                             "list": [
+                                                 "People who usually live outside the UK who are staying in the UK for <b>three months or more</b>",
+                                                 "People who work away from home within the UK  if this is their permanent or family home",
+                                                 "Members of the Armed Forces if this is their permanent or family home",
+                                                 "People who are temporarily outside the UK for <b>less than 12 months</b>",
+                                                 "People staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends",
+                                                 "Other people who usually live here, including anyone temporarily away from home "
+                                             ]
+                                        }
+                                    ],
                                     "type": "General",
                                     "answers": [
                                         {
@@ -142,7 +164,17 @@
                                 {
                                     "id": "who-lives-at-this-address-question",
                                     "title": "2. List the names of everyone who lives at this address",
-                                    "description": "<div> <h4>Include</h4> <ul> <li>Yourself, if this is your permanent or family home</li> <li>Family members including partners, children and babies born on or before 9 April  2017</li> <li>Students and, or school children who live away from home during term time</li> <li>Housemates tenants or lodgers</li></ul> </div>",
+                                    "guidance": [
+                                        {
+                                             "title": "Include",
+                                             "list": [
+                                                 "Yourself, if this is your permanent or family home",
+                                                 "Family members including partners, children and babies born on or before 9 April 2017",
+                                                 "Students and, or school children who live away from home during term time",
+                                                 "Housemates tenants or lodgers"
+                                             ]
+                                        }
+                                    ],
                                     "type": "General",
                                     "answers": [
                                         {
@@ -168,7 +200,19 @@
                                 {
                                     "id": "everyone-at-address-confirmation-question",
                                     "title": "3. Is this everyone for whom this address is their permanent or family home?",
-                                    "description": "<div> <h4>Include</h4> <ul> <li>People who usually live outside the UK who are staying in the UK for three months or more</li> <li>People who work away from home within the UK  if this is their permanent or family home</li> <li>Members of the Armed Forces if this is their permanent or family home</li> <li>People who are temporarily outside the UK for less than 12 months</li> <li>People staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends</li> <li>Other people who usually live here, including anyone temporarily away from home</li></ul> </div>",
+                                    "guidance": [
+                                        {
+                                             "title": "Include",
+                                             "list": [
+                                                 "People who usually live outside the UK who are staying in the UK for <b>three months or more</b>",
+                                                 "People who work away from home within the UK  if this is their permanent or family home",
+                                                 "Members of the Armed Forces if this is their permanent or family home",
+                                                 "People who are temporarily outside the UK for <b>less than 12 months</b>",
+                                                 "People staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends",
+                                                 "Other people who usually live here, including anyone temporarily away from home"
+                                             ]
+                                        }
+                                    ],
                                     "type": "General",
                                     "answers": [
                                         {
@@ -226,7 +270,17 @@
                                 {
                                     "id": "overnight-visitors-question",
                                     "title": "4 How many visitors are staying overnight here on 9th April 2017?",
-                                    "description": "<div> <h4>Include</h4> <ul> <li>People who usually live somewhere else in the UK. For example, boy or girl friends, relatives</li> <li>People staying here because it is their second address, for example, for work. Their permanent or family home is elsewhere</li> <li><People who usually live outside the UK who are visiting the UK for less than three months/li> <li>People here on holiday</li></ul> </div>",
+                                    "guidance": [
+                                        {
+                                             "title": "Include",
+                                             "list": [
+                                                 "People who usually live somewhere else in the UK. For example, boy or girl friends, relatives",
+                                                 "People staying here because it is their second address, for example, for work. Their permanent or family home is elsewhere",
+                                                 "People who usually live outside the UK who are visiting the UK for less than three months",
+                                                 "People here on holiday"
+                                             ]
+                                        }
+                                    ],
                                     "type": "General",
                                     "answers": [
                                         {
@@ -253,7 +307,6 @@
                                 {
                                     "id": "household-relationships-question",
                                     "title": "5. How are members of this household related to each other?",
-                                    "description": "<div> <h4>Include</h4> <ul> <li>Yourself, if this is your permanent or family home </li> <li>Family members including partners, children and babies born on or before 9 April  2017</li> <li>Students and, or school children who live away from home during term time</li> <li>Housemates tenants or lodgers</li></ul> </div>",
                                     "type": "General",
                                     "answers": [
                                         {
@@ -469,7 +522,11 @@
                                 {
                                     "id": "self-contained-accommodation-question",
                                     "title": "2. Is this household’s accommodation self-contained?",
-                                    "description": "This means that all the rooms, including the kitchen, bathroom and toilet, are behind a door that only this household can use",
+                                    "guidance": [
+                                        {
+                                            "description": "This means that all the rooms, including the kitchen, bathroom and toilet, are behind a door that only this household can use"
+                                        }
+                                    ],
                                     "type": "General",
                                     "answers": [
                                         {
@@ -505,7 +562,11 @@
                                 {
                                     "id": "number-of-bedrooms-question",
                                     "title": "3. How many bedrooms are available for use only by this household?",
-                                    "description": "Include all rooms built or converted for use as bedrooms, even if they’re not currently used as bedrooms",
+                                    "guidance": [
+                                        {
+                                            "description": "Include all rooms built or converted for use as bedrooms, even if they’re not currently used as bedrooms"
+                                        }
+                                    ],
                                     "type": "General",
                                     "answers": [
                                         {
@@ -709,7 +770,11 @@
                                 {
                                     "id": "number-of-vehicles-question",
                                     "title": "7. In total, how many cars or vans are owned, or available for use, by members of this household?",
-                                    "description": "Include any company cars or vans available for private use",
+                                    "guidance": [
+                                        {
+                                            "description": "Include any company cars or vans available for private use"
+                                        }
+                                    ],
                                     "type": "General",
                                     "answers": [
                                         {
@@ -1496,7 +1561,11 @@
                                 {
                                     "id": "arrive-in-uk-question",
                                     "title": "10. If you were not born in the United Kingdom, when did you most recently arrive to live here?",
-                                    "description": "Exclude short visits away from the UK",
+                                    "guidance": [
+                                        {
+                                            "description": "Exclude short visits away from the UK"
+                                        }
+                                    ],
                                     "type": "General",
                                     "answers": [
                                         {
@@ -1561,7 +1630,12 @@
                                 {
                                     "id": "carer-question",
                                     "title": "12. Do you look after, or give any help or support to family members, friends, neighbours or others because of either:",
-                                    "description": "<div> <ul> <li>Long-term physical or mental ill-health/disability?</li> <li>Problems related to old age?</li></ul> Exclude  anything you do as part of your paid employment</div>",
+                                    "description": "<div><ul><li>Long-term physical or mental ill-health/disability?</li><li>Problems related to old age?</li></ul></div>",
+                                    "guidance": [
+                                        {
+                                           "description": "Exclude anything you do as part of your paid employment"
+                                        }
+                                    ],
                                     "type": "General",
                                     "answers": [
                                         {
@@ -2525,7 +2599,11 @@
                                 {
                                     "id": "disability-question",
                                     "title": "23. Are your day-to-day activities limited because of a health problem or disability which has lasted, or is expected to last, at least 12 months?",
-                                    "description": "Include Problems related to old age",
+                                    "guidance": [
+                                        {
+                                            "description": "Include Problems related to old age"
+                                        }
+                                    ],
                                     "type": "General",
                                     "answers": [
                                         {
@@ -2737,7 +2815,11 @@
                                 {
                                     "id": "volunteering-question",
                                     "title": "25. Thinking of the last 12 months, have you taken part in any volunteering for any groups, clubs or organisations?",
-                                    "description": "Exclude any Court ordered activities",
+                                    "guidance": [
+                                        {
+                                            "description": "Exclude any Court ordered activities"
+                                        }
+                                    ],
                                     "type": "General",
                                     "answers": [
                                         {
@@ -2781,7 +2863,12 @@
                                 {
                                     "id": "employment-type-question",
                                     "title": "26. Last week were you:",
-                                    "description": "Select all that apply <br /> Include any paid work, including casual or temporary work, even if only for one hour",
+                                    "description": "Select all that apply",
+                                    "guidance": [
+                                        {
+                                            "description": "Include any paid work, including casual or temporary work, even if only for one hour"
+                                        }
+                                    ],
                                     "type": "General",
                                     "answers": [
                                         {
@@ -3042,7 +3129,11 @@
                                 {
                                     "id": "main-job-question",
                                     "title": "32. In your main job, are (were) you:",
-                                    "description": "If you are not working answer the remaining questions about your last main job. <br />Your main job is the job which you usually work (worked) the most hours",
+                                    "guidance": [
+                                        {
+                                            "description": "<p>If you are not working answer the remaining questions about your last main job.</p><p>Your main job is the job which you usually work (worked) the most hours</p>"
+                                        }
+                                    ],
                                     "type": "General",
                                     "answers": [
                                         {
@@ -3082,7 +3173,11 @@
                                 {
                                     "id": "job-title-question",
                                     "title": "33. What is (was) your full and specific job title?",
-                                    "description": "For example, primary school teacher, car mechanic, district nurse, structural engineer <br />Do not state your grade or pay band",
+                                    "guidance": [
+                                        {
+                                            "description": "<p>For example, <b>primary school teacher, car mechanic, district nurse, structural engineer</b></p><p>Do not state your grade or pay band</p>"
+                                        }
+                                    ],
                                     "type": "General",
                                     "answers": [
                                         {
@@ -3135,7 +3230,15 @@
                                 {
                                     "id": "employers-business-question",
                                     "title": "35. At your workplace what is (was) the main activity of your employer or business?",
-                                    "description": "For example, primary education, repairing cars, contract catering, computer servicing <br />If you are (were) a civil servant, write government <br />If you are (were) a local government officer, write local government officer, write local government and give the name of the department within the local authority",
+                                    "guidance": [
+                                        {
+                                            "list": [
+                                                "For example, <b>primary education, repairing cars, contract catering, computer servicing</b>",
+                                                "If you are (were) a civil servant, write <b>government</b>",
+                                                "If you are (were) a local government officer, write local government officer, write <b>local government</b> and give the name of the department within the local authority"
+                                            ]
+                                        }
+                                    ],
                                     "type": "General",
                                     "answers": [
                                         {
@@ -3215,7 +3318,11 @@
                                 {
                                     "id": "business-name-question",
                                     "title": "36a. What is (was) the name of the organisation or business you work (worked) for?",
-                                    "description": "If you were self-employed in your own business write in the business name",
+                                    "guidance": [
+                                        {
+                                            "description": "If you were self-employed in your own business write in the business name"
+                                        }
+                                    ],
                                     "type": "General",
                                     "answers": [
                                         {
@@ -3268,7 +3375,17 @@
                                 {
                                     "id": "number-of-visitors-question",
                                     "title": "Please confirm number of visitors staying overnight here on 9th April 2017",
-                                    "description": "<div> <h4>Include</h4> <ul> <li>People who usually live somewhere else in the UK. For example, boy or girl friends, relatives</li> <li>People staying here because it is their second address, for example, for work. Their permanent or family home is elsewhere</li> <li>People who usually live outside the UK who are visiting the UK for less than three months</li> <li>People here on holiday</li></ul> </div>",
+                                    "guidance": [
+                                        {
+                                             "title": "Include",
+                                             "list": [
+                                                 "People who usually live somewhere else in the UK. For example, boy or girl friends, relatives",
+                                                 "People staying here because it is their second address, for example, for work. Their permanent or family home is elsewhere",
+                                                 "People who usually live outside the UK who are visiting the UK for less than three months",
+                                                 "People here on holiday "
+                                             ]
+                                        }
+                                    ],
                                     "type": "General",
                                     "answers": [
                                         {

--- a/app/data/census_individual.json
+++ b/app/data/census_individual.json
@@ -898,7 +898,11 @@
                                 {
                                     "id": "arrive-in-uk-question",
                                     "title": "10. If you were not born in the United Kingdom, when did you most recently arrive to live here?",
-                                    "description": "Exclude short visits away from the UK",
+                                    "guidance":[
+                                        {
+                                            "description": "Exclude short visits away from the UK"
+                                        }
+                                    ],
                                     "display": {
                                         "properties": {}
                                     },
@@ -1002,7 +1006,12 @@
                                 {
                                     "id": "carer-question",
                                     "title": "12. Do you look after, or give any help or support to family members, friends, neighbours or others because of either:",
-                                    "description": "<div> <ul> <li>Long-term physical or mental ill-health/disability?</li> <li>Problems related to old age?</li></ul> Exclude  anything you do as part of your paid employment</div>",
+                                    "description": "<div> <ul> <li>Long-term physical or mental ill-health/disability?</li> <li>Problems related to old age?</li></ul></div>",
+                                    "guidance": [
+                                        {
+                                             "description": "Exclude anything you do as part of your paid employment"
+                                        }
+                                    ],
                                     "display": {
                                         "properties": {}
                                     },
@@ -2133,7 +2142,11 @@
                                 {
                                     "id": "disability-question",
                                     "title": "22. Are your day-to-day activities limited because of a health problem or disability which has lasted, or is expected to last, at least 12 months?",
-                                    "description": "Include Problems related to old age",
+                                    "guidance": [
+                                        {
+                                            "description": "Include Problems related to old age"
+                                        }
+                                    ],
                                     "display": {
                                         "properties": {}
                                     },
@@ -2394,7 +2407,11 @@
                                 {
                                     "id": "volunteering-question",
                                     "title": "24. Thinking of the last 12 months, have you taken part in any volunteering for any groups, clubs or organisations?",
-                                    "description": "Exclude any Court ordered activities",
+                                    "guidance": [
+                                        {
+                                            "description": "Exclude any Court ordered activities"
+                                        }
+                                    ],
                                     "display": {
                                         "properties": {}
                                     },
@@ -2457,7 +2474,12 @@
                                 {
                                     "id": "employment-type-question",
                                     "title": "25. Last week were you:",
-                                    "description": "Select all that apply <br /> Include any paid work, including casual or temporary work, even if only for one hour",
+                                    "description": "Select all that apply",
+                                    "guidance": [
+                                        {
+                                            "description": "Include any paid work, including casual or temporary work, even if only for one hour"
+                                        }
+                                    ],
                                     "display": {
                                         "properties": {}
                                     },

--- a/app/data/schema/schema-v1.json
+++ b/app/data/schema/schema-v1.json
@@ -108,6 +108,26 @@
                             "description": {
                               "type": "string"
                             },
+                            "guidance": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "title": {
+                                    "type": "string"
+                                  },
+                                  "description": {
+                                    "type": "string"
+                                  },
+                                  "list": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
                             "skip_condition": {
                               "type": "object",
                               "properties": {

--- a/app/data/test_question_guidance.json
+++ b/app/data/test_question_guidance.json
@@ -1,0 +1,216 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "questionnaire_id": "0",
+    "schema_version": "0.0.1",
+    "survey_id": "0",
+    "title": "Question Guidance Test",
+    "theme": "default",
+    "description": "A questionnaire to test question guidance content",
+    "introduction": {},
+    "eq_id": "0",
+    "groups": [
+        {
+            "id": "group",
+            "title": "",
+            "blocks": [
+                {
+                    "id": "block-test-guidance-all",
+                    "title": "",
+                    "sections": [
+                        {
+                            "id": "section-test-guidance-all",
+                            "title": "Section: Test guidance all",
+                            "description": "",
+                            "questions": [
+                                {
+                                    "id": "question-test-guidance-all",
+                                    "title": "Question: Test guidance all",
+                                    "description": "<p>Testing all features of the guidance block enabled together</p>",
+                                    "guidance": [
+                                        {
+                                            "title": "Include",
+                                            "description": "<p>Guidance <b>include</b> description text</p>",
+                                            "list": [
+                                                "Item Include 1",
+                                                "Item Include 2",
+                                                "Item Include 3",
+                                                "Item Include 4"
+                                            ]
+                                        },
+                                        {
+                                            "title": "Exclude",
+                                            "description": "<p>Guidance <b>exclude</b> description text</p>",
+                                            "list": [
+                                                "Item Exclude 1",
+                                                "Item Exclude 2",
+                                                "Item Exclude 3",
+                                                "Item Exclude 4"
+                                            ]
+                                        },
+                                        {
+                                            "title": "Other",
+                                            "description": "<p>Guidance <b>other</b> description text</p>",
+                                            "list": [
+                                                "Item Other 1",
+                                                "Item Other 2",
+                                                "Item Other 3",
+                                                "Item Other 4"
+                                            ]
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "display": {},
+                                            "guidance": "",
+                                            "id": "answer-test-guidance-all",
+                                            "label": "Text question",
+                                            "mandatory": false,
+                                            "options": [],
+                                            "q_code": "0",
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "block-test-guidance-title",
+                    "title": "",
+                    "sections": [
+                        {
+                            "id": "section-test-guidance-title",
+                            "title": "Section: Test guidance title",
+                            "description": "",
+                            "questions": [
+                                {
+                                    "id": "question-test-guidance-title",
+                                    "title": "Question: Test guidance title",
+                                    "description": "<p>Testing combinations of the title within guidance</p>",
+                                    "guidance": [
+                                        {
+                                            "title": "This one has a description but no list",
+                                            "description": "<p>No list items below this text</p>"
+                                        },
+                                        {
+                                            "title": "This one has no list or description"
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "display": {},
+                                            "guidance": "",
+                                            "id": "answer-test-guidance-title",
+                                            "label": "Text question",
+                                            "mandatory": false,
+                                            "options": [],
+                                            "q_code": "0",
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "block-test-guidance-description",
+                    "title": "",
+                    "sections": [
+                        {
+                            "id": "section-test-guidance-description",
+                            "title": "Section: Test guidance descriptions",
+                            "description": "",
+                            "questions": [
+                                {
+                                    "id": "question-test-guidance-description",
+                                    "title": "Question: Test guidance descriptions",
+                                    "description": "<p>Tests the descriptions within guidance</p>",
+                                    "guidance": [
+                                        {
+                                            "description": "<p>No title above this text, list below</p>",
+                                            "list": [
+                                                "Item Include 1",
+                                                "Item Include 2",
+                                                "Item Include 3",
+                                                "Item Include 4"
+                                            ]
+                                        },
+                                        {
+                                            "description": "<p>Just description, no title above this text, no list below</p>"
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "display": {},
+                                            "guidance": "",
+                                            "id": "answer-test-guidance-description",
+                                            "label": "Text question",
+                                            "mandatory": false,
+                                            "options": [],
+                                            "q_code": "0",
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "block-test-guidance-lists",
+                    "title": "",
+                    "sections": [
+                        {
+                            "id": "section-test-guidance-lists",
+                            "title": "Section: Test guidance lists",
+                            "description": "",
+                            "questions": [
+                                {
+                                    "id": "question-test-guidance-lists",
+                                    "title": "Question: Test guidance lists (with no question description below)",
+                                    "guidance": [
+                                        {
+                                            "title": "Title, no description, list follows",
+                                            "list": [
+                                                "Item Include 1",
+                                                "Item Include 2",
+                                                "Item Include 3",
+                                                "Item Include 4"
+                                            ]
+                                        },
+                                        {
+                                            "list": [
+                                                "List with no title or description 1",
+                                                "List with no title or description 2",
+                                                "List with no title or description 3",
+                                                "List with no title or description 4"
+                                            ]
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "display": {},
+                                            "guidance": "",
+                                            "id": "answer-test-guidance-lists",
+                                            "label": "Text question",
+                                            "mandatory": false,
+                                            "options": [],
+                                            "q_code": "0",
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/app/parser/v0_0_1/schema_parser.py
+++ b/app/parser/v0_0_1/schema_parser.py
@@ -253,6 +253,7 @@ class SchemaParser(AbstractSchemaParser):
             question.title = ParserUtils.get_required_string(schema, "title")
             question.description = ParserUtils.get_optional_string(schema, "description")
             question.skip_condition = self._parse_skip_condition(ParserUtils.get_optional(schema, "skip_condition"))
+            question.guidance = ParserUtils.get_optional(schema, "guidance")
             # register the question
             questionnaire.register(question)
 

--- a/app/templates/partials/question.html
+++ b/app/templates/partials/question.html
@@ -4,6 +4,7 @@
 
 {% set question_title = question.schema_item.title %}
 {% set question_subtitle = question.schema_item.subtitle %}
+{% set question_guidance = "" %}
 
 {% set question_titles %}
   {%- if question_title -%}
@@ -12,13 +13,37 @@
   {%- if question_subtitle -%}
     <br />
     <h3 class="question__subtitle mars">{{question_subtitle}}</h3>
-  {%- endif %}
+  {%- endif -%}
 {% endset %}
 
 {% set question_description %}
-  {%- if question.schema_item.description %}
+  {%- if question.schema_item.description -%}
     <div class="question__description mars" id="description-{{question.id}}">
       {{question.schema_item.description|safe}}
+    </div>
+  {% endif %}
+{% endset %}
+
+{% set question_guidance %}
+  {%- if question.schema_item.guidance -%}
+    <div class="u-mb-s u-mb-l@s">
+      <div class="alert alert--simple alert--neutral" id="question-guidance-{{question.id}}">
+        {%- for guidance in question.schema_item.guidance -%}
+          {%- if guidance.title -%}
+            <h3 class="venus">{{guidance.title}}</h3>
+          {% endif %}
+          {%- if guidance.description -%}
+            <div class="mars">{{guidance.description|safe}}</div>
+          {% endif %}
+          {%- if guidance.list -%}
+            <ul class="mars">
+              {%- for item in guidance.list -%}
+                <li>{{item|safe}}</li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+        {% endfor %}
+      </div>
     </div>
   {% endif %}
 {% endset %}
@@ -82,6 +107,7 @@
         </legend>
 
         {{question_description|safe}}
+        {{question_guidance|safe}}
         {{question_answers|safe}}
 
       </fieldset>
@@ -90,6 +116,7 @@
 
       {{question_titles|safe}}
       {{question_description|safe}}
+      {{question_guidance|safe}}
       {{question_answers|safe}}
 
     {% endif %}

--- a/tests/integration/integration_test_case.py
+++ b/tests/integration/integration_test_case.py
@@ -14,7 +14,29 @@ class IntegrationTestCase(unittest.TestCase):
         self.application = create_app()
         self.client = self.application.test_client()
 
-    def tearDown(self):
+        # Clear storage before starting test
         storage = get_storage()
         storage.clear()
+
+    def tearDown(self):
+        # Clear storage after test ends
+        storage = get_storage()
+        storage.clear()
+
+    def postRedirectGet(self, url, post_data):
+        """
+        POSTs to the specified URL with post_data and performs a GET
+        with the URL from the re-direct, returning the re-direct URL and
+        response object.
+
+        :param url: the URL to POST to
+        :param post_data: the data to POST
+        :return: tuple of the re-direct URL and response object from the GET
+        """
+        resp = self.client.post(url, data=post_data, follow_redirects=False)
+        self.assertEquals(resp.status_code, 302)
+        resp_url = resp.headers['Location']
+        resp = self.client.get(resp_url, follow_redirects=False)
+        self.assertEquals(resp.status_code, 200)
+        return resp_url, resp
 

--- a/tests/integration/questionnaire/test_questionnaire_question_guidance.py
+++ b/tests/integration/questionnaire/test_questionnaire_question_guidance.py
@@ -1,0 +1,99 @@
+from tests.integration.create_token import create_token
+from tests.integration.integration_test_case import IntegrationTestCase
+
+
+class TestQuestionnaireQuestionGuidance(IntegrationTestCase):
+
+    def test_question_guidance(self):
+        # Given I launch a questionnaire with various guidance
+        token = create_token('question_guidance', 'test')
+
+        resp = self.client.get('/session?token=' + token.decode(), follow_redirects=False)
+
+        # When we navigate to the block with all guidance features enabled
+        resp_url, resp = self.postRedirectGet(resp.headers['Location'], {'action[start_questionnaire]': ''})
+
+        # Then we are presented with the question guidance with all features enabled
+        self.assertIn('block-test-guidance-all', resp_url)
+
+        content = resp.get_data(True)
+        self.assertIn('Test guidance all', content)
+        self.assertIn('>Include<', content)
+        self.assertIn('>Item Include 1<', content)
+        self.assertIn('>Item Include 2<', content)
+        self.assertIn('>Item Include 3<', content)
+        self.assertIn('>Item Include 4<', content)
+
+        self.assertIn('>Exclude<', content)
+        self.assertIn('>Item Exclude 1<', content)
+        self.assertIn('>Item Exclude 2<', content)
+        self.assertIn('>Item Exclude 3<', content)
+        self.assertIn('>Item Exclude 4<', content)
+
+        self.assertIn('>Other<', content)
+        self.assertIn('>Item Other 1<', content)
+        self.assertIn('>Item Other 2<', content)
+        self.assertIn('>Item Other 3<', content)
+        self.assertIn('>Item Other 4<', content)
+
+        self.assertIn('Guidance <b>include</b> description text', content)
+        self.assertIn('Guidance <b>exclude</b> description text', content)
+        self.assertIn('Guidance <b>other</b> description text', content)
+        self.assertIn('Text question', content)
+        self.assertIn('<input', content)
+
+        # When we continue to the next page with combinations of the guidance title
+        resp_url, resp = self.postRedirectGet(resp_url, {'action[save_continue]': ''})
+
+        # Then I am presented with the title guidance correctly
+        self.assertIn('block-test-guidance-title', resp_url)
+
+        content = resp.get_data(True)
+        self.assertIn('This one has a description but no list', content)
+        self.assertIn('No list items below this text', content)
+        self.assertIn('This one has no list or description', content)
+        self.assertIn('Text question', content)
+        self.assertIn('<input', content)
+
+        # When we continue to the next page with combinations of the guidance descriptions
+        resp_url, resp = self.postRedirectGet(resp_url, {'action[save_continue]': ''})
+
+        # Then I am presented with the description guidance correctly
+        self.assertIn('block-test-guidance-description', resp_url)
+
+        content = resp.get_data(True)
+        self.assertIn('No title above this text, list below', content)
+        self.assertIn('>Item Include 1<', content)
+        self.assertIn('>Item Include 2<', content)
+        self.assertIn('>Item Include 3<', content)
+        self.assertIn('>Item Include 4<', content)
+        self.assertIn('Just description, no title above this text, no list below', content)
+        self.assertIn('Text question', content)
+        self.assertIn('<input', content)
+
+        # When we continue to the next page with combinations of the guidance lists
+        resp_url, resp = self.postRedirectGet(resp_url, {'action[save_continue]': ''})
+
+        # Then I am presented with the lists guidance correctly
+        self.assertIn('block-test-guidance-lists', resp_url)
+
+        content = resp.get_data(True)
+        self.assertIn('Title, no description, list follows', content)
+        self.assertIn('>Item Include 1<', content)
+        self.assertIn('>Item Include 2<', content)
+        self.assertIn('>Item Include 3<', content)
+        self.assertIn('>Item Include 4<', content)
+        self.assertIn('>List with no title or description 1<', content)
+        self.assertIn('>List with no title or description 2<', content)
+        self.assertIn('>List with no title or description 3<', content)
+        self.assertIn('>List with no title or description 4<', content)
+        self.assertIn('Text question', content)
+        self.assertIn('<input', content)
+
+        # And I can continue to the summary page
+        resp_url, resp = self.postRedirectGet(resp_url, {'action[save_continue]': ''})
+        self.assertIn('summary', resp_url)
+
+        # And Submit my answers
+        resp_url, resp = self.postRedirectGet(resp_url, {'action[submit_answers]': ''})
+        self.assertIn('thank-you', resp_url)


### PR DESCRIPTION
### What is the context of this PR?
Trello card: https://trello.com/c/Gaqrltzr

Adding support for question guidance within questions as per the latest tested design prototypes
- See http://onsdigital.github.io/eq-prototypes/ukis/v3/section-11/ for example
- Or http://onsdigital.github.io/eq-prototypes/census-lite/v7/section-4/

<img width="620" alt="screen shot 2016-11-27 at 22 47 14" src="https://cloud.githubusercontent.com/assets/14041600/20652561/7a44c018-b4f3-11e6-8db4-e18f937d2dd2.png">

<img width="655" alt="screen shot 2016-11-27 at 22 46 58" src="https://cloud.githubusercontent.com/assets/14041600/20652563/7df69164-b4f3-11e6-9eaf-15cdbf9c8128.png">

Guidance is attached to questions and can contain optional titles, descriptions and bullet lists of items to show. Multiple guidance elements are allowed per question (they stack below each other).

Here's an example of the JSON to add gudiance to a question object:

```Javascript
"guidance": [
    {
        "title": "Include",
        "description": "<p>Guidance <b>include</b> description text</p>",
        "list": [
            "Item Include 1",
            "Item Include 2",
            "Item Include 3",
            "Item Include 4"
        ]
    },
    {
        "title": "Exclude",
        "description": "<p>Guidance <b>exclude</b> description text</p>",
        "list": [
            "Item Exclude 1",
            "Item Exclude 2",
            "Item Exclude 3",
            "Item Exclude 4"
        ]
    }
```

The general approach (in the schema) was agreed with @ajmaddaford and @hamishtaplin.

### Help needed
This PR needs help on the selenium test, see the strawman approach, is this the right way to go? Should we be checking raw HTML in the test like this?

The frontend changes and SCSS need a FEer to review; noting that the existing alert style used a 90% hint to handle the background, which didn't match the actual approach to the design, so I've added a default to use 90% and the ability to override the alert background if needed (and used that here).

The Census theme hasn't been updated to include the guidance style; it's not clear how best to do this looking at the existing theme (maybe wait for Census Header, Footer & Landing Page Design (8) card?), discuss with @hamishtaplin.

Finally the schemas in #580 will need updating (after that merges) to break out the include/exclude lists etc.

### How to review 
- Run the `test_question_guidance.json` schema to see various examples of question guidance.
- Run each of the existing business surveys schemas (0102, 0112, 0215 etc.) and verify the guidance have been applied correctly.
- Review the schema approach taken and names of elements used, are they acceptable?
- Review the frontend changes to the question.html
- Review the SCSS changes