### PR TITLE
Quick fix for numbering of question 4. for demo

### DIFF
--- a/app/data/census_household.json
+++ b/app/data/census_household.json
@@ -266,7 +266,7 @@
                             "questions": [
                                 {
                                     "id": "overnight-visitors-question",
-                                    "title": "4 How many visitors are staying overnight here on 9th April 2017?",
+                                    "title": "4. How many visitors are staying overnight here on 9th April 2017?",
                                     "guidance": [
                                         {
                                              "title": "Include",


### PR DESCRIPTION
### What is the context of this PR?
Adding full-stop to question number as it looks poor for demo today. This will be removed as soon as #618 is merged.

### How to review 
Look at schema, 1 character should be different. Merge it.
