### PR TITLE
Add multiple repeating answers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ cache:
   - $HOME/.yarn-cache
 install:
 - . $HOME/.nvm/nvm.sh
+- export NVM_NODEJS_ORG_MIRROR=https://npm.taobao.org/mirrors/node
 - nvm install v6.9.1
 - pip install -U pip wheel
 - pip install --require-hashes -r requirements.txt

--- a/app/assets/styles/partials/components/_question.scss
+++ b/app/assets/styles/partials/components/_question.scss
@@ -81,3 +81,12 @@
     margin-bottom: 0;
   }
 }
+
+.question--repeatinganswer {
+  .question__answer {
+    margin-bottom: 2rem;
+  }
+  .answer {
+    margin-bottom: 0.5rem;
+  }
+}

--- a/app/data/census_household.json
+++ b/app/data/census_household.json
@@ -183,11 +183,28 @@
                                     "type": "RepeatingAnswer",
                                     "answers": [
                                         {
-                                            "id": "household-full-name",
-                                            "alias": "person_full_name",
+                                            "alias": "first_name",
+                                            "id": "first-name",
+                                            "label": "First Name",
                                             "mandatory": false,
                                             "q_code": "20",
-                                            "type": "TextField"
+                                            "type": "Textfield"
+                                        },
+                                        {
+                                            "alias": "middle_names",
+                                            "id": "middle-names",
+                                            "label": "Middle Names",
+                                            "mandatory": false,
+                                            "q_code": "20",
+                                            "type": "Textfield"
+                                        },
+                                        {
+                                            "alias": "last_name",
+                                            "id": "last-name",
+                                            "label": "Last Name",
+                                            "mandatory": false,
+                                            "q_code": "20",
+                                            "type": "Textfield"
                                         }
                                     ]
                                 }
@@ -315,7 +332,7 @@
                 {
                     "repeat": {
                         "type": "answer_count_minus_one",
-                        "answer_id": "household-full-name"
+                        "answer_id": "first-name"
                     }
                 }
             ],
