### PR TITLE
EQ 622: Household Composition Summary

### DIFF
--- a/app/data/census_household.json
+++ b/app/data/census_household.json
@@ -219,6 +219,7 @@
                         {
                             "id": "everyone-at-address-confirmation-section",
                             "title": "Who lives here?",
+                            "description": "<h2 class='neptune'>Your household includes:</h2> {{ [answers.first_name, answers.middle_names, answers.last_name]|format_household_summary }}",
                             "number": "3",
                             "questions": [
                                 {

--- a/app/data/test_household_question.json
+++ b/app/data/test_household_question.json
@@ -11,40 +11,37 @@
         "description": "",
         "information_to_provide": []
     },
-    "display": {
-        "properties": {}
-    },
     "eq_id": "1",
     "groups": [
         {
             "blocks": [
-
                 {
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "household-composition",
                     "sections": [
                         {
-                            "display": {
-                                "properties": {}
-                            },
-                            "id": "section",
+                            "id": "composition-section",
                             "questions": [
                                 {
-                                  "description": "",
-                                  "display": {
-                                      "properties": {}
-                                  },
                                   "id": "household-composition-question",
                                   "title": "Who usually lives here?",
-                                  "description": "<br> <div> <h3>Include:</h3> <ul> <li>Yourself, if this is your permanent or family home </li> <li>Family members including partners, children and babies born on or before 9 April 2017</li> <li>Students and/or school children who live away from home during term time</li> <li>Housemates, tenants or lodgers</li> </ul> </div>",
+                                  "guidance": [
+                                      {
+                                          "title": "Include",
+                                          "list": [
+                                              "Yourself, if this is your permanent or family home",
+                                              "Family members including partners, children and babies born on or before 9 April 2017",
+                                              "Students and/or school children who live away from home during term time",
+                                              "Housemates, tenants or lodgers"
+                                          ]
+                                      }
+                                  ],
                                   "type": "RepeatingAnswer",
                                   "validation": [],
                                   "answers": [
                                     {
                                         "display": {},
                                         "id": "first-name",
+                                        "alias": "first_name",
                                         "label": "First Name",
                                         "mandatory": false,
                                         "options": [],
@@ -55,6 +52,7 @@
                                     {
                                         "display": {},
                                         "id": "middle-names",
+                                        "alias": "middle_names",
                                         "label": "Middle Names",
                                         "mandatory": false,
                                         "options": [],
@@ -65,6 +63,7 @@
                                     {
                                         "display": {},
                                         "id": "last-name",
+                                        "alias": "last_name",
                                         "label": "Last Name",
                                         "mandatory": false,
                                         "options": [],
@@ -82,11 +81,87 @@
                     ],
                     "title": "Household",
                     "validation": []
+                },
+                {
+                    "sections": [
+                        {
+                            "id": "further-section",
+                            "questions": [
+                                {
+                                  "id": "household-composition-further",
+                                  "title": "Is this everyone for whom this address is their permanent or family home?",
+                                  "type": "General",
+                                  "validation": [],
+                                  "guidance": [
+                                      {
+                                           "title": "Include",
+                                           "list": [
+                                               "People who usually live outside the UK who are staying in the UK for <b>three months or more</b>",
+                                               "People who work away from home within the UK  if this is their permanent or family home",
+                                               "Members of the Armed Forces if this is their permanent or family home",
+                                               "People who are temporarily outside the UK for <b>less than 12 months</b>",
+                                               "People staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends",
+                                               "Other people who usually live here, including anyone temporarily away from home "
+                                           ]
+                                      }
+                                  ],
+                                  "answers": [
+                                        {
+                                            "guidance": "",
+                                            "id": "household-composition-add-another",
+                                            "label": "",
+                                            "mandatory": true,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No - I need to add another person",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "4",
+                                            "type": "Radio",
+                                            "validation": {
+                                                "messages": {}
+                                            }
+                                        }
+                                  ]
+
+                                }
+                            ],
+                            "title": "Who lives here?",
+                            "description": "<h2 class='neptune'>Your household includes:</h2> {{ [answers.first_name, answers.middle_names, answers.last_name]|format_household_summary }}",
+                            "validation": []
+                        }],
+                        "routing_rules":[
+                            {
+                                "goto": {
+                                    "id" : "household-composition",
+                                    "when": {
+                                        "id" : "household-composition-add-another",
+                                        "condition": "equals",
+                                        "value":"No"
+                                    }
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "id": "summary",
+                                    "when": {
+                                        "id" : "household-composition-add-another",
+                                        "condition": "equals",
+                                        "value":"Yes"
+                                    }
+                                }
+
+                            }
+                        ],
+                    "id": "household-summary",
+                    "title": ""
                 }
             ],
-            "display": {
-                "properties": {}
-            },
             "id": "multiple-questions-group",
             "title": "",
             "validation": []

--- a/app/helpers/schema_helper.py
+++ b/app/helpers/schema_helper.py
@@ -35,9 +35,24 @@ class SchemaHelper(object):
                     yield rule
 
     @classmethod
+    def get_group_blocks(cls, survey_json, group_id):
+        group = cls.get_group(survey_json, group_id)
+
+        for block in group['blocks']:
+            yield block
+
+    @classmethod
     def get_group(cls, survey_json, group_id):
         return next(g for g in cls.get_groups(survey_json) if g["id"] == group_id)
 
     @classmethod
     def get_block(cls, survey_json, block_id):
         return next(b for b in cls.get_blocks(survey_json) if b["id"] == block_id)
+
+    @staticmethod
+    def is_goto_rule(rule):
+        return 'goto' in rule and 'when' in rule['goto'].keys() or 'id' in rule['goto'].keys()
+
+    @staticmethod
+    def is_goto_meta_rule(rule):
+        return 'goto' in rule and 'when' in rule['goto'].keys() and 'meta' in rule['goto']['when'].keys()

--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -54,3 +54,15 @@ def format_str_as_date(value):
 @blueprint.app_template_filter()
 def format_household_member_name(names):
     return ' '.join(map(lambda name: name.strip(), filter(None, names)))
+
+
+@blueprint.app_template_filter()
+def format_household_summary(names):
+    if len(names) > 0:
+        person_list = '<ul>'
+        for first_name, middle_name, last_name in zip(names[0], names[1], names[2]):
+            person_list += '<li>{}</li>'.format(format_household_member_name([first_name, middle_name, last_name]))
+        person_list += '</ul>'
+
+        return person_list
+    return ''

--- a/app/questionnaire/navigator.py
+++ b/app/questionnaire/navigator.py
@@ -1,103 +1,10 @@
 import logging
 
-from app.data_model.answer_store import AnswerStore
+from app.data_model.answer_store import Answer, AnswerStore
 from app.helpers.schema_helper import SchemaHelper
+from app.questionnaire.rules import evaluate_goto, evaluate_repeat
 
 logger = logging.getLogger(__name__)
-
-
-def evaluate_rule(when, answer_value):
-    """
-    Determine whether a rule will be satisfied based on a given answer
-    :param when:
-    :param answer_value:
-    :return:
-    """
-    match_value = when['value']
-    condition = when['condition']
-
-    answer_to_test = str(answer_value)
-
-    if isinstance(answer_value, list):
-        if len(answer_value) == 1:
-            answer_to_test = answer_value[0]
-        else:
-            return False
-
-    # Evaluate the condition on the routing rule
-    if condition == 'equals' and match_value == answer_to_test:
-        return True
-    elif condition == 'not equals' and match_value != answer_to_test:
-        return True
-    return False
-
-
-def evaluate_goto(goto_rule, metadata, answers, group_instance):
-    """
-    Determine whether a goto rule will be satisfied based on a given answer
-    :param goto_rule:
-    :param metadata
-    :param answers:
-    :param group_instance:
-    :return:
-    """
-    if 'when' in goto_rule.keys():
-
-        when = goto_rule['when']
-
-        if 'id' in when:
-            answer_index = when['id']
-            filtered = answers.filter(answer_id=answer_index, group_instance=group_instance)
-            if len(filtered) == 1:
-                return evaluate_rule(when, filtered[0]['value'])
-
-        elif 'meta' in when:
-            key = when['meta']
-            value = get_metadata_value(metadata, key)
-            return evaluate_rule(when, value)
-
-        return False
-    return True
-
-
-def get_metadata_value(metadata, keys):
-    if not _contains_in_dict(metadata, keys):
-        return None
-
-    if "." in keys:
-        key, rest = keys.split(".", 1)
-        return get_metadata_value(metadata[key], rest)
-    else:
-        return metadata[keys]
-
-
-def _contains_in_dict(metadata, keys):
-    if "." in keys:
-        key, rest = keys.split(".", 1)
-        if key not in metadata:
-            return False
-        return _contains_in_dict(metadata[key], rest)
-    else:
-        return keys in metadata
-
-
-def evaluate_repeat(repeat_rule, answers):
-    """
-    Returns the number of times repetition should occur based on answers
-    :param repeat_rule:
-    :param answers:
-    :return: The number of times to repeat
-    """
-    repeat_functions = {
-        'answer_value': lambda filtered_answers: int(filtered_answers[0]['value'] if len(filtered_answers) == 1 else 1),
-        'answer_count': lambda filtered_answers: len(filtered_answers),
-        'answer_count_minus_one': lambda filtered_answers: len(filtered_answers) - 1,
-    }
-    if 'answer_id' in repeat_rule and 'type' in repeat_rule:
-        repeat_index = repeat_rule['answer_id']
-        filtered = answers.filter(answer_id=repeat_index)
-        repeat_function = repeat_functions[repeat_rule['type']]
-        return repeat_function(filtered)
 
 
 class Navigator:
@@ -114,57 +21,77 @@ class Navigator:
         if SchemaHelper.has_introduction(self.survey_json):
             self.preceeding_path = self.PRECEEDING_INTERSTITIAL_PATH
 
-        self.first_block_id = SchemaHelper.get_first_block_id(self.survey_json)
         self.first_group_id = SchemaHelper.get_first_group_id(self.survey_json)
         self.last_group_id = SchemaHelper.get_last_group_id(self.survey_json)
+
+        self.first_block_location = {
+            "group_id": self.first_group_id,
+            "group_instance": 0,
+            "block_id": SchemaHelper.get_first_block_id(self.survey_json),
+        }
         self.location_path = self.get_location_path()
+        self.first_location = self.location_path[0]
 
     @classmethod
     def is_interstitial_block(cls, block_id):
         return block_id in cls.PRECEEDING_INTERSTITIAL_PATH or block_id in cls.CLOSING_INTERSTITIAL_PATH
 
-    def build_path(self, blocks, group_id, group_instance, block_id, path):
+    @classmethod
+    def _block_index_for_location(cls, blocks, location):
+        if not cls.is_interstitial_block(location['block_id']):
+            return next(index for (index, b) in enumerate(blocks) if b["block"]["id"] == location['block_id'] and
+                        b["group_id"] == location['group_id'] and b['group_instance'] == location['group_instance'])
+        return None
+
+    def build_path(self, blocks, this_location, path):
         """
         Recursive method which visits all the blocks and returns path taken
         given a list of answers
 
         :param blocks: A list containing all blocks in the survey
-        :param group_id: The group id to visit
-        :param group_instance: The group instance to visit
-        :param block_id: The block id to visit
+        :param this_location: The location to visit
         :param path: The known path as a list which has been visited already
         :return: A list of block ids followed through the survey
         """
-        if block_id in self.CLOSING_INTERSTITIAL_PATH:
+        if this_location['block_id'] in self.CLOSING_INTERSTITIAL_PATH:
             return path
 
-        this_block = {
-            "block_id": block_id,
-            "group_id": group_id,
-            "group_instance": group_instance,
-        }
-
-        path.append(this_block)
+        path.append(this_location)
 
         # Return the index of the block id to be visited
-        block_id_index = next(index for (index, b) in enumerate(blocks) if b["block"]["id"] == block_id and
-                              b["group_id"] == group_id and b['group_instance'] == group_instance)
+        block_index = self._block_index_for_location(blocks, this_location)
 
-        block = blocks[block_id_index]["block"]
+        block = blocks[block_index]["block"]
 
         if 'routing_rules' in block and len(block['routing_rules']) > 0:
             for rule in block['routing_rules']:
-                is_goto_rule = 'goto' in rule and 'when' in rule['goto'].keys() or 'id' in rule['goto'].keys()
-                if is_goto_rule and evaluate_goto(rule['goto'], self.metadata, self.answer_store, group_instance):
-                    return self.build_path(blocks, group_id, group_instance, rule['goto']['id'], path)
+                if SchemaHelper.is_goto_rule(rule) and evaluate_goto(rule['goto'], self.metadata, self.answer_store, this_location['group_instance']):
+                    is_meta_rule = SchemaHelper.is_goto_meta_rule(rule)
+                    next_location = this_location.copy()
+                    next_location['block_id'] = rule['goto']['id']
+
+                    next_block_index = self._block_index_for_location(blocks, next_location)
+
+                    # We're jumping backwards, so need to delete current answer
+                    if not is_meta_rule and next_block_index is not None and block_index > next_block_index:
+                        answer = Answer(answer_id=rule['goto']['when']['id'],
+                                        answer_instance=0,
+                                        block_id=this_location['block_id'],
+                                        group_id=this_location['group_id'],
+                                        group_instance=this_location['group_instance'])
+                        self.answer_store.remove(answer)
+
+                    return self.build_path(blocks, next_location, path)
 
         # If this isn't the last block in the set evaluated
-        elif block_id_index != len(blocks) - 1:
-            next_block_id = blocks[block_id_index + 1]['block']['id']
-            next_group_id = blocks[block_id_index + 1]['group_id']
-            next_group_instance = blocks[block_id_index + 1]['group_instance']
+        elif block_index != len(blocks) - 1:
+            next_location = {
+                "block_id": blocks[block_index + 1]['block']['id'],
+                "group_id": blocks[block_index + 1]['group_id'],
+                "group_instance": blocks[block_index + 1]['group_instance'],
+            }
 
-            return self.build_path(blocks, next_group_id, next_group_instance, next_block_id, path)
+            return self.build_path(blocks, next_location, path)
         return path
 
     def update_answer_store(self, answer_store):
@@ -181,7 +108,7 @@ class Navigator:
         Returns a list of the block ids visited based on answers provided
         :return: List of block location dicts
         """
-        return self.build_path(self.get_blocks(), self.first_group_id, 0, self.first_block_id, [])
+        return self.build_path(self.get_blocks(), self.first_block_location, [])
 
     def can_reach_summary(self, routing_path=None):
         """
@@ -191,15 +118,14 @@ class Navigator:
         :return:
         """
         blocks = self.get_blocks()
-        routing_path = routing_path or self.build_path(blocks, self.first_group_id, 0, self.first_block_id, [])
+        routing_path = routing_path or self.build_path(blocks, self.first_block_location, [])
         last_routing_block_id = routing_path[-1]['block_id']
         last_block_id = blocks[-1]['block']['id']
 
         if last_block_id == last_routing_block_id:
             return True
 
-        routing_block_id_index = next(
-            index for (index, b) in enumerate(blocks) if b['block']["id"] == last_routing_block_id)
+        routing_block_id_index = next(index for (index, b) in enumerate(blocks) if b['block']["id"] == last_routing_block_id)
 
         last_routing_block = blocks[routing_block_id_index]['block']
 
@@ -239,6 +165,7 @@ class Navigator:
 
     def get_blocks(self):
         blocks = []
+
         for group_index, group in enumerate(SchemaHelper.get_groups(self.survey_json)):
             no_of_repeats = 1
 
@@ -302,15 +229,9 @@ class Navigator:
         :return:
         """
         if completed_blocks:
-            incomplete_blocks = [item for item in self.get_location_path() if item not in completed_blocks]
+            incomplete_blocks = [item for item in self.location_path if item not in completed_blocks]
 
             if incomplete_blocks:
                 return incomplete_blocks[0]
 
-        first_location = self.get_location_path()[0]
-
-        return {
-            'block_id': first_location['block_id'],
-            'group_id': SchemaHelper.get_first_group_id(self.survey_json),
-            'group_instance': 0,
-        }
+        return self.first_location

--- a/app/questionnaire/questionnaire_manager.py
+++ b/app/questionnaire/questionnaire_manager.py
@@ -1,7 +1,8 @@
 import logging
 
 from app.globals import get_answer_store, get_answers, get_metadata, get_questionnaire_store
-from app.questionnaire.navigator import Navigator, evaluate_rule, get_metadata_value
+from app.questionnaire.navigator import Navigator
+from app.questionnaire.rules import evaluate_rule, get_metadata_value
 
 from app.templating.schema_context import build_schema_context
 from app.templating.template_renderer import renderer

--- a/app/questionnaire/rules.py
+++ b/app/questionnaire/rules.py
@@ -1,0 +1,92 @@
+def evaluate_rule(when, answer_value):
+    """
+    Determine whether a rule will be satisfied based on a given answer
+    :param when:
+    :param answer_value:
+    :return:
+    """
+    match_value = when['value']
+    condition = when['condition']
+
+    answer_to_test = str(answer_value)
+
+    if isinstance(answer_value, list):
+        if len(answer_value) == 1:
+            answer_to_test = answer_value[0]
+        else:
+            return False
+
+    # Evaluate the condition on the routing rule
+    if condition == 'equals' and match_value == answer_to_test:
+        return True
+    elif condition == 'not equals' and match_value != answer_to_test:
+        return True
+    return False
+
+
+def evaluate_goto(goto_rule, metadata, answer_store, group_instance):
+    """
+    Determine whether a goto rule will be satisfied based on a given answer
+    :param goto_rule:
+    :param metadata
+    :param answer_store:
+    :param group_instance:
+    :return:
+    """
+    if 'when' in goto_rule.keys():
+
+        when = goto_rule['when']
+
+        if 'id' in when:
+            answer_index = when['id']
+            filtered = answer_store.filter(answer_id=answer_index, group_instance=group_instance)
+            if len(filtered) == 1:
+                return evaluate_rule(when, filtered[0]['value'])
+
+        elif 'meta' in when:
+            key = when['meta']
+            value = get_metadata_value(metadata, key)
+            return evaluate_rule(when, value)
+
+        return False
+    return True
+
+
+def evaluate_repeat(repeat_rule, answer_store):
+    """
+    Returns the number of times repetition should occur based on answers
+    :param repeat_rule:
+    :param answer_store:
+    :return: The number of times to repeat
+    """
+    repeat_functions = {
+        'answer_value': lambda filtered_answers: int(filtered_answers[0]['value'] if len(filtered_answers) == 1 else 1),
+        'answer_count': len,
+        'answer_count_minus_one': lambda filtered_answers: len(filtered_answers) - 1,
+    }
+    if 'answer_id' in repeat_rule and 'type' in repeat_rule:
+        repeat_index = repeat_rule['answer_id']
+        filtered = answer_store.filter(answer_id=repeat_index)
+        repeat_function = repeat_functions[repeat_rule['type']]
+        return repeat_function(filtered)
+
+
+def get_metadata_value(metadata, keys):
+    if not _contains_in_dict(metadata, keys):
+        return None
+
+    if "." in keys:
+        key, rest = keys.split(".", 1)
+        return get_metadata_value(metadata[key], rest)
+    else:
+        return metadata[keys]
+
+
+def _contains_in_dict(metadata, keys):
+    if "." in keys:
+        key, rest = keys.split(".", 1)
+        if key not in metadata:
+            return False
+        return _contains_in_dict(metadata[key], rest)
+    else:
+        return keys in metadata

--- a/app/templates/partials/questions/repeatinganswer.html
+++ b/app/templates/partials/questions/repeatinganswer.html
@@ -1,8 +1,9 @@
 <div class="question question--repeatinganswer" id="{{question.id}}">
 
-  <h2 class="question__title neptune">{{question_title}}</h2>
+  <h2 class="question__title neptune">{{question_title|safe}}</h2>
 
   {{question_description|safe}}
+  {{question_guidance|safe}}
 
   <div class="question__answers">
     {%- for composite_answer in question.answers_grouped_by_instance() %}

--- a/app/templating/summary/question.py
+++ b/app/templating/summary/question.py
@@ -1,4 +1,4 @@
-from app.questionnaire.navigator import evaluate_rule
+from app.questionnaire.rules import evaluate_rule
 from app.questionnaire_state.state_repeating_answer_question import iterate_over_instance_ids
 from app.templating.summary.answer import Answer
 

--- a/app/templating/template_renderer.py
+++ b/app/templating/template_renderer.py
@@ -1,7 +1,6 @@
 import json
 
-from app.jinja_filters import format_date
-from app.jinja_filters import format_household_member_name
+from app.jinja_filters import format_date, format_household_member_name, format_household_summary
 
 from jinja2 import Environment
 
@@ -11,6 +10,7 @@ class TemplateRenderer:
         self.environment = Environment()
         self.environment.filters['format_date'] = format_date
         self.environment.filters['format_household_name'] = format_household_member_name
+        self.environment.filters['format_household_summary'] = format_household_summary
 
     def render(self, renderable, **context):
         """

--- a/tests/app/questionnaire/test_navigator.py
+++ b/tests/app/questionnaire/test_navigator.py
@@ -1,6 +1,6 @@
 import unittest
 
-from app.questionnaire.navigator import evaluate_rule, Navigator
+from app.questionnaire.navigator import Navigator
 from app.schema_loader.schema_loader import load_schema_file
 from app.data_model.answer_store import Answer, AnswerStore
 
@@ -897,8 +897,8 @@ class TestNavigator(unittest.TestCase):
         navigator = Navigator(survey, metadata=metadata)
 
         self.assertEqual(expected_next_block_id, navigator.get_next_location(current_group_id=current_group_id,
-                                                                    current_block_id=current_block_id,
-                                                                    current_iteration=current_iteration))
+                                                                             current_block_id=current_block_id,
+                                                                             current_iteration=current_iteration))
 
     def test_next_with_conditional_path_when_value_not_in_metadata(self):
         survey = load_schema_file("test_metadata_routing.json")
@@ -930,25 +930,138 @@ class TestNavigator(unittest.TestCase):
         navigator = Navigator(survey, metadata=metadata)
 
         self.assertEqual(expected_next_block_id, navigator.get_next_location(current_group_id=current_group_id,
-                                                                    current_block_id=current_block_id,
-                                                                    current_iteration=current_iteration))
+                                                                             current_block_id=current_block_id,
+                                                                             current_iteration=current_iteration))
 
-    def test_evaluate_rule_uses_single_value_from_list(self):
-        when = {
-            "value": 'singleAnswer',
-            "condition": 'equals'
-        }
+    def test_routing_backwards_loops_to_previous_block(self):
+        survey = load_schema_file("test_household_question.json")
 
-        list_of_answers = ['singleAnswer']
+        expected_path = [{
+            'group_instance': 0,
+            'group_id': 'multiple-questions-group',
+            'block_id': 'introduction'
+        }, {
+            'group_instance': 0,
+            'group_id': 'multiple-questions-group',
+            'block_id': 'household-composition'
+        }, {
+            'group_instance': 0,
+            'group_id': 'multiple-questions-group',
+            'block_id': 'household-summary'
+        }, {
+            'group_instance': 0,
+            'group_id': 'multiple-questions-group',
+            'block_id': 'household-composition'
+        }]
 
-        self.assertTrue(evaluate_rule(when, list_of_answers))
+        current_group_id = expected_path[2]["group_id"]
+        current_block_id = expected_path[2]["block_id"]
+        current_iteration = expected_path[2]["group_instance"]
 
-    def test_evaluate_rule_uses_multiple_values_in_list_returns_false(self):
-        when = {
-            "value": 'firstAnswer',
-            "condition": 'equals'
-        }
+        expected_next_location = expected_path[3]
 
-        list_of_answers = ['firstAnswer', 'secondAnswer']
+        answers = AnswerStore()
 
-        self.assertFalse(evaluate_rule(when, list_of_answers))
+        answer_1 = Answer(
+            group_id="multiple-questions-group",
+            group_instance=0,
+            block_id="household-composition",
+            answer_id="household-full-name",
+            answer_instance=0,
+            value="Joe Bloggs"
+        )
+
+        answer_2 = Answer(
+            group_id="multiple-questions-group",
+            group_instance=0,
+            block_id="household-composition",
+            answer_id="household-full-name",
+            answer_instance=1,
+            value="Sophie Bloggs"
+        )
+
+        answer_3 = Answer(
+            group_id="multiple-questions-group",
+            group_instance=0,
+            block_id="household-summary",
+            answer_id="household-composition-add-another",
+            answer_instance=0,
+            value="No"
+        )
+
+        answers.add(answer_1)
+        answers.add(answer_2)
+        answers.add(answer_3)
+
+        navigator = Navigator(survey, answer_store=answers)
+
+        self.assertEqual(expected_next_location, navigator.get_next_location(current_group_id=current_group_id,
+                                                                             current_block_id=current_block_id,
+                                                                             current_iteration=current_iteration))
+
+    def test_routing_backwards_continues_to_summary_when_complete(self):
+        survey = load_schema_file("test_household_question.json")
+
+        expected_path = [{
+            'group_instance': 0,
+            'group_id': 'multiple-questions-group',
+            'block_id': 'introduction'
+        }, {
+            'group_instance': 0,
+            'group_id': 'multiple-questions-group',
+            'block_id': 'household-composition'
+        }, {
+            'group_instance': 0,
+            'group_id': 'multiple-questions-group',
+            'block_id': 'household-summary'
+        }, {
+            'group_instance': 0,
+            'group_id': 'multiple-questions-group',
+            'block_id': 'summary'
+        }]
+
+        current_group_id = expected_path[2]["group_id"]
+        current_block_id = expected_path[2]["block_id"]
+        current_iteration = expected_path[2]["group_instance"]
+
+        expected_next_location = expected_path[3]
+
+        answers = AnswerStore()
+
+        answer_1 = Answer(
+            group_id="multiple-questions-group",
+            group_instance=0,
+            block_id="household-composition",
+            answer_id="household-full-name",
+            answer_instance=0,
+            value="Joe Bloggs"
+        )
+
+        answer_2 = Answer(
+            group_id="multiple-questions-group",
+            group_instance=0,
+            block_id="household-composition",
+            answer_id="household-full-name",
+            answer_instance=1,
+            value="Sophie Bloggs"
+        )
+
+        answer_3 = Answer(
+            group_id="multiple-questions-group",
+            group_instance=0,
+            block_id="household-summary",
+            answer_id="household-composition-add-another",
+            answer_instance=0,
+            value="Yes"
+        )
+
+        answers.add(answer_1)
+        answers.add(answer_2)
+        answers.add(answer_3)
+
+        navigator = Navigator(survey, answer_store=answers)
+
+        self.assertEqual(expected_next_location, navigator.get_next_location(current_group_id=current_group_id,
+                                                                             current_block_id=current_block_id,
+                                                                             current_iteration=current_iteration))
+

--- a/tests/app/questionnaire/test_rules.py
+++ b/tests/app/questionnaire/test_rules.py
@@ -1,0 +1,108 @@
+from unittest import TestCase
+
+from app.data_model.answer_store import AnswerStore, Answer
+from app.questionnaire.rules import evaluate_rule, evaluate_goto, evaluate_repeat
+
+
+class TestRules(TestCase):
+    def test_evaluate_rule_uses_single_value_from_list(self):
+        when = {
+            'value': 'singleAnswer',
+            'condition': 'equals'
+        }
+
+        list_of_answers = ['singleAnswer']
+
+        self.assertTrue(evaluate_rule(when, list_of_answers))
+
+    def test_evaluate_rule_uses_multiple_values_in_list_returns_false(self):
+        when = {
+            'value': 'firstAnswer',
+            'condition': 'equals'
+        }
+
+        list_of_answers = ['firstAnswer', 'secondAnswer']
+
+        self.assertFalse(evaluate_rule(when, list_of_answers))
+
+    def test_go_to_next_question_for_answer(self):
+        # Given
+        goto = {
+            'goto': {
+                'id': 'next-question',
+                'when': {
+                    'id': 'my_answer',
+                    'condition': 'equals',
+                    'value': 'Yes'
+                }
+            }
+        }
+        answer_store = AnswerStore()
+        answer_store.add(Answer(answer_id='my_answer', value='Yes'))
+
+        # When
+        goto = evaluate_goto(goto, {}, answer_store, 0)
+
+        self.assertEqual(goto, True)
+
+    def test_do_not_go_to_next_question_for_answer(self):
+        # Given
+        goto = {
+            'id': 'next-question',
+            'when': {
+                'id': 'my_answer',
+                'condition': 'equals',
+                'value': 'Yes'
+            }
+        }
+        answer_store = AnswerStore()
+        answer_store.add(Answer(answer_id='my_answer', value='No'))
+
+        # When
+        goto = evaluate_goto(goto, {}, answer_store, 0)
+
+        self.assertEqual(goto, False)
+
+    def test_should_repeat_for_answer_answer_value(self):
+        # Given
+        repeat = {
+            'answer_id': 'my_answer',
+            'type': 'answer_value'
+        }
+        answer_store = AnswerStore()
+        answer_store.add(Answer(answer_id='my_answer', value='3'))
+
+        # When
+        number_of_repeats = evaluate_repeat(repeat,answer_store)
+
+        self.assertEqual(number_of_repeats, 3)
+
+    def test_should_repeat_for_answer_answer_count(self):
+        # Given
+        repeat = {
+            'answer_id': 'my_answer',
+            'type': 'answer_count'
+        }
+        answer_store = AnswerStore()
+        answer_store.add(Answer(answer_id='my_answer', value='3'))
+        answer_store.add(Answer(answer_id='my_answer', value='4', answer_instance=1))
+
+        # When
+        number_of_repeats = evaluate_repeat(repeat, answer_store)
+
+        self.assertEqual(number_of_repeats, 2)
+
+    def test_should_repeat_for_answer_answer_count_minus_one(self):
+        # Given
+        repeat = {
+            'answer_id': 'my_answer',
+            'type': 'answer_count_minus_one'
+        }
+        answer_store = AnswerStore()
+        answer_store.add(Answer(answer_id='my_answer', value='3'))
+        answer_store.add(Answer(answer_id='my_answer', value='4', answer_instance=1))
+
+        # When
+        number_of_repeats = evaluate_repeat(repeat, answer_store)
+
+        self.assertEqual(number_of_repeats, 1)

--- a/tests/app/routing/test_conditional_display.py
+++ b/tests/app/routing/test_conditional_display.py
@@ -1,4 +1,4 @@
-from app.questionnaire.navigator import evaluate_rule
+from app.questionnaire.rules import evaluate_rule
 
 from tests.app.framework.sr_unittest import SurveyRunnerTestCase
 

--- a/tests/functional/helpers.js
+++ b/tests/functional/helpers.js
@@ -6,7 +6,7 @@ export const getUri = uri => browser.options.baseUrl + uri
 
 export const getRandomString = length => sampleSize('ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789', length).join('')
 
-export const openAndStartCensusQuestionnaire = (schema, sexualIdentity = false, region = 'GB-ENG') => {
+export const startCensusQuestionnaire = (schema, sexualIdentity = false, region = 'GB-ENG') => {
   devPage.open()
     .setUserId(getRandomString(10))
     .setCollectionId(getRandomString(10))

--- a/tests/functional/pages/surveys/household_composition/summary.page.js
+++ b/tests/functional/pages/surveys/household_composition/summary.page.js
@@ -2,42 +2,24 @@ import SummaryPage from '../../summary.page'
 
 class HouseholdCompositionSummary extends SummaryPage {
 
-  clickEdit() {
-    browser.click('[data-qa="first-name-edit"]')
+  clickAddAnother() {
+    browser.click('[name="household-composition-add-another"][value="No"]')
     return this
   }
 
-  getFirstName(index) {
-    return this.getFirstNames()[index]
+  submit() {
+    browser.click('.qa-btn-submit')
+    return this
   }
 
-  getMiddleName(index) {
-    return this.getMiddleNames()[index]
-  }
-
-  getLastName(index) {
-    return this.getLastNames()[index]
-  }
-
-  getElementText(name, index) {
-    return this.getElementTextForAnswer(name)[index]
-  }
-
-  getFirstNames() {
-    return this.getElementTextForAnswer('first-name')
-  }
-
-  getMiddleNames() {
-    return this.getElementTextForAnswer('middle-names')
-  }
-
-  getLastNames() {
-    return this.getElementTextForAnswer('last-name')
+  isNameDisplayed(name) {
+    return browser.element('#further-section ul li').getText() === name
   }
 
   getElementTextForAnswer(answer) {
     var householdNames = []
-    var elements = browser.elements('[data-qa="' + answer + '-answer"]')
+    var elements = browser.elements('#further-section ul li')
+
     elements.value.forEach((elem) => {
       householdNames.push(browser.elementIdText(elem.ELEMENT).value)
     })

--- a/tests/functional/spec/census-household.spec.js
+++ b/tests/functional/spec/census-household.spec.js
@@ -1,5 +1,5 @@
 import chai from 'chai'
-import {openAndStartCensusQuestionnaire} from '../helpers'
+import {startCensusQuestionnaire} from '../helpers'
 
 import PermanentOrFamilyHome from '../pages/surveys/census/household/permanent-or-family-home.page.js'
 import ElsePermanentOrFamilyHome from '../pages/surveys/census/household/else-permanent-or-family-home.page.js'
@@ -79,7 +79,7 @@ const expect = chai.expect
 describe('Census Household', function () {
 
     it('Given Respondent Home has identified the respondent should have the Household Questionnaire without the sexual id question, When I complete the EQ, Then I should not be asked the sexual id question', function () {
-        openAndStartCensusQuestionnaire('census_household.json')
+        startCensusQuestionnaire('census_household.json')
 
         // who-lives-here
         PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
@@ -105,7 +105,7 @@ describe('Census Household', function () {
     })
 
     it('Given Respondent Home has identified the respondent should have the Household Questionnaire with the sexual id question, When I complete the EQ, Then I should be asked the sexual id question', function () {
-        openAndStartCensusQuestionnaire('census_household.json', true)
+        startCensusQuestionnaire('census_household.json', true)
 
         // who-lives-here
         PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
@@ -154,7 +154,7 @@ describe('Census Household', function () {
     })
 
     it('Given a census household survey with welsh region, When i enter valid data, Then the survey should submit successfully', function () {
-        openAndStartCensusQuestionnaire('census_household.json', false, 'GB-WLS')
+        startCensusQuestionnaire('census_household.json', false, 'GB-WLS')
 
         // who-lives-here
         PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
@@ -202,7 +202,7 @@ describe('Census Household', function () {
     })
 
     it('Given a census household survey, When one person in household, Then persons name should appear on member details pages.', function () {
-        openAndStartCensusQuestionnaire('census_household.json', false, 'GB-WLS')
+        startCensusQuestionnaire('census_household.json', false, 'GB-WLS')
 
         // who-lives-here
         var person = 'John Smith'
@@ -273,7 +273,7 @@ describe('Census Household', function () {
     })
 
     it('Given two people are in the household, When I complete the household details for person one, Then I should be asked household details for person two.', function () {
-        openAndStartCensusQuestionnaire('census_household.json')
+        startCensusQuestionnaire('census_household.json')
 
         // who-lives-here
         PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
@@ -301,7 +301,7 @@ describe('Census Household', function () {
     })
 
     it('Given I have two visitors, When I complete the visitor details for person one, Then I should be asked visitor details for person two.', function () {
-        openAndStartCensusQuestionnaire('census_household.json')
+        startCensusQuestionnaire('census_household.json')
 
         // who-lives-here
         PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
@@ -373,4 +373,3 @@ describe('Census Household', function () {
     }
 
 })
-

--- a/tests/functional/spec/census-individual.spec.js
+++ b/tests/functional/spec/census-individual.spec.js
@@ -1,5 +1,5 @@
 import chai from 'chai'
-import {openAndStartCensusQuestionnaire} from '../helpers'
+import {startCensusQuestionnaire} from '../helpers'
 
 import CorrectName from '../pages/surveys/census/individual/correct-name.page.js'
 import Sex from '../pages/surveys/census/individual/sex.page.js'
@@ -53,7 +53,7 @@ const expect = chai.expect
 describe('Census Individual', function () {
 
     it('Given Respondent Home has identified the respondent should have the Individual Questionnaire without the sexual id question, When I complete the EQ, Then I should not be asked the sexual id question', function () {
-        openAndStartCensusQuestionnaire('census_individual.json')
+        startCensusQuestionnaire('census_individual.json')
 
         // household-member
         CorrectName.setFirstName("Paul").setLastName("Smith").submit()
@@ -86,7 +86,7 @@ describe('Census Individual', function () {
     })
 
     it('Given Respondent Home has identified the respondent should have the Individual Questionnaire with the sexual id question, When I complete the EQ, Then I should be asked the sexual id question', function () {
-        openAndStartCensusQuestionnaire('census_individual.json', true)
+        startCensusQuestionnaire('census_individual.json', true)
 
         // household-member
         CorrectName.setFirstName("Paul").setLastName("Smith").submit()
@@ -121,7 +121,7 @@ describe('Census Individual', function () {
 
 
     it('Given Respondent Home has identified the respondent should have the Individual Questionnaire with the sexual id question, When I complete the EQ stating i am over 16, Then I should be asked the sexual id question', function () {
-        openAndStartCensusQuestionnaire('census_individual.json', true)
+        startCensusQuestionnaire('census_individual.json', true)
 
         // household-member
         CorrectName.setFirstName("Paul").setLastName("Smith").submit()
@@ -156,7 +156,7 @@ describe('Census Individual', function () {
 
 
     it('Given Respondent Home has identified the respondent should have the Individual Questionnaire with the sexual id question, When I complete the EQ stating i am under 16, Then I should not be asked the sexual id question', function () {
-        openAndStartCensusQuestionnaire('census_individual.json', true)
+        startCensusQuestionnaire('census_individual.json', true)
 
         // household-member
         CorrectName.setFirstName("Paul").setLastName("Smith").submit()
@@ -190,7 +190,7 @@ describe('Census Individual', function () {
 
     it('Given the census theme is selected, then the help should not be visible', function() {
         // Given
-        openAndStartCensusQuestionnaire('census_individual.json')
+        startCensusQuestionnaire('census_individual.json')
         // Then
         expect(browser.isVisible('.js-help-body')).to.be.false
     })
@@ -198,7 +198,7 @@ describe('Census Individual', function () {
     it('Given the census theme is selected, when I click the "help and support" button, then the help should be visible', function() {
 
         // Given
-        openAndStartCensusQuestionnaire('census_individual.json')
+        startCensusQuestionnaire('census_individual.json')
 
         // When
         browser.click('.js-help-btn')

--- a/tests/functional/spec/census/issues/are-you-a-schoolchild.spec.js
+++ b/tests/functional/spec/census/issues/are-you-a-schoolchild.spec.js
@@ -1,5 +1,5 @@
 import chai from 'chai'
-import {openAndStartCensusQuestionnaire} from '../../../helpers'
+import {startCensusQuestionnaire} from '../../../helpers'
 
 import PermanentOrFamilyHome from '../../../pages/surveys/census/household/permanent-or-family-home.page.js'
 import ElsePermanentOrFamilyHome from '../../../pages/surveys/census/household/else-permanent-or-family-home.page.js'
@@ -79,7 +79,7 @@ const expect = chai.expect
 describe('Are-you-a-schoolchild', function () {
 
   it('Given I am answering question 7 in the individual detail section - 7. Are you a schoolchild or student in full-time education?, When I do not select any respone, Then I am routed to 9. What is your country of birth?', function () {
-   openAndStartCensusQuestionnaire('census_household.json', true)
+   startCensusQuestionnaire('census_household.json', true)
    PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
    HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
    EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()

--- a/tests/functional/spec/census/issues/arrive-in-uk-question.spec.js
+++ b/tests/functional/spec/census/issues/arrive-in-uk-question.spec.js
@@ -1,5 +1,5 @@
   import chai from 'chai'
-  import {openAndStartCensusQuestionnaire} from '../../../helpers'
+  import {startCensusQuestionnaire} from '../../../helpers'
 
   import PermanentOrFamilyHome from '../../../pages/surveys/census/household/permanent-or-family-home.page.js'
   import ElsePermanentOrFamilyHome from '../../../pages/surveys/census/household/else-permanent-or-family-home.page.js'
@@ -78,7 +78,7 @@
 
   describe('ArriveInUk', function () {
     it('Given a census schema, When I select bottom 2 options for Question - 9. What is your country of birth?, Then I should be displayed with ArriveInUk screen ', function () {
-        openAndStartCensusQuestionnaire('census_household.json', true)
+        startCensusQuestionnaire('census_household.json', true)
         PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
         HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
         EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()

--- a/tests/functional/spec/census/issues/fulltime-education-question.spec.js
+++ b/tests/functional/spec/census/issues/fulltime-education-question.spec.js
@@ -1,5 +1,5 @@
   import chai from 'chai'
-  import {openAndStartCensusQuestionnaire} from '../../../helpers'
+  import {startCensusQuestionnaire} from '../../../helpers'
 
   import PermanentOrFamilyHome from '../../../pages/surveys/census/household/permanent-or-family-home.page.js'
   import ElsePermanentOrFamilyHome from '../../../pages/surveys/census/household/else-permanent-or-family-home.page.js'
@@ -78,7 +78,7 @@
 
   describe('term-time-location', function () {
     it('Given a census schema, When I select option Yes for Question - Are you a schoolchild or student in full-time education?, Then I should be displayed with term-time-location screen ', function () {
-        openAndStartCensusQuestionnaire('census_household.json', true)
+        startCensusQuestionnaire('census_household.json', true)
         PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
         HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(0, 'Jane Smith').submit()
         EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()

--- a/tests/functional/spec/census/issues/individual-Q1-are-these-details-correct.spec.js
+++ b/tests/functional/spec/census/issues/individual-Q1-are-these-details-correct.spec.js
@@ -1,4 +1,4 @@
-import {openAndStartCensusQuestionnaire} from '../../../helpers'
+import {startCensusQuestionnaire} from '../../../helpers'
 
 import PermanentOrFamilyHome from '../../../pages/surveys/census/household/permanent-or-family-home.page.js'
 import HouseholdComposition from '../../../pages/surveys/census/household/household-composition.page.js'
@@ -21,7 +21,7 @@ import Sex from '../../../pages/surveys/census/household/sex.page.js'
 describe('Individual section Question 1', function () {
 
   it('Given I am answering question 1 in the individual detail section, When I do not select any response, Then I am routed to What is you sex question 2 ', function () {
-    openAndStartCensusQuestionnaire('census_household.json', true)
+    startCensusQuestionnaire('census_household.json', true)
     PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
     HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
     EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()

--- a/tests/functional/spec/census/issues/number-of-visitors-issue.spec.js
+++ b/tests/functional/spec/census/issues/number-of-visitors-issue.spec.js
@@ -1,5 +1,5 @@
 import chai from 'chai'
-import {openAndStartCensusQuestionnaire} from '../../../helpers'
+import {startCensusQuestionnaire} from '../../../helpers'
 
 import PermanentOrFamilyHome from '../../../pages/surveys/census/household/permanent-or-family-home.page.js'
 import ElsePermanentOrFamilyHome from '../../../pages/surveys/census/household/else-permanent-or-family-home.page.js'
@@ -78,7 +78,7 @@ const expect = chai.expect
 
 describe('Number of visitors', function () {
   it('Given a census schema, When I dont enter any value for question: How many visitors are staying overnight here on 9th April 2017?, Then I should get an error message ', function () {
-      openAndStartCensusQuestionnaire('census_household.json', true)
+      startCensusQuestionnaire('census_household.json', true)
       PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
       HouseholdComposition.setPersonName(0, 'John Smith').submit()
       EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()

--- a/tests/functional/spec/census/issues/routing-last-week-were-you.spec.js
+++ b/tests/functional/spec/census/issues/routing-last-week-were-you.spec.js
@@ -1,4 +1,4 @@
-import {openAndStartCensusQuestionnaire} from '../../../helpers'
+import {startCensusQuestionnaire} from '../../../helpers'
 
 import PermanentOrFamilyHome from '../../../pages/surveys/census/household/permanent-or-family-home.page.js'
 import HouseholdComposition from '../../../pages/surveys/census/household/household-composition.page.js'
@@ -40,7 +40,7 @@ import Jobseeker from '../../../pages/surveys/census/household/jobseeker.page.js
 
 describe('ArriveInUk', function () {
   it('Given I am answering question 28.	Last week were you.., When I dont not select any response, Then I am routed to 29. Were you actively looking for...?', function () {
-      openAndStartCensusQuestionnaire('census_household.json')
+      startCensusQuestionnaire('census_household.json')
 
       // who-lives-here
       PermanentOrFamilyHome

--- a/tests/functional/spec/census/issues/who-lives-here-no-response.spec.js
+++ b/tests/functional/spec/census/issues/who-lives-here-no-response.spec.js
@@ -1,5 +1,5 @@
 import chai from 'chai'
-import {openAndStartCensusQuestionnaire} from '../../../helpers'
+import {startCensusQuestionnaire} from '../../../helpers'
 
 import PermanentOrFamilyHome from '../../../pages/surveys/census/household/permanent-or-family-home.page.js'
 import ElsePermanentOrFamilyHome from '../../../pages/surveys/census/household/else-permanent-or-family-home.page.js'
@@ -79,7 +79,7 @@ const expect = chai.expect
 describe('ArriveInUk', function () {
 
   it('Given I am answering question 3 in the who lives here section, When I dont select any respone, Then I am routed to Who lives here question 4 ', function () {
-      openAndStartCensusQuestionnaire('census_household.json', true)
+      startCensusQuestionnaire('census_household.json', true)
       PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
       HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
       EveryoneAtAddressConfirmation.submit()

--- a/tests/functional/spec/census/routing/census-routing-scenarios.spec.js
+++ b/tests/functional/spec/census/routing/census-routing-scenarios.spec.js
@@ -1,5 +1,5 @@
   import chai from 'chai'
-  import {openAndStartCensusQuestionnaire} from '../../../helpers'
+  import {startCensusQuestionnaire} from '../../../helpers'
 
   import PermanentOrFamilyHome from '../../../pages/surveys/census/household/permanent-or-family-home.page.js'
   import ElsePermanentOrFamilyHome from '../../../pages/surveys/census/household/else-permanent-or-family-home.page.js'
@@ -76,517 +76,516 @@
 
   const expect = chai.expect
 
-  describe('Census routing Scenarios', function () {
+describe('Census routing Scenarios', function () {
 
-    it('Given I am answering question 1 in the who lives here section, When I select -yes- as the respone, Then I am routed to Who lives here question 2 ', function () {
-        openAndStartCensusQuestionnaire('census_household.json', true)
+    it('Given I am answering question 1 in the who lives here section, When I select -yes- as the response, Then I am routed to Who lives here question 2 ', function () {
+        startCensusQuestionnaire('census_household.json', true)
         PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
         HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
     })
 
-    it('Given I am answering question 1 in the who lives here section, When I select -no- as the respone, Then I am routed to Who lives here question 2 ', function () {
-        openAndStartCensusQuestionnaire('census_household.json', true)
+    it('Given I am answering question 1 in the who lives here section, When I select -no- as the response, Then I am routed to Who lives here question 2 ', function () {
+        startCensusQuestionnaire('census_household.json', true)
         PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerNo().submit()
         ElsePermanentOrFamilyHome.clickElsePermanentOrFamilyHomeAnswerYes()
     })
 
-    it('Given I am answering question 1 in the who lives here section, When I dont select any respone, Then I a alert msg saying mandatory field must be displayed ', function () {
-        openAndStartCensusQuestionnaire('census_household.json', true)
+    it('Given I am answering question 1 in the who lives here section, When I dont select any response, Then I a alert msg saying mandatory field must be displayed ', function () {
+        startCensusQuestionnaire('census_household.json', true)
         PermanentOrFamilyHome.submit()
         expect(PermanentOrFamilyHome.getAlertText()).to.contain('This field is mandatory.')
     })
 
-    it('Given I am answering question 1a in the who lives here section, When I select -yes- as the respone, Then I am routed to Who lives here question 2 ', function () {
-        openAndStartCensusQuestionnaire('census_household.json', true)
+    it('Given I am answering question 1a in the who lives here section, When I select -yes- as the response, Then I am routed to Who lives here question 2 ', function () {
+        startCensusQuestionnaire('census_household.json', true)
         PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerNo().submit()
         ElsePermanentOrFamilyHome.clickElsePermanentOrFamilyHomeAnswerYes().submit()
         HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
     })
 
-    it('Given I am answering question 1a in the who lives here section, When I select -no- as the respone, Then I am routed to How many visitors... question 4 ', function () {
-        openAndStartCensusQuestionnaire('census_household.json', true)
+    it('Given I am answering question 1a in the who lives here section, When I select -no- as the response, Then I am routed to How many visitors... question 4 ', function () {
+        startCensusQuestionnaire('census_household.json', true)
         PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerNo().submit()
         ElsePermanentOrFamilyHome.clickElsePermanentOrFamilyHomeAnswerNo().submit()
         OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
     })
 
-    it('Given I am answering question 1a in the who lives here section, When I select -no- as the respone, Then I am routed to How many visitors... question 4 ', function () {
-        openAndStartCensusQuestionnaire('census_household.json', true)
+    it('Given I am answering question 1a in the who lives here section, When I select -no- as the response, Then I am routed to How many visitors... question 4 ', function () {
+        startCensusQuestionnaire('census_household.json', true)
         PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerNo().submit()
         ElsePermanentOrFamilyHome.submit()
         expect(ElsePermanentOrFamilyHome.getAlertText()).to.contain('This field is mandatory.')
     })
 
-    it('Given I am answering question 3 in the who lives here section, When I select -yes- as the respone, Then I am routed to Who lives here question 4 ', function () {
-        openAndStartCensusQuestionnaire('census_household.json', true)
+    it('Given I am answering question 3 in the who lives here section, When I select -yes- as the response, Then I am routed to Who lives here question 4 ', function () {
+        startCensusQuestionnaire('census_household.json', true)
         PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
         HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
         EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
         OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
     })
-    // issue present error 500
-  /*  it('Given I am answering question 3 in the who lives here section, When I select -no- as the respone, Then I am routed back to Who lives here question 2 ', function () {
-        openAndStartCensusQuestionnaire('census_household.json', true)
+
+    it('Given I am answering question 3 in the who lives here section, When I select -no- as the response, Then I am routed back to Who lives here question 2 ', function () {
+        startCensusQuestionnaire('census_household.json', true)
         PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
         HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
         EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerNoINeedToAddAnotherPerson().submit()
         HouseholdComposition.submit()
     })
+
     // issue present - displaying on screen validation error which is not in spec
-    it('Given I am answering question 3 in the who lives here section, When I dont select any respone, Then I am routed to Who lives here question 4 ', function () {
-        openAndStartCensusQuestionnaire('census_household.json', true)
+    it('Given I am answering question 3 in the who lives here section, When I dont select any response, Then I am routed to Who lives here question 4 ', function () {
+        startCensusQuestionnaire('census_household.json', true)
         PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
         HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
         EveryoneAtAddressConfirmation.submit()
         OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
-    }) */
-
-    it('Given I am answering question 1 in the individual detail section, When I select -yes- as respone, Then I am routed to What is you sex question 2 ', function () {
-      openAndStartCensusQuestionnaire('census_household.json', true)
-      PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
-      HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
-      EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
-      OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
-      HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
-      WhoLivesHereCompleted.submit()
-
-    // household-and-accommodation
-      TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
-      TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
-      SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
-      NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
-      CentralHeating.clickCentralHeatingAnswerGas().submit()
-      OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
-      NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
-      HouseholdAndAccommodationCompleted.submit()
-
-    // household-member
-      HouseholdMemberBegin.submit()
-      DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
-      Sex.clickSexAnswerMale().submit()
-  })
-
-  it('Given I am answering question 1 in the individual detail section, When I select -no- as respone, Then I am routed to What is your correct name question 1a ', function () {
-    openAndStartCensusQuestionnaire('census_household.json', true)
-    PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
-    HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
-    EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
-    OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
-    HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
-    WhoLivesHereCompleted.submit()
-
-  // household-and-accommodation
-    TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
-    TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
-    SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
-    NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
-    CentralHeating.clickCentralHeatingAnswerGas().submit()
-    OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
-    NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
-    HouseholdAndAccommodationCompleted.submit()
-
-  // household-member
-    HouseholdMemberBegin.submit()
-    DetailsCorrect.clickDetailsCorrectAnswerNoINeedToChangeMyName().submit()
-    CorrectName.setCorrectNameAnswer('Yoganand Kumar Kunche').submit()
-  })
-
-  //issue present - error 404
-
-/*  it('Given I am answering question 1 in the individual detail section, When I do not select any respone, Then I am routed to What is you sex question 2 ', function () {
-    openAndStartCensusQuestionnaire('census_household.json', true)
-    PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
-    HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
-    EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
-    OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
-    HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
-    WhoLivesHereCompleted.submit()
-
-  // household-and-accommodation
-    TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
-    TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
-    SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
-    NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
-    CentralHeating.clickCentralHeatingAnswerGas().submit()
-    OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
-    NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
-    HouseholdAndAccommodationCompleted.submit()
-
-  // household-member
-    HouseholdMemberBegin.submit()
-    DetailsCorrect.submit()
-    Sex.clickSexAnswerMale().submit()
-  }) */
-
-  it('Given I am answering question 5 in the individual detail section -Do you stay at another address for more than 30 days a year?, When I select -no- as respone, Then I am routed to 7. Are you a schoolchild or student in full-time education', function () {
-    openAndStartCensusQuestionnaire('census_household.json', true)
-    PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
-    HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
-    EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
-    OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
-    HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
-    WhoLivesHereCompleted.submit()
-
-  // household-and-accommodation
-    TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
-    TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
-    SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
-    NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
-    CentralHeating.clickCentralHeatingAnswerGas().submit()
-    OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
-    NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
-    HouseholdAndAccommodationCompleted.submit()
-
-  // household-member
-    HouseholdMemberBegin.submit()
-    DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
-    Sex.clickSexAnswerMale().submit()
-    DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(3).setDateOfBirthAnswerYear(1980).submit()
-    Over16.clickOver16AnswerYes().submit()
-    MaritalStatus.clickMaritalStatusAnswerMarried().submit()
-    AnotherAddress.clickAnotherAddressAnswerNo().submit()
-    InEducation.clickInEducationAnswerNo().submit()
-  })
-
-  it('Given I am answering question 5 in the individual detail section -Do you stay at another address for more than 30 days a year?, When I select -Yes, an address within the UK- as respone, Then I am routed to 5a. Enter details of the other UK address where you stay more than 30 days a year?', function () {
-    openAndStartCensusQuestionnaire('census_household.json', true)
-    PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
-    HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
-    EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
-    OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
-    HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
-    WhoLivesHereCompleted.submit()
-
-  // household-and-accommodation
-    TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
-    TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
-    SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
-    NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
-    CentralHeating.clickCentralHeatingAnswerGas().submit()
-    OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
-    NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
-    HouseholdAndAccommodationCompleted.submit()
-
-  // household-member
-    HouseholdMemberBegin.submit()
-    DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
-    Sex.clickSexAnswerMale().submit()
-    DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(3).setDateOfBirthAnswerYear(1980).submit()
-    Over16.clickOver16AnswerYes().submit()
-    MaritalStatus.clickMaritalStatusAnswerMarried().submit()
-    AnotherAddress.clickAnotherAddressAnswerYesAnAddressWithinTheUk().submit()
-    OtherAddress.setOtherAddressAnswerBuilding('Gov Buildings').submit()
-  })
-
-  it('Given I am answering question 5 in the individual detail section -Do you stay at another address for more than 30 days a year?, When I select -Yes, an address outside the UK- and enter text in other field as respone, Then I am routed to 6. What is that address?', function () {
-    openAndStartCensusQuestionnaire('census_household.json', true)
-    PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
-    HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
-    EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
-    OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
-    HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
-    WhoLivesHereCompleted.submit()
-
-  // household-and-accommodation
-    TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
-    TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
-    SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
-    NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
-    CentralHeating.clickCentralHeatingAnswerGas().submit()
-    OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
-    NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
-    HouseholdAndAccommodationCompleted.submit()
-
-  // household-member
-    HouseholdMemberBegin.submit()
-    DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
-    Sex.clickSexAnswerMale().submit()
-    DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(3).setDateOfBirthAnswerYear(1980).submit()
-    Over16.clickOver16AnswerYes().submit()
-    MaritalStatus.clickMaritalStatusAnswerMarried().submit()
-    AnotherAddress.clickAnotherAddressAnswerOther().submit()
-    AddressType.clickAddressTypeAnswerArmedForcesBaseAddress().submit()
-  })
-
-  it('Given I am answering question 7 in the individual detail section - 7. Are you a schoolchild or student in full-time education?, When I dselect -No- as respone, Then I am routed to 9. What is your country of birth?', function () {
-    openAndStartCensusQuestionnaire('census_household.json', true)
-    PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
-    HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
-    EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
-    OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
-    HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
-    WhoLivesHereCompleted.submit()
-
-  // household-and-accommodation
-    TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
-    TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
-    SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
-    NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
-    CentralHeating.clickCentralHeatingAnswerGas().submit()
-    OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
-    NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
-    HouseholdAndAccommodationCompleted.submit()
-
-  // household-member
-    HouseholdMemberBegin.submit()
-    DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
-    Sex.clickSexAnswerMale().submit()
-    DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(3).setDateOfBirthAnswerYear(1980).submit()
-    Over16.clickOver16AnswerYes().submit()
-    MaritalStatus.clickMaritalStatusAnswerMarried().submit()
-    AnotherAddress.clickAnotherAddressAnswerNo().submit()
-    InEducation.clickInEducationAnswerNo().submit()
-    CountryOfBirth.clickCountryOfBirthEnglandAnswerEngland().submit()
-  })
-
-// Issue 404
-/*  it('Given I am answering question 7 in the individual detail section - 7. Are you a schoolchild or student in full-time education?, When I do not select any respone, Then I am routed to 9. What is your country of birth?', function () {
-    openAndStartCensusQuestionnaire('census_household.json', true)
-    PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
-    HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
-    EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
-    OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
-    HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
-    WhoLivesHereCompleted.submit()
-
-  // household-and-accommodation
-    TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
-    TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
-    SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
-    NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
-    CentralHeating.clickCentralHeatingAnswerGas().submit()
-    OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
-    NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
-    HouseholdAndAccommodationCompleted.submit()
-
-  // household-member
-    HouseholdMemberBegin.submit()
-    DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
-    Sex.clickSexAnswerMale().submit()
-    DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(3).setDateOfBirthAnswerYear(1980).submit()
-    Over16.clickOver16AnswerYes().submit()
-    MaritalStatus.clickMaritalStatusAnswerMarried().submit()
-    AnotherAddress.clickAnotherAddressAnswerNo().submit()
-    InEducation.submit()
-    CountryOfBirth.clickCountryOfBirthEnglandAnswerEngland().submit()
-  }) */
-
-  it('Given I am answering question 7 in the individual detail section - 7. Are you a schoolchild or student in full-time education?, When I select -Yes- as respone, Then I am routed to 8. During term time, do you live:', function () {
-    openAndStartCensusQuestionnaire('census_household.json', true)
-    PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
-    HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
-    EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
-    OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
-    HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
-    WhoLivesHereCompleted.submit()
-
-  // household-and-accommodation
-    TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
-    TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
-    SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
-    NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
-    CentralHeating.clickCentralHeatingAnswerGas().submit()
-    OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
-    NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
-    HouseholdAndAccommodationCompleted.submit()
-
-  // household-member
-    HouseholdMemberBegin.submit()
-    DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
-    Sex.clickSexAnswerMale().submit()
-    DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(3).setDateOfBirthAnswerYear(1980).submit()
-    Over16.clickOver16AnswerYes().submit()
-    MaritalStatus.clickMaritalStatusAnswerMarried().submit()
-    AnotherAddress.clickAnotherAddressAnswerNo().submit()
-    InEducation.clickInEducationAnswerYes().submit()
-    TermTimeLocation.clickTermTimeLocationAnswerAtThisAddress().submit()
-  })
-
-  it('Given I am answering question 12. Do you look after, or give any help or support..., When I select -No- as respone, Then I am routed to 13. How would you describe your national identity?', function () {
-    openAndStartCensusQuestionnaire('census_household.json', true)
-    PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
-    HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
-    EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
-    OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
-    HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
-    WhoLivesHereCompleted.submit()
-
-  // household-and-accommodation
-    TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
-    TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
-    SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
-    NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
-    CentralHeating.clickCentralHeatingAnswerGas().submit()
-    OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
-    NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
-    HouseholdAndAccommodationCompleted.submit()
-
-  // household-member
-    HouseholdMemberBegin.submit()
-    DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
-    Sex.clickSexAnswerMale().submit()
-    DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(3).setDateOfBirthAnswerYear(1980).submit()
-    Over16.clickOver16AnswerYes().submit()
-    MaritalStatus.clickMaritalStatusAnswerMarried().submit()
-    AnotherAddress.clickAnotherAddressAnswerNo().submit()
-    InEducation.clickInEducationAnswerYes().submit()
-    TermTimeLocation.clickTermTimeLocationAnswerAtThisAddress().submit()
-    CountryOfBirth.clickCountryOfBirthEnglandAnswerEngland().submit()
-    Carer.clickCarerAnswerNo().submit()
-    NationalIdentity.clickNationalIdentityAnswerBritish().submit()
-  })
-
-  it('Given I am answering question 12. Do you look after, or give any help or support..., When I select -Yes 1-19 Hours A Week- as respone, Then I am routed to 13. How would you describe your national identity?', function () {
-    openAndStartCensusQuestionnaire('census_household.json', true)
-    PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
-    HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
-    EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
-    OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
-    HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
-    WhoLivesHereCompleted.submit()
-
-  // household-and-accommodation
-    TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
-    TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
-    SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
-    NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
-    CentralHeating.clickCentralHeatingAnswerGas().submit()
-    OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
-    NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
-    HouseholdAndAccommodationCompleted.submit()
-
-  // household-member
-    HouseholdMemberBegin.submit()
-    DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
-    Sex.clickSexAnswerMale().submit()
-    DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(3).setDateOfBirthAnswerYear(1980).submit()
-    Over16.clickOver16AnswerYes().submit()
-    MaritalStatus.clickMaritalStatusAnswerMarried().submit()
-    AnotherAddress.clickAnotherAddressAnswerNo().submit()
-    InEducation.clickInEducationAnswerYes().submit()
-    TermTimeLocation.clickTermTimeLocationAnswerAtThisAddress().submit()
-    CountryOfBirth.clickCountryOfBirthEnglandAnswerEngland().submit()
-    Carer.clickCarerAnswerYes119HoursAWeek().submit()
-    NationalIdentity.clickNationalIdentityAnswerNorthernIrish().submit()
-  })
-
-  it('Given I am answering question 12. Do you look after, or give any help or support..., When I select -Yes 20-49 Hours A Week- as respone, Then I am routed to 13. How would you describe your national identity?', function () {
-    openAndStartCensusQuestionnaire('census_household.json', true)
-    PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
-    HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
-    EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
-    OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
-    HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
-    WhoLivesHereCompleted.submit()
-
-  // household-and-accommodation
-    TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
-    TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
-    SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
-    NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
-    CentralHeating.clickCentralHeatingAnswerGas().submit()
-    OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
-    NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
-    HouseholdAndAccommodationCompleted.submit()
-
-  // household-member
-    HouseholdMemberBegin.submit()
-    DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
-    Sex.clickSexAnswerMale().submit()
-    DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(3).setDateOfBirthAnswerYear(1980).submit()
-    Over16.clickOver16AnswerYes().submit()
-    MaritalStatus.clickMaritalStatusAnswerMarried().submit()
-    AnotherAddress.clickAnotherAddressAnswerNo().submit()
-    InEducation.clickInEducationAnswerYes().submit()
-    TermTimeLocation.clickTermTimeLocationAnswerAtThisAddress().submit()
-    CountryOfBirth.clickCountryOfBirthEnglandAnswerEngland().submit()
-    Carer.clickCarerAnswerYes2049HoursAWeek().submit()
-    NationalIdentity.clickNationalIdentityAnswerEnglish().submit()
-  })
-
-  it('Given I am answering question 12. Do you look after, or give any help or support..., When I select -Yes 50 or more Hours A Week- as respone, Then I am routed to 13. How would you describe your national identity?', function () {
-    openAndStartCensusQuestionnaire('census_household.json', true)
-    PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
-    HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
-    EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
-    OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
-    HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
-    WhoLivesHereCompleted.submit()
-
-  // household-and-accommodation
-    TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
-    TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
-    SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
-    NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
-    CentralHeating.clickCentralHeatingAnswerGas().submit()
-    OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
-    NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
-    HouseholdAndAccommodationCompleted.submit()
-
-  // household-member
-    HouseholdMemberBegin.submit()
-    DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
-    Sex.clickSexAnswerMale().submit()
-    DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(3).setDateOfBirthAnswerYear(1980).submit()
-    Over16.clickOver16AnswerYes().submit()
-    MaritalStatus.clickMaritalStatusAnswerMarried().submit()
-    AnotherAddress.clickAnotherAddressAnswerNo().submit()
-    InEducation.clickInEducationAnswerYes().submit()
-    TermTimeLocation.clickTermTimeLocationAnswerAtThisAddress().submit()
-    CountryOfBirth.clickCountryOfBirthEnglandAnswerEngland().submit()
-    Carer.clickCarerAnswerYes50OrMoreHoursAWeek().submit()
-    NationalIdentity.clickNationalIdentityAnswerScottish().submit()
-  })
-
-  it('Given I am answering question 25. Thinking of the last 12 months, have you..., When I select -No- as respone, Then I am routed to 26. Last week were you:', function () {
-      openAndStartCensusQuestionnaire('census_household.json')
-
-      // who-lives-here
-      PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
-      HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
-      EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
-      OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
-      HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
-      WhoLivesHereCompleted.submit()
-
-      // household-and-accommodation
-      TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
-      TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
-      SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
-      NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
-      CentralHeating.clickCentralHeatingAnswerGas().submit()
-      OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
-      NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
-      HouseholdAndAccommodationCompleted.submit()
-
-      // household-member
-      HouseholdMemberBegin.submit()
-      DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
-      Sex.clickSexAnswerMale().submit()
-      DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(3).setDateOfBirthAnswerYear(1980).submit()
-      Over16.clickOver16AnswerYes().submit()
-      MaritalStatus.clickMaritalStatusAnswerMarried().submit()
-      AnotherAddress.clickAnotherAddressAnswerNo().submit()
-      InEducation.clickInEducationAnswerNo().submit()
-      CountryOfBirth.clickCountryOfBirthEnglandAnswerEngland().submit()
-      Carer.clickCarerAnswerNo().submit()
-      NationalIdentity.clickNationalIdentityAnswerBritish().submit()
-      EthnicGroup.clickEthnicGroupAnswerWhite().submit()
-      WhiteEthnicGroup.clickWhiteEthnicGroupAnswerEnglishWelshScottishNorthernIrishBritish().submit()
-      UnderstandWelsh.clickUnderstandWelshAnswerNoneOfTheAbove().submit()
-      Language.clickLanguageAnswerEnglish().submit()
-      Religion.clickReligionAnswerNoReligion().submit()
-      PastUsualAddress.clickPastUsualAddressAnswerThisAddress().submit()
-      Passports.clickPassportsAnswerUnitedKingdom().submit()
-      Disability.clickDisabilityAnswerNo().submit()
-      Qualifications.clickQualificationsAnswerUndergraduateDegree().submit()
-      Volunteering.clickVolunteeringAnswerNo().submit()
-      EmploymentType.clickEmploymentTypeAnswerWorkingAsAnEmployee().submit()
-      HouseholdMemberCompleted.submit()
     })
 
-    it('Given I am answering question 25. Thinking of the last 12 months, have you..., When I select -Yes, at least once a week- as respone, Then I am routed to 26. Last week were you:', function () {
-        openAndStartCensusQuestionnaire('census_household.json')
+    it('Given I am answering question 1 in the individual detail section, When I select -yes- as response, Then I am routed to What is you sex question 2 ', function () {
+        startCensusQuestionnaire('census_household.json', true)
+        PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
+        HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
+        EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
+        OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
+        HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
+        WhoLivesHereCompleted.submit()
+
+        // household-and-accommodation
+        TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
+        TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
+        SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
+        NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
+        CentralHeating.clickCentralHeatingAnswerGas().submit()
+        OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
+        NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
+        HouseholdAndAccommodationCompleted.submit()
+
+        // household-member
+        HouseholdMemberBegin.submit()
+        DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
+        Sex.clickSexAnswerMale().submit()
+    })
+
+    it('Given I am answering question 1 in the individual detail section, When I select -no- as response, Then I am routed to What is your correct name question 1a ', function () {
+        startCensusQuestionnaire('census_household.json', true)
+        PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
+        HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
+        EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
+        OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
+        HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
+        WhoLivesHereCompleted.submit()
+
+      // household-and-accommodation
+        TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
+        TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
+        SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
+        NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
+        CentralHeating.clickCentralHeatingAnswerGas().submit()
+        OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
+        NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
+        HouseholdAndAccommodationCompleted.submit()
+
+      // household-member
+        HouseholdMemberBegin.submit()
+        DetailsCorrect.clickDetailsCorrectAnswerNoINeedToChangeMyName().submit()
+        CorrectName.setCorrectNameAnswer('Yoganand Kumar Kunche').submit()
+    })
+
+    it('Given I am answering question 1 in the individual detail section, When I do not select any response, Then I am routed to What is you sex question 2 ', function () {
+        startCensusQuestionnaire('census_household.json', true)
+        PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
+        HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
+        EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
+        OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
+        HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
+        WhoLivesHereCompleted.submit()
+
+      // household-and-accommodation
+        TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
+        TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
+        SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
+        NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
+        CentralHeating.clickCentralHeatingAnswerGas().submit()
+        OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
+        NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
+        HouseholdAndAccommodationCompleted.submit()
+
+      // household-member
+        HouseholdMemberBegin.submit()
+        DetailsCorrect.submit()
+        Sex.clickSexAnswerMale().submit()
+    })
+
+    it('Given I am answering question 5 in the individual detail section -Do you stay at another address for more than 30 days a year?, When I select -no- as response, Then I am routed to 7. Are you a schoolchild or student in full-time education', function () {
+        startCensusQuestionnaire('census_household.json', true)
+        PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
+        HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
+        EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
+        OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
+        HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
+        WhoLivesHereCompleted.submit()
+
+        // household-and-accommodation
+        TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
+        TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
+        SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
+        NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
+        CentralHeating.clickCentralHeatingAnswerGas().submit()
+        OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
+        NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
+        HouseholdAndAccommodationCompleted.submit()
+
+        // household-member
+        HouseholdMemberBegin.submit()
+        DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
+        Sex.clickSexAnswerMale().submit()
+        DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(3).setDateOfBirthAnswerYear(1980).submit()
+        Over16.clickOver16AnswerYes().submit()
+        MaritalStatus.clickMaritalStatusAnswerMarried().submit()
+        AnotherAddress.clickAnotherAddressAnswerNo().submit()
+        InEducation.clickInEducationAnswerNo().submit()
+    })
+
+    it('Given I am answering question 5 in the individual detail section -Do you stay at another address for more than 30 days a year?, When I select -Yes, an address within the UK- as response, Then I am routed to 5a. Enter details of the other UK address where you stay more than 30 days a year?', function () {
+        startCensusQuestionnaire('census_household.json', true)
+        PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
+        HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
+        EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
+        OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
+        HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
+        WhoLivesHereCompleted.submit()
+
+        // household-and-accommodation
+        TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
+        TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
+        SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
+        NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
+        CentralHeating.clickCentralHeatingAnswerGas().submit()
+        OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
+        NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
+        HouseholdAndAccommodationCompleted.submit()
+
+        // household-member
+        HouseholdMemberBegin.submit()
+        DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
+        Sex.clickSexAnswerMale().submit()
+        DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(3).setDateOfBirthAnswerYear(1980).submit()
+        Over16.clickOver16AnswerYes().submit()
+        MaritalStatus.clickMaritalStatusAnswerMarried().submit()
+        AnotherAddress.clickAnotherAddressAnswerYesAnAddressWithinTheUk().submit()
+        OtherAddress.setOtherAddressAnswerBuilding('Gov Buildings').submit()
+    })
+
+    it('Given I am answering question 5 in the individual detail section -Do you stay at another address for more than 30 days a year?, When I select -Yes, an address outside the UK- and enter text in other field as response, Then I am routed to 6. What is that address?', function () {
+        startCensusQuestionnaire('census_household.json', true)
+        PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
+        HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
+        EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
+        OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
+        HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
+        WhoLivesHereCompleted.submit()
+
+        // household-and-accommodation
+        TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
+        TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
+        SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
+        NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
+        CentralHeating.clickCentralHeatingAnswerGas().submit()
+        OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
+        NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
+        HouseholdAndAccommodationCompleted.submit()
+
+        // household-member
+        HouseholdMemberBegin.submit()
+        DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
+        Sex.clickSexAnswerMale().submit()
+        DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(3).setDateOfBirthAnswerYear(1980).submit()
+        Over16.clickOver16AnswerYes().submit()
+        MaritalStatus.clickMaritalStatusAnswerMarried().submit()
+        AnotherAddress.clickAnotherAddressAnswerOther().submit()
+        AddressType.clickAddressTypeAnswerArmedForcesBaseAddress().submit()
+    })
+
+    it('Given I am answering question 7 in the individual detail section - 7. Are you a schoolchild or student in full-time education?, When I dselect -No- as response, Then I am routed to 9. What is your country of birth?', function () {
+        startCensusQuestionnaire('census_household.json', true)
+        PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
+        HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
+        EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
+        OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
+        HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
+        WhoLivesHereCompleted.submit()
+
+        // household-and-accommodation
+        TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
+        TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
+        SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
+        NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
+        CentralHeating.clickCentralHeatingAnswerGas().submit()
+        OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
+        NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
+        HouseholdAndAccommodationCompleted.submit()
+
+        // household-member
+        HouseholdMemberBegin.submit()
+        DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
+        Sex.clickSexAnswerMale().submit()
+        DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(3).setDateOfBirthAnswerYear(1980).submit()
+        Over16.clickOver16AnswerYes().submit()
+        MaritalStatus.clickMaritalStatusAnswerMarried().submit()
+        AnotherAddress.clickAnotherAddressAnswerNo().submit()
+        InEducation.clickInEducationAnswerNo().submit()
+        CountryOfBirth.clickCountryOfBirthEnglandAnswerEngland().submit()
+    })
+
+    // Issue 404
+    it('Given I am answering question 7 in the individual detail section - 7. Are you a schoolchild or student in full-time education?, When I do not select any response, Then I am routed to 9. What is your country of birth?', function () {
+        startCensusQuestionnaire('census_household.json', true)
+        PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
+        HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
+        EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
+        OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
+        HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
+        WhoLivesHereCompleted.submit()
+
+        // household-and-accommodation
+        TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
+        TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
+        SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
+        NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
+        CentralHeating.clickCentralHeatingAnswerGas().submit()
+        OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
+        NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
+        HouseholdAndAccommodationCompleted.submit()
+
+        // household-member
+        HouseholdMemberBegin.submit()
+        DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
+        Sex.clickSexAnswerMale().submit()
+        DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(3).setDateOfBirthAnswerYear(1980).submit()
+        Over16.clickOver16AnswerYes().submit()
+        MaritalStatus.clickMaritalStatusAnswerMarried().submit()
+        AnotherAddress.clickAnotherAddressAnswerNo().submit()
+        InEducation.submit()
+        CountryOfBirth.clickCountryOfBirthEnglandAnswerEngland().submit()
+    })
+
+    it('Given I am answering question 7 in the individual detail section - 7. Are you a schoolchild or student in full-time education?, When I select -Yes- as response, Then I am routed to 8. During term time, do you live:', function () {
+        startCensusQuestionnaire('census_household.json', true)
+        PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
+        HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
+        EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
+        OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
+        HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
+        WhoLivesHereCompleted.submit()
+
+        // household-and-accommodation
+        TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
+        TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
+        SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
+        NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
+        CentralHeating.clickCentralHeatingAnswerGas().submit()
+        OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
+        NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
+        HouseholdAndAccommodationCompleted.submit()
+
+        // household-member
+        HouseholdMemberBegin.submit()
+        DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
+        Sex.clickSexAnswerMale().submit()
+        DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(3).setDateOfBirthAnswerYear(1980).submit()
+        Over16.clickOver16AnswerYes().submit()
+        MaritalStatus.clickMaritalStatusAnswerMarried().submit()
+        AnotherAddress.clickAnotherAddressAnswerNo().submit()
+        InEducation.clickInEducationAnswerYes().submit()
+        TermTimeLocation.clickTermTimeLocationAnswerAtThisAddress().submit()
+    })
+
+    it('Given I am answering question 12. Do you look after, or give any help or support..., When I select -No- as response, Then I am routed to 13. How would you describe your national identity?', function () {
+        startCensusQuestionnaire('census_household.json', true)
+        PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
+        HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
+        EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
+        OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
+        HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
+        WhoLivesHereCompleted.submit()
+
+        // household-and-accommodation
+        TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
+        TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
+        SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
+        NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
+        CentralHeating.clickCentralHeatingAnswerGas().submit()
+        OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
+        NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
+        HouseholdAndAccommodationCompleted.submit()
+
+        // household-member
+        HouseholdMemberBegin.submit()
+        DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
+        Sex.clickSexAnswerMale().submit()
+        DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(3).setDateOfBirthAnswerYear(1980).submit()
+        Over16.clickOver16AnswerYes().submit()
+        MaritalStatus.clickMaritalStatusAnswerMarried().submit()
+        AnotherAddress.clickAnotherAddressAnswerNo().submit()
+        InEducation.clickInEducationAnswerYes().submit()
+        TermTimeLocation.clickTermTimeLocationAnswerAtThisAddress().submit()
+        CountryOfBirth.clickCountryOfBirthEnglandAnswerEngland().submit()
+        Carer.clickCarerAnswerNo().submit()
+        NationalIdentity.clickNationalIdentityAnswerBritish().submit()
+    })
+
+    it('Given I am answering question 12. Do you look after, or give any help or support..., When I select -Yes 1-19 Hours A Week- as response, Then I am routed to 13. How would you describe your national identity?', function () {
+        startCensusQuestionnaire('census_household.json', true)
+        PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
+        HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
+        EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
+        OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
+        HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
+        WhoLivesHereCompleted.submit()
+
+      // household-and-accommodation
+        TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
+        TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
+        SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
+        NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
+        CentralHeating.clickCentralHeatingAnswerGas().submit()
+        OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
+        NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
+        HouseholdAndAccommodationCompleted.submit()
+
+      // household-member
+        HouseholdMemberBegin.submit()
+        DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
+        Sex.clickSexAnswerMale().submit()
+        DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(3).setDateOfBirthAnswerYear(1980).submit()
+        Over16.clickOver16AnswerYes().submit()
+        MaritalStatus.clickMaritalStatusAnswerMarried().submit()
+        AnotherAddress.clickAnotherAddressAnswerNo().submit()
+        InEducation.clickInEducationAnswerYes().submit()
+        TermTimeLocation.clickTermTimeLocationAnswerAtThisAddress().submit()
+        CountryOfBirth.clickCountryOfBirthEnglandAnswerEngland().submit()
+        Carer.clickCarerAnswerYes119HoursAWeek().submit()
+        NationalIdentity.clickNationalIdentityAnswerNorthernIrish().submit()
+    })
+
+    it('Given I am answering question 12. Do you look after, or give any help or support..., When I select -Yes 20-49 Hours A Week- as response, Then I am routed to 13. How would you describe your national identity?', function () {
+        startCensusQuestionnaire('census_household.json', true)
+        PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
+        HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
+        EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
+        OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
+        HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
+        WhoLivesHereCompleted.submit()
+
+        // household-and-accommodation
+        TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
+        TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
+        SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
+        NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
+        CentralHeating.clickCentralHeatingAnswerGas().submit()
+        OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
+        NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
+        HouseholdAndAccommodationCompleted.submit()
+
+        // household-member
+        HouseholdMemberBegin.submit()
+        DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
+        Sex.clickSexAnswerMale().submit()
+        DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(3).setDateOfBirthAnswerYear(1980).submit()
+        Over16.clickOver16AnswerYes().submit()
+        MaritalStatus.clickMaritalStatusAnswerMarried().submit()
+        AnotherAddress.clickAnotherAddressAnswerNo().submit()
+        InEducation.clickInEducationAnswerYes().submit()
+        TermTimeLocation.clickTermTimeLocationAnswerAtThisAddress().submit()
+        CountryOfBirth.clickCountryOfBirthEnglandAnswerEngland().submit()
+        Carer.clickCarerAnswerYes2049HoursAWeek().submit()
+        NationalIdentity.clickNationalIdentityAnswerEnglish().submit()
+    })
+
+    it('Given I am answering question 12. Do you look after, or give any help or support..., When I select -Yes 50 or more Hours A Week- as response, Then I am routed to 13. How would you describe your national identity?', function () {
+        startCensusQuestionnaire('census_household.json', true)
+        PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
+        HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
+        EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
+        OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
+        HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
+        WhoLivesHereCompleted.submit()
+
+        // household-and-accommodation
+        TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
+        TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
+        SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
+        NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
+        CentralHeating.clickCentralHeatingAnswerGas().submit()
+        OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
+        NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
+        HouseholdAndAccommodationCompleted.submit()
+
+        // household-member
+        HouseholdMemberBegin.submit()
+        DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
+        Sex.clickSexAnswerMale().submit()
+        DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(3).setDateOfBirthAnswerYear(1980).submit()
+        Over16.clickOver16AnswerYes().submit()
+        MaritalStatus.clickMaritalStatusAnswerMarried().submit()
+        AnotherAddress.clickAnotherAddressAnswerNo().submit()
+        InEducation.clickInEducationAnswerYes().submit()
+        TermTimeLocation.clickTermTimeLocationAnswerAtThisAddress().submit()
+        CountryOfBirth.clickCountryOfBirthEnglandAnswerEngland().submit()
+        Carer.clickCarerAnswerYes50OrMoreHoursAWeek().submit()
+        NationalIdentity.clickNationalIdentityAnswerScottish().submit()
+    })
+
+    it('Given I am answering question 25. Thinking of the last 12 months, have you..., When I select -No- as response, Then I am routed to 26. Last week were you:', function () {
+        startCensusQuestionnaire('census_household.json')
+
+        // who-lives-here
+        PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
+        HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
+        EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
+        OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
+        HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
+        WhoLivesHereCompleted.submit()
+
+        // household-and-accommodation
+        TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
+        TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
+        SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
+        NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
+        CentralHeating.clickCentralHeatingAnswerGas().submit()
+        OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
+        NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
+        HouseholdAndAccommodationCompleted.submit()
+
+        // household-member
+        HouseholdMemberBegin.submit()
+        DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
+        Sex.clickSexAnswerMale().submit()
+        DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(3).setDateOfBirthAnswerYear(1980).submit()
+        Over16.clickOver16AnswerYes().submit()
+        MaritalStatus.clickMaritalStatusAnswerMarried().submit()
+        AnotherAddress.clickAnotherAddressAnswerNo().submit()
+        InEducation.clickInEducationAnswerNo().submit()
+        CountryOfBirth.clickCountryOfBirthEnglandAnswerEngland().submit()
+        Carer.clickCarerAnswerNo().submit()
+        NationalIdentity.clickNationalIdentityAnswerBritish().submit()
+        EthnicGroup.clickEthnicGroupAnswerWhite().submit()
+        WhiteEthnicGroup.clickWhiteEthnicGroupAnswerEnglishWelshScottishNorthernIrishBritish().submit()
+        UnderstandWelsh.clickUnderstandWelshAnswerNoneOfTheAbove().submit()
+        Language.clickLanguageAnswerEnglish().submit()
+        Religion.clickReligionAnswerNoReligion().submit()
+        PastUsualAddress.clickPastUsualAddressAnswerThisAddress().submit()
+        Passports.clickPassportsAnswerUnitedKingdom().submit()
+        Disability.clickDisabilityAnswerNo().submit()
+        Qualifications.clickQualificationsAnswerUndergraduateDegree().submit()
+        Volunteering.clickVolunteeringAnswerNo().submit()
+        EmploymentType.clickEmploymentTypeAnswerWorkingAsAnEmployee().submit()
+        HouseholdMemberCompleted.submit()
+    })
+
+    it('Given I am answering question 25. Thinking of the last 12 months, have you..., When I select -Yes, at least once a week- as response, Then I am routed to 26. Last week were you:', function () {
+        startCensusQuestionnaire('census_household.json')
 
         // who-lives-here
         PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
@@ -630,99 +629,99 @@
         Volunteering.clickVolunteeringAnswerYesAtLeastOnceAWeek().submit()
         EmploymentType.clickEmploymentTypeAnswerWorkingAsAnEmployee().submit()
         HouseholdMemberCompleted.submit()
-      })
+    })
 
-      it('Given I am answering question 25. Thinking of the last 12 months, have you..., When I select -Yes, less than once a week but at least once a month-, at least once a week- as respone, Then I am routed to 26. Last week were you:', function () {
-          openAndStartCensusQuestionnaire('census_household.json')
+    it('Given I am answering question 25. Thinking of the last 12 months, have you..., When I select -Yes, less than once a week but at least once a month-, at least once a week- as response, Then I am routed to 26. Last week were you:', function () {
+        startCensusQuestionnaire('census_household.json')
 
-          // who-lives-here
-          PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
-          HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
-          EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
-          OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
-          HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
-          WhoLivesHereCompleted.submit()
+        // who-lives-here
+        PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
+        HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
+        EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
+        OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
+        HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
+        WhoLivesHereCompleted.submit()
 
-          // household-and-accommodation
-          TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
-          TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
-          SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
-          NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
-          CentralHeating.clickCentralHeatingAnswerGas().submit()
-          OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
-          NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
-          HouseholdAndAccommodationCompleted.submit()
+        // household-and-accommodation
+        TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
+        TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
+        SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
+        NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
+        CentralHeating.clickCentralHeatingAnswerGas().submit()
+        OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
+        NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
+        HouseholdAndAccommodationCompleted.submit()
 
-          // household-member
-          HouseholdMemberBegin.submit()
-          DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
-          Sex.clickSexAnswerMale().submit()
-          DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(3).setDateOfBirthAnswerYear(1980).submit()
-          Over16.clickOver16AnswerYes().submit()
-          MaritalStatus.clickMaritalStatusAnswerMarried().submit()
-          AnotherAddress.clickAnotherAddressAnswerNo().submit()
-          InEducation.clickInEducationAnswerNo().submit()
-          CountryOfBirth.clickCountryOfBirthEnglandAnswerEngland().submit()
-          Carer.clickCarerAnswerNo().submit()
-          NationalIdentity.clickNationalIdentityAnswerBritish().submit()
-          EthnicGroup.clickEthnicGroupAnswerWhite().submit()
-          WhiteEthnicGroup.clickWhiteEthnicGroupAnswerEnglishWelshScottishNorthernIrishBritish().submit()
-          UnderstandWelsh.clickUnderstandWelshAnswerNoneOfTheAbove().submit()
-          Language.clickLanguageAnswerEnglish().submit()
-          Religion.clickReligionAnswerNoReligion().submit()
-          PastUsualAddress.clickPastUsualAddressAnswerThisAddress().submit()
-          Passports.clickPassportsAnswerUnitedKingdom().submit()
-          Disability.clickDisabilityAnswerNo().submit()
-          Qualifications.clickQualificationsAnswerUndergraduateDegree().submit()
-          Volunteering.clickVolunteeringAnswerYesLessThanOnceAWeekButAtLeastOnceAMonth().submit()
-          EmploymentType.clickEmploymentTypeAnswerWorkingAsAnEmployee().submit()
-          HouseholdMemberCompleted.submit()
-        })
+        // household-member
+        HouseholdMemberBegin.submit()
+        DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
+        Sex.clickSexAnswerMale().submit()
+        DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(3).setDateOfBirthAnswerYear(1980).submit()
+        Over16.clickOver16AnswerYes().submit()
+        MaritalStatus.clickMaritalStatusAnswerMarried().submit()
+        AnotherAddress.clickAnotherAddressAnswerNo().submit()
+        InEducation.clickInEducationAnswerNo().submit()
+        CountryOfBirth.clickCountryOfBirthEnglandAnswerEngland().submit()
+        Carer.clickCarerAnswerNo().submit()
+        NationalIdentity.clickNationalIdentityAnswerBritish().submit()
+        EthnicGroup.clickEthnicGroupAnswerWhite().submit()
+        WhiteEthnicGroup.clickWhiteEthnicGroupAnswerEnglishWelshScottishNorthernIrishBritish().submit()
+        UnderstandWelsh.clickUnderstandWelshAnswerNoneOfTheAbove().submit()
+        Language.clickLanguageAnswerEnglish().submit()
+        Religion.clickReligionAnswerNoReligion().submit()
+        PastUsualAddress.clickPastUsualAddressAnswerThisAddress().submit()
+        Passports.clickPassportsAnswerUnitedKingdom().submit()
+        Disability.clickDisabilityAnswerNo().submit()
+        Qualifications.clickQualificationsAnswerUndergraduateDegree().submit()
+        Volunteering.clickVolunteeringAnswerYesLessThanOnceAWeekButAtLeastOnceAMonth().submit()
+        EmploymentType.clickEmploymentTypeAnswerWorkingAsAnEmployee().submit()
+        HouseholdMemberCompleted.submit()
+    })
 
-      it('Given I am answering question 25. Thinking of the last 12 months, have you..., When I select -Yes, less often-, at least once a week- as respone, Then I am routed to 26. Last week were you:', function () {
-            openAndStartCensusQuestionnaire('census_household.json')
+    it('Given I am answering question 25. Thinking of the last 12 months, have you..., When I select -Yes, less often-, at least once a week- as response, Then I am routed to 26. Last week were you:', function () {
+        startCensusQuestionnaire('census_household.json')
 
-            // who-lives-here
-            PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
-            HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
-            EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
-            OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
-            HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
-            WhoLivesHereCompleted.submit()
+        // who-lives-here
+        PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
+        HouseholdComposition.setPersonName(0, 'John Smith').addPerson().setPersonName(1, 'Jane Smith').submit()
+        EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
+        OvernightVisitors.setOvernightVisitorsAnswer(0).submit()
+        HouseholdRelationships.clickHouseholdRelationshipsAnswerHusbandOrWife().submit()
+        WhoLivesHereCompleted.submit()
 
-            // household-and-accommodation
-            TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
-            TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
-            SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
-            NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
-            CentralHeating.clickCentralHeatingAnswerGas().submit()
-            OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
-            NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
-            HouseholdAndAccommodationCompleted.submit()
+        // household-and-accommodation
+        TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
+        TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
+        SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
+        NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
+        CentralHeating.clickCentralHeatingAnswerGas().submit()
+        OwnOrRent.clickOwnOrRentAnswerOwnsOutright().submit()
+        NumberOfVehicles.setNumberOfVehiclesAnswer(2).submit()
+        HouseholdAndAccommodationCompleted.submit()
 
-            // household-member
-            HouseholdMemberBegin.submit()
-            DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
-            Sex.clickSexAnswerMale().submit()
-            DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(3).setDateOfBirthAnswerYear(1980).submit()
-            Over16.clickOver16AnswerYes().submit()
-            MaritalStatus.clickMaritalStatusAnswerMarried().submit()
-            AnotherAddress.clickAnotherAddressAnswerNo().submit()
-            InEducation.clickInEducationAnswerNo().submit()
-            CountryOfBirth.clickCountryOfBirthEnglandAnswerEngland().submit()
-            Carer.clickCarerAnswerNo().submit()
-            NationalIdentity.clickNationalIdentityAnswerBritish().submit()
-            EthnicGroup.clickEthnicGroupAnswerWhite().submit()
-            WhiteEthnicGroup.clickWhiteEthnicGroupAnswerEnglishWelshScottishNorthernIrishBritish().submit()
-            UnderstandWelsh.clickUnderstandWelshAnswerNoneOfTheAbove().submit()
-            Language.clickLanguageAnswerEnglish().submit()
-            Religion.clickReligionAnswerNoReligion().submit()
-            PastUsualAddress.clickPastUsualAddressAnswerThisAddress().submit()
-            Passports.clickPassportsAnswerUnitedKingdom().submit()
-            Disability.clickDisabilityAnswerNo().submit()
-            Qualifications.clickQualificationsAnswerUndergraduateDegree().submit()
-            Volunteering.clickVolunteeringAnswerYesLessOften().submit()
-            EmploymentType.clickEmploymentTypeAnswerWorkingAsAnEmployee().submit()
-            HouseholdMemberCompleted.submit()
+        // household-member
+        HouseholdMemberBegin.submit()
+        DetailsCorrect.clickDetailsCorrectAnswerYesThisIsMyFullName().submit()
+        Sex.clickSexAnswerMale().submit()
+        DateOfBirth.setDateOfBirthAnswerDay(2).setDateOfBirthAnswerMonth(3).setDateOfBirthAnswerYear(1980).submit()
+        Over16.clickOver16AnswerYes().submit()
+        MaritalStatus.clickMaritalStatusAnswerMarried().submit()
+        AnotherAddress.clickAnotherAddressAnswerNo().submit()
+        InEducation.clickInEducationAnswerNo().submit()
+        CountryOfBirth.clickCountryOfBirthEnglandAnswerEngland().submit()
+        Carer.clickCarerAnswerNo().submit()
+        NationalIdentity.clickNationalIdentityAnswerBritish().submit()
+        EthnicGroup.clickEthnicGroupAnswerWhite().submit()
+        WhiteEthnicGroup.clickWhiteEthnicGroupAnswerEnglishWelshScottishNorthernIrishBritish().submit()
+        UnderstandWelsh.clickUnderstandWelshAnswerNoneOfTheAbove().submit()
+        Language.clickLanguageAnswerEnglish().submit()
+        Religion.clickReligionAnswerNoReligion().submit()
+        PastUsualAddress.clickPastUsualAddressAnswerThisAddress().submit()
+        Passports.clickPassportsAnswerUnitedKingdom().submit()
+        Disability.clickDisabilityAnswerNo().submit()
+        Qualifications.clickQualificationsAnswerUndergraduateDegree().submit()
+        Volunteering.clickVolunteeringAnswerYesLessOften().submit()
+        EmploymentType.clickEmploymentTypeAnswerWorkingAsAnEmployee().submit()
+        HouseholdMemberCompleted.submit()
     })
 })

--- a/tests/functional/spec/household-composition.spec.js
+++ b/tests/functional/spec/household-composition.spec.js
@@ -19,8 +19,7 @@ describe('Household composition question for census test.', function() {
     HouseholdCompositionPage.setPersonName(0, 'Alpha', '', 'One').submit()
 
     // Then
-    expect(HouseholdCompositionSummary.getFirstName(0)).to.equal('Alpha')
-    expect(HouseholdCompositionSummary.getLastName(0)).to.equal('One')
+    HouseholdCompositionSummary.isNameDisplayed('Alpha One')
   })
 
   it('Given no people added, when I enter another name, then there should be two input fields displayed.', function() {
@@ -49,10 +48,9 @@ describe('Household composition question for census test.', function() {
         .submit()
 
     // Then
-    var names = HouseholdCompositionSummary.getFirstNames()
-    assert.include(names, 'Alpha')
-    assert.include(names, 'Bravo')
-    assert.include(names, 'Charlie')
+    HouseholdCompositionSummary.isNameDisplayed('Alpha One')
+    HouseholdCompositionSummary.isNameDisplayed('Bravo Two')
+    HouseholdCompositionSummary.isNameDisplayed('Charlie Three')
   })
 
  it('Given two people added, when I remove second person, only first person should appear on summary.', function() {
@@ -67,17 +65,17 @@ describe('Household composition question for census test.', function() {
         .submit()
 
     // Then
-    var names = HouseholdCompositionSummary.getFirstNames()
-    assert.include(names, 'Alpha')
-    assert.include(names, 'Bravo')
+    HouseholdCompositionSummary.isNameDisplayed('Alpha')
+    HouseholdCompositionSummary.isNameDisplayed('Bravo')
 
     // When
-    HouseholdCompositionSummary.clickEdit()
+    HouseholdCompositionSummary.clickAddAnother().submit()
     HouseholdCompositionPage.removePerson(1).submit()
 
     // Then
-    names = HouseholdCompositionSummary.getFirstNames()
-    assert.include(names, 'Alpha')
+
+    HouseholdCompositionSummary.isNameDisplayed('Alpha')
+    HouseholdCompositionSummary.isNameDisplayed('Bravo')
   })
 
  it('Given three people added, when I remove second person, first and third person should appear on summary.', function() {
@@ -94,19 +92,17 @@ describe('Household composition question for census test.', function() {
         .submit()
 
     // Then
-    var names = HouseholdCompositionSummary.getFirstNames()
-    assert.include(names, 'Alpha')
-    assert.include(names, 'Bravo')
-    assert.include(names, 'Charlie')
+    HouseholdCompositionSummary.isNameDisplayed('Alpha One')
+    HouseholdCompositionSummary.isNameDisplayed('Bravo Two')
+    HouseholdCompositionSummary.isNameDisplayed('Charlie Three')
 
     // When
-    HouseholdCompositionSummary.clickEdit()
+    HouseholdCompositionSummary.clickAddAnother().submit()
     HouseholdCompositionPage.removePerson(1).submit()
 
     // Then
-    names = HouseholdCompositionSummary.getFirstNames()
-    assert.include(names, 'Alpha')
-    assert.include(names, 'Charlie')
+    HouseholdCompositionSummary.isNameDisplayed('Alpha One')
+    HouseholdCompositionSummary.isNameDisplayed('Charlie Three')
   })
 
   it('Given first, middle and last names entered, then each part of name should appear on summary.', function() {
@@ -121,17 +117,8 @@ describe('Household composition question for census test.', function() {
         .submit()
 
     // Then
-    var firstNames = HouseholdCompositionSummary.getFirstNames()
-    assert.include(firstNames, 'Alpha')
-    assert.include(firstNames, 'Delta')
-
-    var middleNames = HouseholdCompositionSummary.getMiddleNames()
-    assert.include(middleNames, 'Bravo')
-    assert.include(middleNames, 'Echo')
-
-    var lastNames = HouseholdCompositionSummary.getLastNames()
-    assert.include(lastNames, 'Charlie')
-    assert.include(lastNames, 'Foxtrot')
+    HouseholdCompositionSummary.isNameDisplayed('Alpha Bravo Charlie')
+    HouseholdCompositionSummary.isNameDisplayed('Delta Echo Foxtrot')
   })
 
 })

--- a/tests/integration/household_composition/test_household_question.py
+++ b/tests/integration/household_composition/test_household_question.py
@@ -25,14 +25,77 @@ class TestHouseholdQuestion(IntegrationTestCase):
         first_page = self.add_answers()
         self.submit_answers(first_page)
 
+    def test_can_return_to_composition_and_add_entries(self):
+        first_page = self.add_answers()
+
+        form_data = MultiDict()
+        form_data.add("first-name", 'Person One')
+        form_data.add("first-name_1", 'Person Two')
+
+        form_data.add("action[save_continue]", "")
+
+        resp_url, resp = self.postRedirectGet(first_page, form_data)
+
+        self.assertRegex(resp_url, 'household-summary')
+
+        form_data = MultiDict()
+        form_data.add("household-composition-add-another", 'No')
+        form_data.add("action[save_continue]", "")
+
+        resp = self.client.post(resp_url, data=form_data, follow_redirects=False)
+        resp_url = resp.headers['Location']
+
+        self.assertEquals(resp.status_code, 302)
+
+        self.assertRegex(resp_url, 'household-composition')
+
+        form_data = MultiDict()
+        form_data.add("first-name", 'Person One')
+        form_data.add("first-name_1", 'Person Two')
+        form_data.add("first-name_2", 'Person Three')
+
+        resp_url, resp = self.postRedirectGet(first_page, form_data)
+        content = resp.get_data(True)
+
+        self.assertRegex(content, 'Person One')
+        self.assertRegex(content, 'Person Two')
+        self.assertRegex(content, 'Person Three')
+
+        self.assertRegex(resp_url, 'household-summary')
+
+    def test_composition_complete_progresses_to_summary(self):
+        first_page = self.add_answers()
+
+        form_data = MultiDict()
+        form_data.add("first-name", 'Person One')
+        form_data.add("first-name_1", 'Person Two')
+        form_data.add("action[save_continue]", "")
+
+        resp_url, resp = self.postRedirectGet(first_page, form_data)
+
+        self.assertRegex(resp_url, 'household-summary')
+
+        form_data = MultiDict()
+        form_data.add("household-composition-add-another", 'Yes')
+        form_data.add("action[save_continue]", "")
+
+        resp = self.client.post(resp_url, data=form_data, follow_redirects=False)
+        resp_url = resp.headers['Location']
+
+        self.assertEquals(resp.status_code, 302)
+
+        self.assertRegex(resp_url, '/summary')
+
     def submit_answers(self, page):
         # Add first person
         form_data = MultiDict()
+
         form_data.add("first-name", 'Person One')
         form_data.add("first-name_1", 'Person Two')
         form_data.add("first-name_2", 'Person Three')
         form_data.add("first-name_3", 'Person Four')
         form_data.add("action[save_continue]", "") # Remove person two.
+
         resp = self.client.post(page, data=form_data, follow_redirects=False)
         self.assertEquals(resp.status_code, 302)
 
@@ -42,7 +105,6 @@ class TestHouseholdQuestion(IntegrationTestCase):
         resp = self.navigate_to_page(summary_page)
         content = resp.get_data(True)
 
-        self.assertRegex(content, 'Your responses')
         self.assertRegex(content, 'Person One')
         self.assertRegex(content, 'Person Two')
         self.assertRegex(content, 'Person Three')
@@ -144,6 +206,3 @@ class TestHouseholdQuestion(IntegrationTestCase):
         resp = self.client.get(page, follow_redirects=False)
         self.assertEquals(resp.status_code, 200)
         return resp
-
-
-


### PR DESCRIPTION
### What is the context of this PR?
Adds the household composition summary page, showing a list of users entered and giving the option to return to edit the list.

In order to support this I've added conditional routing to a previous location. Allows us to support the routing of users to the household composition screen in census, based on the answer to a question. This is handled by adding a route to the routing path and removing the users current answer to this question (which would otherwise prevent the location path being calculated by navigator). This also fixes #629.

### How to review 
There are unit tests in navigator and integration tests to cover new behaviour. I've had to update current composition selenium tests to work with the new block.


