### PR TITLE
Stop passing the full schema into the templates

### DIFF
--- a/app/main/views/questionnaire.py
+++ b/app/main/views/questionnaire.py
@@ -363,10 +363,14 @@ def _render_template(context, group_id=None, group_instance=0, block_id=None, te
     group_id = group_id or SchemaHelper.get_first_group_id(g.schema_json)
     navigator = Navigator(g.schema_json, get_metadata(current_user), get_answer_store(current_user))
     completed_blocks = get_completed_blocks(current_user)
-    front_end_navigation = navigator.get_front_end_navigation(completed_blocks, group_id, group_instance)
     previous_location = navigator.get_previous_location(current_group_id=group_id,
                                                         current_block_id=block_id,
                                                         current_iteration=group_instance)
+
+    front_end_navigation = None
+
+    if 'navigation' in g.schema_json and g.schema_json['navigation']:
+        front_end_navigation = navigator.get_front_end_navigation(completed_blocks, group_id, group_instance)
 
     previous_url = None
 
@@ -391,4 +395,4 @@ def _render_template(context, group_id=None, group_instance=0, block_id=None, te
                                  content=context,
                                  previous_location=previous_url,
                                  navigation=front_end_navigation,
-                                 schema=g.schema_json)
+                                 schema_title=g.schema_json['title'])

--- a/app/templates/partials/topbar.html
+++ b/app/templates/partials/topbar.html
@@ -2,10 +2,10 @@
   <div class="bar__inner container">
     <div class="badge badge--amber u-mr-xs">BETA</div>
     {% if is_hero %}
-      <h1 class="bar__title jupiter">{% if meta %}{{ schema['title'] }}{% endif %}</h1>
+      <h1 class="bar__title jupiter">{{ schema_title }}</h1>
       <h2 class="venus">Notice is given under section 1 of the Statistics of Trade Act 1947</h2>
     {% else %}
-      <div class="bar__title venus">{% if schema %}{{ schema['title'] }}{% endif %}</div>
+      <div class="bar__title venus">{{ schema_title }}</div>
     {% endif %}
   </div>
 </div>

--- a/app/templates/questionnaire.html
+++ b/app/templates/questionnaire.html
@@ -10,14 +10,14 @@
 
 {%- block subheader -%}
 
-  {% if previous_location or schema.navigation %}
+  {% if previous_location or navigation %}
 
   <div class="container">
     {% if previous_location %}
       <a class="page__previous" id="top-previous" href="{{previous_location}}">Previous</a>
     {% endif %}
 
-    {% if schema.navigation %}
+    {% if navigation %}
       <div class="page__menubtn">
         <button class="btn btn--link btn--menu js-menu-btn" data-close-label="{{_('Hide sections')}}" type="button" id="menu-btn">{{_('View sections')}}</button>
       </div>
@@ -33,7 +33,7 @@
 
 <div class="grid grid--reverse">
   <div class="grid__col col-4@m">
-    {% if schema.navigation %}
+    {% if navigation %}
       {% include theme('partials/navigation.html') %}
     {% endif %}
   </div>

--- a/app/templates/thank-you.html
+++ b/app/templates/thank-you.html
@@ -9,7 +9,7 @@
 
       <div class="u-mb-s">
         <h1 class="saturn">Submission Successful</h1>
-        <p>Thank you for submitting the {{ schema['title'] }}, your responses have been successfully received.</p>
+        <p>Thank you for submitting the {{ schema_title }}, your responses have been successfully received.</p>
       </div>
 
       <div class="panel panel--simple panel--success panel--spacious">


### PR DESCRIPTION
### What is the context of this PR?
We are currently passing the full schema through to the templates.
This isn't needed as we are only using the title from it.