### PR TITLE
Fix survey_id to 'census' for census schemas

### DIFF
--- a/app/data/census_communal.json
+++ b/app/data/census_communal.json
@@ -3,7 +3,7 @@
     "questionnaire_id": "",
     "schema_version": "0.0.1",
     "data_version": "0.0.2",
-    "survey_id": "",
+    "survey_id": "census",
     "title": "Census England Communal Schema",
     "description": "Census England Communal Schema",
     "theme": "census",

--- a/app/data/census_household.json
+++ b/app/data/census_household.json
@@ -3,7 +3,7 @@
     "questionnaire_id": "",
     "schema_version": "0.0.1",
     "data_version": "0.0.2",
-    "survey_id": "",
+    "survey_id": "census",
     "title": "Census England Household Schema",
     "description": "Census England Household Schema",
     "theme": "census",

--- a/app/data/census_individual.json
+++ b/app/data/census_individual.json
@@ -3,7 +3,7 @@
     "questionnaire_id": "",
     "schema_version": "0.0.1",
     "data_version": "0.0.2",
-    "survey_id": "",
+    "survey_id": "census",
     "title": "Census England Individual Schema",
     "description": "Census England Individual Schema",
     "theme": "census",


### PR DESCRIPTION
### What is the context of this PR?
Fixed the survey_id for census schemas to 'census' 

### How to review 
Review schemas and check all tests are passing