@@ -911,17 +928,18 @@
                 {
                     "type": "interstitial",
                     "id": "household-member-begin",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "household member begin",
                     "sections": [
                         {
-                            "title": "{{ answers.person_full_name[group_instance] }}",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "id": "household-member-begin-section",
                             "number": "1",
                             "questions": [
                                 {
                                     "id": "household-member-begin-question",
-                                    "title": "The following questions are for:",
                                     "number": "1",
+                                    "title": "The following questions are for:",
+                                    "description": "<div style='background-color: #efefef; padding: .7em; display: inline-block; border: 2px solid #ccc; font-weight: bold;'>{{ [answers.first_name[group_instance], answers.middle_names[group_instance], answers.last_name[group_instance]] | format_household_name }}</div>",
                                     "type": "General",
                                     "answers": []
                                 }
@@ -931,12 +949,12 @@
                 },
                 {
                     "id": "details-correct",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "details correct",
                     "sections": [
                         {
                             "id": "details-correct-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "1",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "details-correct-display-name",
@@ -991,12 +1009,12 @@
                 },
                 {
                     "id": "correct-name",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "correct name",
                     "sections": [
                         {
                             "id": "correct-name-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "1",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "correct-name-question",
@@ -1018,12 +1036,12 @@
                 },
                 {
                     "id": "sex",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "sex",
                     "sections": [
                         {
                             "id": "sex-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "2",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "sex-question",
@@ -1055,12 +1073,12 @@
                 },
                 {
                     "id": "date-of-birth",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "date of birth",
                     "sections": [
                         {
                             "id": "date-of-birth-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "3",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "date-of-birth-question",
@@ -1083,12 +1101,12 @@
                 },
                 {
                     "id": "over-16",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "over 16",
                     "sections": [
                         {
                             "id": "over-16-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "3",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "over-16-question",
@@ -1120,12 +1138,12 @@
                 },
                 {
                     "id": "marital-status",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "marital status",
                     "sections": [
                         {
                             "id": "marital-status-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "4",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "marital-status-question",
@@ -1185,12 +1203,12 @@
                 },
                 {
                     "id": "another-address",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "another address",
                     "sections": [
                         {
                             "id": "another-address-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "5",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "another-address-question",
@@ -1266,12 +1284,12 @@
                 },
                 {
                     "id": "other-address",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "other address",
                     "sections": [
                         {
                             "id": "other-address-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "5",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "other-address-question",
@@ -1322,12 +1340,12 @@
                 },
                 {
                     "id": "address-type",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "address type",
                     "sections": [
                         {
                             "id": "address-type-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "6",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "address-type-question",
@@ -1382,12 +1400,12 @@
                 },
                 {
                     "id": "in-education",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "in education",
                     "sections": [
                         {
                             "id": "in-education-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "7",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "in-education-question",
@@ -1436,12 +1454,12 @@
                 },
                 {
                     "id": "term-time-location",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "term-time location",
                     "sections": [
                         {
                             "id": "term-time-location-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "8",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "term-time-location-question",
@@ -1490,12 +1508,12 @@
                 },
                 {
                     "id": "country-of-birth",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "country of birth",
                     "sections": [
                         {
                             "id": "country-of-birth-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "9",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "country-of-birth-england-question",
@@ -1690,12 +1708,12 @@
                 },
                 {
                     "id": "arrive-in-uk",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "arrive in uk",
                     "sections": [
                         {
                             "id": "arrive-in-uk-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "10",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "arrive-in-uk-question",
@@ -1722,12 +1740,12 @@
                 },
                 {
                     "id": "length-of-stay",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "length of stay",
                     "sections": [
                         {
                             "id": "length-of-stay-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "11",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "length-of-stay-question",
@@ -1763,12 +1781,12 @@
                 },
                 {
                     "id": "carer",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "carer",
                     "sections": [
                         {
                             "id": "carer-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "12",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "carer-question",
@@ -1814,12 +1832,12 @@
                 },
                 {
                     "id": "national-identity",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "national identity",
                     "sections": [
                         {
                             "id": "national-identity-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "13",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "national-identity-question",
@@ -1871,12 +1889,12 @@
                 },
                 {
                     "id": "ethnic-group",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "ethnic group",
                     "sections": [
                         {
                             "id": "ethnic-group-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "14",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "ethnic-group-question",
@@ -1992,12 +2010,12 @@
                 },
                 {
                     "id": "white-ethnic-group",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "white ethnic group",
                     "sections": [
                         {
                             "id": "white-ethnic-group-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "14",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "white-ethnic-group-question",
@@ -2057,12 +2075,12 @@
                 },
                 {
                     "id": "mixed-ethnic-group",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "mixed ethnic group",
                     "sections": [
                         {
                             "id": "mixed-ethnic-group-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "14",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "mixed-ethnic-group-question",
@@ -2122,12 +2140,12 @@
                 },
                 {
                     "id": "asian-ethnic-group",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "asian ethnic group",
                     "sections": [
                         {
                             "id": "asian-ethnic-group-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "14",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "asian-ethnic-group-question",
@@ -2191,12 +2209,12 @@
                 },
                 {
                     "id": "black-ethnic-group",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "black ethnic group",
                     "sections": [
                         {
                             "id": "black-ethnic-group-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "14",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "black-ethnic-group-question",
@@ -2252,12 +2270,12 @@
                 },
                 {
                     "id": "other-ethnic-group",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "other ethnic group",
                     "sections": [
                         {
                             "id": "other-ethnic-group-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "14",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "other-ethnic-group-question",
@@ -2309,12 +2327,12 @@
                 },
                 {
                     "id": "sexual-identity",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "sexual identity",
                     "sections": [
                         {
                             "id": "sexual-identity-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "15",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "sexual-identity-question",
@@ -2358,12 +2376,12 @@
                 },
                 {
                     "id": "understand-welsh",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "understand welsh",
                     "sections": [
                         {
                             "id": "understand-welsh-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "16",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "understand-welsh-question",
@@ -2408,12 +2426,12 @@
                 },
                 {
                     "id": "language",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "language",
                     "sections": [
                         {
                             "id": "language-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "17",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "language-question",
@@ -2518,12 +2536,12 @@
                 },
                 {
                     "id": "english",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "english",
                     "sections": [
                         {
                             "id": "english-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "18",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "english-question",
@@ -2563,12 +2581,12 @@
                 },
                 {
                     "id": "religion",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "religion",
                     "sections": [
                         {
                             "id": "religion-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "19",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "religion-question",
@@ -2692,12 +2710,12 @@
                 },
                 {
                     "id": "past-usual-address",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "past usual address",
                     "sections": [
                         {
                             "id": "past-usual-address-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "20",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "past-usual-address-question",
@@ -2767,12 +2785,12 @@
                 },
                 {
                     "id": "last-year-address",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "last year address",
                     "sections": [
                         {
                             "id": "last-year-address-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "21",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "last-year-address-question",
@@ -2823,12 +2841,12 @@
                 },
                 {
                     "id": "passports",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "passports",
                     "sections": [
                         {
                             "id": "passports-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "22",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "passports-question",
@@ -2871,12 +2889,12 @@
                 },
                 {
                     "id": "disability",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "disability",
                     "sections": [
                         {
                             "id": "disability-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "23",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "disability-question",
@@ -2917,12 +2935,12 @@
                 },
                 {
                     "id": "qualifications",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "qualifications",
                     "sections": [
                         {
                             "id": "qualifications-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "24",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "qualifications-question",
@@ -3106,12 +3124,12 @@
                 },
                 {
                     "id": "volunteering",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "volunteering",
                     "sections": [
                         {
                             "id": "volunteering-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "25",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "volunteering-question",
@@ -3156,12 +3174,12 @@
                 },
                 {
                     "id": "employment-type",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "employment type",
                     "sections": [
                         {
                             "id": "employment-type-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "26",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "employment-type-question",
@@ -3286,12 +3304,12 @@
                 },
                 {
                     "id": "jobseeker",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "jobseeker",
                     "sections": [
                         {
                             "id": "jobseeker-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "27",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "jobseeker-question",
@@ -3323,12 +3341,12 @@
                 },
                 {
                     "id": "job-availability",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "job availability",
                     "sections": [
                         {
                             "id": "job-availability-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "28",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "job-availability-question",
@@ -3360,12 +3378,12 @@
                 },
                 {
                     "id": "job-pending",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "job pending",
                     "sections": [
                         {
                             "id": "job-pending-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "29",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "job-pending-question",
@@ -3397,12 +3415,12 @@
                 },
                 {
                     "id": "occupation",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "occupation",
                     "sections": [
                         {
                             "id": "occupation-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "30",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "occupation-question",
@@ -3447,12 +3465,12 @@
                 },
                 {
                     "id": "ever-worked",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "ever worked",
                     "sections": [
                         {
                             "id": "ever-worked-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "31",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "ever-worked-question",
@@ -3484,12 +3502,12 @@
                 },
                 {
                     "id": "main-job",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "main job",
                     "sections": [
                         {
                             "id": "main-job-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "32",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "main-job-question",
@@ -3530,12 +3548,12 @@
                 },
                 {
                     "id": "job-title",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "job title",
                     "sections": [
                         {
                             "id": "job-title-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "33",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "job-title-question",
@@ -3563,12 +3581,12 @@
                 },
                 {
                     "id": "job-description",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "job description",
                     "sections": [
                         {
                             "id": "job-description-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "34",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "job-description-question",
@@ -3591,12 +3609,12 @@
                 },
                 {
                     "id": "employers-business",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "employers business",
                     "sections": [
                         {
                             "id": "employers-business-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "35",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "employers-business-question",
@@ -3628,12 +3646,12 @@
                 },
                 {
                     "id": "main-job-type",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "main job type",
                     "sections": [
                         {
                             "id": "main-job-type-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "36",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "main-job-type-question",
@@ -3687,12 +3705,12 @@
                 },
                 {
                     "id": "business-name",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "business name",
                     "sections": [
                         {
                             "id": "business-name-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "36",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "business-name-question",
@@ -3824,12 +3842,12 @@
                 },
                 {
                     "id": "visitor-sex",
-                    "title": "{{ answers.person_full_name[group_instance] }}",
+                    "title": "visitor sex",
                     "sections": [
                         {
                             "id": "visitor-sex-section",
-                            "title": "{{ answers.person_full_name[group_instance] }}",
                             "number": "2",
+                            "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "visitor-sex-question",

--- a/app/data/census_household.json
+++ b/app/data/census_household.json
@@ -920,7 +920,7 @@
                 {
                     "repeat": {
                         "type": "answer_count",
-                        "answer_id": "household-full-name"
+                        "answer_id": "first-name"
                     }
                 }
             ],
@@ -928,7 +928,7 @@
                 {
                     "type": "interstitial",
                     "id": "household-member-begin",
-                    "title": "household member begin",
+                    "title": "Household Member Begin",
                     "sections": [
                         {
                             "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
@@ -938,8 +938,7 @@
                                 {
                                     "id": "household-member-begin-question",
                                     "number": "1",
-                                    "title": "The following questions are for:",
-                                    "description": "<div style='background-color: #efefef; padding: .7em; display: inline-block; border: 2px solid #ccc; font-weight: bold;'>{{ [answers.first_name[group_instance], answers.middle_names[group_instance], answers.last_name[group_instance]] | format_household_name }}</div>",
+                                    "title": "The following questions are for {{ [answers.first_name[group_instance], answers.middle_names[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                                     "type": "General",
                                     "answers": []
                                 }
@@ -958,7 +957,7 @@
                             "questions": [
                                 {
                                     "id": "details-correct-display-name",
-                                    "title": "The following questions are for:",
+                                    "title": "The following questions are for {{ [answers.first_name[group_instance], answers.middle_names[group_instance], answers.last_name[group_instance]] | format_household_name }}:",
                                     "type": "General",
                                     "answers": []
                                 },

--- a/app/data/census_household.json
+++ b/app/data/census_household.json
@@ -188,7 +188,7 @@
                                             "label": "First Name",
                                             "mandatory": false,
                                             "q_code": "20",
-                                            "type": "Textfield"
+                                            "type": "TextField"
                                         },
                                         {
                                             "alias": "middle_names",
@@ -196,7 +196,7 @@
                                             "label": "Middle Names",
                                             "mandatory": false,
                                             "q_code": "20",
-                                            "type": "Textfield"
+                                            "type": "TextField"
                                         },
                                         {
                                             "alias": "last_name",
@@ -204,7 +204,7 @@
                                             "label": "Last Name",
                                             "mandatory": false,
                                             "q_code": "20",
-                                            "type": "Textfield"
+                                            "type": "TextField"
                                         }
                                     ]
                                 }

--- a/app/data/census_individual.json
+++ b/app/data/census_individual.json
@@ -34,7 +34,7 @@
                                             "label": "First Name",
                                             "mandatory": false,
                                             "q_code": "20",
-                                            "type": "Textfield"
+                                            "type": "TextField"
                                         },
                                         {
                                             "alias": "middle_names",
@@ -42,7 +42,7 @@
                                             "label": "Middle Names",
                                             "mandatory": false,
                                             "q_code": "20",
-                                            "type": "Textfield"
+                                            "type": "TextField"
                                         },
                                         {
                                             "alias": "last_name",
@@ -50,7 +50,7 @@
                                             "label": "Last Name",
                                             "mandatory": false,
                                             "q_code": "20",
-                                            "type": "Textfield"
+                                            "type": "TextField"
                                         }
                                     ]
                                 }

--- a/app/data/census_individual.json
+++ b/app/data/census_individual.json
@@ -29,11 +29,28 @@
                                     "type": "General",
                                     "answers": [
                                         {
-                                            "id": "correct-name-answer",
+                                            "alias": "first_name",
+                                            "id": "first-name",
+                                            "label": "First Name",
                                             "mandatory": false,
                                             "q_code": "20",
-                                            "type": "TextField",
-                                            "alias": "person_full_name"
+                                            "type": "Textfield"
+                                        },
+                                        {
+                                            "alias": "middle_names",
+                                            "id": "middle-names",
+                                            "label": "Middle Names",
+                                            "mandatory": false,
+                                            "q_code": "20",
+                                            "type": "Textfield"
+                                        },
+                                        {
+                                            "alias": "last_name",
+                                            "id": "last-name",
+                                            "label": "Last Name",
+                                            "mandatory": false,
+                                            "q_code": "20",
+                                            "type": "Textfield"
                                         }
                                     ]
                                 }
@@ -47,8 +64,8 @@
                     "sections": [
                         {
                             "id": "sex-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "2",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "sex-question",
@@ -84,8 +101,8 @@
                     "sections": [
                         {
                             "id": "date-of-birth-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "3",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "date-of-birth-question",
@@ -112,8 +129,8 @@
                     "sections": [
                         {
                             "id": "over-16-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "3",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "over-16-question",
@@ -149,8 +166,8 @@
                     "sections": [
                         {
                             "id": "marital-status-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "4",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "marital-status-question",
@@ -214,8 +231,8 @@
                     "sections": [
                         {
                             "id": "another-address-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "5",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "another-address-question",
@@ -285,8 +302,8 @@
                     "sections": [
                         {
                             "id": "other-address-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "5",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "other-address-question",
@@ -341,8 +358,8 @@
                     "sections": [
                         {
                             "id": "address-type-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "6",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "address-type-question",
@@ -401,8 +418,8 @@
                     "sections": [
                         {
                             "id": "in-education-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "7",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "in-education-question",
@@ -455,8 +472,8 @@
                     "sections": [
                         {
                             "id": "term-time-location-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "8",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "term-time-location-question",
@@ -509,8 +526,8 @@
                     "sections": [
                         {
                             "id": "country-of-birth-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "9",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "country-of-birth-england-question",
@@ -709,8 +726,8 @@
                     "sections": [
                         {
                             "id": "arrive-in-uk-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "10",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "arrive-in-uk-question",
@@ -742,8 +759,8 @@
                     "sections": [
                         {
                             "id": "length-of-stay-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "11",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "length-of-stay-question",
@@ -783,8 +800,8 @@
                     "sections": [
                         {
                             "id": "carer-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "12",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "carer-question",
@@ -834,8 +851,8 @@
                     "sections": [
                         {
                             "id": "national-identity-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "13",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "national-identity-question",
@@ -891,8 +908,8 @@
                     "sections": [
                         {
                             "id": "ethnic-group-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "14",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "ethnic-group-question",
@@ -1002,8 +1019,8 @@
                     "sections": [
                         {
                             "id": "white-ethnic-group-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "14",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "white-ethnic-group-question",
@@ -1077,8 +1094,8 @@
                     "sections": [
                         {
                             "id": "mixed-ethnic-group-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "14",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "mixed-ethnic-group-question",
@@ -1152,8 +1169,8 @@
                     "sections": [
                         {
                             "id": "asian-ethnic-group-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "14",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "asian-ethnic-group-question",
@@ -1231,8 +1248,8 @@
                     "sections": [
                         {
                             "id": "black-ethnic-group-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "14",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "black-ethnic-group-question",
@@ -1302,8 +1319,8 @@
                     "sections": [
                         {
                             "id": "other-ethnic-group-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "14",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "other-ethnic-group-question",
@@ -1369,8 +1386,8 @@
                     "sections": [
                         {
                             "id": "sexual-identity-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "15",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "sexual-identity-question",
@@ -1418,8 +1435,8 @@
                     "sections": [
                         {
                             "id": "understand-welsh-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "16",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "understand-welsh-question",
@@ -1468,8 +1485,8 @@
                     "sections": [
                         {
                             "id": "language-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "17",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "language-question",
@@ -1578,8 +1595,8 @@
                     "sections": [
                         {
                             "id": "english-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "18",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "english-question",
@@ -1623,8 +1640,8 @@
                     "sections": [
                         {
                             "id": "religion-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "19",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "religion-question",
@@ -1752,8 +1769,8 @@
                     "sections": [
                         {
                             "id": "past-usual-address-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "20",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "past-usual-address-question",
@@ -1827,8 +1844,8 @@
                     "sections": [
                         {
                             "id": "last-year-address-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "21",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "last-year-address-question",
@@ -1883,8 +1900,8 @@
                     "sections": [
                         {
                             "id": "passports-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "22",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "passports-question",
@@ -1931,8 +1948,8 @@
                     "sections": [
                         {
                             "id": "disability-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "23",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "disability-question",
@@ -1977,8 +1994,8 @@
                     "sections": [
                         {
                             "id": "qualifications-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "24",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "qualifications-question",
@@ -2166,8 +2183,8 @@
                     "sections": [
                         {
                             "id": "volunteering-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "25",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "volunteering-question",
@@ -2216,8 +2233,8 @@
                     "sections": [
                         {
                             "id": "employment-type-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "26",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "employment-type-question",
@@ -2296,8 +2313,8 @@
                     "sections": [
                         {
                             "id": "jobseeker-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "27",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "jobseeker-question",
@@ -2333,8 +2350,8 @@
                     "sections": [
                         {
                             "id": "job-availability-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "28",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "job-availability-question",
@@ -2370,8 +2387,8 @@
                     "sections": [
                         {
                             "id": "job-pending-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "29",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "job-pending-question",
@@ -2407,8 +2424,8 @@
                     "sections": [
                         {
                             "id": "occupation-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "30",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "occupation-question",
@@ -2457,8 +2474,8 @@
                     "sections": [
                         {
                             "id": "ever-worked-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "31",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "ever-worked-question",
@@ -2494,8 +2511,8 @@
                     "sections": [
                         {
                             "id": "main-job-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "32",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "main-job-question",
@@ -2536,8 +2553,8 @@
                     "sections": [
                         {
                             "id": "job-title-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "33",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "job-title-question",
@@ -2565,8 +2582,8 @@
                     "sections": [
                         {
                             "id": "job-description-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "34",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "job-description-question",
@@ -2593,8 +2610,8 @@
                     "sections": [
                         {
                             "id": "employers-business-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "35",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "employers-business-question",
@@ -2622,8 +2639,8 @@
                     "sections": [
                         {
                             "id": "main-job-type-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "36",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "main-job-type-question",
@@ -2681,8 +2698,8 @@
                     "sections": [
                         {
                             "id": "business-name-section",
-                            "title": "{{ answers.person_full_name }}",
                             "number": "36",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
                             "questions": [
                                 {
                                     "id": "business-name-question",

--- a/app/data/test_household_question.json
+++ b/app/data/test_household_question.json
@@ -49,7 +49,7 @@
                                         "mandatory": false,
                                         "options": [],
                                         "q_code": "1",
-                                        "type": "Textfield",
+                                        "type": "TextField",
                                         "validation": {}
                                     },
                                     {
@@ -59,7 +59,7 @@
                                         "mandatory": false,
                                         "options": [],
                                         "q_code": "1",
-                                        "type": "Textfield",
+                                        "type": "TextField",
                                         "validation": {}
                                     },
                                     {

--- a/app/data/test_household_question.json
+++ b/app/data/test_household_question.json
@@ -44,9 +44,29 @@
                                   "answers": [
                                     {
                                         "display": {},
-                                        "id": "household-full-name",
-                                        "label": "Full Name",
-                                        "mandatory": true,
+                                        "id": "first-name",
+                                        "label": "First Name",
+                                        "mandatory": false,
+                                        "options": [],
+                                        "q_code": "1",
+                                        "type": "Textfield",
+                                        "validation": {}
+                                    },
+                                    {
+                                        "display": {},
+                                        "id": "middle-names",
+                                        "label": "Middle Names",
+                                        "mandatory": false,
+                                        "options": [],
+                                        "q_code": "1",
+                                        "type": "Textfield",
+                                        "validation": {}
+                                    },
+                                    {
+                                        "display": {},
+                                        "id": "last-name",
+                                        "label": "Last Name",
+                                        "mandatory": false,
                                         "options": [],
                                         "q_code": "1",
                                         "type": "TextField",

--- a/app/data/test_relationship_household.json
+++ b/app/data/test_relationship_household.json
@@ -37,8 +37,28 @@
                                   "answers": [
                                     {
                                         "display": {},
-                                        "id": "household-full-name",
-                                        "label": "Full Name",
+                                        "id": "first-name",
+                                        "label": "First Name",
+                                        "mandatory": false,
+                                        "options": [],
+                                        "q_code": "1",
+                                        "type": "Textfield",
+                                        "validation": {}
+                                    },
+                                    {
+                                        "display": {},
+                                        "id": "middle-names",
+                                        "label": "Middle Names",
+                                        "mandatory": false,
+                                        "options": [],
+                                        "q_code": "1",
+                                        "type": "Textfield",
+                                        "validation": {}
+                                    },
+                                    {
+                                        "display": {},
+                                        "id": "last-name",
+                                        "label": "Last Name",
                                         "mandatory": false,
                                         "options": [],
                                         "q_code": "1",
@@ -60,7 +80,7 @@
                 {
                     "repeat": {
                         "type": "answer_count_minus_one",
-                        "answer_id": "household-full-name"
+                        "answer_id": "first-name"
                     }
                 }
             ],

--- a/app/data/test_relationship_household.json
+++ b/app/data/test_relationship_household.json
@@ -42,7 +42,7 @@
                                         "mandatory": false,
                                         "options": [],
                                         "q_code": "1",
-                                        "type": "Textfield",
+                                        "type": "TextField",
                                         "validation": {}
                                     },
                                     {
@@ -52,7 +52,7 @@
                                         "mandatory": false,
                                         "options": [],
                                         "q_code": "1",
-                                        "type": "Textfield",
+                                        "type": "TextField",
                                         "validation": {}
                                     },
                                     {

--- a/app/data/test_repeating_household.json
+++ b/app/data/test_repeating_household.json
@@ -56,7 +56,7 @@
                                         "mandatory": false,
                                         "options": [],
                                         "q_code": "1",
-                                        "type": "Textfield",
+                                        "type": "TextField",
                                         "validation": {}
                                     },
                                     {
@@ -67,7 +67,7 @@
                                         "mandatory": false,
                                         "options": [],
                                         "q_code": "1",
-                                        "type": "Textfield",
+                                        "type": "TextField",
                                         "validation": {}
                                     }
                                   ]

--- a/app/data/test_repeating_household.json
+++ b/app/data/test_repeating_household.json
@@ -38,16 +38,37 @@
                                   "validation": [],
                                   "answers": [
                                     {
-                                        "alias": "person_full_name",
+                                        "alias": "first_name",
                                         "display": {},
-                                        "id": "household-full-name",
-                                        "label": "Full Name",
-                                        "mandatory": true,
+                                        "id": "first-name",
+                                        "label": "First Name",
+                                        "mandatory": false,
                                         "options": [],
                                         "q_code": "1",
                                         "type": "TextField",
-                                        "validation": {},
-                                        "repeats": true
+                                        "validation": {}
+                                    },
+                                    {
+                                        "alias": "middle_names",
+                                        "display": {},
+                                        "id": "middle-names",
+                                        "label": "Middle Names",
+                                        "mandatory": false,
+                                        "options": [],
+                                        "q_code": "1",
+                                        "type": "Textfield",
+                                        "validation": {}
+                                    },
+                                    {
+                                        "alias": "last_name",
+                                        "display": {},
+                                        "id": "last-name",
+                                        "label": "Last Name",
+                                        "mandatory": false,
+                                        "options": [],
+                                        "q_code": "1",
+                                        "type": "Textfield",
+                                        "validation": {}
                                     }
                                   ]
 
@@ -72,8 +93,8 @@
             "id": "repeating-block-1",
             "title": "Block 2",
             "sections": [{
-                "title": "{{answers.person_full_name[group_instance]}}",
-                "description": "",
+                "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                "description": "This question is for {{ [answers.first_name[group_instance], answers.middle_names[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                 "id": "91631df0-4356-4e9f-a9d9-ce8b08d26eb3",
                 "questions": [{
                     "id": "c1d9976e-d031-4fab-96fc-1d37d4a8b86b",
@@ -99,7 +120,7 @@
             "id": "repeating-block-2",
             "title": "Block 3",
             "sections": [{
-                "title": "{{answers.person_full_name[group_instance]}}",
+                "title": "{{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
                 "description": "",
                 "id": "2e0989b8-5185-4ba6-b73f-c126e3a06ba7",
                 "questions": [{
@@ -128,7 +149,7 @@
         "routing_rules": [{
             "repeat": {
                 "type": "answer_count",
-                "answer_id": "household-full-name"
+                "answer_id": "first-name"
             }
         }]
     }]

--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -49,3 +49,8 @@ def format_str_as_month_year_date(value):
 @blueprint.app_template_filter()
 def format_str_as_date(value):
     return format_str_as_short_date(value)
+
+
+@blueprint.app_template_filter()
+def format_household_member_name(names):
+    return ' '.join(map(lambda name: name.strip(), filter(None, names)))

--- a/app/main/views/questionnaire.py
+++ b/app/main/views/questionnaire.py
@@ -250,7 +250,7 @@ def post_household_composition(eq_id, form_type, collection_id, group_id):
         return get_block(eq_id, form_type, collection_id, group_id, 0, 'household-composition')
 
     elif 'action[remove_answer]' in request.form:
-        index_to_remove = request.form.get('action[remove_answer]')
+        index_to_remove = int(request.form.get('action[remove_answer]'))
         questionnaire_manager.remove_answer(this_block, answer_store, index_to_remove)
         return get_block(eq_id, form_type, collection_id, group_id, 0, 'household-composition')
 

--- a/app/questionnaire/questionnaire_manager.py
+++ b/app/questionnaire/questionnaire_manager.py
@@ -149,9 +149,12 @@ class QuestionnaireManager(object):
         return next_answer_instance_id
 
     def remove_answer(self, location, answer_store, index_to_remove):
-        answer = self.state.get_answers()[int(index_to_remove)]
-        question = answer.parent
-        question.remove_answer(answer)
 
-        answer_store.remove(answer.flatten())
+        state_answers = self.state.get_answers()
+        for state_answer in state_answers:
+            if state_answer.answer_instance == index_to_remove:
+                question = state_answer.parent
+                question.remove_answer(state_answer)
+                answer_store.remove(state_answer.flatten())
+
         self.update_questionnaire_store(location)

--- a/app/questionnaire_state/relationship_state_question.py
+++ b/app/questionnaire_state/relationship_state_question.py
@@ -1,4 +1,5 @@
 from app.globals import get_answer_store
+from app.jinja_filters import format_household_member_name
 from app.questionnaire_state.state_repeating_answer_question import RepeatingAnswerStateQuestion
 
 from flask_login import current_user
@@ -11,13 +12,26 @@ class RelationshipStateQuestion(RepeatingAnswerStateQuestion):
     def build_repeating_state(self, user_input):
         template_answer = self.answers.pop()
         group_instance = template_answer.group_instance
-        household_answers = get_answer_store(current_user).filter(answer_id='household-full-name')
-        sorted(household_answers, key=lambda household_answer: household_answer['answer_instance'])
-        remaining_answers = household_answers[group_instance + 1:] if self.group_instance < len(household_answers) else []
+        first_names = get_answer_store(current_user).filter(answer_id='first-name')
+        last_names = get_answer_store(current_user).filter(answer_id='last-name')
+
+        household_answers = list(zip(first_names, last_names))
+        remaining_answers = list(zip(first_names[group_instance + 1:], last_names[group_instance + 1:])) \
+            if self.group_instance < len(household_answers) else []
 
         for index, answer in enumerate(remaining_answers):
             for answer_schema in self.schema_item.answers:
                 new_answer_state = self.create_new_answer_state(answer_schema, index, group_instance)
-                new_answer_state.schema_item.widget.current_person = household_answers[group_instance]['value']
-                new_answer_state.schema_item.widget.other_person = answer['value']
+
+                current_person_name = format_household_member_name([
+                    household_answers[group_instance][0]['value'],
+                    household_answers[group_instance][1]['value'],
+                ])
+                new_answer_state.schema_item.widget.current_person = current_person_name
+
+                other_person_name = format_household_member_name([
+                    answer[0]['value'],
+                    answer[1]['value'],
+                ])
+                new_answer_state.schema_item.widget.other_person = other_person_name
                 self.answers.append(new_answer_state)

--- a/app/questionnaire_state/relationship_state_question.py
+++ b/app/questionnaire_state/relationship_state_question.py
@@ -12,26 +12,36 @@ class RelationshipStateQuestion(RepeatingAnswerStateQuestion):
     def build_repeating_state(self, user_input):
         template_answer = self.answers.pop()
         group_instance = template_answer.group_instance
-        first_names = get_answer_store(current_user).filter(answer_id='first-name')
-        last_names = get_answer_store(current_user).filter(answer_id='last-name')
 
-        household_answers = list(zip(first_names, last_names))
-        remaining_answers = list(zip(first_names[group_instance + 1:], last_names[group_instance + 1:])) \
-            if self.group_instance < len(household_answers) else []
+        first_name_answers = get_answer_store(current_user).filter(answer_id='first-name')
+        last_name_answers = get_answer_store(current_user).filter(answer_id='last-name')
 
-        for index, answer in enumerate(remaining_answers):
+        first_names = [answer['value'] for answer in first_name_answers]
+        last_names = [answer['value'] for answer in last_name_answers]
+
+        household_members = []
+        for first_name, last_name in zip(first_names, last_names):
+            household_members.append({
+                'first-name': first_name,
+                'last-name': last_name,
+            })
+
+        remaining_people = household_members[group_instance + 1:] if self.group_instance < len(household_members) else []
+
+        current_person_name = format_household_member_name([
+            household_members[group_instance]['first-name'],
+            household_members[group_instance]['last-name'],
+        ])
+
+        for index, remaining_person in enumerate(remaining_people):
             for answer_schema in self.schema_item.answers:
                 new_answer_state = self.create_new_answer_state(answer_schema, index, group_instance)
 
-                current_person_name = format_household_member_name([
-                    household_answers[group_instance][0]['value'],
-                    household_answers[group_instance][1]['value'],
-                ])
                 new_answer_state.schema_item.widget.current_person = current_person_name
 
                 other_person_name = format_household_member_name([
-                    answer[0]['value'],
-                    answer[1]['value'],
+                    remaining_person['first-name'],
+                    remaining_person['last-name'],
                 ])
                 new_answer_state.schema_item.widget.other_person = other_person_name
                 self.answers.append(new_answer_state)

--- a/app/questionnaire_state/state_repeating_answer_question.py
+++ b/app/questionnaire_state/state_repeating_answer_question.py
@@ -53,18 +53,18 @@ class RepeatingAnswerStateQuestion(StateQuestion):
         :return: A list of lists containing the answers grouped by answer_instance.
         """
 
-        answers_by_id = defaultdict(list)
-        for answer in self.answers:
-            answers_by_id[answer.id].append(answer)
+        answer_states_by_id = defaultdict(list)
+        for answer_state in self.answers:
+            answer_states_by_id[answer_state.id].append(answer_state)
 
-        answers_by_answer_instance = OrderedDict()
+        answer_states_grouped_by_instance = OrderedDict()
         for answer_schema in self.schema_item.answers:
-            answer_states = answers_by_id.get(answer_schema.id)
+            answer_states = answer_states_by_id.get(answer_schema.id)
             if answer_states:
-                for answer in answer_states:
-                    answers_by_answer_instance.setdefault(answer.answer_instance, []).append(answer)
+                for answer_state in answer_states:
+                    answer_states_grouped_by_instance.setdefault(answer_state.answer_instance, []).append(answer_state)
 
-        return list(answers_by_answer_instance.values())
+        return list(answer_states_grouped_by_instance.values())
 
 
 def iterate_over_instance_ids(answer_instances):

--- a/app/questionnaire_state/state_repeating_answer_question.py
+++ b/app/questionnaire_state/state_repeating_answer_question.py
@@ -1,6 +1,9 @@
 import copy
 import re
 
+from collections import defaultdict
+from collections import OrderedDict
+
 from app.data_model.answer_store import natural_order
 from app.questionnaire_state.state_answer import StateAnswer
 from app.questionnaire_state.state_question import StateQuestion
@@ -43,6 +46,25 @@ class RepeatingAnswerStateQuestion(StateQuestion):
 
     def add_new_answer_state(self, answer_state):
         self.answers.append(answer_state)
+
+    def answers_grouped_by_instance(self):
+        """
+        Groups answers by their answer_instance Id.
+        :return: A list of lists containing the answers grouped by answer_instance.
+        """
+
+        answers_by_id = defaultdict(list)
+        for answer in self.answers:
+            answers_by_id[answer.id].append(answer)
+
+        answers_by_answer_instance = OrderedDict()
+        for answer_schema in self.schema_item.answers:
+            answer_states = answers_by_id.get(answer_schema.id)
+            if answer_states:
+                for answer in answer_states:
+                    answers_by_answer_instance.setdefault(answer.answer_instance, []).append(answer)
+
+        return list(answers_by_answer_instance.values())
 
 
 def iterate_over_instance_ids(answer_instances):

--- a/app/templates/partials/answer.html
+++ b/app/templates/partials/answer.html
@@ -2,14 +2,14 @@
 
 {% set invalid = answer.is_valid == False %}
 
-<div class="answer answer--{{answer.schema_item.type|lower}} {{'js-has-errors' if invalid}}" id="{{answer.id}}">
+<div class="answer answer--{{answer.schema_item.type|lower}} {{'js-has-errors' if invalid}}" id="{{answer.schema_item.widget.id}}">
 
   {%- set answer_guidance %}
     {% if answer.schema_item.guidance %}
       {% include 'partials/guidance.html' %}
     {% endif %}
   {% endset -%}
-  
+
   {%- set answer_fields %}
     <div class="answer__fields">
       {% if answer.schema_item.display and answer.schema_item.display.properties %}

--- a/app/templates/partials/question.html
+++ b/app/templates/partials/question.html
@@ -9,14 +9,14 @@
 
 {% set question_titles %}
   {%- if question_title -%}
-<h2 class="question__title neptune">
-    {%- if question_number -%}
+    <h2 class="question__title neptune">
+      {%- if question_number -%}
         <span>{{question_number}}. </span>
-    {% endif %}
-    {{question_title}}</h2>
+      {% endif %}
+      {{question_title}}
+    </h2>
   {%- endif %}
   {%- if question_subtitle -%}
-    <br />
     <h3 class="question__subtitle mars">{{question_subtitle}}</h3>
   {%- endif -%}
 {% endset %}

--- a/app/templates/partials/questions/repeatinganswer.html
+++ b/app/templates/partials/questions/repeatinganswer.html
@@ -1,92 +1,37 @@
-{% set question_answers %}
- <div class="question__answers">
- {%- for composite_answer in question.answers_grouped_by_instance() %}
-   <div class="question__answer js-household-person">
-     <h3 class="neptune">{{ _('Person ') }}<span class="js-household-loopindex">{{ loop.index }}</span>
-       <small>(
-       {%- if loop.index == 1 -%}
-          <span class="js-household-action">{{ _('You') }}</span>
-       {%- else -%}
-           <button class="btn btn--link" name="action[remove_answer]"
-                   value="{{ loop.index0 }}">{{ _('Remove') }}
-               <span class="u-vh">{{ _('Person') }} {{loop.index0}}</span>
-           </button>
-       {%- endif -%}
-       )</small>
-     </h3>
-       {% for answer in composite_answer %}
-         {% include theme('partials/answer.html') %}
-       {% endfor %}
-   </div>
- {%- endfor %}
- </div>
-{% endset %}
+<div class="question question--repeatinganswer" id="{{question.id}}">
 
-{% set question_actions %}
-  <div class="question__actions">
-    <button class="btn btn--border btn--secondary venus js-household-btn" type="submit"
-          name="action[add_answer]">{{ _('Add another person') }}</button>
-  </div>
-{% endset %}
+  <h2 class="question__title neptune">{{question_title}}</h2>
 
+  {{question_description|safe}}
 
-<div class="question" id="{{question.id}}">
-
-  {% set question_markup %}
-
-    {% if question.answers|length > 1 %}
-
-      <fieldset class="question__fieldset">
-
-        <legend class="question__legend">
-          {%- if question_title -%}
-            <span class="question__title neptune">{{question_title}}</span>
-          {%- endif %}
-          {%- if question_subtitle -%}
-            <br />
-            <span class="question__subtitle venus">{{question_subtitle}}</span>
-          {%- endif %}
-        </legend>
-
-        {{question_description|safe}}
-        {{question_guidance|safe}}
-        {{question_answers|safe}}
-
-      </fieldset>
-
-    {% else %}
-
-      {{question_titles|safe}}
-      {{question_description|safe}}
-      {{question_guidance|safe}}
-      {{question_answers|safe}}
-
-    {% endif %}
-
-  {% endset %}
-
-  {% if invalid %}
-
-    <div class="alert alert--simple alert--error">
-      <div class="alert__header">
-        {% if question.errors %}
-        <ul class="list list--bare list--errors">
-          {% for error in question.errors %}
-            <li class="list__item venus" {{helpers.errorTracking(question.id, error)}}>{{ error }}</li>
+  <div class="question__answers">
+    {%- for composite_answer in question.answers_grouped_by_instance() %}
+      <div class="question__answer js-household-person">
+        <h3 class="neptune">{{ _('Person ') }}<span class="js-household-loopindex">{{ loop.index }}</span>
+          <small>(
+          {%- if loop.index == 1 -%}
+             <span class="js-household-action">{{ _('You') }}</span>
+          {%- else -%}
+            <button class="btn btn--link" name="action[remove_answer]" value="{{ loop.index0 }}">{{ _('Remove') }}
+              <span class="u-vh">{{ _('Person') }} {{loop.index0}}</span>
+            </button>
+          {%- endif -%}
+          )</small>
+        </h3>
+        <fieldset class="question__fieldset">
+          <legend class="u-vh">{{ _('Person ') }} {{ loop.index }}</legend>
+          {% for answer in composite_answer %}
+            {% include theme('partials/answer.html') %}
           {% endfor %}
-        </ul>
-        {% endif %}
+        </fieldset>
       </div>
-      <div class="alert__body">
-        {{question_markup|safe}}
-      </div>
-    </div>
+    {%- endfor %}
+  </div>
 
-  {% else %}
-
-    {{question_markup|safe}}
-    {{question_actions|safe}}
-
-  {% endif %}
+  <div class="question__actions">
+    <button class="btn btn--border btn--secondary venus js-household-btn" type="submit" name="action[add_answer]">
+      {{ _('Add another person') }}
+    </button>
+  </div>
 
 </div>

--- a/app/templates/partials/questions/repeatinganswer.html
+++ b/app/templates/partials/questions/repeatinganswer.html
@@ -1,36 +1,92 @@
-<div class="question question--repeatinganswer" id="{{question.id}}">
-
-  <fieldset class="question__fieldset">
-
-    <legend class="question__legend">
-      {{question_title}}
-    </legend>
-
-    {{question_description|safe}}
-
-    {%- for answer in question.answers %}
-       <div class="question__answer js-household-person">
-         <h3 class="neptune">{{ _('Person ') }}<span class="js-household-loopindex">{{ loop.index }}</span>
-           <small>(
-           {%- if loop.index == 1 -%}
-              <span class="js-household-action">{{ _('You') }}</span>
-           {%- else -%}
-               <button class="btn btn--link" name="action[remove_answer]" value="{{ loop.index0 }}">{{ _('Remove') }}
-                   <span class="u-vh">{{ _('Person') }} {{loop.index0}}</span>
-               </button>
-           {%- endif -%}
-           )</small>
-         </h3>
+{% set question_answers %}
+ <div class="question__answers">
+ {%- for composite_answer in question.answers_grouped_by_instance() %}
+   <div class="question__answer js-household-person">
+     <h3 class="neptune">{{ _('Person ') }}<span class="js-household-loopindex">{{ loop.index }}</span>
+       <small>(
+       {%- if loop.index == 1 -%}
+          <span class="js-household-action">{{ _('You') }}</span>
+       {%- else -%}
+           <button class="btn btn--link" name="action[remove_answer]"
+                   value="{{ loop.index0 }}">{{ _('Remove') }}
+               <span class="u-vh">{{ _('Person') }} {{loop.index0}}</span>
+           </button>
+       {%- endif -%}
+       )</small>
+     </h3>
+       {% for answer in composite_answer %}
          {% include theme('partials/answer.html') %}
-       </div>
-     {%- endfor %}
+       {% endfor %}
+   </div>
+ {%- endfor %}
+ </div>
+{% endset %}
 
-  </fieldset>
-
+{% set question_actions %}
   <div class="question__actions">
-    <button class="btn btn--border btn--secondary venus js-household-btn" type="submit" name="action[add_answer]">
-      {{ _('Add another person') }}
-    </button>
+    <button class="btn btn--border btn--secondary venus js-household-btn" type="submit"
+          name="action[add_answer]">{{ _('Add another person') }}</button>
   </div>
+{% endset %}
+
+
+<div class="question" id="{{question.id}}">
+
+  {% set question_markup %}
+
+    {% if question.answers|length > 1 %}
+
+      <fieldset class="question__fieldset">
+
+        <legend class="question__legend">
+          {%- if question_title -%}
+            <span class="question__title neptune">{{question_title}}</span>
+          {%- endif %}
+          {%- if question_subtitle -%}
+            <br />
+            <span class="question__subtitle venus">{{question_subtitle}}</span>
+          {%- endif %}
+        </legend>
+
+        {{question_description|safe}}
+        {{question_guidance|safe}}
+        {{question_answers|safe}}
+
+      </fieldset>
+
+    {% else %}
+
+      {{question_titles|safe}}
+      {{question_description|safe}}
+      {{question_guidance|safe}}
+      {{question_answers|safe}}
+
+    {% endif %}
+
+  {% endset %}
+
+  {% if invalid %}
+
+    <div class="alert alert--simple alert--error">
+      <div class="alert__header">
+        {% if question.errors %}
+        <ul class="list list--bare list--errors">
+          {% for error in question.errors %}
+            <li class="list__item venus" {{helpers.errorTracking(question.id, error)}}>{{ error }}</li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+      </div>
+      <div class="alert__body">
+        {{question_markup|safe}}
+      </div>
+    </div>
+
+  {% else %}
+
+    {{question_markup|safe}}
+    {{question_actions|safe}}
+
+  {% endif %}
 
 </div>

--- a/app/templating/template_renderer.py
+++ b/app/templating/template_renderer.py
@@ -1,6 +1,7 @@
 import json
 
 from app.jinja_filters import format_date
+from app.jinja_filters import format_household_member_name
 
 from jinja2 import Environment
 
@@ -9,6 +10,7 @@ class TemplateRenderer:
     def __init__(self):
         self.environment = Environment()
         self.environment.filters['format_date'] = format_date
+        self.environment.filters['format_household_name'] = format_household_member_name
 
     def render(self, renderable, **context):
         """

--- a/tests/app/questionnaire/test_navigator.py
+++ b/tests/app/questionnaire/test_navigator.py
@@ -612,7 +612,7 @@ class TestNavigator(unittest.TestCase):
             answer_instance=0,
             answer_id="first-name",
             block_id="household-composition",
-            value="Joe Bloggs"
+            value="Joe"
         )
 
         answer_2 = Answer(
@@ -621,7 +621,7 @@ class TestNavigator(unittest.TestCase):
             answer_instance=1,
             answer_id="first-name",
             block_id="household-composition",
-            value="Sophie Bloggs"
+            value="Sophie"
         )
 
         answers = AnswerStore()

--- a/tests/app/questionnaire/test_navigator.py
+++ b/tests/app/questionnaire/test_navigator.py
@@ -466,7 +466,7 @@ class TestNavigator(unittest.TestCase):
         answer = Answer(
             group_id="multiple-questions-group",
             group_instance=0,
-            answer_id="household-full-name",
+            answer_id="first-name",
             block_id="household-composition",
             value="2"
         )
@@ -494,7 +494,7 @@ class TestNavigator(unittest.TestCase):
         answer = Answer(
             group_id="multiple-questions-group",
             group_instance=0,
-            answer_id="household-full-name",
+            answer_id="first-name",
             block_id="household-composition",
             value="0"
         )
@@ -550,27 +550,27 @@ class TestNavigator(unittest.TestCase):
             group_id="multiple-questions-group",
             group_instance=0,
             answer_instance=0,
-            answer_id="household-full-name",
+            answer_id="first-name",
             block_id="household-composition",
-            value="Joe Bloggs"
+            value="Joe"
         )
 
         answer_2 = Answer(
             group_id="multiple-questions-group",
             group_instance=0,
             answer_instance=1,
-            answer_id="household-full-name",
+            answer_id="first-name",
             block_id="household-composition",
-            value="Sophie Bloggs"
+            value="Sophie"
         )
 
         answer_3 = Answer(
             group_id="multiple-questions-group",
             group_instance=0,
             answer_instance=2,
-            answer_id="household-full-name",
+            answer_id="first-name",
             block_id="household-composition",
-            value="Gregg Bloggs"
+            value="Gregg"
         )
 
         answers = AnswerStore()
@@ -610,7 +610,7 @@ class TestNavigator(unittest.TestCase):
             group_id="multiple-questions-group",
             group_instance=0,
             answer_instance=0,
-            answer_id="household-full-name",
+            answer_id="first-name",
             block_id="household-composition",
             value="Joe Bloggs"
         )
@@ -619,7 +619,7 @@ class TestNavigator(unittest.TestCase):
             group_id="multiple-questions-group",
             group_instance=0,
             answer_instance=1,
-            answer_id="household-full-name",
+            answer_id="first-name",
             block_id="household-composition",
             value="Sophie Bloggs"
         )
@@ -687,7 +687,7 @@ class TestNavigator(unittest.TestCase):
         answer = Answer(
             group_id="multiple-questions-group",
             answer_instance=0,
-            answer_id="household-full-name",
+            answer_id="first-name",
             block_id="household-composition",
             value="Joe Bloggs"
         )
@@ -695,7 +695,7 @@ class TestNavigator(unittest.TestCase):
         answer_2 = Answer(
             group_id="multiple-questions-group",
             answer_instance=1,
-            answer_id="household-full-name",
+            answer_id="first-name",
             block_id="household-composition",
             value="Sophie Bloggs"
         )
@@ -751,7 +751,7 @@ class TestNavigator(unittest.TestCase):
         answer = Answer(
             group_id="multiple-questions-group",
             answer_instance=0,
-            answer_id="household-full-name",
+            answer_id="first-name",
             block_id="household-composition",
             value="Joe Bloggs"
         )
@@ -759,7 +759,7 @@ class TestNavigator(unittest.TestCase):
         answer_2 = Answer(
             group_id="multiple-questions-group",
             answer_instance=1,
-            answer_id="household-full-name",
+            answer_id="first-name",
             block_id="household-composition",
             value="Sophie Bloggs"
         )

--- a/tests/app/questionnaire_state/test_relationship_state_question.py
+++ b/tests/app/questionnaire_state/test_relationship_state_question.py
@@ -20,19 +20,37 @@ class TestRelationshipStateQuestion(TestCase):
 
     household_answers = [
         {
-            "answer_id": "household-full-name",
+            "answer_id": "first-name",
             "answer_instance": 0,
-            "value": "John Doe"
+            "value": "John"
         },
         {
-            "answer_id": "household-full-name",
+            "answer_id": "first-name",
             "answer_instance": 1,
-            "value": "Jane Doe"
+            "value": "Jane"
         },
         {
-            "answer_id": "household-full-name",
+            "answer_id": "first-name",
             "answer_instance": 2,
-            "value": "Joe Bloggs"
+            "value": "Joe"
+        }
+    ]
+
+    last_names = [
+        {
+            "answer_id": "last-name",
+            "answer_instance": 0,
+            "value": "Doe"
+        },
+        {
+            "answer_id": "last-name",
+            "answer_instance": 1,
+            "value": "Doe"
+        },
+        {
+            "answer_id": "last-name",
+            "answer_instance": 2,
+            "value": "Bloggs"
         }
     ]
 
@@ -114,7 +132,8 @@ class TestRelationshipStateQuestion(TestCase):
         relationship_state_question.answers = [answer_state]
 
         with patch('app.questionnaire_state.relationship_state_question.get_answer_store') as get_answer_store:
-            get_answer_store().filter = Mock(return_value=self.household_answers)
+            get_answer_store().filter = Mock()
+            get_answer_store().filter.side_effect = [self.household_answers, self.last_names]
             # When
             relationship_state_question.update_state({})
 
@@ -130,9 +149,116 @@ class TestRelationshipStateQuestion(TestCase):
         relationship_state_question.answers = [answer_state]
 
         with patch('app.questionnaire_state.relationship_state_question.get_answer_store') as get_answer_store:
-            get_answer_store().filter = Mock(return_value=self.household_answers)
+            get_answer_store().filter = Mock()
+            get_answer_store().filter.side_effect = [self.household_answers, self.last_names]
             # When
             relationship_state_question.update_state({})
 
         # Then
         self.assertEqual(relationship_state_question.children[0].schema_item.widget.other_person, 'Joe Bloggs')
+
+    def test_should_display_first_name_if_no_surname_provided(self):
+        # Given
+        answer_state = create_answer(group_instance=0)
+        question_schema = Question()
+        question_schema.answers = [answer_state.schema_item]
+        relationship_state_question = RelationshipStateQuestion('relationship', question_schema)
+        relationship_state_question.answers = [answer_state]
+
+        first_names = [
+            {
+                "answer_id": "first-name",
+                "answer_instance": 0,
+                "value": "John"
+            },
+            {
+                "answer_id": "first-name",
+                "answer_instance": 1,
+                "value": None
+            },
+            {
+                "answer_id": "first-name",
+                "answer_instance": 2,
+                "value": 'Joe'
+            }
+        ]
+
+        last_names = [
+            {
+                "answer_id": "last-name",
+                "answer_instance": 0,
+                "value": None
+            },
+            {
+                "answer_id": "last-name",
+                "answer_instance": 1,
+                "value": 'Doe'
+            },
+            {
+                "answer_id": "last-name",
+                "answer_instance": 2,
+                "value": 'Bloggs'
+            }
+        ]
+
+        with patch('app.questionnaire_state.relationship_state_question.get_answer_store') as get_answer_store:
+            get_answer_store().filter = Mock()
+            get_answer_store().filter.side_effect = [first_names, last_names]
+            # When
+            relationship_state_question.update_state({})
+
+        # Then
+        self.assertEqual(relationship_state_question.children[0].schema_item.widget.current_person, 'John')
+
+    def test_should_display_surname_if_no_first_name_provided(self):
+        # Given
+        answer_state = create_answer(group_instance=0)
+        question_schema = Question()
+        question_schema.answers = [answer_state.schema_item]
+        relationship_state_question = RelationshipStateQuestion('relationship', question_schema)
+        relationship_state_question.answers = [answer_state]
+
+        first_names = [
+            {
+                "answer_id": "first-name",
+                "answer_instance": 0,
+                "value": "John"
+            },
+            {
+                "answer_id": "first-name",
+                "answer_instance": 1,
+                "value": None
+            },
+            {
+                "answer_id": "first-name",
+                "answer_instance": 2,
+                "value": 'Joe'
+            }
+        ]
+
+        last_names = [
+            {
+                "answer_id": "last-name",
+                "answer_instance": 0,
+                "value": None
+            },
+            {
+                "answer_id": "last-name",
+                "answer_instance": 1,
+                "value": 'Doe'
+            },
+            {
+                "answer_id": "last-name",
+                "answer_instance": 2,
+                "value": 'Bloggs'
+            }
+        ]
+
+        with patch('app.questionnaire_state.relationship_state_question.get_answer_store') as get_answer_store:
+            get_answer_store().filter = Mock()
+            get_answer_store().filter.side_effect = [first_names, last_names]
+            # When
+            relationship_state_question.update_state({})
+
+        # Then
+            self.assertEqual(relationship_state_question.children[0].schema_item.widget.other_person, 'Doe')

--- a/tests/app/questionnaire_state/test_repeating_answer_state_question.py
+++ b/tests/app/questionnaire_state/test_repeating_answer_state_question.py
@@ -147,3 +147,254 @@ class TestRepeatingAnswerStateQuestion(TestCase):
         answer_id, answer_index = extract_answer_instance_id('abcdefg_12345')
         self.assertEqual(answer_id, 'abcdefg')
         self.assertEqual(answer_index, 12345)
+
+    def test_answers_grouped_by_instance_id_no_answers(self):
+        # Given
+        question_state = RepeatingAnswerStateQuestion('question_id', MagicMock())
+
+        # When
+        answers = question_state.answers_grouped_by_instance()
+
+        # Then
+        self.assertEqual(len(answers), 0)
+
+    def test_answers_grouped_by_instance_id_one_answer_no_instances(self):
+        # Given
+        question_state = RepeatingAnswerStateQuestion('question_id', MagicMock())
+
+        schema_answer = Answer('answer')
+        schema_answer.widget = TextWidget('answer')
+        question_state.schema_item.answers = [schema_answer]
+
+        question_state.answers = []
+
+        # When
+        result = question_state.answers_grouped_by_instance()
+
+        # Then
+        self.assertEqual(len(result), 0)
+
+    def test_answers_grouped_by_instance_id_one_answer_one_instance(self):
+        # Given
+        question_state = RepeatingAnswerStateQuestion('question_id', MagicMock())
+
+        schema_answer = Answer('answer')
+        schema_answer.widget = TextWidget('answer')
+        question_state.schema_item.answers = [schema_answer]
+
+        state_answer = MagicMock()
+        state_answer.id = 'answer'
+        state_answer.answer_instance = 0
+
+        question_state.answers = [state_answer]
+
+        # When
+        result = question_state.answers_grouped_by_instance()
+
+        # Then
+        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result[0]), 1)
+        self.assertEqual(result[0][0], state_answer)
+
+    def test_answers_grouped_by_instance_id_one_answer_many_instances(self):
+        # Given
+        question_state = RepeatingAnswerStateQuestion('question_id', MagicMock())
+
+        schema_answer = Answer('answer')
+        schema_answer.widget = TextWidget('answer')
+        question_state.schema_item.answers = [schema_answer]
+
+        state_answer = MagicMock()
+        state_answer.id = 'answer'
+        state_answer.answer_instance = 0
+
+        state_answer1 = MagicMock()
+        state_answer1.id = 'answer'
+        state_answer1.answer_instance = 1
+
+        question_state.answers = [state_answer, state_answer1]
+
+        # When
+        result = question_state.answers_grouped_by_instance()
+
+        # Then
+        self.assertEqual(len(result), 2)
+        self.assertEqual(len(result[0]), 1)
+        self.assertEqual(result[0][0], state_answer)
+        self.assertEqual(len(result[1]), 1)
+        self.assertEqual(result[1][0], state_answer1)
+
+    def test_answers_grouped_by_instance_id_many_answers_one_instance(self):
+        # Given
+        question_state = RepeatingAnswerStateQuestion('question_id', MagicMock())
+
+        first_name_schema = Answer('first-name')
+        first_name_schema.widget = TextWidget('first-name')
+
+        middle_name_schema = Answer('middle-names')
+        middle_name_schema.widget = TextWidget('middle-names')
+
+        last_name_schema = Answer('last-name')
+        last_name_schema.widget = TextWidget('last-name')
+
+        question_state.schema_item.answers = [
+            first_name_schema,
+            middle_name_schema,
+            last_name_schema
+        ]
+
+        first_name = MagicMock()
+        first_name.id = 'first-name'
+        first_name.answer_instance = 0
+
+        middle_name = MagicMock()
+        middle_name.id = 'middle-names'
+        middle_name.answer_instance = 0
+
+        last_name = MagicMock()
+        last_name.id = 'last-name'
+        last_name.answer_instance = 0
+
+        question_state.answers = [first_name, middle_name, last_name]
+
+        # When
+        result = question_state.answers_grouped_by_instance()
+
+        # Then
+        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result[0]), 3)
+        self.assertEqual(result[0][0], first_name)
+        self.assertEqual(result[0][1], middle_name)
+        self.assertEqual(result[0][2], last_name)
+
+    def test_answers_grouped_by_instance_id_many_answers_many_instance(self):
+        # Given
+        question_state = RepeatingAnswerStateQuestion('question_id', MagicMock())
+
+        first_name_schema = Answer('first-name')
+        first_name_schema.widget = TextWidget('first-name')
+
+        middle_name_schema = Answer('middle-names')
+        middle_name_schema.widget = TextWidget('middle-names')
+
+        last_name_schema = Answer('last-name')
+        last_name_schema.widget = TextWidget('last-name')
+
+        question_state.schema_item.answers = [
+            first_name_schema,
+            middle_name_schema,
+            last_name_schema
+        ]
+
+        first_name = MagicMock()
+        first_name.id = 'first-name'
+        first_name.answer_instance = 0
+
+        middle_name = MagicMock()
+        middle_name.id = 'middle-names'
+        middle_name.answer_instance = 0
+
+        last_name = MagicMock()
+        last_name.id = 'last-name'
+        last_name.answer_instance = 0
+
+        first_name1 = MagicMock()
+        first_name1.id = 'first-name'
+        first_name1.answer_instance = 1
+
+        middle_name1 = MagicMock()
+        middle_name1.id = 'middle-names'
+        middle_name1.answer_instance = 1
+
+        last_name1 = MagicMock()
+        last_name1.id = 'last-name'
+        last_name1.answer_instance = 1
+
+        first_name2 = MagicMock()
+        first_name2.id = 'first-name'
+        first_name2.answer_instance = 2
+
+        middle_name2 = MagicMock()
+        middle_name2.id = 'middle-names'
+        middle_name2.answer_instance = 2
+
+        last_name2 = MagicMock()
+        last_name2.id = 'last-name'
+        last_name2.answer_instance = 2
+
+        question_state.answers = [
+            first_name, middle_name, last_name,
+            first_name1, middle_name1, last_name1,
+            first_name2, middle_name2, last_name2,
+        ]
+
+        # When
+        result = question_state.answers_grouped_by_instance()
+
+        # Then
+        self.assertEqual(len(result), 3)
+
+        # Instance 0
+        self.assertEqual(len(result[0]), 3)
+        self.assertEqual(result[0][0], first_name)
+        self.assertEqual(result[0][1], middle_name)
+        self.assertEqual(result[0][2], last_name)
+
+        # Instance 1
+        self.assertEqual(len(result[1]), 3)
+        self.assertEqual(result[1][0], first_name1)
+        self.assertEqual(result[1][1], middle_name1)
+        self.assertEqual(result[1][2], last_name1)
+
+        # Instance 2
+        self.assertEqual(len(result[2]), 3)
+        self.assertEqual(result[2][0], first_name2)
+        self.assertEqual(result[2][1], middle_name2)
+        self.assertEqual(result[2][2], last_name2)
+
+    def test_answers_grouped_by_instance_id_odd_number_of_instances(self):
+        # Given
+        question_state = RepeatingAnswerStateQuestion('question_id', MagicMock())
+
+        first_name_schema = Answer('first-name')
+        first_name_schema.widget = TextWidget('first-name')
+
+        last_name_schema = Answer('last-name')
+        last_name_schema.widget = TextWidget('last-name')
+
+        question_state.schema_item.answers = [
+            first_name_schema,
+            last_name_schema
+        ]
+
+        first_name = MagicMock()
+        first_name.id = 'first-name'
+        first_name.answer_instance = 0
+
+        last_name = MagicMock()
+        last_name.id = 'last-name'
+        last_name.answer_instance = 0
+
+        first_name1 = MagicMock()
+        first_name1.id = 'first-name'
+        first_name1.answer_instance = 1
+
+        question_state.answers = [
+            first_name, last_name,
+            first_name1
+        ]
+
+        # When
+        result = question_state.answers_grouped_by_instance()
+
+        # Then
+        self.assertEqual(len(result), 2)
+
+        # Instance 0
+        self.assertEqual(len(result[0]), 2)
+        self.assertEqual(result[0][0], first_name)
+        self.assertEqual(result[0][1], last_name)
+
+        # Instance 1
+        self.assertEqual(len(result[1]), 1)
+        self.assertEqual(result[1][0], first_name1)

--- a/tests/app/test_jinja_filters.py
+++ b/tests/app/test_jinja_filters.py
@@ -5,6 +5,7 @@ from app.jinja_filters import format_date
 from app.jinja_filters import format_str_as_date_range
 from app.jinja_filters import format_str_as_date
 from app.jinja_filters import format_str_as_month_year_date
+from app.jinja_filters import format_household_member_name
 
 
 class TestJinjaFilters(TestCase):
@@ -44,3 +45,84 @@ class TestJinjaFilters(TestCase):
         format_value = format_str_as_date(date)
 
         self.assertEquals(format_value, '02 March 2017')
+
+    def test_format_household_member_name(self):
+        # Given
+        name = ['John', 'Doe']
+
+        # When
+        format_value = format_household_member_name(name)
+
+        self.assertEqual(format_value, 'John Doe')
+
+    def test_format_household_member_name_no_surname(self):
+        # Given
+        name = ['John', '']
+
+        # When
+        format_value = format_household_member_name(name)
+
+        self.assertEqual(format_value, 'John')
+
+    def test_format_household_member_name_surname_is_none(self):
+        # Given
+        name = ['John', None]
+
+        # When
+        format_value = format_household_member_name(name)
+
+        self.assertEqual(format_value, 'John')
+
+    def test_format_household_member_name_no_first_name(self):
+        # Given
+        name = ['', 'Doe']
+
+        # When
+        format_value = format_household_member_name(name)
+
+        self.assertEqual(format_value, 'Doe')
+
+    def test_format_household_member_name_first_name_is_none(self):
+        # Given
+        name = [None, 'Doe']
+
+        # When
+        format_value = format_household_member_name(name)
+
+        self.assertEqual(format_value, 'Doe')
+
+    def test_format_household_member_name_first_middle_and_last(self):
+        # Given
+        name = ['John', 'J', 'Doe']
+
+        # When
+        format_value = format_household_member_name(name)
+
+        self.assertEqual(format_value, 'John J Doe')
+
+    def test_format_household_member_name_no_middle_name(self):
+        # Given
+        name = ['John', '', 'Doe']
+
+        # When
+        format_value = format_household_member_name(name)
+
+        self.assertEqual(format_value, 'John Doe')
+
+    def test_format_household_member_name_middle_name_is_none(self):
+        # Given
+        name = ['John', None, 'Doe']
+
+        # When
+        format_value = format_household_member_name(name)
+
+        self.assertEqual(format_value, 'John Doe')
+
+    def test_format_household_member_name_trim_spaces(self):
+        # Given
+        name = ['John  ', '   Doe   ']
+
+        # When
+        format_value = format_household_member_name(name)
+
+        self.assertEqual(format_value, 'John Doe')

--- a/tests/functional/pages/surveys/census/household/household-composition.page.js
+++ b/tests/functional/pages/surveys/census/household/household-composition.page.js
@@ -16,7 +16,7 @@ class HouseholdCompositionPage extends QuestionPage {
   }
 
   getInputFieldName(index) {
-    var field = 'household-full-name'
+    var field = 'first-name'
     if (index > 0) {
       field = field + '_' + index
     }

--- a/tests/functional/pages/surveys/census/individual/correct-name.page.js
+++ b/tests/functional/pages/surveys/census/individual/correct-name.page.js
@@ -2,8 +2,18 @@ import QuestionPage from '../../question.page'
 
 class CorrectNamePage extends QuestionPage {
 
-  setCorrectNameAnswer(value) {
-    browser.setValue('[name="correct-name-answer"]', value)
+  setFirstName(value) {
+    browser.setValue('[name="first-name"]', value)
+    return this
+  }
+
+  setMiddleNames(value) {
+    browser.setValue('[name="middle-names"]', value)
+    return this
+  }
+
+  setLastName(value) {
+    browser.setValue('[name="last-name"]', value)
     return this
   }
 

--- a/tests/functional/pages/surveys/household_composition/household-composition.page.js
+++ b/tests/functional/pages/surveys/household_composition/household-composition.page.js
@@ -2,21 +2,35 @@ import QuestionPage from '../question.page'
 
 class HouseholdCompositionPage extends QuestionPage {
 
-  setPersonName(index, value) {
-    browser.setValue(this.getInputSelector(index), value)
+  setPersonName(index, first = '', middle = '', last = '') {
+    return this.setFirstName(index, first).setMiddleNames(index, middle).setLastName(index, last)
+  }
+
+  setFirstName(index, value) {
+    browser.setValue(this.getInputSelector(index, 'first-name'), value)
     return this
   }
 
-  getInputSelector(index) {
-    return 'input[name="' + this.getInputFieldName(index) + '"]'
+  setMiddleNames(index, value) {
+    browser.setValue(this.getInputSelector(index, 'middle-names'), value)
+    return this
   }
 
-  isInputVisible(index) {
-    return browser.isVisible(this.getInputSelector(index))
+  setLastName(index, value) {
+    browser.setValue(this.getInputSelector(index, 'last-name'), value)
+    return this
   }
 
-  getInputFieldName(index) {
-    var field = 'household-full-name'
+  getInputSelector(index, name) {
+    return 'input[name="' + this.getInputFieldName(index, name) + '"]'
+  }
+
+  isInputVisible(index, name) {
+    return browser.isVisible(this.getInputSelector(index, name))
+  }
+
+  getInputFieldName(index, name) {
+    var field = name
     if (index > 0) {
       field = field + '_' + index
     }

--- a/tests/functional/pages/surveys/household_composition/summary.page.js
+++ b/tests/functional/pages/surveys/household_composition/summary.page.js
@@ -3,17 +3,41 @@ import SummaryPage from '../../summary.page'
 class HouseholdCompositionSummary extends SummaryPage {
 
   clickEdit() {
-    browser.click('[data-qa="household-full-name-edit"]')
+    browser.click('[data-qa="first-name-edit"]')
     return this
   }
 
-  isNameDisplayed(name) {
-    return browser.element('[data-qa="household-full-name-answer"]').getText() === name
+  getFirstName(index) {
+    return this.getFirstNames()[index]
   }
 
-  getHouseholdNames() {
+  getMiddleName(index) {
+    return this.getMiddleNames()[index]
+  }
+
+  getLastName(index) {
+    return this.getLastNames()[index]
+  }
+
+  getElementText(name, index) {
+    return this.getElementTextForAnswer(name)[index]
+  }
+
+  getFirstNames() {
+    return this.getElementTextForAnswer('first-name')
+  }
+
+  getMiddleNames() {
+    return this.getElementTextForAnswer('middle-names')
+  }
+
+  getLastNames() {
+    return this.getElementTextForAnswer('last-name')
+  }
+
+  getElementTextForAnswer(answer) {
     var householdNames = []
-    var elements = browser.elements('[data-qa="household-full-name-answer"]')
+    var elements = browser.elements('[data-qa="' + answer + '-answer"]')
     elements.value.forEach((elem) => {
       householdNames.push(browser.elementIdText(elem.ELEMENT).value)
     })

--- a/tests/functional/spec/census-individual.spec.js
+++ b/tests/functional/spec/census-individual.spec.js
@@ -56,7 +56,7 @@ describe('Census Individual', function () {
         openAndStartCensusQuestionnaire('census_individual.json')
 
         // household-member
-        CorrectName.setCorrectNameAnswer("Paul Smith").submit()
+        CorrectName.setFirstName("Paul").setLastName("Smith").submit()
         Sex.clickSexAnswerMale().submit()
         DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(8).setDateOfBirthAnswerYear(1980).submit()
         Over16.clickOver16AnswerYes().submit()
@@ -89,7 +89,7 @@ describe('Census Individual', function () {
         openAndStartCensusQuestionnaire('census_individual.json', true)
 
         // household-member
-        CorrectName.setCorrectNameAnswer("Paul Smith").submit()
+        CorrectName.setFirstName("Paul").setLastName("Smith").submit()
         Sex.clickSexAnswerMale().submit()
         DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(9).setDateOfBirthAnswerYear(1980).submit()
         Over16.clickOver16AnswerYes().submit()
@@ -124,7 +124,7 @@ describe('Census Individual', function () {
         openAndStartCensusQuestionnaire('census_individual.json', true)
 
         // household-member
-        CorrectName.setCorrectNameAnswer("Paul Smith").submit()
+        CorrectName.setFirstName("Paul").setLastName("Smith").submit()
         Sex.clickSexAnswerMale().submit()
         DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(9).setDateOfBirthAnswerYear(1980).submit()
         Over16.clickOver16AnswerYes().submit()
@@ -159,7 +159,7 @@ describe('Census Individual', function () {
         openAndStartCensusQuestionnaire('census_individual.json', true)
 
         // household-member
-        CorrectName.setCorrectNameAnswer("Paul Smith").submit()
+        CorrectName.setFirstName("Paul").setLastName("Smith").submit()
         Sex.clickSexAnswerMale().submit()
         DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(9).setDateOfBirthAnswerYear(2001).submit()
         Over16.clickOver16AnswerNo().submit()

--- a/tests/functional/spec/household-composition.spec.js
+++ b/tests/functional/spec/household-composition.spec.js
@@ -16,10 +16,11 @@ describe('Household composition question for census test.', function() {
     startQuestionnaire(household_composition_schema)
 
     //When
-    HouseholdCompositionPage.setPersonName(0, 'Person One').submit()
+    HouseholdCompositionPage.setPersonName(0, 'Alpha', '', 'One').submit()
 
     // Then
-    expect(HouseholdCompositionSummary.isNameDisplayed('Person One')).to.be.true
+    expect(HouseholdCompositionSummary.getFirstName(0)).to.equal('Alpha')
+    expect(HouseholdCompositionSummary.getLastName(0)).to.equal('One')
   })
 
   it('Given no people added, when I enter another name, then there should be two input fields displayed.', function() {
@@ -27,11 +28,11 @@ describe('Household composition question for census test.', function() {
     startQuestionnaire(household_composition_schema)
 
     //When
-    HouseholdCompositionPage.setPersonName(0, 'Person One').addPerson()
+    HouseholdCompositionPage.setPersonName(0, 'Alpha', '', 'One').addPerson()
 
     // Then
-    expect(HouseholdCompositionPage.isInputVisible(0)).to.be.true
-    expect(HouseholdCompositionPage.isInputVisible(1)).to.be.true
+    expect(HouseholdCompositionPage.isInputVisible(0, 'first-name')).to.be.true
+    expect(HouseholdCompositionPage.isInputVisible(1, 'first-name')).to.be.true
   })
 
   it('Given three people added, when submitted, all three names should appear on summary.', function() {
@@ -40,18 +41,18 @@ describe('Household composition question for census test.', function() {
 
     //When
     HouseholdCompositionPage
-        .setPersonName(0, 'Person One')
+        .setPersonName(0, 'Alpha', '', 'One')
         .addPerson()
-        .setPersonName(1, 'Person Two')
+        .setPersonName(1, 'Bravo', '', 'Two')
         .addPerson()
-        .setPersonName(2, 'Person Three')
+        .setPersonName(2, 'Charlie', '', 'Three')
         .submit()
 
     // Then
-    var names = HouseholdCompositionSummary.getHouseholdNames()
-    assert.include(names, 'Person One')
-    assert.include(names, 'Person Two')
-    assert.include(names, 'Person Three')
+    var names = HouseholdCompositionSummary.getFirstNames()
+    assert.include(names, 'Alpha')
+    assert.include(names, 'Bravo')
+    assert.include(names, 'Charlie')
   })
 
  it('Given two people added, when I remove second person, only first person should appear on summary.', function() {
@@ -60,52 +61,77 @@ describe('Household composition question for census test.', function() {
 
     //When
     HouseholdCompositionPage
-        .setPersonName(0, 'Person One')
+        .setPersonName(0, 'Alpha', '', 'One')
         .addPerson()
-        .setPersonName(1, 'Person Two')
+        .setPersonName(1, 'Bravo', '', 'Two')
         .submit()
 
     // Then
-    var names = HouseholdCompositionSummary.getHouseholdNames()
-    assert.include(names, 'Person One')
-    assert.include(names, 'Person Two')
+    var names = HouseholdCompositionSummary.getFirstNames()
+    assert.include(names, 'Alpha')
+    assert.include(names, 'Bravo')
 
     // When
     HouseholdCompositionSummary.clickEdit()
     HouseholdCompositionPage.removePerson(1).submit()
 
     // Then
-    names = HouseholdCompositionSummary.getHouseholdNames()
-    assert.include(names, 'Person One')
+    names = HouseholdCompositionSummary.getFirstNames()
+    assert.include(names, 'Alpha')
   })
 
-   it('Given three people added, when I remove second person, first and third person should appear on summary.', function() {
+ it('Given three people added, when I remove second person, first and third person should appear on summary.', function() {
     //Given
     startQuestionnaire(household_composition_schema)
 
     //When
     HouseholdCompositionPage
-        .setPersonName(0, 'Person One')
+        .setPersonName(0, 'Alpha', '', 'One')
         .addPerson()
-        .setPersonName(1, 'Person Two')
+        .setPersonName(1, 'Bravo', '', 'Two')
         .addPerson()
-        .setPersonName(2, 'Person Three')
+        .setPersonName(2, 'Charlie', '', 'Three')
         .submit()
 
     // Then
-    var names = HouseholdCompositionSummary.getHouseholdNames()
-    assert.include(names, 'Person One')
-    assert.include(names, 'Person Two')
-    assert.include(names, 'Person Three')
+    var names = HouseholdCompositionSummary.getFirstNames()
+    assert.include(names, 'Alpha')
+    assert.include(names, 'Bravo')
+    assert.include(names, 'Charlie')
 
     // When
     HouseholdCompositionSummary.clickEdit()
     HouseholdCompositionPage.removePerson(1).submit()
 
     // Then
-    names = HouseholdCompositionSummary.getHouseholdNames()
-    assert.include(names, 'Person One')
-    assert.include(names, 'Person Three')
+    names = HouseholdCompositionSummary.getFirstNames()
+    assert.include(names, 'Alpha')
+    assert.include(names, 'Charlie')
+  })
+
+  it('Given first, middle and last names entered, then each part of name should appear on summary.', function() {
+    //Given
+    startQuestionnaire(household_composition_schema)
+
+    //When
+    HouseholdCompositionPage
+        .setPersonName(0, 'Alpha', 'Bravo', 'Charlie')
+        .addPerson()
+        .setPersonName(1, 'Delta', 'Echo', 'Foxtrot')
+        .submit()
+
+    // Then
+    var firstNames = HouseholdCompositionSummary.getFirstNames()
+    assert.include(firstNames, 'Alpha')
+    assert.include(firstNames, 'Delta')
+
+    var middleNames = HouseholdCompositionSummary.getMiddleNames()
+    assert.include(middleNames, 'Bravo')
+    assert.include(middleNames, 'Echo')
+
+    var lastNames = HouseholdCompositionSummary.getLastNames()
+    assert.include(lastNames, 'Charlie')
+    assert.include(lastNames, 'Foxtrot')
   })
 
 })

--- a/tests/integration/household_composition/test_household_question.py
+++ b/tests/integration/household_composition/test_household_question.py
@@ -28,10 +28,10 @@ class TestHouseholdQuestion(IntegrationTestCase):
     def submit_answers(self, page):
         # Add first person
         form_data = MultiDict()
-        form_data.add("household-full-name", 'Person One')
-        form_data.add("household-full-name_1", 'Person Two')
-        form_data.add("household-full-name_2", 'Person Three')
-        form_data.add("household-full-name_3", 'Person Four')
+        form_data.add("first-name", 'Person One')
+        form_data.add("first-name_1", 'Person Two')
+        form_data.add("first-name_2", 'Person Three')
+        form_data.add("first-name_3", 'Person Four')
         form_data.add("action[save_continue]", "") # Remove person two.
         resp = self.client.post(page, data=form_data, follow_redirects=False)
         self.assertEquals(resp.status_code, 302)
@@ -51,10 +51,10 @@ class TestHouseholdQuestion(IntegrationTestCase):
     def remove_answer(self, page):
         # Add first person
         form_data = MultiDict()
-        form_data.add("household-full-name", 'Person One')
-        form_data.add("household-full-name_1", 'Person Two')
-        form_data.add("household-full-name_2", 'Person Three')
-        form_data.add("household-full-name_3", '')
+        form_data.add("first-name", 'Person One')
+        form_data.add("first-name_1", 'Person Two')
+        form_data.add("first-name_2", 'Person Three')
+        form_data.add("first-name_3", '')
         form_data.add("action[remove_answer]", "1") # Remove person two.
         resp = self.client.post(page, data=form_data, follow_redirects=False)
 
@@ -62,11 +62,11 @@ class TestHouseholdQuestion(IntegrationTestCase):
 
         resp = self.navigate_to_page(page)
         content = resp.get_data(True)
-        self.assertRegex(content, 'household-full-name')
-        self.assertRegex(content, 'household-full-name_2')
-        self.assertRegex(content, 'household-full-name_3')
+        self.assertRegex(content, 'first-name')
+        self.assertRegex(content, 'first-name_2')
+        self.assertRegex(content, 'first-name_3')
 
-        self.assertNotRegex(content, 'household-full-name_1')
+        self.assertNotRegex(content, 'first-name_1')
 
     def add_answers(self):
         self.login_and_check_introduction_text()
@@ -74,7 +74,7 @@ class TestHouseholdQuestion(IntegrationTestCase):
 
         # Add first person
         form_data = MultiDict()
-        form_data.add("household-full-name", 'Person One')
+        form_data.add("first-name", 'Person One')
         form_data.add("action[add_answer]", "")
         resp = self.client.post(first_page, data=form_data, follow_redirects=False)
 
@@ -82,12 +82,12 @@ class TestHouseholdQuestion(IntegrationTestCase):
 
         resp = self.navigate_to_page(first_page)
         content = resp.get_data(True)
-        self.assertRegex(content, 'household-full-name_1')
+        self.assertRegex(content, 'first-name_1')
 
         # Add second person
         form_data = MultiDict()
-        form_data.add("household-full-name", 'Person One')
-        form_data.add("household-full-name_1", 'Person Two')
+        form_data.add("first-name", 'Person One')
+        form_data.add("first_1", 'Person Two')
         form_data.add("action[add_answer]", "")
         resp = self.client.post(first_page, data=form_data, follow_redirects=False)
 
@@ -95,14 +95,14 @@ class TestHouseholdQuestion(IntegrationTestCase):
 
         resp = self.navigate_to_page(first_page)
         content = resp.get_data(True)
-        self.assertRegex(content, 'household-full-name_1')
-        self.assertRegex(content, 'household-full-name_2')
+        self.assertRegex(content, 'first-name_1')
+        self.assertRegex(content, 'first-name_2')
 
         # Add third person
         form_data = MultiDict()
-        form_data.add("household-full-name", 'Person One')
-        form_data.add("household-full-name_1", 'Person Two')
-        form_data.add("household-full-name_2", 'Person Three')
+        form_data.add("first-name", 'Person One')
+        form_data.add("first-name_1", 'Person Two')
+        form_data.add("first-name_2", 'Person Three')
         form_data.add("action[add_answer]", "")
         resp = self.client.post(first_page, data=form_data, follow_redirects=False)
 
@@ -110,9 +110,9 @@ class TestHouseholdQuestion(IntegrationTestCase):
 
         resp = self.navigate_to_page(first_page)
         content = resp.get_data(True)
-        self.assertRegex(content, 'household-full-name_1')
-        self.assertRegex(content, 'household-full-name_2')
-        self.assertRegex(content, 'household-full-name_3')
+        self.assertRegex(content, 'first-name_1')
+        self.assertRegex(content, 'first-name_2')
+        self.assertRegex(content, 'first-name_3')
 
         return first_page
 


### PR DESCRIPTION
### What is the context of this PR?
This PR implements the next part of the household composition question.
It allows multiple answers to be repeated for a question.
For instance, instead of Full Name, this PR splits out the fields into First, Middle and Last name fields whilst retaining the ability to add and remove answers dynamically.

### How to review 
Open the test_household_qustion.json schema.
Observe that there are now 3 fields for the question.
Add and remove answers to observe that answers are added and removed appropriately.

