### PR TITLE
Fixes #667 other value not retained throughout census survey.

### DIFF
--- a/app/schema/widgets/multiple_choice_widget.py
+++ b/app/schema/widgets/multiple_choice_widget.py
@@ -62,8 +62,10 @@ class MultipleChoiceWidget(Widget, metaclass=ABCMeta):
         Compare the posted_data with the options in the schema, if there is a value which doesn't match
         the options it must be the other value
         """
-        if posted_data and 'other' in posted_data:
+        if posted_data and 'other' in (value.lower() for value in posted_data):
             for answer in posted_data:
-                if answer and not answer.isspace() and not any(option['value'] == answer for option in options) and answer is not 'other':
+                answer_in_options = any(option['value'] == answer for option in options)
+                if answer and not answer.isspace() and not answer_in_options and answer.lower() != 'other':
                     return answer
+
         return None

--- a/tests/app/questionnaire_state/test_state_answer.py
+++ b/tests/app/questionnaire_state/test_state_answer.py
@@ -1,0 +1,89 @@
+import unittest
+
+from werkzeug.datastructures import MultiDict
+
+from app.questionnaire_state.state_answer import StateAnswer
+from app.schema.answer import Answer
+from app.schema.widgets.text_widget import TextWidget
+
+
+class TestStateAnswer(unittest.TestCase):
+
+    def setUp(self):
+        self.answer_schema = Answer('multiple-choice-with-other')
+        self.answer_schema.widget = TextWidget(self.answer_schema.id)
+        self.answer_schema.options = [
+            {
+                "label": "Yes",
+                "value": "Yes"
+            },
+            {
+                "label": "No",
+                "value": "No",
+                "other": {
+                    "label": "Please enter the country of usual residence"
+                }
+            }
+        ]
+
+    def test_should_restore_other_value(self):
+        # Given
+        answer = StateAnswer(self.answer_schema.id, self.answer_schema)
+        answer.input = 'Some entered value'
+
+        post_vars = {
+            'multiple-choice-with-other': 'Some entered value',
+        }
+
+        # When
+        answer._restore_other_value(post_vars)
+
+        # Then
+        self.assertEqual(answer.other, 'Some entered value')
+
+    def test_should_set_input_to_schema_option_label_value(self):
+        # Given
+        answer = StateAnswer(self.answer_schema.id, self.answer_schema)
+        answer.input = 'Some entered value'
+
+        post_vars = {
+            'multiple-choice-with-other': 'Some entered value',
+        }
+
+        # When
+        answer._restore_other_value(post_vars)
+
+        # Then
+        self.assertEqual(answer.input, 'No')
+
+    def test_should_select_schema_option_if_other_input_text_already_an_option_in_the_schema(self):
+        # Given
+        answer = StateAnswer(self.answer_schema.id, self.answer_schema)
+        answer.input = 'No'
+
+        post_vars = MultiDict()
+        post_vars.add('multiple-choice-with-other', 'No')
+        post_vars.add('multiple-choice-with-other', 'Yes')
+
+        # When
+        answer._restore_other_value(post_vars)
+
+        # Then
+        self.assertEqual(answer.input, 'Yes')
+
+    def test_should_deselect_other_if_other_input_text_option_in_schema(self):
+        # Given
+        answer = StateAnswer(self.answer_schema.id, self.answer_schema)
+        answer.input = 'No'
+
+        post_vars = MultiDict()
+        post_vars.add('multiple-choice-with-other', 'No')
+        post_vars.add('multiple-choice-with-other', 'Yes')
+
+        # When
+        answer._restore_other_value(post_vars)
+
+        # Then
+        self.assertIsNone(answer.other)
+
+


### PR DESCRIPTION
### What is the context of this PR?
Fixes #667 other value not retained throughout census survey.

Turns out there were two issues:

1. Case sensitive match for 'other'. In the census schemas the value to be matched is 'Other'. I changed this to perform a case insensitive match when checking to see if an other value was posted.

2. When restoring the Other value an assumption was being made that the other option in the radio had the label 'Other'. This has now been changed to get the label from the schema option.

### How to review 
Re-test the issue #667.
Observe that the text entered in the 'other' text field in radio options is retained.
All tests should pass.

