### PR TITLE
If no routing rules match then continue to evaluate path

### DIFF
--- a/app/questionnaire/navigator.py
+++ b/app/questionnaire/navigator.py
@@ -145,7 +145,7 @@ class Navigator:
                     return self.build_path(blocks, group_id, group_instance, rule['goto']['id'], path)
 
         # If this isn't the last block in the set evaluated
-        elif block_id_index != len(blocks) - 1:
+        if block_id_index != len(blocks) - 1:
             next_block_id = blocks[block_id_index + 1]['block']['id']
             next_group_id = blocks[block_id_index + 1]['group_id']
             next_group_instance = blocks[block_id_index + 1]['group_instance']


### PR DESCRIPTION
### What is the context of this PR?
Fixes #601 and Fixes #602

When routing rules are defined but none of them match, we should continue to evaluate the path.

### How to review 
Re-test raised issues.
