### PR TITLE
Add Location class

### DIFF
--- a/app/data_model/answer_store.py
+++ b/app/data_model/answer_store.py
@@ -151,7 +151,7 @@ class AnswerStore(object):
 
         return len(self.filter(answer.group_id, answer.block_id, answer.answer_id, answer.group_instance, answer.answer_instance))
 
-    def filter(self, group_id=None, block_id=None, answer_id=None, group_instance=None, answer_instance=None):
+    def filter(self, group_id=None, block_id=None, answer_id=None, group_instance=None, answer_instance=None, location=None):
         """
         Find all answers in the answer store for a given set of filter parameter matches.
         If no filter parameters are passed it returns a copy of the list of all answers.
@@ -171,6 +171,11 @@ class AnswerStore(object):
             "answer_instance": answer_instance,
             "group_instance": group_instance,
         }
+        if location:
+            filter_vars['group_id'] = location.group_id
+            filter_vars['group_instance'] = location.group_instance
+            filter_vars['block_id'] = location.block_id
+
         for answer in self.answers:
             matches = True
             for k, v in filter_vars.items():
@@ -214,7 +219,7 @@ class AnswerStore(object):
         if index is not None:
             del self.answers[index]
 
-    def remove(self, group_id=None, block_id=None, answer_id=None, group_instance=None, answer_instance=None):
+    def remove(self, group_id=None, block_id=None, answer_id=None, group_instance=None, answer_instance=None, location=None):
         """
         Removes answer(s) from the answer store.
 
@@ -223,8 +228,10 @@ class AnswerStore(object):
         :param group_id:
         :param answer_instance:
         :param group_instance:
+        :param location:
         """
-        for answer in self.filter(group_id, block_id, answer_id, group_instance, answer_instance):
+
+        for answer in self.filter(group_id, block_id, answer_id, group_instance, answer_instance, location):
             self.answers.remove(answer)
 
 

--- a/app/data_model/answer_store.py
+++ b/app/data_model/answer_store.py
@@ -156,12 +156,13 @@ class AnswerStore(object):
         Find all answers in the answer store for a given set of filter parameter matches.
         If no filter parameters are passed it returns a copy of the list of all answers.
 
-        :param answer_id:
-        :param block_id:
-        :param group_id:
-        :param answer_instance:
-        :param group_instance:
-        :return:
+        :param answer_id: The answer id to filter results by
+        :param block_id: The block id to filter results by
+        :param group_id: The group id to filter results by
+        :param answer_instance: The answer instance to filter results by
+        :param group_instance: The group instance to filter results by
+        :param location: The location to filter results by (takes precedence over group_id, group_instance and block_id)
+        :return: Return a list of answers which satisfy the filter criteria
         """
         filtered = []
         filter_vars = {
@@ -172,6 +173,9 @@ class AnswerStore(object):
             "group_instance": group_instance,
         }
         if location:
+            assert not (group_id or group_instance or block_id), \
+                "Expected either a location object or one or more of group_id, group_instance, block_id params"
+
             filter_vars['group_id'] = location.group_id
             filter_vars['group_instance'] = location.group_instance
             filter_vars['block_id'] = location.block_id
@@ -223,12 +227,12 @@ class AnswerStore(object):
         """
         Removes answer(s) from the answer store.
 
-        :param answer_id:
-        :param block_id:
-        :param group_id:
-        :param answer_instance:
-        :param group_instance:
-        :param location:
+        :param answer_id: The answer id to filter results to remove
+        :param block_id: The block id to filter results to remove
+        :param group_id: The group id to filter results to remove
+        :param answer_instance: The answer instance to filter results to remove
+        :param group_instance: The group instance to filter results to remove
+        :param location: The location to filter results to remove (takes precedence over group_id, group_instance and block_id)
         """
 
         for answer in self.filter(group_id, block_id, answer_id, group_instance, answer_instance, location):

--- a/app/data_model/questionnaire_store.py
+++ b/app/data_model/questionnaire_store.py
@@ -2,6 +2,7 @@ import json
 import logging
 
 from app.data_model.answer_store import AnswerStore
+from app.questionnaire.location import Location
 from app.storage.storage_factory import get_storage
 
 logger = logging.getLogger(__name__)
@@ -34,7 +35,13 @@ class QuestionnaireStore:
                 self.answer_store.answers = data['ANSWERS']
 
             if 'COMPLETED_BLOCKS' in data:
-                self.completed_blocks = data['COMPLETED_BLOCKS']
+                for location_dict in data['COMPLETED_BLOCKS']:
+                    location = Location(
+                        location_dict['group_id'],
+                        location_dict['group_instance'],
+                        location_dict['block_id'],
+                    )
+                    self.completed_blocks.append(location)
 
         self.initial_hash = hash(self.get_json())
 
@@ -42,7 +49,7 @@ class QuestionnaireStore:
         return {
             "METADATA": self.metadata,
             "ANSWERS": self.answer_store.answers,
-            "COMPLETED_BLOCKS": self.completed_blocks,
+            "COMPLETED_BLOCKS": [b.__dict__ for b in self.completed_blocks],
         }
 
     def get_json(self):

--- a/app/helpers/schema_helper.py
+++ b/app/helpers/schema_helper.py
@@ -1,3 +1,6 @@
+from app.questionnaire.location import Location
+
+
 class SchemaHelper(object):
 
     @staticmethod
@@ -13,6 +16,10 @@ class SchemaHelper(object):
         group = cls.get_group(survey_json, group_id)
         if group:
             return group['blocks'][0]['id']
+
+    @staticmethod
+    def get_last_block_id(survey_json):
+        return survey_json['groups'][0]['blocks'][-1]['id']
 
     @staticmethod
     def get_last_group_id(survey_json):
@@ -63,3 +70,19 @@ class SchemaHelper(object):
             repeating_rule = cls.get_repeating_rule(group)
             if repeating_rule and repeating_rule['answer_id'] == answer_id:
                 yield group
+
+    @classmethod
+    def get_first_location(cls, survey_json):
+        return Location(
+            group_id=cls.get_first_group_id(survey_json),
+            group_instance=0,
+            block_id=cls.get_first_block_id(survey_json),
+        )
+
+    @classmethod
+    def get_last_location(cls, survey_json):
+        return Location(
+            group_id=cls.get_last_group_id(survey_json),
+            group_instance=0,
+            block_id=cls.get_last_block_id(survey_json),
+        )

--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -52,12 +52,6 @@ def format_str_as_date(value):
 
 
 @blueprint.app_template_filter()
-def format_url(metadata, group_id, group_instance, block_id):
-    return '/questionnaire/' + metadata['eq_id'] + '/' + metadata['form_type'] + '/' + metadata['collection_id'] + \
-           '/' + str(group_id) + '/' + str(group_instance) + '/' + str(block_id)
-
-
-@blueprint.app_template_filter()
 def format_household_member_name(names):
     return ' '.join(map(lambda name: name.strip(), filter(None, names)))
 

