### PR TITLE
Add suites to functional tests and default to just core suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The functional tests can be executed with a couple of options.
 
 `--env=preprod` Will run the test against preprod.
 `--spec=mci` Will run a single test spec (`mci.spec.js`) instead of the entire suite.
+`--suite=core` Will run a suite of tests (core) instead of the entire suite.
 
 These options can be combined with `test_functional` or `test_functional_sauce`, eg:
 

--- a/gulp/tests.js
+++ b/gulp/tests.js
@@ -39,6 +39,9 @@ export function functionalTests(done) {
   if (yargs.argv.spec) {
     webdriverOpts.spec = `${paths.test.wdioSpec}/${yargs.argv.spec}.spec.js`
   }
+  if (yargs.argv.suite) {
+    webdriverOpts.suite = yargs.argv.suite
+  }
   gulp.src(paths.test.wdioConf)
     .pipe(webdriver(webdriverOpts))
     .on('error', (err) => {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint": "gulp lint",
     "test": "gulp test",
     "test_unit": "gulp test:scripts:unit:watch",
+    "test_unit_no_watch": "gulp test:scripts:unit",
     "test_functional": "gulp test:scripts:functional",
     "test_functional_sauce": "gulp test:scripts:functional --sauce",
     "a11y": "gulp test:a11ym"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -40,5 +40,18 @@ display_result $? 2 "Unit tests"
 
 # Run front end tests
 npm config set python python2.7
-yarn test
-display_result $? 1 "Front end tests"
+
+yarn test_unit_no_watch
+display_result $? 1 "Front end unit tests"
+
+if [ -z "$EQ_FUNCTIONAL_TEST_SUITES" ]; then
+    if [ "${TRAVIS_BRANCH}" = "master" ]; then
+        export EQ_FUNCTIONAL_TEST_SUITES="core,census"
+    else
+        export EQ_FUNCTIONAL_TEST_SUITES="core"
+    fi
+fi
+echo "Running front end functional tests [${EQ_FUNCTIONAL_TEST_SUITES}]"
+yarn test_functional -- --suite ${EQ_FUNCTIONAL_TEST_SUITES}
+
+display_result $? 1 "Front end functional tests"

--- a/tests/functional/config.js
+++ b/tests/functional/config.js
@@ -13,6 +13,14 @@ let config = {
   waitforTimeout: 20000,
   updateJob: true,
   specs: [`${paths.test.wdioSpec}/**/*.spec.js`],
+  suites: {
+    core: [
+      `${paths.test.wdioSpec}/*.spec.js`
+    ],
+    census: [
+      `${paths.test.wdioSpec}/census/**/*.spec.js`
+    ]
+  },
   sync: true,
   connectionRetryTimeout: 5000,
   connectionRetryCount: 3,


### PR DESCRIPTION
### What is the context of this PR?
The Census tests take a long time to complete and are holding up builds. Two suites have been created - core and census. The 'core' suite contains the core functionality tests and the 'census' suite contains all of the extended Census tests (issues, routing etc).

By default run_tests.sh now just runs the core tests. To run all tests from the command line you can still run 'yarn test_functional', or to run just the extended Census tests you can use `yarn test_functional -- --suite=census`.

As Travis uses run_tests.sh, it will only run the core tests.

### How to review 
- Run `./scripts/run_tests.sh`, verify it passes and only core tests are run
- Run `yarn test_functional -- --suite=census`, verify only the extended census tests are run