### PR TITLE
Fix repeating group bug for census

### DIFF
--- a/app/main/views/questionnaire.py
+++ b/app/main/views/questionnaire.py
@@ -247,14 +247,7 @@ def post_household_composition(eq_id, form_type, collection_id, group_id):
     }
 
     if 'action[save_continue]' in request.form:
-        answer_store.remove(group_id=group_id, block_id='household-composition')
-
-        questionnaire_store = get_questionnaire_store(current_user.user_id, current_user.user_ik)
-        for answer in SchemaHelper.get_answers_that_repeat_in_block(g.schema_json, 'household-composition'):
-            groups_to_delete = SchemaHelper.get_groups_that_repeat_with_answer_id(g.schema_json, answer['id'])
-            for group in groups_to_delete:
-                answer_store.remove(group_id=group['id'])
-                questionnaire_store.completed_blocks[:] = [b for b in questionnaire_store.completed_blocks if b.get('group_id') != group['id']]
+        _remove_repeating_on_household_answers(answer_store, group_id)
 
     valid = questionnaire_manager.process_incoming_answers(this_block, request.form)
 
@@ -274,6 +267,25 @@ def post_household_composition(eq_id, form_type, collection_id, group_id):
     next_location = navigator.get_next_location(current_block_id='household-composition', current_iteration=0, current_group_id=group_id)
 
     return redirect(location_url(eq_id, form_type, collection_id, next_location))
+
+
+@questionnaire_blueprint.route('<group_id>/<int:group_instance>/permanent-or-family-home', methods=["POST"])
+@login_required
+def post_everyone_at_address_confirmation(eq_id, form_type, collection_id, group_id, group_instance):
+    if request.form.get('permanent-or-family-home-answer') == 'No':
+        _remove_repeating_on_household_answers(get_answer_store(current_user), group_id)
+    return post_block(eq_id, form_type, collection_id, group_id, group_instance, 'permanent-or-family-home')
+
+
+def _remove_repeating_on_household_answers(answer_store, group_id):
+    answer_store.remove(group_id=group_id, block_id='household-composition')
+    questionnaire_store = get_questionnaire_store(current_user.user_id, current_user.user_ik)
+    for answer in SchemaHelper.get_answers_that_repeat_in_block(g.schema_json, 'household-composition'):
+        groups_to_delete = SchemaHelper.get_groups_that_repeat_with_answer_id(g.schema_json, answer['id'])
+        for group in groups_to_delete:
+            answer_store.remove(group_id=group['id'])
+            questionnaire_store.completed_blocks[:] = [b for b in questionnaire_store.completed_blocks if
+                                                       b.get('group_id') != group['id']]
 
 
 def _delete_user_data():

--- a/tests/functional/spec/census/routing/remove-household-member.spec.js
+++ b/tests/functional/spec/census/routing/remove-household-member.spec.js
@@ -1,0 +1,47 @@
+import chai from 'chai'
+import {startCensusQuestionnaire} from '../../../helpers'
+
+import PermanentOrFamilyHome from '../../../pages/surveys/census/household/permanent-or-family-home.page.js'
+import ElsePermanentOrFamilyHome from '../../../pages/surveys/census/household/else-permanent-or-family-home.page.js'
+import HouseholdComposition from '../../../pages/surveys/census/household/household-composition.page.js'
+import EveryoneAtAddressConfirmation from '../../../pages/surveys/census/household/everyone-at-address-confirmation.page.js'
+import OvernightVisitors from '../../../pages/surveys/census/household/overnight-visitors.page.js'
+import WhoLivesHereCompleted from '../../../pages/surveys/census/household/who-lives-here-completed.page.js'
+import TypeOfAccommodation from '../../../pages/surveys/census/household/type-of-accommodation.page.js'
+import TypeOfHouse from '../../../pages/surveys/census/household/type-of-house.page.js'
+import SelfContainedAccommodation from '../../../pages/surveys/census/household/self-contained-accommodation.page.js'
+import NumberOfBedrooms from '../../../pages/surveys/census/household/number-of-bedrooms.page.js'
+import CentralHeating from '../../../pages/surveys/census/household/central-heating.page.js'
+import HouseholdAndAccommodationCompleted from '../../../pages/surveys/census/household/household-and-accommodation-completed.page.js'
+import VisitorBegin from '../../../pages/surveys/census/household/visitor-begin.page.js'
+
+const expect = chai.expect
+
+describe('Census routing Scenarios', function () {
+
+  it('Given I have added a person in my household, When I change my mind and they should be visitors, Then I do not have to answer household member details', function () {
+    startCensusQuestionnaire('census_household.json')
+
+    // Given
+    PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
+    HouseholdComposition.setFirstName('John').submit()
+    EveryoneAtAddressConfirmation.previous()
+    HouseholdComposition.previous()
+    PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerNo().submit()
+    ElsePermanentOrFamilyHome.clickElsePermanentOrFamilyHomeAnswerNoOneLivesHereAsTheirPermanentHome().submit()
+
+    // When
+    OvernightVisitors.setOvernightVisitorsAnswer(1).submit()
+    WhoLivesHereCompleted.submit()
+    TypeOfAccommodation.clickTypeOfAccommodationAnswerWholeHouseOrBungalow().submit()
+    TypeOfHouse.clickTypeOfHouseAnswerSemiDetached().submit()
+    SelfContainedAccommodation.clickSelfContainedAccommodationAnswerYesAllTheRoomsAreBehindADoorThatOnlyThisHouseholdCanUse().submit()
+    NumberOfBedrooms.setNumberOfBedroomsAnswer(3).submit()
+    CentralHeating.clickCentralHeatingAnswerGas().submit()
+    HouseholdAndAccommodationCompleted.submit()
+
+    // Then
+    expect(VisitorBegin.isOpen()).to.equal(true, 'Expected to skip household details')
+  })
+
+})