--- a/app/questionnaire/location.py
+++ b/app/questionnaire/location.py
@@ -1,0 +1,74 @@
+from flask import url_for
+
+
+class Location(object):
+
+    def __init__(self, group_id, group_instance, block_id):
+
+        self.group_id = group_id
+        self.group_instance = group_instance
+        self.block_id = block_id
+
+    def __eq__(self, other):
+        """
+        Check to see if two locations are equal.
+        Two answers are considered to be equal if their dictionary representations equal one another.
+
+        :param other: An answer to compare
+        :return: True if both answers match, otherwise False.
+        """
+        return isinstance(other, Location) and self.__dict__ == other.__dict__
+
+    def __hash__(self):
+        return hash(self.__dict__.values())
+
+    def __str__(self):
+        """
+        String representation of the location, handy for debug messages
+
+        :return:
+        """
+        return "{}/{}/{}".format(self.group_id, self.group_instance, self.block_id)
+
+    def is_interstitial(self):
+        return self.block_id in ['introduction', 'summary', 'thank-you']
+
+    def url(self, metadata):
+        """
+        Return the survey runner url that this location represents
+
+        :param metadata:
+        :return:
+        """
+        eq_id = metadata["eq_id"]
+        collection_id = metadata["collection_exercise_sid"]
+        form_type = metadata["form_type"]
+
+        if self.is_interstitial():
+            if self.block_id == 'summary':
+                return url_for('questionnaire.get_summary',
+                               eq_id=eq_id,
+                               form_type=form_type,
+                               collection_id=collection_id)
+            elif self.block_id == 'introduction':
+                return url_for('questionnaire.get_introduction',
+                               eq_id=eq_id,
+                               form_type=form_type,
+                               collection_id=collection_id)
+            elif self.block_id == 'confirmation':
+                return url_for('questionnaire.get_confirmation',
+                               eq_id=eq_id,
+                               form_type=form_type,
+                               collection_id=collection_id)
+            elif self.block_id == 'thank-you':
+                return url_for('questionnaire.get_thank_you',
+                               eq_id=eq_id,
+                               form_type=form_type,
+                               collection_id=collection_id)
+        return url_for('questionnaire.get_block',
+                       eq_id=eq_id,
+                       form_type=form_type,
+                       collection_id=collection_id,
+                       group_id=self.group_id,
+                       group_instance=self.group_instance,
+                       block_id=self.block_id)

--- a/app/questionnaire/navigator.py
+++ b/app/questionnaire/navigator.py
@@ -1,9 +1,11 @@
+import copy
 import logging
 
 from collections import defaultdict
 
 from app.data_model.answer_store import AnswerStore
 from app.helpers.schema_helper import SchemaHelper
+from app.questionnaire.location import Location
 from app.questionnaire.rules import evaluate_goto, evaluate_repeat, evaluate_skip_condition, is_goto_rule
 
 
@@ -24,20 +26,15 @@ class Navigator:
         if SchemaHelper.has_introduction(self.survey_json):
             self.preceeding_path = self.PRECEEDING_INTERSTITIAL_PATH
 
-    @classmethod
-    def is_interstitial_block(cls, block_id):
-        return block_id in cls.PRECEEDING_INTERSTITIAL_PATH or block_id in cls.CLOSING_INTERSTITIAL_PATH
-
-    @classmethod
-    def _block_index_for_location(cls, blocks, location):
+    @staticmethod
+    def _block_index_for_location(blocks, location):
         try:
-            if not cls.is_interstitial_block(location['block_id']):
-                return next(index for (index, b) in enumerate(blocks) if b["block"]["id"] == location['block_id'] and
-                            b["group_id"] == location['group_id'] and b['group_instance'] == location['group_instance'])
+            if not location.is_interstitial():
+                return next(index for (index, b) in enumerate(blocks) if b["block"]["id"] == location.block_id and
+                            b["group_id"] == location.group_id and b['group_instance'] == location.group_instance)
         except StopIteration:
             logger.error("Navigation failure looking for %s", location)
             raise
-
         return None
 
     def build_path(self, blocks, this_location):
@@ -45,8 +42,8 @@ class Navigator:
         Visits all the blocks from a location forwards and returns path
         taken given a list of answers.
 
-        :param blocks: A list containing all blocks in the survey
-        :param this_location: The location to start navigating from
+        :param blocks: A list containing all block content in the survey
+        :param this_location: The location to visit, represented as a dict
         :return: A list of locations followed through the survey
         """
         path = []
@@ -55,10 +52,10 @@ class Navigator:
 
         # Keep going unless we've hit the last block
         while block_index < blocks_len:
-            if this_location['block_id'] in self.CLOSING_INTERSTITIAL_PATH:
+            if this_location.block_id in self.CLOSING_INTERSTITIAL_PATH:
                 return path
 
-            block_index = self._block_index_for_location(blocks, this_location)
+            block_index = Navigator._block_index_for_location(blocks, this_location)
             if block_index is None:
                 logger.error('build_path: _block_index_for_location %s is None (invalid location)', this_location)
                 return path
@@ -68,15 +65,15 @@ class Navigator:
 
             # If routing rules exist then a rule must match (i.e. default goto)
             if 'routing_rules' in block and len(block['routing_rules']) > 0:
-                original_this_location = this_location.copy()
+                original_this_location = copy.copy(this_location)
                 for rule in filter(is_goto_rule, block['routing_rules']):
-                    should_goto = evaluate_goto(rule['goto'], self.metadata, self.answer_store, this_location['group_instance'])
+                    should_goto = evaluate_goto(rule['goto'], self.metadata, self.answer_store, this_location.group_instance)
 
                     if should_goto:
-                        next_location = this_location.copy()
-                        next_location['block_id'] = rule['goto']['id']
+                        next_location = copy.copy(this_location)
+                        next_location.block_id = rule['goto']['id']
 
-                        next_block_index = self._block_index_for_location(blocks, next_location)
+                        next_block_index = Navigator._block_index_for_location(blocks, next_location)
                         next_precedes_current = next_block_index is not None and next_block_index < block_index
 
                         if next_precedes_current:
@@ -91,11 +88,9 @@ class Navigator:
 
             # No routing rules, so if this isn't the last block, step forward a block
             elif block_index < len(blocks) - 1:
-                this_location = {
-                    "block_id": blocks[block_index + 1]['block']['id'],
-                    "group_id": blocks[block_index + 1]['group_id'],
-                    "group_instance": blocks[block_index + 1]['group_instance'],
-                }
+                this_location = Location(blocks[block_index + 1]['group_id'],
+                                         blocks[block_index + 1]['group_instance'],
+                                         blocks[block_index + 1]['block']['id'])
 
             # If we've reached last block stop evaluating the path
             else:
@@ -111,9 +106,7 @@ class Navigator:
                 if 'meta' not in condition.keys():
                     self.answer_store.remove(answer_id=condition['id'],
                                              answer_instance=0,
-                                             block_id=location['block_id'],
-                                             group_id=location['group_id'],
-                                             group_instance=location['group_instance'])
+                                             location=location)
 
     def get_routing_path(self, group_id=None, group_instance=0):
         """
@@ -123,12 +116,9 @@ class Navigator:
         if group_id is None:
             group_id = SchemaHelper.get_first_group_id(self.survey_json)
 
-        first_block_in_group = SchemaHelper.get_group(self.survey_json, group_id)['blocks'][0]['id']
-        location = {
-            "group_id": group_id,
-            "group_instance": group_instance,
-            "block_id": first_block_in_group,
-        }
+        first_block_in_group = SchemaHelper.get_first_block_id_for_group(self.survey_json, group_id)
+        location = Location(group_id, group_instance, first_block_in_group)
+
         return self.build_path(self.get_blocks(), location)
 
     def can_reach_summary(self, routing_path):
