### PR TITLE
eq-718, eq-732 Fix JS issue with analytics

### DIFF
--- a/app/assets/js/app/modules/analytics.js
+++ b/app/assets/js/app/modules/analytics.js
@@ -2,8 +2,15 @@ import forEach from 'lodash/forEach'
 import domready from './domready'
 
 export default function initAnalytics() {
-  if (typeof ga === 'undefined') {
-    return false
+  let trackEvent = (event, data) => {
+    console.log(`[Analytics disabled] Event: ${event}`)
+    console.log(data)
+  }
+
+  if (typeof window.ga !== 'undefined') {
+    trackEvent = window.ga
+  } else {
+    console.log('Analytics disabled')
   }
 
   const errors = document.querySelectorAll('[data-error=true]')
@@ -18,11 +25,11 @@ export default function initAnalytics() {
       eventAction: errorMsg,
       eventLabel: elementId
     }
-    ga('send', errorData)
+    trackEvent('send', errorData)
   })
 
   forEach(guidances, guidance => {
-    const trigger = guidance.querySelector('.js-data-guidance-trigger')
+    const trigger = guidance.querySelector('[data-guidance-trigger]')
     const questionLabel = guidance.getAttribute('data-guidance-label')
     const questionId = guidance.getAttribute('data-guidance')
 
@@ -34,10 +41,12 @@ export default function initAnalytics() {
         eventAction: questionLabel,
         eventLabel: questionId
       }
-      ga('send', triggerData)
+      trackEvent('send', triggerData)
     }
 
-    trigger.addEventListener('click', onClick)
+    if (trigger) {
+      trigger.addEventListener('click', onClick)
+    }
   })
 }
 


### PR DESCRIPTION
### What is the context of this PR?

Fixes #718 and #732 caused by a JS error.

- adds fallback for event tracking by logging to console instead
- corrected DOM selector causing the problem
- added additional check that DOM element is not null before attaching event listener

### How to review 

- run app with analytics loaded (set `EQ_UA_ID` env var to`UA-56892037-7`)
- confirm no JS errors in console
- run app with analytics (remove `EQ_UA_ID` env var)
- confirm analytics events (errors, guidance) are logged to console