### PR TITLE
Bleach values entering AnswerStore

### DIFF
--- a/app/data_model/answer_store.py
+++ b/app/data_model/answer_store.py
@@ -71,8 +71,8 @@ class AnswerStore(object):
 
         if isinstance(answer.value, list):
             bleached_values = []
-            for index, answer_from_list in enumerate(answer.value):
-                bleached_values.append(self._bleach(answer.value[index]))
+            for answer_from_list in answer.value:
+                bleached_values.append(self._bleach(answer_from_list))
 
             return bleached_values
         else:

--- a/app/schema/answer.py
+++ b/app/schema/answer.py
@@ -5,8 +5,6 @@ from app.questionnaire_state.state_answer import StateAnswer
 from app.schema.exceptions import TypeCheckingException
 from app.schema.item import Item
 
-import bleach
-
 logger = logging.getLogger(__name__)
 
 
@@ -58,14 +56,12 @@ class Answer(Item):
 
     def get_typed_value(self, raw_input):
 
-        user_input = bleach.clean(raw_input)
-
         for checker in self.type_checkers:
-            result = checker.validate(user_input)
+            result = checker.validate(raw_input)
             if not result.is_valid:
                 raise TypeCheckingException(result.errors[0])
 
-        return self._cast_user_input(user_input)
+        return self._cast_user_input(raw_input)
 
     @staticmethod
     def _cast_user_input(user_input):

--- a/app/schema/answers/percentage_answer.py
+++ b/app/schema/answers/percentage_answer.py
@@ -9,4 +9,4 @@ class PercentageAnswer(Answer):
 
     @staticmethod
     def _cast_user_input(user_input):
-        return float(user_input)
+        return float(str(user_input))

--- a/tests/app/data_model/test_answer_store.py
+++ b/tests/app/data_model/test_answer_store.py
@@ -624,3 +624,18 @@ class TestAnswerStore(unittest.TestCase):
 
         self.store.remove()
         self.assertEqual(self.store.map(), {})
+
+    def test_answer_store_bleaches_answers(self):
+        answer_1 = Answer(
+            block_id="3",
+            answer_id="4",
+            answer_instance=1,
+            group_id="5",
+            group_instance=1,
+            value='<img src="https://www.google.co.uk/images/branding/googlelogo/2x/googlelogo_color_120x44dp.png"/>',
+        )
+
+        self.store.add(answer_1)
+
+        self.assertNotEqual(self.store.get(answer_1), '<img src="https://www.google.co.uk/images/branding/googlelogo/2x/googlelogo_color_120x44dp.png"/>')
+        self.assertFalse('<' in self.store.get(answer_1))

--- a/tests/app/data_model/test_answer_store.py
+++ b/tests/app/data_model/test_answer_store.py
@@ -638,4 +638,4 @@ class TestAnswerStore(unittest.TestCase):
         self.store.add(answer_1)
 
         self.assertNotEqual(self.store.get(answer_1), '<img src="https://www.google.co.uk/images/branding/googlelogo/2x/googlelogo_color_120x44dp.png"/>')
-        self.assertFalse('<' in self.store.get(answer_1))
+        self.assertNotIn('<', self.store.get(answer_1))


### PR DESCRIPTION
### What is the context of this PR?
Move the bleaching of input to when the value is entered into the AnswerStore. This should then catch all input.

Fixes https://github.com/ONSdigital/eq-survey-runner/issues/699