@@ -140,8 +130,7 @@ class Navigator:
         :return:
         """
         blocks = self.get_blocks()
-        routing_path = routing_path or self.get_routing_path()
-        last_routing_block_id = routing_path[-1]['block_id']
+        last_routing_block_id = routing_path[-1].block_id
         last_block_id = blocks[-1]['block']['id']
 
         if last_block_id == last_routing_block_id:
@@ -170,21 +159,13 @@ class Navigator:
         can_reach_summary = self.can_reach_summary(routing_path)
 
         # Make sure we don't update original
-        location_path = [{
-            "block_id": block_id,
-            "group_id": group_id,
-            "group_instance": 0,
-        } for block_id in self.preceeding_path]
+        location_path = [Location(group_id, 0, block_id) for block_id in self.preceeding_path]
 
         location_path += routing_path
 
         if can_reach_summary:
             for block_id in Navigator.CLOSING_INTERSTITIAL_PATH:
-                location_path.append({
-                    "block_id": block_id,
-                    "group_id": SchemaHelper.get_last_group_id(self.survey_json),
-                    "group_instance": 0,
-                })
+                location_path.append(Location(SchemaHelper.get_last_group_id(self.survey_json), 0, block_id))
 
         return location_path
 
@@ -211,44 +192,34 @@ class Navigator:
                 } for block in group['blocks']])
         return blocks
 
-    def _get_current_location_index(self, path, current_group_id, current_block_id, current_iteration):
-        first_group_id = SchemaHelper.get_first_group_id(self.survey_json)
-        current_group_id = current_group_id or first_group_id
-        this_block = {
-            "block_id": current_block_id,
-            "group_id": current_group_id,
-            "group_instance": current_iteration,
-        }
-
-        if this_block in path:
-            return path.index(this_block)
+    @staticmethod
+    def _get_current_location_index(path, current_location):
+        if current_location in path:
+            return path.index(current_location)
         return None
 
-    def get_next_location(self, current_group_id=None, current_block_id=None, current_iteration=0):
+    def get_next_location(self, current_location):
         """
         Returns the next 'location' to visit given a set of user answers
-        :param current_group_id:
-        :param current_block_id:
-        :param current_iteration:
+        :param current_location:
         :return: The next location as a dict
         """
-        location_path = self.get_location_path(current_group_id, current_iteration)
-        current_location_index = self._get_current_location_index(location_path, current_group_id, current_block_id, current_iteration)
+        location_path = self.get_location_path(current_location.group_id, current_location.group_instance)
+        current_location_index = Navigator._get_current_location_index(location_path, current_location)
 
         if current_location_index is not None and current_location_index < len(location_path) - 1:
             return location_path[current_location_index + 1]
         return None
 
-    def get_previous_location(self, current_group_id=None, current_block_id=None, current_iteration=0):
+    def get_previous_location(self, current_location):
         """
-        Returns the next 'location' to visit given a set of user answers
-        :param current_group_id:
-        :param current_block_id:
+        Returns the previous 'location' to visit given a set of user answers
+        :param current_location:
         :return: The previous location as a dict
         :return:
         """
-        location_path = self.get_location_path(current_group_id, current_iteration)
-        current_location_index = self._get_current_location_index(location_path, current_group_id, current_block_id, current_iteration)
+        location_path = self.get_location_path(current_location.group_id, current_location.group_instance)
+        current_location_index = Navigator._get_current_location_index(location_path, current_location)
 
         if current_location_index is not None and current_location_index != 0:
             return location_path[current_location_index - 1]
@@ -263,7 +234,7 @@ class Navigator:
         """
         location_path = self.get_location_path()
         if completed_blocks:
-            incomplete_blocks = [item for item in location_path if item not in completed_blocks]
+            incomplete_blocks = [item for item in location_path if item.__dict__ not in completed_blocks]
 
             if incomplete_blocks:
                 return incomplete_blocks[0]
@@ -305,29 +276,23 @@ class Navigator:
                 self._add_single_navigation_item(completed_blocks, completed_id, group, current_group_id, navigation)
         return navigation
 
