### PR TITLE
Fixes #690 Quotes in household name causes error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ install:
     - pip install -U pip wheel
     - pip install --require-hashes -r requirements.txt
     - pip install -r requirements_for_test.txt
+
 before_script:
     - yarn compile
     - ./scripts/run_app.sh

--- a/app/templating/template_renderer.py
+++ b/app/templating/template_renderer.py
@@ -19,10 +19,11 @@ class TemplateRenderer:
         :param context: the variables to substitute
         :return: the rendered version of the original renderable dict
         """
-        json_string = json.dumps(renderable)
+        json_string = json.dumps(renderable) if isinstance(renderable, dict) else renderable
         template = self.environment.from_string(json_string)
         rendered = template.render(**context)
-        return json.loads(rendered)
+        result = rendered if isinstance(renderable, dict) else json.dumps(rendered)
+        return json.loads(result)
 
     def render_state(self, state, context):
         """

--- a/tests/app/templating/test_template_renderer.py
+++ b/tests/app/templating/test_template_renderer.py
@@ -26,3 +26,40 @@ class TestTemplateRenderer(unittest.TestCase):
         rendered = TemplateRenderer().render(date, **context)
 
         self.assertEqual(rendered, '1 January 2017')
+
+    def test_strings_containing_backslashes_are_escaped(self):
+        title = '{{ [answers.person_name] | format_household_name }}'
+        context = {
+            'answers': {
+                'person_name': '\\',
+            }
+        }
+
+        rendered = TemplateRenderer().render(title, **context)
+
+        self.assertEqual(rendered, '\\')
+
+    def test_strings_containing_quotes_are_escaped(self):
+        title = '{{ [answers.person_name] | format_household_name }}'
+        context = {
+            'answers': {
+                'person_name': '"',
+            }
+        }
+
+        rendered = TemplateRenderer().render(title, **context)
+
+        self.assertEqual(rendered, '"')
+
+    def test_household_summary_values_are_escaped(self):
+        description = "<h2 class='neptune'>Your household includes:</h2> {{ [answers.first_name, answers.middle_names, answers.last_name]|format_household_summary }}"
+        context = {
+            'answers': {
+                'first_name': ['Alice', 'Bob', '\\', 'Dave'],
+                'middle_names': ['', 'Berty', '"', 'Dixon'],
+                'last_name': ['Aardvark', 'Brown', '!', 'Davies'],
+            }
+        }
+
+        rendered = TemplateRenderer().render(description, **context)
+        self.assertEqual(rendered, '<h2 class=\'neptune\'>Your household includes:</h2> <ul><li>Alice Aardvark</li><li>Bob Berty Brown</li><li>\ " !</li><li>Dave Dixon Davies</li></ul>')

--- a/tests/functional/config.js
+++ b/tests/functional/config.js
@@ -24,7 +24,11 @@ let config = {
   sync: true,
   connectionRetryTimeout: 5000,
   connectionRetryCount: 3,
-  capabilities: [chrome],
+  capabilities: [{
+    name: 'Chrome (local)',
+    browserName: 'chrome',
+    maxInstances: 1
+  }],
   framework: 'mocha',
   reporters: ['spec'],
   mochaOpts: {

--- a/tests/functional/config.js
+++ b/tests/functional/config.js
@@ -24,11 +24,7 @@ let config = {
   sync: true,
   connectionRetryTimeout: 5000,
   connectionRetryCount: 3,
-  capabilities: [{
-    name: 'Chrome (local)',
-    browserName: 'chrome',
-    maxInstances: 1
-  }],
+  capabilities: [chrome],
   framework: 'mocha',
   reporters: ['spec'],
   mochaOpts: {


### PR DESCRIPTION
### What is the context of this PR?
Fixes #690.
Render function gets called both with dict and string in different places.
When called with string (substituting piping values) need to escape characters to ensure valid JSON.

### How to review 
Re-test the defect.
Ensure can enter quotes or backslashes for household member names.
Names should be displayed appropriately.