### PR TITLE
Remove manipulation of focus on guidance toggle

### DIFF
--- a/app/assets/js/app/modules/details-toggle.js
+++ b/app/assets/js/app/modules/details-toggle.js
@@ -39,9 +39,7 @@ export function applyDetailsToggle(elDetails) {
 }
 
 export function open(elDetails, elBody, elLabel, elTrigger) {
-  if (document.activeElement !== document.body) document.activeElement.blur()
   elDetails.classList.add(classExpandedState)
-  elBody.focus()
   elLabel.innerHTML = elDetails.getAttribute(attrHideLbl)
   elTrigger.setAttribute(attrAriaExpanaded, true)
   elBody.setAttribute(attrAriaHidden, false)
@@ -49,7 +47,6 @@ export function open(elDetails, elBody, elLabel, elTrigger) {
 
 export function close(elDetails, elBody, elLabel, elTrigger) {
   elDetails.classList.remove(classExpandedState)
-  elBody.blur()
   elLabel.innerHTML = elDetails.getAttribute(attrShowLbl)
   elTrigger.setAttribute(attrAriaExpanaded, false)
   elBody.setAttribute(attrAriaHidden, true)

--- a/gulp/scripts.js
+++ b/gulp/scripts.js
@@ -71,8 +71,8 @@ export function lint(done) {
     .pipe(eslint.format())
     .pipe(eslint.failOnError())
     .on('error', (error) => {
-      gutil.log('linting failed');
-      gutil.log(error);
-      process.exit(1);
+      gutil.log('linting failed')
+      gutil.log(error)
+      process.exit(1)
     })
 }

--- a/gulp/tests.js
+++ b/gulp/tests.js
@@ -19,11 +19,13 @@ export function unitTests(done, watch) {
   server.on('browser_error', function(browser, err) {
     gutil.log(err)
     gutil.log('Karma Run Failed: ' + err.message)
+    if (!watch) process.exit(1)
     throw err
   })
 
   server.on('run_complete', function(browsers, results) {
     if (results.failed) {
+      if (!watch) process.exit(1)
       throw new Error('Karma: Tests Failed')
     }
     gutil.log('Karma Run Complete: No Failures')

--- a/tests/karma/spec/details-toggle.spec.js
+++ b/tests/karma/spec/details-toggle.spec.js
@@ -1,7 +1,8 @@
 import { applyDetailsToggle, classTrigger, classDetails, classBody, classExpandedState } from 'app/modules/details-toggle'
 
 const strTemplate = `<div class="guidance ${classDetails}" data-show-label="Show further guidance" data-hide-label="Hide further guidance">
-  <a class="guidance__link ${classTrigger}" href="#guidance-response" id="guidance-response-link" aria-controls="guidance-response-main" aria-expanded="false"><span class="u-vh">Click here to </span><span class="js-details-label">Show further guidance</span>
+  <a class="guidance__link ${classTrigger} js-details-label" href="#guidance-response" id="guidance-response-link" aria-controls="guidance-response-main" aria-expanded="false">
+    Show further guidance
   </a>
   <div class="guidance__main ${classBody}" id="guidance-response-main" aria-hidden="true">
     Vestibulum id ligula porta felis euismod semper. Curabitur blandit tempus porttitor. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Donec sed odio dui. Aenean lacinia bibendum nulla sed consectetur.
@@ -29,13 +30,5 @@ describe('Details Toggle', () => {
     expect(elDetails.classList.contains(classExpandedState)).to.equal(true)
     elTrigger.click()
     expect(elDetails.classList.contains(classExpandedState)).to.equal(false)
-  })
-
-  it('Body should not recieve focus when collapsed', () => {
-    elBody.focus()
-    expect(document.activeElement.classList.contains(classBody)).to.equal(false)
-    elTrigger.click()
-    elBody.focus()
-    expect(document.activeElement.classList.contains(classBody)).to.equal(true)
   })
 })


### PR DESCRIPTION
### What is the context of this PR?

* Removes messing with focus when users toggle guidance
* Removed test for this behaviour
* Enforced JS unit tests on Travis so they exit with code 1 on failure

### How to review 

* run tests