-    @staticmethod
-    def _add_repeating_navigation_item(link_names, completed_blocks, completed_id, group, current_group_id,
+    def _add_repeating_navigation_item(self, link_names, completed_blocks, completed_id, group, current_group_id,
                                        current_group_instance, navigation, no_of_repeats):
         for i in range(no_of_repeats):
             if link_names:
                 navigation.append({
                     'link_name': link_names.get(i),
-                    'group_id': group['id'],
-                    'instance': i,
-                    'block_id': group['blocks'][0]['id'],
+                    'link_url': Location(group['id'], i, group['blocks'][0]['id']).url(self.metadata),
                     'completed': any(item for item in completed_blocks if item['group_instance'] == i and
                                      item["block_id"] == completed_id),
                     'highlight': group['id'] == current_group_id and i == current_group_instance,
                     'repeating': True
                 })
 
-    @staticmethod
-    def _add_single_navigation_item(completed_blocks, completed_id, group, current_group_id, navigation):
+    def _add_single_navigation_item(self, completed_blocks, completed_id, group, current_group_id, navigation):
         navigation.append({
             'link_name': group['title'],
-            'group_id': group['id'],
-            'instance': 0,
-            'block_id': group['blocks'][0]['id'],
+            'link_url': Location(group['id'], 0, group['blocks'][0]['id']).url(self.metadata),
             'completed': any(item for item in completed_blocks if item["block_id"] == completed_id),
             'highlight': (group['id'] != current_group_id and current_group_id in group['highlight_when']
                           if 'highlight_when' in group else False) or group['id'] == current_group_id,

--- a/app/questionnaire/navigator.py
+++ b/app/questionnaire/navigator.py
@@ -158,7 +158,6 @@ class Navigator:
         routing_path = self.get_routing_path(group_id, group_instance)
         can_reach_summary = self.can_reach_summary(routing_path)
 
-        # Make sure we don't update original
         location_path = [Location(group_id, 0, block_id) for block_id in self.preceeding_path]
 
         location_path += routing_path
@@ -234,7 +233,7 @@ class Navigator:
         """
         location_path = self.get_location_path()
         if completed_blocks:
-            incomplete_blocks = [item for item in location_path if item.__dict__ not in completed_blocks]
+            incomplete_blocks = [item for item in location_path if item not in completed_blocks]
 
             if incomplete_blocks:
                 return incomplete_blocks[0]
@@ -283,8 +282,8 @@ class Navigator:
                 navigation.append({
                     'link_name': link_names.get(i),
                     'link_url': Location(group['id'], i, group['blocks'][0]['id']).url(self.metadata),
-                    'completed': any(item for item in completed_blocks if item['group_instance'] == i and
-                                     item["block_id"] == completed_id),
+                    'completed': any(item for item in completed_blocks if item.group_instance == i and
+                                     item.block_id == completed_id),
                     'highlight': group['id'] == current_group_id and i == current_group_instance,
                     'repeating': True
                 })
@@ -293,7 +292,7 @@ class Navigator:
         navigation.append({
             'link_name': group['title'],
             'link_url': Location(group['id'], 0, group['blocks'][0]['id']).url(self.metadata),
-            'completed': any(item for item in completed_blocks if item["block_id"] == completed_id),
+            'completed': any(item for item in completed_blocks if item.block_id == completed_id),
             'highlight': (group['id'] != current_group_id and current_group_id in group['highlight_when']
                           if 'highlight_when' in group else False) or group['id'] == current_group_id,
             'repeating': False,

--- a/app/questionnaire/questionnaire_manager.py
+++ b/app/questionnaire/questionnaire_manager.py
@@ -60,11 +60,11 @@ class QuestionnaireManager(object):
         # Store answers in QuestionnaireStore
         questionnaire_store = get_questionnaire_store(current_user.user_id, current_user.user_ik)
 
-        for answer in self.get_state_answers(location['block_id']):
+        for answer in self.get_state_answers(location.block_id):
             questionnaire_store.answer_store.add_or_update(answer.flatten())
 
-        if location not in questionnaire_store.completed_blocks:
-            questionnaire_store.completed_blocks.append(location)
+        if location.__dict__ not in questionnaire_store.completed_blocks:
+            questionnaire_store.completed_blocks.append(location.__dict__)
 
     def process_incoming_answers(self, location, post_data):
         logger.debug("Processing post data for %s", location)
@@ -79,19 +79,19 @@ class QuestionnaireManager(object):
     def build_state(self, location, answers):
         # Build the state from the answers
         self.state = None
-        if self._schema.item_exists(location['block_id']):
+        if self._schema.item_exists(location.block_id):
             metadata = get_metadata(current_user)
             answer_store = get_answer_store(current_user)
-            schema_item = self._schema.get_item_by_id(location['block_id'])
+            schema_item = self._schema.get_item_by_id(location.block_id)
             self.state = schema_item.construct_state()
 
-            for answer in self.get_state_answers(location['block_id']):
-                answer.group_id = location['group_id']
-                answer.group_instance = location['group_instance']
+            for answer in self.get_state_answers(location.block_id):
+                answer.group_id = location.group_id
+                answer.group_instance = location.group_instance
             self.state.update_state(answers)
             self.state.set_skipped(get_answers(current_user), metadata)
 
-            context = build_schema_context(metadata, self._schema.aliases, answer_store, location['group_instance'])
+            context = build_schema_context(metadata, self._schema.aliases, answer_store, location.group_instance)
             renderer.render_state(self.state, context)
 
     def get_state_answers(self, item_id):

--- a/app/questionnaire/questionnaire_manager.py
+++ b/app/questionnaire/questionnaire_manager.py
@@ -63,8 +63,8 @@ class QuestionnaireManager(object):
         for answer in self.get_state_answers(location.block_id):
             questionnaire_store.answer_store.add_or_update(answer.flatten())
 
-        if location.__dict__ not in questionnaire_store.completed_blocks:
-            questionnaire_store.completed_blocks.append(location.__dict__)
+        if location not in questionnaire_store.completed_blocks:
+            questionnaire_store.completed_blocks.append(location)
 
     def process_incoming_answers(self, location, post_data):
         logger.debug("Processing post data for %s", location)

--- a/app/submitter/converter.py
+++ b/app/submitter/converter.py
@@ -128,7 +128,7 @@ def convert_answers_to_census_data(answer_store, routing_path):
     """
     data = []
     for location in routing_path:
-        answers_in_block = answer_store.filter(group_id=location['group_id'], group_instance=location['group_instance'], block_id=location['block_id'])
+        answers_in_block = answer_store.filter(location=location)
         data.extend(answers_in_block)
     return data
 

--- a/app/templates/partials/navigation.html
+++ b/app/templates/partials/navigation.html
@@ -1,12 +1,12 @@
 <div class="nav nav--sections nav--vertical js-nav page__nav" id="section-nav">
   <h2 class="nav__title venus">{{_('Sections')}}</h2>
   <ul class="nav__list js-nav-list">
-  {% for group in navigation %}
-    <li class="nav__item  pluto {{ 'nav__item--completed' if group.completed }} {{ 'nav__item--current' if group.highlight }}">
-      {% if group.current_location %}
-        <div>{{group.link_name}}</div>
+  {% for nav_item in navigation %}
+    <li class="nav__item  pluto {{ 'nav__item--completed' if nav_item.completed }} {{ 'nav__item--current' if nav_item.highlight }}">
+      {% if nav_item.current_location %}
+        <div>{{nav_item.link_name}}</div>
       {% else %}
-        <a class="nav__link" href="{{meta.survey|format_url(group.group_id, group.instance, group.block_id)}}" data-qa="navigate-to-{{group.group_id}}">{{group.link_name}}</a>
+        <a class="nav__link" href="{{nav_item.link_url}}">{{nav_item.link_name}}</a>
       {% endif %}
       </li>
     {% endfor %}

--- a/app/templating/summary_context.py
+++ b/app/templating/summary_context.py
@@ -21,7 +21,7 @@ def build_summary_rendering_context(schema_json, answer_store, metadata):
     sections = []
     for group in schema_json['groups']:
         for block in group['blocks']:
-            if block['id'] in [b['block_id'] for b in path]:
+            if block['id'] in [location.block_id for location in path]:
                 if "type" not in block or block['type'] != "interstitial":
                     link = url_for('questionnaire.get_block',
                                    eq_id=metadata['eq_id'],

--- a/app/views/main.py
+++ b/app/views/main.py
@@ -11,7 +11,6 @@ from flask import redirect
 from flask import request
 from flask import session
 from flask import Blueprint
-from flask import url_for
 
 from flask.ext.themes2 import render_theme_template
 
@@ -67,7 +66,6 @@ def login():
     metadata = get_metadata(current_user)
 
     eq_id = metadata["eq_id"]
-    collection_id = metadata["collection_exercise_sid"]
     form_type = metadata["form_type"]
 
     logger.debug("Requested questionnaire %s for form type %s", eq_id, form_type)
@@ -81,31 +79,4 @@ def login():
     navigator = Navigator(json, metadata, get_answer_store(current_user))
     current_location = navigator.get_latest_location(get_completed_blocks(current_user))
 
-    if current_location['block_id'] == 'introduction':
-        return redirect(url_for('questionnaire.get_introduction',
-                                eq_id=eq_id,
-                                form_type=form_type,
-                                collection_id=collection_id))
-    elif current_location['block_id'] == 'summary':
-        return redirect(url_for('questionnaire.get_summary',
-                                eq_id=eq_id,
-                                form_type=form_type,
-                                collection_id=collection_id))
-    elif current_location['block_id'] == 'thank-you':
-        return redirect(url_for('questionnaire.get_thank_you',
-                                eq_id=eq_id,
-                                form_type=form_type,
-                                collection_id=collection_id))
-    elif current_location['block_id'] == 'confirmation':
-        return redirect(url_for('questionnaire.get_confirmation',
-                                eq_id=eq_id,
-                                form_type=form_type,
-                                collection_id=collection_id))
-
-    return redirect(url_for('questionnaire.get_block',
-                            eq_id=eq_id,
-                            form_type=form_type,
-                            collection_id=collection_id,
-                            group_id=current_location['group_id'],
-                            group_instance=current_location['group_instance'],
-                            block_id=current_location['block_id']))
+    return redirect(current_location.url(metadata))

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -3,6 +3,7 @@ import logging
 from app.authentication.session_manager import session_manager
 from app.globals import get_answer_store, get_completed_blocks, get_metadata, get_questionnaire_store
 from app.helpers.schema_helper import SchemaHelper
+from app.questionnaire.location import Location
 from app.questionnaire.navigator import Navigator
 from app.questionnaire.questionnaire_manager import get_questionnaire_manager
 from app.submitter.converter import convert_answers
@@ -71,19 +72,17 @@ def get_block(eq_id, form_type, collection_id, group_id, group_instance, block_i
     answer_store = get_answer_store(current_user)
     answers = answer_store.map(group_id=group_id, group_instance=group_instance, block_id=block_id)
 
-    this_block = {
-        'group_id': group_id,
-        'group_instance': group_instance,
-        'block_id': block_id,
-    }
+    this_location = Location(group_id, group_instance, block_id)
 
     q_manager = get_questionnaire_manager(g.schema, g.schema_json)
-    q_manager.build_state(this_block, answers)
+    q_manager.build_state(this_location, answers)
 
     block = g.schema.get_item_by_id(block_id)
     template = block.type if block and block.type else 'questionnaire'
 
-    return _render_template(q_manager.state, group_id, group_instance, block_id, template=template)
+    current_location = Location(group_id, group_instance, block_id)
+
+    return _render_template(q_manager.state, current_location=current_location, template=template)
 
 
 @questionnaire_blueprint.route('<group_id>/<int:group_instance>/<block_id>', methods=["POST"])
@@ -92,33 +91,26 @@ def post_block(eq_id, form_type, collection_id, group_id, group_instance, block_
     navigator = Navigator(g.schema_json, get_metadata(current_user), get_answer_store(current_user))
     q_manager = get_questionnaire_manager(g.schema, g.schema_json)
 
-    this_block = {
-        'group_id': group_id,
-        'group_instance': group_instance,
-        'block_id': block_id,
-    }
+    this_location = Location(group_id, group_instance, block_id)
 
-    valid_location = this_block in navigator.get_routing_path(group_id, group_instance)
-    valid_data = q_manager.validate(this_block, request.form)
+    valid_location = this_location in navigator.get_routing_path(group_id, group_instance)
+    valid_data = q_manager.validate(this_location, request.form)
 
     if not valid_location or not valid_data:
-        return _render_template(q_manager.state, group_id, group_instance, block_id, template='questionnaire')
+        return _render_template(q_manager.state, block_id=block_id, template='questionnaire')
     else:
-        q_manager.update_questionnaire_store(this_block)
+        q_manager.update_questionnaire_store(this_location)
 
-    next_location = navigator.get_next_location(current_group_id=group_id, current_iteration=group_instance, current_block_id=block_id)
+    next_location = navigator.get_next_location(current_location=this_location)
+    metadata = get_metadata(current_user)
 
     if next_location is None:
         raise NotFound
 
-    metadata = get_metadata(current_user)
-
-    if next_location['block_id'] == 'confirmation':
+    if next_location.block_id == 'confirmation':
         return redirect_to_confirmation(eq_id, form_type, collection_id)
 
-    logger.info("Redirecting user to next location %s with tx_id=%s", str(next_location), metadata["tx_id"])
-
-    return redirect(block_url(eq_id, form_type, collection_id, next_location['group_id'], next_location['group_instance'], next_location['block_id']))
+    return redirect(next_location.url(metadata))
 
 
 @questionnaire_blueprint.route('introduction', methods=["GET"])
@@ -133,20 +125,16 @@ def post_interstitial(eq_id, form_type, collection_id, block_id):
     navigator = Navigator(g.schema_json, get_metadata(current_user), get_answer_store(current_user))
     q_manager = get_questionnaire_manager(g.schema, g.schema_json)
 
-    this_block = {
-        'block_id': block_id,
-        'group_id': SchemaHelper.get_first_group_id(g.schema_json),
-        'group_instance': 0,
-    }
+    this_location = Location(SchemaHelper.get_first_group_id(g.schema_json), 0, block_id)
 
-    valid_location = this_block in navigator.get_location_path()
-    q_manager.process_incoming_answers(this_block, request.form)
+    valid_location = this_location in navigator.get_location_path()
+    q_manager.process_incoming_answers(this_location, request.form)
 
     # Don't care if data is valid because there isn't any for interstitial
     if not valid_location:
-        return _render_template(q_manager.state, this_block['group_id'], this_block['group_instance'], block_id, template='questionnaire')
+        return _render_template(q_manager.state, current_location=this_location, template='questionnaire')
 
-    next_location = navigator.get_next_location(current_block_id=block_id, current_iteration=0, current_group_id=this_block['group_id'])
+    next_location = navigator.get_next_location(current_location=this_location)
     metadata = get_metadata(current_user)
 
     if next_location is None:
@@ -154,7 +142,7 @@ def post_interstitial(eq_id, form_type, collection_id, block_id):
 
     logger.info("Redirecting user to next location %s with tx_id=%s", str(next_location), metadata["tx_id"])
 
-    return redirect(location_url(eq_id, form_type, collection_id, next_location))
+    return redirect(next_location.url(metadata))
 
 
 @questionnaire_blueprint.route('summary', methods=["GET"])
@@ -164,19 +152,16 @@ def get_summary(eq_id, form_type, collection_id):
     answer_store = get_answer_store(current_user)
     navigator = Navigator(g.schema_json, get_metadata(current_user), answer_store)
     latest_location = navigator.get_latest_location(get_completed_blocks(current_user))
+    metadata = get_metadata(current_user)
 
-    if latest_location['block_id'] is 'summary':
-        metadata = get_metadata(current_user)
+    if latest_location.block_id is 'summary':
         answers = get_answer_store(current_user)
         schema_context = build_schema_context(metadata, g.schema.aliases, answers)
         rendered_schema_json = renderer.render(g.schema_json, **schema_context)
         summary_context = build_summary_rendering_context(rendered_schema_json, answer_store, metadata)
-        return _render_template(summary_context,
-                                group_id=latest_location['group_id'],
-                                group_instance=latest_location['group_instance'],
-                                block_id=latest_location['block_id'])
+        return _render_template(summary_context, current_location=latest_location)
 
-    return redirect(location_url(eq_id, form_type, collection_id, latest_location))
+    return redirect(latest_location.url(metadata))
 
 
 @questionnaire_blueprint.route('confirmation', methods=["GET"])
@@ -187,25 +172,17 @@ def get_confirmation(eq_id, form_type, collection_id):
 
     latest_location = navigator.get_latest_location(get_completed_blocks(current_user))
 
-    if latest_location['block_id'] == 'confirmation':
-        this_block = {
-            'block_id': latest_location['block_id'],
-            'group_id': SchemaHelper.get_first_group_id(g.schema_json),
-            'group_instance': 0,
-        }
+    if latest_location.block_id == 'confirmation':
 
         q_manager = get_questionnaire_manager(g.schema, g.schema_json)
-        q_manager.build_state(this_block, answer_store)
+        this_location = Location(SchemaHelper.get_first_group_id(g.schema_json), 0, 'confirmation')
+        q_manager.build_state(this_location, answer_store)
 
-        return _render_template(q_manager.state,
-                                group_id=latest_location['group_id'],
-                                group_instance=latest_location['group_instance'],
-                                block_id=latest_location['block_id'])
+        return _render_template(q_manager.state, current_location=latest_location)
 
-    return redirect(block_url(eq_id, form_type, collection_id,
-                              group_id=latest_location['group_id'],
-                              group_instance=latest_location['group_instance'],
-                              block_id=latest_location['block_id']))
+    metadata = get_metadata(current_user)
+
+    return redirect(latest_location.url(metadata))
 
 
 @questionnaire_blueprint.route('thank-you', methods=["GET"])
@@ -226,9 +203,9 @@ def submit_answers(eq_id, form_type, collection_id):
     q_manager = get_questionnaire_manager(g.schema, g.schema_json)
     # check that all the answers we have are valid before submitting the data
     is_valid, invalid_location = q_manager.validate_all_answers()
+    metadata = get_metadata(current_user)
 
     if is_valid:
-        metadata = get_metadata(current_user)
         answer_store = get_answer_store(current_user)
         navigator = Navigator(g.schema_json, metadata, answer_store)
         submitter = SubmitterFactory.get_submitter()
@@ -237,10 +214,7 @@ def submit_answers(eq_id, form_type, collection_id):
         logger.info("Responses submitted tx_id=%s", metadata["tx_id"])
         return redirect_to_thank_you(eq_id, form_type, collection_id)
     else:
-        return redirect(block_url(eq_id, form_type, collection_id,
-                                  group_id=invalid_location['group_id'],
-                                  group_instance=invalid_location['group_instance'],
-                                  block_id=invalid_location['block_id']))
+        return redirect(invalid_location.url(metadata))
 
 
 @questionnaire_blueprint.route('<group_id>/0/household-composition', methods=["POST"])
@@ -250,32 +224,30 @@ def post_household_composition(eq_id, form_type, collection_id, group_id):
     questionnaire_manager = get_questionnaire_manager(g.schema, g.schema_json)
     answer_store = get_answer_store(current_user)
 
-    this_block = {
-        'block_id': 'household-composition',
-        'group_id': group_id,
-        'group_instance': 0,
-    }
+    this_location = Location(group_id, 0, 'household-composition')
 
     if 'action[save_continue]' in request.form:
         _remove_repeating_on_household_answers(answer_store, group_id)
 
-    valid = questionnaire_manager.process_incoming_answers(this_block, request.form)
+    valid = questionnaire_manager.process_incoming_answers(this_location, request.form)
 
     if 'action[add_answer]' in request.form:
-        questionnaire_manager.add_answer(this_block, 'household-composition-question', answer_store)
+        questionnaire_manager.add_answer(this_location, 'household-composition-question', answer_store)
         return get_block(eq_id, form_type, collection_id, group_id, 0, 'household-composition')
 
     elif 'action[remove_answer]' in request.form:
         index_to_remove = int(request.form.get('action[remove_answer]'))
-        questionnaire_manager.remove_answer(this_block, answer_store, index_to_remove)
+        questionnaire_manager.remove_answer(this_location, answer_store, index_to_remove)
         return get_block(eq_id, form_type, collection_id, group_id, 0, 'household-composition')
 
     if not valid:
-        return _render_template(questionnaire_manager.state, group_id, 0, 'household-composition', template='questionnaire')
+        return _render_template(questionnaire_manager.state, current_location=this_location, template='questionnaire')
 
-    next_location = navigator.get_next_location(current_block_id='household-composition', current_iteration=0, current_group_id=group_id)
+    next_location = navigator.get_next_location(current_location=this_location)
 
-    return redirect(location_url(eq_id, form_type, collection_id, next_location))
+    metadata = get_metadata(current_user)
+
+    return redirect(next_location.url(metadata))
 
 
 @questionnaire_blueprint.route('<group_id>/<int:group_instance>/permanent-or-family-home', methods=["POST"])
@@ -300,10 +272,6 @@ def _remove_repeating_on_household_answers(answer_store, group_id):
 def _delete_user_data():
     get_questionnaire_store(current_user.user_id, current_user.user_ik).delete()
     session_manager.clear()
-
-
-def redirect_to_summary(eq_id, form_type, collection_id):
-    return redirect(interstitial_url(eq_id, form_type, collection_id, 'summary'))
 
 
 def redirect_to_thank_you(eq_id, form_type, collection_id):
@@ -337,27 +305,6 @@ def interstitial_url(eq_id, form_type, collection_id, block_id):
                        collection_id=collection_id)
 
 
-def location_url(eq_id, form_type, collection_id, location):
-    return block_url(eq_id=eq_id,
-                     form_type=form_type,
-                     collection_id=collection_id,
-                     group_id=location['group_id'],
-                     group_instance=location['group_instance'],
-                     block_id=location['block_id'])
-
-
-def block_url(eq_id, form_type, collection_id, group_id, group_instance, block_id):
-    if Navigator.is_interstitial_block(block_id):
-        return interstitial_url(eq_id, form_type, collection_id, block_id)
-    return url_for('.get_block',
-                   eq_id=eq_id,
-                   form_type=form_type,
-                   collection_id=collection_id,
-                   group_id=group_id,
-                   group_instance=group_instance,
-                   block_id=block_id)
-
-
 def _same_survey(eq_id, form_type, collection_id):
     metadata = get_metadata(current_user)
     current_survey = eq_id + form_type + collection_id
@@ -365,31 +312,27 @@ def _same_survey(eq_id, form_type, collection_id):
     return current_survey == metadata_survey
 
 
-def _render_template(context, group_id=None, group_instance=0, block_id=None, template=None):
+def _render_template(context, current_location=None, block_id=None, template=None):
     metadata = get_metadata(current_user)
     metadata_context = build_metadata_context(metadata)
 
-    group_id = group_id or SchemaHelper.get_first_group_id(g.schema_json)
+    if current_location is None:
+        group_id = SchemaHelper.get_first_group_id(g.schema_json)
+        current_location = Location(group_id, 0, block_id)
+
     navigator = Navigator(g.schema_json, get_metadata(current_user), get_answer_store(current_user))
     completed_blocks = get_completed_blocks(current_user)
-    previous_location = navigator.get_previous_location(current_group_id=group_id,
-                                                        current_block_id=block_id,
-                                                        current_iteration=group_instance)
-
-    front_end_navigation = None
-
-    if 'navigation' in g.schema_json and g.schema_json['navigation']:
-        front_end_navigation = navigator.get_front_end_navigation(completed_blocks, group_id, group_instance)
+    front_end_navigation = navigator.get_front_end_navigation(
+        completed_blocks,
+        current_location.group_id,
+        current_location.group_instance,
+    )
+    previous_location = navigator.get_previous_location(current_location)
 
     previous_url = None
 
-    if previous_location is not None and block_id != SchemaHelper.get_first_block_id_for_group(g.schema_json, group_id):
-        previous_url = block_url(eq_id=metadata['eq_id'],
-                                 form_type=metadata['form_type'],
-                                 collection_id=metadata['collection_exercise_sid'],
-                                 group_id=previous_location['group_id'],
-                                 group_instance=previous_location['group_instance'],
-                                 block_id=previous_location['block_id'])
+    if previous_location is not None and current_location.block_id != SchemaHelper.get_first_block_id_for_group(g.schema_json, current_location.group_id):
+        previous_url = previous_location.url(metadata)
 
     try:
         theme = g.schema_json['theme']
@@ -398,7 +341,7 @@ def _render_template(context, group_id=None, group_instance=0, block_id=None, te
         logger.info("No theme set")
         theme = None
 
-    template = '{}.html'.format(template or block_id)
+    template = '{}.html'.format(template or current_location.block_id)
 
     return render_theme_template(theme, template, meta=metadata_context,
                                  content=context,

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -266,7 +266,7 @@ def _remove_repeating_on_household_answers(answer_store, group_id):
         for group in groups_to_delete:
             answer_store.remove(group_id=group['id'])
             questionnaire_store.completed_blocks[:] = [b for b in questionnaire_store.completed_blocks if
-                                                       b.get('group_id') != group['id']]
+                                                       b.group_id != group['id']]
 
 
 def _delete_user_data():

--- a/tests/app/confirmation_page/test_confirmation_page.py
+++ b/tests/app/confirmation_page/test_confirmation_page.py
@@ -1,5 +1,6 @@
 from app.questionnaire.navigator import Navigator
 from app.data_model.answer_store import Answer, AnswerStore
+from app.helpers.schema_helper import SchemaHelper
 from app.schema_loader.schema_loader import load_schema_file
 import unittest
 
@@ -7,7 +8,6 @@ import unittest
 class TestConfirmationPage(unittest.TestCase):
 
     def test_get_next_location_confirmation(self):
-        last_block_id = "5e633f04-073a-44c0-a9da-a7cc2116b937"
         answer = Answer(
             answer_id="ca3ce3a3-ae44-4e30-8f85-5b6a7a2fb23c",
             value="Orson Krennic",
@@ -15,7 +15,8 @@ class TestConfirmationPage(unittest.TestCase):
         answer_store = AnswerStore()
         answer_store.add(answer)
 
-        navigator = Navigator(load_schema_file("0_rogue_one.json"), {}, answer_store)
-        next_location = navigator.get_next_location(current_block_id=last_block_id)
+        survey = load_schema_file("0_rogue_one.json")
+        navigator = Navigator(survey, {}, answer_store)
+        next_location = navigator.get_next_location(SchemaHelper.get_last_location(survey))
 
-        self.assertEqual('summary', next_location['block_id'])
+        self.assertEqual('summary', next_location.block_id)

--- a/tests/app/data_model/test_answer_store.py
+++ b/tests/app/data_model/test_answer_store.py
@@ -1,5 +1,7 @@
 import unittest
+
 from app.data_model.answer_store import Answer, AnswerStore
+from app.questionnaire.location import Location
 
 
 class TestAnswer(unittest.TestCase):
@@ -256,6 +258,33 @@ class TestAnswerStore(unittest.TestCase):
         self.assertEqual(len(filtered), 1)
 
         filtered = self.store.filter(group_id="6")
+
+        self.assertEqual(len(filtered), 1)
+
+    def test_filters_answers_by_location(self):
+        answer_1 = Answer(
+            block_id="1",
+            answer_id="2",
+            answer_instance=1,
+            group_id="5",
+            group_instance=1,
+            value=25,
+        )
+        answer_2 = Answer(
+            block_id="1",
+            answer_id="5",
+            answer_instance=1,
+            group_id="6",
+            group_instance=1,
+            value=65,
+        )
+
+        self.store.add(answer_1)
+        self.store.add(answer_2)
+
+        location = Location("6", 1, "1")
+
+        filtered = self.store.filter(location=location)
 
         self.assertEqual(len(filtered), 1)
 
@@ -555,6 +584,43 @@ class TestAnswerStore(unittest.TestCase):
         expected_answers = {
             "answer1": 10,
         }
+        self.assertEqual(self.store.map(), expected_answers)
+
+    def test_remove_multiple_answers_by_location(self):
+        answer_1 = Answer(
+            group_id="group1",
+            group_instance=0,
+            block_id="block1",
+            answer_id="answer1",
+            value=10,
+        )
+        answer_2 = Answer(
+            group_id="group1",
+            group_instance=0,
+            block_id="block1",
+            answer_id="answer2",
+            value=20,
+        )
+        answer_3 = Answer(
+            group_id="group1",
+            group_instance=0,
+            block_id="block2",
+            answer_id="answer3",
+            value=30,
+        )
+
+        self.store.add(answer_1)
+        self.store.add(answer_2)
+        self.store.add(answer_3)
+
+        location = Location("group1", 0, "block1")
+
+        self.store.remove(location=location)
+
+        expected_answers = {
+            "answer3": 30,
+        }
+
         self.assertEqual(self.store.map(), expected_answers)
 
     def test_remove_answers_by_group_id_that_does_not_exist(self):

--- a/tests/app/questionnaire/test_location.py
+++ b/tests/app/questionnaire/test_location.py
@@ -1,0 +1,26 @@
+import unittest
+
+from app import create_app
+
+from app.questionnaire.location import Location
+
+
+class TestLocation(unittest.TestCase):
+
+    def setUp(self):
+        self.app = create_app()
+        self.app.config['SERVER_NAME'] = "test"
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+
+    def test_location_url(self):
+        location = Location('some-group', 0, 'some-block')
+
+        metadata = {
+            "eq_id": '1',
+            "collection_exercise_sid": '999',
+            "form_type": "some_form"
+        }
+        location_url = location.url(metadata)
+
+        self.assertEqual(location_url, "http://test/questionnaire/1/some_form/999/some-group/0/some-block")

--- a/tests/app/questionnaire/test_navigator.py
+++ b/tests/app/questionnaire/test_navigator.py
@@ -869,27 +869,12 @@ class TestNavigator(unittest.TestCase):
         }
 
         navigator = Navigator(survey, metadata)
+
         completed_blocks = [
-            {
-                'group_instance': 0,
-                'block_id': 'introduction',
-                'group_id': 'property-details'
-            },
-            {
-                'group_instance': 0,
-                'block_id': 'insurance-type',
-                'group_id': 'property-details'
-            },
-            {
-                'group_instance': 0,
-                'block_id': 'insurance-address',
-                'group_id': 'property-details'
-            },
-            {
-                'group_instance': 0,
-                'block_id': 'property-interstitial',
-                'group_id': 'property-details'
-            }
+            Location('property-details', 0, 'introduction'),
+            Location('property-details', 0, 'insurance-type'),
+            Location('property-details', 0, 'insurance-address'),
+            Location('property-details', 0, 'property-interstitial')
         ]
 
         user_navigation = [
@@ -1061,38 +1046,16 @@ class TestNavigator(unittest.TestCase):
                 'block_id': 'repeating-block-2'
             }
         ]
+
         completed_blocks = [
-            {
-                'group_instance': 0,
-                'group_id': 'property-details',
-                'block_id': 'introduction'
-            },
-            {
-                'group_instance': 0,
-                'group_id': 'multiple-questions-group',
-                'block_id': 'household-composition'
-            },
-            {
-                'group_instance': 0,
-                'group_id': 'repeating-group',
-                'block_id': 'repeating-block-1'
-            },
-            {
-                'group_instance': 0,
-                'group_id': 'repeating-group',
-                'block_id': 'repeating-block-2'
-            },
-            {
-                'group_instance': 1,
-                'group_id': 'repeating-group',
-                'block_id': 'repeating-block-1'
-            },
-            {
-                'group_instance': 1,
-                'group_id': 'repeating-group',
-                'block_id': 'repeating-block-2'
-            }
+            Location('property-details', 0, 'introduction'),
+            Location('multiple-questions-group', 0, 'household-composition'),
+            Location('repeating-group', 0, 'repeating-block-1'),
+            Location('repeating-group', 0, 'repeating-block-2'),
+            Location('repeating-group', 1, 'repeating-block-1'),
+            Location('repeating-group', 1, 'repeating-block-2')
         ]
+
         user_navigation = [
             {
                 'link_name': 'Property Details',
@@ -1183,36 +1146,12 @@ class TestNavigator(unittest.TestCase):
         ]
 
         completed_blocks = [
-            {
-                'block_id': 'introduction',
-                'group_instance': 0,
-                'group_id': 'property-details'
-            },
-            {
-                'block_id': 'insurance-type',
-                'group_instance': 0,
-                'group_id': 'property-details'
-            },
-            {
-                'block_id': 'cd6a5727-8cab-4737-aa4e-d666d98b3f92',
-                'group_instance': 0,
-                'group_id': 'property-details'
-            },
-            {
-                'block_id': 'personal-interstitial',
-                'group_instance': 0,
-                'group_id': 'property-details'
-            },
-            {
-                'block_id': 'extra-cover-block',
-                'group_instance': 0,
-                'group_id': 'extra-cover'
-            },
-            {
-                'block_id': 'ea651fa7-6b9d-4b6f-ba72-79133f312039',
-                'group_instance': 0,
-                'group_id': 'extra-cover'
-            }
+            Location('property-details', 0, 'introduction'),
+            Location('property-details', 0, 'insurance-type'),
+            Location('property-details', 0, 'cd6a5727-8cab-4737-aa4e-d666d98b3f92'),
+            Location('property-details', 0, 'personal-interstitial'),
+            Location('extra-cover', 0, 'extra-cover-block'),
+            Location('extra-cover', 0, 'ea651fa7-6b9d-4b6f-ba72-79133f312039'),
         ]
 
         user_navigation = [
@@ -1312,32 +1251,13 @@ class TestNavigator(unittest.TestCase):
         ]
 
         completed_blocks = [
-            {
-                'block_id': 'introduction',
-                'group_id': 'property-details',
-                'group_instance': 0
-            },
-            {
-                'block_id': 'extra-cover-block',
-                'group_instance': 0,
-                'group_id': 'extra-cover'
-            },
-            {
-                'group_id': 'extra-cover',
-                'group_instance': 0,
-                'block_id': 'extra-cover-interstitial'
-            },
-            {
-                'block_id': 'extra-cover-items',
-                'group_instance': 0,
-                'group_id': 'extra-cover-items-group'
-            },
-            {
-                'group_id': 'extra-cover-items-group',
-                'group_instance': 1,
-                'block_id': 'extra-cover-items'
-            }
+            Location('property-details', 0, 'introduction'),
+            Location('extra-cover', 0, 'extra-cover-block'),
+            Location('extra-cover', 0, 'extra-cover-interstitial'),
+            Location('extra-cover-items-group', 0, 'extra-cover-items'),
+            Location('extra-cover-items-group', 1, 'extra-cover-items'),
         ]
+
         user_navigation = [
             {
                 'repeating': False,
@@ -1445,16 +1365,8 @@ class TestNavigator(unittest.TestCase):
         ]
 
         completed_blocks = [
-            {
-                'group_instance': 0,
-                'group_id': 'multiple-questions-group',
-                'block_id': 'introduction'
-            },
-            {
-                'group_instance': 0,
-                'group_id': 'multiple-questions-group',
-                'block_id': 'household-composition'
-            }
+            Location('multiple-questions-group', 0, 'introduction'),
+            Location('multiple-questions-group', 0, 'household-composition'),
         ]
 
         user_navigation = [

--- a/tests/app/submitter/test_converter.py
+++ b/tests/app/submitter/test_converter.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 
 from app.data_model.answer_store import AnswerStore
 from app.parser.metadata_parser import parse_metadata
+from app.questionnaire.location import Location
 from app.schema.answer import Answer
 from app.schema.block import Block
 from app.schema.group import Group
@@ -167,9 +168,9 @@ class TestConverter(SurveyRunnerTestCase):
 
     def test_convert_census_answers(self):
         with self.application.test_request_context():
-            routing_path = [location(group_id='personal details', block_id='about you'),
-                            location(group_id='household', block_id='where you live'),
-                            location(group_id='household', block_id='where you live', group_instance=1)]
+            routing_path = [Location(group_id='personal details', group_instance=0, block_id='about you'),
+                            Location(group_id='household', group_instance=0, block_id='where you live'),
+                            Location(group_id='household', group_instance=1, block_id='where you live')]
             answers = [create_answer('name', 'Joe Bloggs', group_id='personal details', block_id='about you'),
                        create_answer('name', 'Fred Bloggs', group_id='personal details', block_id='about you', answer_instance=1),
                        create_answer('address', '62 Somewhere', group_id='household', block_id='where you live'),
@@ -206,7 +207,7 @@ class TestConverter(SurveyRunnerTestCase):
 
     def test_convert_census_answers_multiple_answers(self):
         with self.application.test_request_context():
-            routing_path = [location(group_id='favourite food', block_id='crisps')]
+            routing_path = [Location(group_id='favourite food', group_instance=0, block_id='crisps')]
             answers = [create_answer('name', ['Ready salted', 'Sweet chilli'], group_id='favourite food', block_id='crisps')]
             questionnaire = Questionnaire()
             questionnaire.survey_id = '021'
@@ -243,12 +244,4 @@ def create_answer(answer_id, value, group_id=None, block_id=None, answer_instanc
         'answer_instance': answer_instance,
         'group_instance': group_instance,
         'value': value,
-    }
-
-
-def location(group_id, block_id, group_instance=0):
-    return {
-        'group_id': group_id,
-        'block_id': block_id,
-        'group_instance': group_instance
     }

--- a/tests/app/templating/test_summary_context.py
+++ b/tests/app/templating/test_summary_context.py
@@ -3,6 +3,7 @@ import unittest
 from app import create_app
 from mock import MagicMock, Mock, patch
 
+from app.questionnaire.location import Location
 from app.templating.summary_context import build_summary_rendering_context
 from app.utilities.schema import load_and_parse_schema
 
@@ -33,11 +34,11 @@ class TestSummaryContext(unittest.TestCase):
 
     def test_build_summary_rendering_context(self):
         answer_store = MagicMock()
-        routing_path = [{
-            'block_id': 'f22b1ba4-d15f-48b8-a1f3-db62b6f34cc0',
-            'group_id': '14ba4707-321d-441d-8d21-b8367366e766',
-            'group_instance': 0,
-        }]
+        routing_path = [Location(
+            block_id='f22b1ba4-d15f-48b8-a1f3-db62b6f34cc0',
+            group_id='14ba4707-321d-441d-8d21-b8367366e766',
+            group_instance=0,
+        )]
         navigator = Mock()
         navigator.get_routing_path = Mock(return_value=routing_path)
 

--- a/tests/functional/pages/surveys/census/household/navigation.js
+++ b/tests/functional/pages/surveys/census/household/navigation.js
@@ -1,7 +1,7 @@
 class Navigation {
 
   navigateToHouseholdAndAccommodation() {
-    browser.element('[data-qa="navigate-to-household-and-accommodation"]').click()
+    browser.element('//a[text()="Household and Accommodation"]').click()
     return this
   }
 


### PR DESCRIPTION
### What is the context of this PR?

Updates survey runner to use a Location class for representation of group/instance/block locations and updates navigator to return lists of them when requesting paths. 

Allows us to generate urls from locations when metadata is known, which negates the need for jinja filter to create navigation links.

Updated version of https://github.com/ONSdigital/eq-survey-runner/pull/661, based on huge amount of work gone in of late.

### How to review 
Take a look at the approach, see if you approve.

