### PR TITLE
Workaround for bug in Travis CI release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 sudo: required
 dist: trusty
+# Workaround for https://github.com/travis-ci/travis-ci/issues/6928#issuecomment-264227708
+group: deprecated
 python: '3.5'
 env:
     global:


### PR DESCRIPTION
### What is the context of this PR?
Selenium section of the travis build is failing due to a bug introduced
into the latest travis release.

Suggestions on an open issue relating to openjdk8 having issues link to
using `group: deprecated` to fix the issue

[Bug report](travis-ci/travis-ci#6928 (comment))

### How to review 
Selenium tests should pass