--- a/tests/integration/questionnaire/test_questionnaire_remove_repeat_answers.py
+++ b/tests/integration/questionnaire/test_questionnaire_remove_repeat_answers.py
@@ -1,0 +1,46 @@
+from mock import patch, call
+
+from tests.integration.create_token import create_token
+from tests.integration.integration_test_case import IntegrationTestCase
+
+
+class TestQuestionnaireRemoveRepeatAnswers(IntegrationTestCase):
+
+    def test_should_remove_household_composition_answer_when_no_answer(self):
+        with patch('app.main.views.questionnaire.get_answer_store') as get_answer_store:
+            # Given
+            self.token = create_token('household', 'census')
+            self.client.get('/session?token=' + self.token.decode(), follow_redirects=True)
+            answer = {'permanent-or-family-home-answer': 'No'}
+
+            # When
+            self.client.post('/questionnaire/census/household/789/who-lives-here/0/permanent-or-family-home', data=answer)
+
+            # Then
+            get_answer_store().assert_has_calls([call.remove(block_id='household-composition', group_id='who-lives-here')])
+
+    def test_should_not_remove_answers_when_yes_answer(self):
+        with patch('app.main.views.questionnaire.get_answer_store') as get_answer_store:
+            # Given
+            self.token = create_token('household', 'census')
+            self.client.get('/session?token=' + self.token.decode(), follow_redirects=True)
+            answer = {'permanent-or-family-home-answer': 'Yes'}
+
+            # When
+            self.client.post('/questionnaire/census/household/789/who-lives-here/0/permanent-or-family-home', data=answer)
+
+            # Then
+            assert get_answer_store().remove.call_count == 0
+
+    def test_should_remove_all_repeating_groups(self):
+        with patch('app.main.views.questionnaire.get_answer_store') as get_answer_store:
+            # Given
+            self.token = create_token('household', 'census')
+            self.client.get('/session?token=' + self.token.decode(), follow_redirects=True)
+            answer = {'permanent-or-family-home-answer': 'No'}
+
+            # When
+            self.client.post('/questionnaire/census/household/789/who-lives-here/0/permanent-or-family-home', data=answer)
+
+            # Then
+            get_answer_store().assert_has_calls([call.remove(group_id='who-lives-here-relationship'), call.remove(group_id='household-member')])


### PR DESCRIPTION
### What is the context of this PR?

Repeating answers will repeat if the answer which determines the repeat
was originally answered but if the user then changes their mind to go
down a path where the answer which determines the repeat will no longer
appear on. The expected result is for those repeating answers to not be
repeated. The actual result is that the repeating answers are repeated.

The scenario this occurs under is:
Given I have added a person in my household, When I change my mind and
they should be visitors, Then I do not have to answer household member
details

The short term fix for this is to remove the answer which determines the
repeat when the user goes down the other path which is consistent with
what we do when a user changes their answer which determines the number
of repeats.

The ideal fix going forward would be to check if the answer which
determines the repeating answers is on the path that the user is being
followed.

[trello](https://trello.com/c/vnjf9dR9/813-eq-survey-runner-727-when-clicking-previous-after-adding-household-members-the-reporting-groups-still-repeat-issue)
[trello for the real fix](https://trello.com/c/QXkI2J6i/298-repeating-groups-should-only-be-evaluated-if-the-answer-which-determines-the-repeating-groups-in-on-the-path)

### How to review 
All selenium tests should still pass and also the BDD test `Given I have added a person in my household, When I change my mind they should be visitors, Then I do not have to answer household details`

Fixes #727 
