### PR TITLE
Add welsh census household and individual survey json

### DIFF
--- a/app/data/cy/census_household.json
+++ b/app/data/cy/census_household.json
@@ -1,0 +1,4786 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "questionnaire_id": "",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "census",
+    "title": "Census England Household Schema",
+    "description": "Census England Household Schema",
+    "theme": "census",
+    "navigation": true,
+    "eq_id": "census",
+    "groups": [
+        {
+            "id": "who-lives-here",
+            "title": "Pwy sy’n byw yma?",
+            "completed_id": "who-lives-here-completed",
+            "highlight_when": [
+                "who-lives-here-relationship",
+                "who-lives-here-interstitial"
+            ],
+            "blocks": [
+                {
+                    "type": "questionnaire",
+                    "id": "permanent-or-family-home",
+                    "title": "Who lives here?",
+                    "sections": [
+                        {
+                            "id": "permanent-or-family-home-section",
+                            "title": "Pwy sy’n byw yma?",
+                            "questions": [
+                                {
+                                    "id": "permanent-or-family-home-question",
+                                    "title": "A oes unrhyw un yn byw yma fel eu cartref parhaol neu gartref y teulu?",
+                                    "number": "1",
+                                    "guidance": [
+                                        {
+                                            "title": "Dylech gynnwys",
+                                            "list": [
+                                                "Chi’ch hun, os mai hwn yw eich cartref parhaol neu gartref y teulu",
+                                                "Aelodau o’r teulu, gan gynnwys partneriaid, plant a babanod a anwyd ar 9 Ebrill 2017 neu cyn y dyddiad hwnnw",
+                                                "Myfyrwyr a/neu blant ysgol sy’n byw oddi cartref yn ystod y tymor",
+                                                "Tenantiaid, lojers neu bobl sy’n rhannu cartref"
+                                            ]
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "permanent-or-family-home-answer",
+                                            "mandatory": true,
+                                            "guidance": "<p>I’r rhan fwyaf o bobl, eu cartref parhaol fydd y cyfeiriad lle maent yn treulio’r rhan fwyaf o’r amser.</p>",
+                                            "options": [
+                                                {
+                                                    "label": "Oes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "Nac oes",
+                                                    "value": "No",
+                                                    "description": "Er enghraifft ail gyfeiriad neu dŷ gwyliau yw hwn"
+                                                }
+                                            ],
+                                            "type": "Radio",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Dewiswch ateb i barhau"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "household-composition",
+                                "when": [
+                                    {
+                                        "id": "permanent-or-family-home-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "else-permanent-or-family-home",
+                                "when": [
+                                    {
+                                        "id": "permanent-or-family-home-answer",
+                                        "condition": "equals",
+                                        "value": "No"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "else-permanent-or-family-home",
+                    "title": "Who lives here?",
+                    "sections": [
+                        {
+                            "id": "else-permanent-or-family-home-section",
+                            "title": "Pwy sy’n byw yma?",
+                            "questions": [
+                                {
+                                    "id": "else-permanent-or-family-home-question",
+                                    "title": "A allwch gadarnhau nad oes neb yn byw yma fel eu cartref parhaol neu gartref y teulu?",
+                                    "number": "1a",
+                                    "guidance": [
+                                        {
+                                            "title": "Gallai hyn gynnwys:",
+                                            "list": [
+                                                "Pobl sy’n byw y tu allan i’r Deyrnas Unedig fel arfer, ond sy’n aros yn y Deyrnas Unedig am <b>dri mis neu fwy</b>",
+                                                "Pobl sy’n gweithio oddi cartref yn y Deyrnas Unedig os mai hwn yw eu cyfeiriad parhaol neu gyfeiriad y teulu",
+                                                "Aelodau o’r Lluoedd Arfog os mai hwn yw eu cyfeiriad parhaol neu gyfeiriad y teulu",
+                                                "Pobl sydd y tu allan i’r Deyrnas Unedig dros dro am <b>lai na 12 mis</b>",
+                                                "Pobl sy’n aros dros dro, sy’n byw yn y Deyrnas Unedig fel arfer, ond sydd heb gyfeiriad arall yn y Deyrnas Unedig, er enghraifft perthnasau, ffrindiau",
+                                                "Pobl eraill sy’n byw yma fel arfer, gan gynnwys unrhyw un sydd oddi cartref dros dro"
+                                            ]
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "else-permanent-or-family-home-answer",
+                                            "mandatory": true,
+                                            "options": [
+                                                {
+                                                    "label": "Mae rhywun yn byw yma fel eu cartref parhaol",
+                                                    "value": "Someone lives here as their permanent home"
+                                                },
+                                                {
+                                                    "label": "Nid oes neb yn byw yma fel eu cartref parhaol",
+                                                    "value": "No one lives here as their permanent home"
+                                                }
+                                            ],
+                                            "type": "Radio",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Dewiswch ateb i barhau"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "household-composition",
+                                "when": [
+                                    {
+                                        "id": "else-permanent-or-family-home-answer",
+                                        "condition": "equals",
+                                        "value": "Someone lives here as their permanent home"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "overnight-visitors",
+                                "when": [
+                                    {
+                                        "id": "else-permanent-or-family-home-answer",
+                                        "condition": "equals",
+                                        "value": "No one lives here as their permanent home"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "household-composition",
+                    "title": "Who lives here?",
+                    "sections": [
+                        {
+                            "id": "household-composition-section",
+                            "title": "Pwy sy’n byw yma?",
+                            "questions": [
+                                {
+                                    "id": "household-composition-question",
+                                    "title": "Rhestrwch enwau pawb sy’n byw yma.",
+                                    "number": "2",
+                                    "guidance": [
+                                        {
+                                            "title": "Dylech gynnwys",
+                                            "list": [
+                                                "Chi’ch hun, os mai hwn yw eich cartref parhaol neu gartref y teulu",
+                                                "Aelodau o’r teulu, gan gynnwys partneriaid, plant a babanod a anwyd ar 9 Ebrill 2017 neu cyn y dyddiad hwnnw",
+                                                "Myfyrwyr a/neu blant ysgol sy’n byw oddi cartref yn ystod y tymor",
+                                                "Tenantiaid, lojers neu bobl sy’n rhannu cartref"
+                                            ]
+                                        }
+                                    ],
+                                    "type": "RepeatingAnswer",
+                                    "answers": [
+                                        {
+                                            "alias": "first_name",
+                                            "id": "first-name",
+                                            "label": "Enw cyntaf",
+                                            "mandatory": true,
+                                            "type": "TextField",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Nodwch enw neu dilëwch y person i barhau"
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "alias": "middle_names",
+                                            "id": "middle-names",
+                                            "label": "Enwau canol",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "alias": "last_name",
+                                            "id": "last-name",
+                                            "label": "Cyfenw",
+                                            "mandatory": false,
+                                            "guidance": "<p>Nodwch enwau cyntaf, enwau canol a chyfenwau presennol pawb sy’n byw yma fel arfer.</p><p>Os nad ydych wedi enwi’ch baban newydd eto, nodwch ‘Baban’ fel ei enw cyntaf ac yna nodwch ei gyfenw.</p><p>Dylech hefyd gynnwys aelodau o’r cartref sydd wedi gofyn am ffurflen bersonol.</p><p>Hefyd nodwch enwau pobl sy’n aros gyda chi dros dro nad oes ganddynt gyfeiriad arferol yn y DU. Y rheswm dros hyn yw er mwyn sicrhau ein bod yn cyfrif pawb.</p><p>Dylech gynnwys:</strong></p><ul><li>Pobl sydd fel arfer yn byw y tu allan i’r Deyrnas Unedig sy’n aros yma am dri mis neu fwy</li><li>Pobl sy’n gweithio oddi cartref yn y Deyrnas Unedig os mai hwn yw eu cartref parhaol neu gartref y teulu</li><li>Aelodau o’r Lluoedd Arfog os mai hwn yw eu cartref parhaol neu gartref y teulu</li><li>Pobl sydd y tu allan i’r Deyrnas Unedig dros dro am lai na 12 mis</li><li>Pobl sy’n aros dros dro sydd fel arfer yn byw yn y Deyrnas Unedig ond nad oes ganddynt gyfeiriad arall yn y Deyrnas Unedig, er enghraifft perthnasau, ffrindiau</li></ul>",
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "everyone-at-address-confirmation",
+                    "title": "Who lives here?",
+                    "sections": [
+                        {
+                            "id": "everyone-at-address-confirmation-section",
+                            "title": "Pwy sy’n byw yma?",
+                            "description": "<h2 class='neptune'>Mae eich cartref yn cynnwys:</h2> {{ [answers.first_name, answers.middle_names, answers.last_name]|format_household_summary }}",
+                            "questions": [
+                                {
+                                    "id": "everyone-at-address-confirmation-question",
+                                    "title": "A ydych wedi nodi pawb y mae hwn yn gartref parhaol neu’n gartref y teulu iddynt?",
+                                    "number": "3",
+                                    "description": "Nodwch y bydd angen i chi sicrhau bod pawb wedi’u cynnwys oherwydd ni fyddwch yn gallu gwneud unrhyw newidiadau yn hwyrach",
+                                    "guidance": [
+                                        {
+                                            "title": "Dylech gynnwys",
+                                            "list": [
+                                                "Pobl sy’n byw y tu allan i’r Deyrnas Unedig fel arfer, ond sy’n aros yn y Deyrnas Unedig am <b>dri mis neu fwy</b>",
+                                                "Pobl sy’n gweithio oddi cartref yn y Deyrnas Unedig os mai hwn yw eu cyfeiriad parhaol neu gyfeiriad y teulu",
+                                                "Aelodau o’r Lluoedd Arfog os mai hwn yw eu cyfeiriad parhaol neu gyfeiriad y teulu",
+                                                "Pobl sydd y tu allan i’r Deyrnas Unedig dros dro am <b>lai na 12 mis</b>",
+                                                "Pobl sy’n aros dros dro, sy’n byw yn y Deyrnas Unedig fel arfer, ond sydd heb gyfeiriad arall yn y Deyrnas Unedig, er enghraifft perthnasau, ffrindiau",
+                                                "Pobl eraill sy’n byw yma fel arfer, gan gynnwys unrhyw un sydd oddi cartref dros dro"
+                                            ]
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "everyone-at-address-confirmation-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Do",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "Naddo, mae angen i mi ychwanegu rhywun arall",
+                                                    "value": "No, I need to add another person"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "household-composition",
+                                "when": [
+                                    {
+                                        "id": "everyone-at-address-confirmation-answer",
+                                        "condition": "equals",
+                                        "value": "No, I need to add another person"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "overnight-visitors"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "overnight-visitors",
+                    "title": "Who lives here?",
+                    "sections": [
+                        {
+                            "id": "overnight-visitors-section",
+                            "title": "Pwy sy’n byw yma?",
+                            "questions": [
+                                {
+                                    "id": "overnight-visitors-question",
+                                    "title": "Faint o ymwelwyr sy’n aros yma dros nos ar 9 Ebrill 2017?",
+                                    "number": "4",
+                                    "guidance": [
+                                        {
+                                            "title": "Dylech gynnwys",
+                                            "list": [
+                                                "Pobl sydd fel arfer yn byw yn rhywle arall yn y Deyrnas Unedig. Er enghraifft, cariad neu berthynas",
+                                                "Pobl sy’n aros yma gan mai dyma eu hail gyfeiriad, er enghraifft, oherwydd gwaith. Mae eu cyfeiriad parhaol neu gyfeiriad y teulu rywle arall",
+                                                "Pobl sy’n byw y tu allan i’r Deyrnas Unedig fel arfer, sy’n ymweld â‘r Deyrnas Unedig am lai na thri mis",
+                                                "Pobl sydd ar wyliau yma"
+                                            ]
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "overnight-visitors-answer",
+                                            "label": "Nifer yr ymwelwyr (nodwch 0 os nad oes unrhyw ymwelwyr)",
+                                            "mandatory": true,
+                                            "type": "PositiveInteger",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Nodwch werth hyd yn oed os mai 0 ydyw",
+                                                    "NOT_INTEGER": "Mae’r gwerth rydych wedi ei nodi yn annilys. Nodwch werth rhifyddol."
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "who-lives-here-relationship",
+            "title": "Relationships",
+            "hide_in_navigation": true,
+            "routing_rules": [
+                {
+                    "repeat": {
+                        "type": "answer_count_minus_one",
+                        "answer_id": "first-name"
+                    }
+                }
+            ],
+            "blocks": [
+                {
+                    "type": "questionnaire",
+                    "id": "household-relationships",
+                    "title": "Who lives here?",
+                    "sections": [
+                        {
+                            "id": "household-relationships-section",
+                            "title": "Pwy sy’n byw yma?",
+                            "questions": [
+                                {
+                                    "id": "household-relationships-question",
+                                    "title": "Sut mae aelodau o’r cartref hwn yn perthyn i’w gilydd?",
+                                    "number": "5",
+                                    "description": "Os nad yw aelodau’n perthyn i’w gilydd, dewiswch yr opsiwn ‘ddim yn perthyn’",
+                                    "guidance": [
+                                        {
+                                            "list": [
+                                                "Dewiswch y berthynas rhwng aelodau o’ch cartref",
+                                                "Os ydych yn rhieni i blant sydd wedi’u mabwysiadu, dewiswch yr opsiwn ‘Mam neu dad’ er mwyn dangos eich perthynas â nhw.",
+                                                "Os oes plant maeth yn byw gyda chi, dewiswch yr opsiwn ‘Ddim yn perthyn’ ar eu cyfer nhw.",
+                                                "Dylech gynnwys hanner brodyr a hanner chwiorydd yn y categori ‘Llysfrawd neu lyschwaer’.",
+                                                "Caiff partner sifil o’r un rhyw ei ddefnyddio i ddisgrifio’r berthynas rhwng dau berson sydd wedi cofrestru partneriaeth sifil yn gyfreithiol.",
+                                                "Os nad oes unrhyw opsiwn yn adlewyrchu eich perthynas yn llawn, dewiswch yr un sy’n disgrifio eich sefyllfa orau yn eich barn chi."
+                                            ]
+                                        }
+                                    ],
+                                    "type": "Relationship",
+                                    "answers": [
+                                        {
+                                            "id": "household-relationships-answer",
+                                            "label": "%(current_person)s yw &hellip; %(other_person)s",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Gŵr neu wraig",
+                                                    "value": "Husband or wife"
+                                                },
+                                                {
+                                                    "label": "Partner sifil o’r un rhyw",
+                                                    "value": "Same-sex civil partner"
+                                                },
+                                                {
+                                                    "label": "Partner",
+                                                    "value": "Partner"
+                                                },
+                                                {
+                                                    "label": "Taid / tad-cu neu nain / mam-gu",
+                                                    "value": "Grandparent"
+                                                },
+                                                {
+                                                    "label": "Mam neu dad",
+                                                    "value": "Mother or father"
+                                                },
+                                                {
+                                                    "label": "Llysfam neu lystad",
+                                                    "value": "Step-mother or step-father"
+                                                },
+                                                {
+                                                    "label": "Mab neu ferch",
+                                                    "value": "Son or daughter"
+                                                },
+                                                {
+                                                    "label": "Llysblentyn",
+                                                    "value": "Step-child"
+                                                },
+                                                {
+                                                    "label": "Brawd neu chwaer",
+                                                    "value": "Brother or sister"
+                                                },
+                                                {
+                                                    "label": "Llysfrawd neu lyschwaer",
+                                                    "value": "Step–brother or step–sister"
+                                                },
+                                                {
+                                                    "label": "Ŵyr neu wyres",
+                                                    "value": "Grandchild"
+                                                },
+                                                {
+                                                    "label": "Perthynas - arall",
+                                                    "value": "Relation - other"
+                                                },
+                                                {
+                                                    "label": "Ddim yn perthyn (gan gynnwys plentyn maeth)",
+                                                    "value": "Unrelated (including foster child)"
+                                                }
+                                            ],
+                                            "type": "Relationship"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "who-lives-here-interstitial",
+            "title": "Pwy sy’n byw yma?",
+            "hide_in_navigation": true,
+            "blocks": [
+                {
+                    "type": "interstitial",
+                    "id": "who-lives-here-completed",
+                    "title": "",
+                    "sections": [
+                        {
+                            "id": "who-lives-here-completed-section",
+                            "questions": [
+                                {
+                                    "description": "Yn yr adran nesaf byddwn yn gofyn i chi am y cartref a’r llety rydych yn byw ynddo.",
+                                    "answers": [],
+                                    "id": "who-lives-here-completed-question",
+                                    "title": "",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Rydych wedi cwblhau’r adran ‘Pwy sy’n byw yma?’ yn llwyddiannus"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "household-and-accommodation",
+            "title": "Cartref a Llety",
+            "completed_id": "household-and-accommodation-completed",
+            "blocks": [
+                {
+                    "type": "questionnaire",
+                    "id": "type-of-accommodation",
+                    "title": "Household and Accommodation",
+                    "sections": [
+                        {
+                            "id": "type-of-accommodation-section",
+                            "title": "Cartref a Llety",
+                            "questions": [
+                                {
+                                    "id": "type-of-accommodation-question",
+                                    "title": "Pa fath o lety yw hwn?",
+                                    "number": "1",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "type-of-accommodation-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Tŷ neu fyngalo cyfan",
+                                                    "value": "Whole house or bungalow"
+                                                },
+                                                {
+                                                    "label": "Fflat, maisonette neu randy (gan gynnwys fflatiau un ystafell)",
+                                                    "value": "Flat, maisonette or apartment (including bedsits)"
+                                                },
+                                                {
+                                                    "label": "Carafán neu fath arall o gartref symudol neu dros dro",
+                                                    "value": "Caravan or other mobile or temporary structure"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "type-of-house",
+                                "when": [
+                                    {
+                                        "id": "type-of-accommodation-answer",
+                                        "condition": "equals",
+                                        "value": "Whole house or bungalow"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "type-of-flat",
+                                "when": [
+                                    {
+                                        "id": "type-of-accommodation-answer",
+                                        "condition": "equals",
+                                        "value": "Flat, maisonette or apartment (including bedsits)"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "self-contained-accommodation"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "type-of-house",
+                    "title": "Household and Accommodation",
+                    "sections": [
+                        {
+                            "id": "type-of-house-section",
+                            "title": "Cartref a Llety",
+                            "questions": [
+                                {
+                                    "id": "type-of-house-question",
+                                    "title": "A yw’ch tŷ neu’ch byngalo yn:",
+                                    "number": "1a",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "type-of-house-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Adeilad ar wahân",
+                                                    "value": "Detached"
+                                                },
+                                                {
+                                                    "label": "Adeilad Semi",
+                                                    "value": "Semi-detached"
+                                                },
+                                                {
+                                                    "label": "Adeilad Teras (gan gynnwys ar y pen)",
+                                                    "value": "Terraced"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "self-contained-accommodation"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "type-of-flat",
+                    "title": "Household and Accommodation",
+                    "sections": [
+                        {
+                            "id": "type-of-flat-section",
+                            "title": "Cartref a Llety",
+                            "questions": [
+                                {
+                                    "id": "type-of-flat-question",
+                                    "title": "A yw’ch fflat, maisonette neu randy:",
+                                    "number": "1a",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "type-of-flat-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Mewn bloc o fflatiau neu denement a adeiladwyd yn bwrpasol",
+                                                    "value": "In a purpose-built block of flats or tenement"
+                                                },
+                                                {
+                                                    "label": "Yn rhan o dŷ wedi’i addasu neu dŷ a gaiff ei rannu (gan gynnwys fflatiau un ystafell)",
+                                                    "value": "Part of a converted or shared house (including bedsits)"
+                                                },
+                                                {
+                                                    "label": "Mewn adeilad masnachol (er enghraifft, mewn adeilad o swyddfeydd, gwesty, neu uwchben siop).",
+                                                    "value": "In a commercial building (for example, in an office building, hotel, or over a  shop)."
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "self-contained-accommodation",
+                    "title": "Household and Accommodation",
+                    "sections": [
+                        {
+                            "id": "self-contained-accommodation-section",
+                            "title": "Cartref a Llety",
+                            "questions": [
+                                {
+                                    "id": "self-contained-accommodation-question",
+                                    "title": "A yw’r cartref hwn yn hunan-gynhwysol?",
+                                    "number": "2",
+                                    "guidance": [
+                                        {
+                                            "description": "Mae hyn yn golygu bod pob ystafell, gan gynnwys y gegin, yr ystafell ymolchi a’r toiled, y tu ôl i ddrws sydd ddim ond yn cael ei ddefnyddio gan aelodau o’r cartref hwn"
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "self-contained-accommodation-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Ydy, mae pob ystafell y tu ôl i ddrws sydd ddim ond yn cael ei ddefnyddio gan aelodau o’r cartref hwn",
+                                                    "value": "Yes, all the rooms are behind a door that only this household can use"
+                                                },
+                                                {
+                                                    "label": "Nac ydy",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "number-of-bedrooms",
+                    "title": "Household and Accommodation",
+                    "sections": [
+                        {
+                            "id": "number-of-bedrooms-section",
+                            "title": "Cartref a Llety",
+                            "questions": [
+                                {
+                                    "id": "number-of-bedrooms-question",
+                                    "title": "Sawl ystafell sydd ar gael at ddefnydd aelodau o’r cartref hwn yn unig?",
+                                    "number": "3",
+                                    "guidance": [
+                                        {
+                                            "description": "Dylech gynnwys pob ystafell a gafodd ei hadeiladu neu ei throi i’w defnyddio fel ystafell wely, hyd yn oed os nad yw’n cael ei defnyddio fel ystafell wely ar hyn o bryd"
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "number-of-bedrooms-answer",
+                                            "label": "Nifer yr ystafelloedd gwely",
+                                            "mandatory": false,
+                                            "type": "PositiveInteger",
+                                            "validation": {
+                                                "messages": {
+                                                    "NOT_INTEGER": "Mae’r gwerth rydych wedi ei nodi yn annilys. Nodwch werth rhifyddol."
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "central-heating",
+                    "title": "Household and Accommodation",
+                    "sections": [
+                        {
+                            "id": "central-heating-section",
+                            "title": "Cartref a Llety",
+                            "questions": [
+                                {
+                                    "id": "central-heating-question",
+                                    "title": "Pa fath o wres canolog sydd yn y cartref hwn?",
+                                    "number": "4",
+                                    "description": "<p>System ganolog sy’n cynhyrchu gwres ar gyfer nifer o ystafelloedd yw gwres canolog.</p><p>Dewiswch bob un sy’n berthnasol, hyd yn oed os nad ydych yn defnyddio’r gwres canolog.</p>",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "central-heating-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Dim gwres canolog",
+                                                    "value": "No central heating"
+                                                },
+                                                {
+                                                    "label": "Nwy",
+                                                    "value": "Gas"
+                                                },
+                                                {
+                                                    "label": "Trydan (gan gynnwys gwresogyddion stôr)",
+                                                    "value": "Electric (including storage heaters)"
+                                                },
+                                                {
+                                                    "label": "Olew",
+                                                    "value": "Oil"
+                                                },
+                                                {
+                                                    "label": "Tanwydd solet (er enghraifft coed, glo)",
+                                                    "value": "Solid fuel (for example wood, coal)"
+                                                },
+                                                {
+                                                    "label": "Math arall o wres canolog",
+                                                    "value": "Other central heating"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "own-or-rent",
+                                "when": [
+                                    {
+                                        "id": "permanent-or-family-home-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "own-or-rent",
+                                "when": [
+                                    {
+                                        "id": "else-permanent-or-family-home-answer",
+                                        "condition": "equals",
+                                        "value": "Someone lives here as their permanent home"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "household-and-accommodation-completed"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "own-or-rent",
+                    "title": "Household and Accommodation",
+                    "sections": [
+                        {
+                            "id": "own-or-rent-section",
+                            "title": "Cartref a Llety",
+                            "questions": [
+                                {
+                                    "id": "own-or-rent-question",
+                                    "title": "A yw aelod neu aelodau o’ch cartref yn berchen ar y cartref hwn neu’n ei rentu?",
+                                    "number": "5",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "own-or-rent-answer",
+                                            "mandatory": false,
+                                            "guidance": "<p>Ystyr ‘yn berchen arno’n gyfan gwbl’ yw eich bod yn berchen ar eich cartref heb forgais na benthyciad, hyd yn oed os ydych yn talu swm bach o arian i’r benthyciwr er mwyn iddo ofalu am y gweithredoedd.</p><p>Ystyr ‘Yn berchen arno’n rhannol ac yn ei rentu’n rhannol’ yw eich bod yn berchen ar ran o’ch llety a hefyd yn talu rhent am ran ohono. Gallwch fod yn berchen ar eich cartref yn rhannol gyda morgais neu fenthyciad neu heb hynny.</p><p>Os caiff eich rhent ei dalu gyda chymorth budd-dal tai, dewiswch ‘Yn ei rentu (gyda chymorth budd-dal tai neu hebddo)‘.</p><p>Os nad ydych yn talu rhent, ond yn cyfrannu at gostau’r cartref, rydych yn byw heb dalu rhent.</p>",
+                                            "options": [
+                                                {
+                                                    "label": "Yn berchen arno’n gyfan gwbl",
+                                                    "value": "Owns outright"
+                                                },
+                                                {
+                                                    "label": "Yn berchen arno gyda morgais neu fenthyciad",
+                                                    "value": "Owns with a mortgage or loan"
+                                                },
+                                                {
+                                                    "label": "Yn berchen arno’n rhannol ac yn ei rentu’n rhannol (cynllun rhan-berchenogaeth)",
+                                                    "value": "Part owns and part rents (shared ownership)"
+                                                },
+                                                {
+                                                    "label": "Yn ei rentu (gyda chymorth budd-dal tai neu hebddo)",
+                                                    "value": "Rents (with or without housing benefit)"
+                                                },
+                                                {
+                                                    "label": "Yn byw yma heb dalu rhent",
+                                                    "value": "Lives here rent free"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "number-of-vehicles",
+                                "when": [
+                                    {
+                                        "id": "own-or-rent-answer",
+                                        "condition": "equals",
+                                        "value": "Owns outright"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "number-of-vehicles",
+                                "when": [
+                                    {
+                                        "id": "own-or-rent-answer",
+                                        "condition": "equals",
+                                        "value": "Owns with a mortgage or loan"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "landlord"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "landlord",
+                    "title": "Household and Accommodation",
+                    "sections": [
+                        {
+                            "id": "landlord-section",
+                            "title": "Cartref a Llety",
+                            "questions": [
+                                {
+                                    "id": "landlord-question",
+                                    "title": "Pwy yw eich landlord?",
+                                    "number": "6",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "landlord-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Cymdeithas dai, cwmni tai cydweithredol, ymddiriedolaeth elusennol, landlord cymdeithasol cofrestredig",
+                                                    "value": "Housing association, housing co-operative, charitable trust, registered social landlord"
+                                                },
+                                                {
+                                                    "label": "Y cyngor (awdurdod lleol)",
+                                                    "value": "Council (local authority)"
+                                                },
+                                                {
+                                                    "label": "Landlord preifat neu asiantaeth gosod tai",
+                                                    "value": "Private landlord or letting agency"
+                                                },
+                                                {
+                                                    "label": "Cyflogwr aelod o’r cartref",
+                                                    "value": "Employer of a household member"
+                                                },
+                                                {
+                                                    "label": "Perthynas neu ffrind i aelod o’r cartref",
+                                                    "value": "Relative or friend of a household member"
+                                                },
+                                                {
+                                                    "label": "Arall",
+                                                    "value": "Other"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "number-of-vehicles",
+                    "title": "Household and Accommodation",
+                    "sections": [
+                        {
+                            "id": "number-of-vehicles-section",
+                            "title": "Cartref a Llety",
+                            "questions": [
+                                {
+                                    "id": "number-of-vehicles-question",
+                                    "title": "Sawl car neu fan sy’n eiddo i aelodau o’ch cartref, neu sydd ar gael i’w defnyddio ganddynt?",
+                                    "number": "7",
+                                    "guidance": [
+                                        {
+                                            "description": "Dylech gynnwys unrhyw geir neu faniau cwmni os ydynt ar gael at ddefnydd preifat"
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "number-of-vehicles-answer",
+                                            "label": "Nifer y cerbydau",
+                                            "mandatory": false,
+                                            "type": "PositiveInteger",
+                                            "validation": {
+                                                "messages": {
+                                                    "NOT_INTEGER": "Mae’r gwerth rydych wedi ei nodi yn annilys. Nodwch werth rhifyddol."
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "interstitial",
+                    "id": "household-and-accommodation-completed",
+                    "title": "You have completed Household and Accommodation",
+                    "sections": [
+                        {
+                            "title": "Rydych wedi cwblhau’r adran ‘Cartref a Llety’ yn llwyddiannus",
+                            "id": "household-and-accommodation-completed-section",
+                            "questions": []
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "household-member",
+            "title": "Household Member Details",
+            "routing_rules": [
+                {
+                    "repeat": {
+                        "type": "answer_count",
+                        "answer_id": "first-name",
+                        "navigation_label_answer_ids": [
+                            "first-name",
+                            "last-name"
+                        ]
+                    }
+                }
+            ],
+            "blocks": [
+                {
+                    "type": "interstitial",
+                    "id": "household-member-begin",
+                    "title": "Household member begin",
+                    "sections": [
+                        {
+                            "id": "household-member-begin-section",
+                            "title": "Mae’r adran nesaf yn cynnwys cwestiynau i unigolion ar gyfer {{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "answers": [],
+                                    "id": "household-member-begin-question",
+                                    "title": "",
+                                    "type": "General"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "details-correct",
+                    "title": "details correct",
+                    "sections": [
+                        {
+                            "id": "details-correct-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "details-correct-question",
+                                    "title": "A yw’r enw {{ [answers.first_name[group_instance], answers.middle_names[group_instance], answers.last_name[group_instance]] | format_household_name }} yn gywir, gan gynnwys unrhyw enw(au) canol?",
+                                    "number": "1",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "details-correct-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Ydy, dyma fy enw llawn",
+                                                    "value": "Yes, this is my full name"
+                                                },
+                                                {
+                                                    "label": "Nac ydy, mae angen i mi newid fy enw",
+                                                    "value": "No, I need to change my name"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "correct-name",
+                                "when": [
+                                    {
+                                        "id": "details-correct-answer",
+                                        "condition": "equals",
+                                        "value": "No, I need to change my name"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "over-16"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "correct-name",
+                    "title": "correct name",
+                    "sections": [
+                        {
+                            "id": "correct-name-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "correct-name-question",
+                                    "title": "Beth yw eich enw cywir?",
+                                    "number": "1a",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "correct-first-name",
+                                            "label": "Enw cyntaf",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "correct-middle-names",
+                                            "label": "Enwau canol",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "correct-last-name",
+                                            "label": "Cyfenw",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "over-16",
+                    "title": "over 16",
+                    "sections": [
+                        {
+                            "id": "over-16-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "over-16-question",
+                                    "title": "Ydych chi’n 16 oed neu’n hŷn?",
+                                    "number": "1b",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "over-16-answer",
+                                            "mandatory": true,
+                                            "options": [
+                                                {
+                                                    "label": "Ydw",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "Nac ydw",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "type": "Radio",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Dewiswch ateb i barhau"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "private-response",
+                                "when": [
+                                    {
+                                        "id": "over-16-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "sex"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "private-response",
+                    "title": "Private response",
+                    "sections": [
+                        {
+                            "id": "private-response-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "private-response-question",
+                                    "title": "A hoffech ofyn am ffurflen bersonol?",
+                                    "description": "Gall unrhyw un sy’n 16 oed neu’n hŷn sydd am gadw ei atebion yn breifat ofyn am ffurflen bersonol a chyfrinachol.",
+                                    "number": "1c",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "private-response-answer",
+                                            "mandatory": false,
+                                            "guidance": "Os byddwch yn gofyn am ffurflen bersonol neu gyfrinachol byddwn yn anfon cod mynediad unigryw atoch a fydd yn eich galluogi i gwblhau’r cwestiynau i unigolion drosoch chi’ch hun. Ni fydd neb arall yn gallu gweld yr atebion rydych yn eu rhoi.",
+                                            "options": [
+                                                {
+                                                    "label": "Na, nid wyf am ofyn am ffurflen bersonol",
+                                                    "value": "No, I do not want to request a personal form"
+                                                },
+                                                {
+                                                    "label": "Hoffwn ofyn am ffurflen bersonol",
+                                                    "value": "Yes, I want to request a personal form"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "request-private-response",
+                                "when": [
+                                    {
+                                        "id": "private-response-answer",
+                                        "condition": "equals",
+                                        "value": "Yes, I want to request a personal form"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "sex"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "interstitial",
+                    "id": "request-private-response",
+                    "title": "Request private response",
+                    "sections": [
+                        {
+                            "title": "Cais am ffurflen bersonol a chyfrinachol",
+                            "id": "request-private-response-section",
+                            "questions": [
+                                {
+                                    "description": "<p>Gallwch <a rel='noopener noreferrer' target='_blank' href='https://census.gov.uk/individualquestionnaire'>ofyn am ffurflen bersonol a chyfrinachol ar lein</a>.</p> <p>Neu, ffoniwch <a href='tel:03000683001'>0300 068 3001</a>.</p>",
+                                    "answers": [],
+                                    "id": "request-private-response-question",
+                                    "title": "",
+                                    "type": "General"
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "household-member-completed"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "sex",
+                    "title": "sex",
+                    "sections": [
+                        {
+                            "id": "sex-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "sex-question",
+                                    "title": "Beth yw eich rhyw?",
+                                    "number": "2",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "sex-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Gwryw",
+                                                    "value": "Male"
+                                                },
+                                                {
+                                                    "label": "Benyw",
+                                                    "value": "Female"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "date-of-birth",
+                    "title": "date of birth",
+                    "sections": [
+                        {
+                            "id": "date-of-birth-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "date-of-birth-question",
+                                    "title": "Beth yw dyddiad eich geni?",
+                                    "number": "3",
+                                    "description": "Er enghraifft 20 Mawrth 1980",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "date-of-birth-answer",
+                                            "mandatory": false,
+                                            "type": "Date",
+                                            "validation": {
+                                                "messages": {
+                                                    "INVALID_DATE": "Nid yw’r dyddiad a roddwyd yn ddilys. Cywirwch eich ateb"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "marital-status",
+                    "title": "marital status",
+                    "sections": [
+                        {
+                            "id": "marital-status-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "marital-status-question",
+                                    "title": "Ar 9 Ebrill 2017, beth, yn gyfreithiol, yw’ch statws priodasol neu statws eich partneriaeth sifil o’r un rhyw?",
+                                    "number": "4",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "marital-status-answer",
+                                            "mandatory": false,
+                                            "guidance": "<p>Atebwch yn ôl eich statws ar 9 Ebrill 2017.</p><p>Atebwch y cwestiwn hwn ar gyfer plant, er nad ydynt efallai yn ddigon hen i briodi nac i ffurfio partneriaeth sifil o’r un rhyw.</p><p>Os oeddech yn briod (neu wedi ffurfio partneriaeth gofrestredig o’r un rhyw) dramor, a bod hyn yn eich galluogi i gael eich cydnabod yn briod neu mewn partneriaeth sifil yn y Deyrnas Unedig, atebwch y cwestiwn gan adlewyrchu’r bartneriaeth gyfreithiol honno.</p>",
+                                            "options": [
+                                                {
+                                                    "label": "Erioed wedi priodi na chofrestru partneriaeth sifil o’r un rhyw",
+                                                    "value": "Never married and never registered a same-sex civil partnership"
+                                                },
+                                                {
+                                                    "label": "Priod",
+                                                    "value": "Married"
+                                                },
+                                                {
+                                                    "label": "Mewn partneriaeth sifil gofrestredig o’r un rhyw",
+                                                    "value": "In a registered same-sex civil partnership"
+                                                },
+                                                {
+                                                    "label": "Wedi gwahanu, ond yn gyfreithiol yn dal i fod yn briod",
+                                                    "value": "Separated, but still legally married"
+                                                },
+                                                {
+                                                    "label": "Wedi gwahanu, ond yn gyfreithiol yn dal i fod mewn partneriaeth sifil o’r un rhyw",
+                                                    "value": "Separated, but still legally in a same-sex civil partnership"
+                                                },
+                                                {
+                                                    "label": "Wedi ysgaru",
+                                                    "value": "Divorced"
+                                                },
+                                                {
+                                                    "label": "Wedi bod mewn partneriaeth sifil o’r un rhyw sydd bellach wedi’i diddymu’n gyfreithiol",
+                                                    "value": "Formerly in a same-sex civil partnership which is now legally dissolved"
+                                                },
+                                                {
+                                                    "label": "Gweddw",
+                                                    "value": "Widowed"
+                                                },
+                                                {
+                                                    "label": "Wedi colli partner sifil o’r un rhyw trwy farwolaeth",
+                                                    "value": "Surviving partner from a same-sex civil partnership"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "another-address",
+                    "title": "another address",
+                    "sections": [
+                        {
+                            "id": "another-address-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "another-address-question",
+                                    "title": "A ydych yn aros mewn cyfeiriad arall am fwy na 30 diwrnod y flwyddyn?",
+                                    "number": "5",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "another-address-answer",
+                                            "mandatory": false,
+                                            "guidance": "<p>Gall yr enghreifftiau gynnwys cyfeiriad rhiant arall, cyfeiriad un o ganolfannau’r lluoedd arfog, tŷ gwyliau, neu gyfeiriad yn ystod y tymor.</p><p>Nid oes rhaid i’r diwrnodau rydych yn aros yn y cyfeiriad fod mewn rhes. Gallant fod ar unrhyw adeg o’r flwyddyn.</p>",
+                                            "options": [
+                                                {
+                                                    "label": "Nac ydw",
+                                                    "value": "No"
+                                                },
+                                                {
+                                                    "label": "Ydw, yn y Deyrnas Unedig",
+                                                    "value": "Yes, an address within the UK"
+                                                },
+                                                {
+                                                    "label": "Ydw, y tu allan i’r Deyrnas Unedig (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch enw’r wlad"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "in-education",
+                                "when": [
+                                    {
+                                        "id": "another-address-answer",
+                                        "condition": "equals",
+                                        "value": "No"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "other-address",
+                                "when": [
+                                    {
+                                        "id": "another-address-answer",
+                                        "condition": "equals",
+                                        "value": "Yes, an address within the UK"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "address-type",
+                                "when": [
+                                    {
+                                        "id": "another-address-answer",
+                                        "condition": "equals",
+                                        "value": "Other"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "address-type",
+                                "when": [
+                                    {
+                                        "id": "another-address-answer",
+                                        "condition": "not equals",
+                                        "value": "Other"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "in-education"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "other-address",
+                    "title": "other address",
+                    "sections": [
+                        {
+                            "id": "other-address-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "other-address-question",
+                                    "title": "Rhowch fanylion y cyfeiriad arall yn y Deyrnas Unedig lle rydych yn aros am fwy na 30 diwrnod y flwyddyn",
+                                    "number": "5a",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "other-address-answer-building",
+                                            "label": "Adeilad",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "other-address-answer-street",
+                                            "label": "Stryd",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "other-address-answer-city",
+                                            "label": "Tref neu ddinas",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "other-address-answer-county",
+                                            "label": "Sir (dewisol)",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "other-address-answer-postcode",
+                                            "label": "Cod post",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "address-type",
+                    "title": "address type",
+                    "sections": [
+                        {
+                            "id": "address-type-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "address-type-question",
+                                    "title": "Pa fath o gyfeiriad yw’r cyfeiriad hwnnw?",
+                                    "number": "6",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "address-type-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Cyfeiriad un o ganolfannau’r lluoedd arfog",
+                                                    "value": "Armed forces base address"
+                                                },
+                                                {
+                                                    "label": "Cyfeiriad arall wrth weithio oddi cartref",
+                                                    "value": "Another address when working away from home"
+                                                },
+                                                {
+                                                    "label": "Cyfeiriad cartref myfyriwr",
+                                                    "value": "Student’s home address"
+                                                },
+                                                {
+                                                    "label": "Cyfeiriad myfyriwr yn ystod y tymor",
+                                                    "value": "Student’s term time address"
+                                                },
+                                                {
+                                                    "label": "Cyfeiriad cartref rhiant neu warcheidwad arall",
+                                                    "value": "Another parent or guardian’s address"
+                                                },
+                                                {
+                                                    "label": "Cyfeiriad tŷ gwyliau",
+                                                    "value": "Holiday home"
+                                                },
+                                                {
+                                                    "label": "Arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch y math o gyfeiriad"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "in-education",
+                    "title": "in education",
+                    "sections": [
+                        {
+                            "id": "in-education-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "in-education-question",
+                                    "title": "A ydych yn blentyn ysgol neu’n fyfyriwr mewn addysg amser llawn?",
+                                    "number": "7",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "in-education-answer",
+                                            "mandatory": false,
+                                            "guidance": "<p>Ystyrir bod y canlynol mewn addysg amser llawn:</p><p>Plant o dan 16 oed</p><p>Pobl ifanc 16-18 oed os ydynt yn mynychu mwy na 12 awr yr wythnos o astudiaethau ar gwrs hyd at ac yn cynnwys Safon Uwch</p><p>Unrhyw un sydd ar gwrs uwchlaw Safon Uwch os yw’n astudio mewn sefydliad yn y Deyrnas Unedig, ar gwrs sydd</p><ul><li>yn para o leiaf un flwyddyn academaidd</li><li>yn cynnwys o leiaf 24 wythnos y flwyddyn, ac</li><li>yn cynnwys o leiaf 21 awr yr wythnos o astudiaethau, dosbarthiadau neu brofiad gwaith yn ystod y tymor (gan gynnwys astudiaethau distrwythur)</li></ul>",
+                                            "options": [
+                                                {
+                                                    "label": "Ydw",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "Nac ydw",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "term-time-location",
+                                "when": [
+                                    {
+                                        "id": "in-education-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "country-of-birth"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "term-time-location",
+                    "title": "term-time location",
+                    "sections": [
+                        {
+                            "id": "term-time-location-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "term-time-location-question",
+                                    "title": "Yn ystod y tymor a ydych yn byw:",
+                                    "number": "8",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "term-time-location-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "yma, yn y cyfeiriad hwn",
+                                                    "value": "here, at this address"
+                                                },
+                                                {
+                                                    "label": "mewn cyfeiriad arall",
+                                                    "value": "at another address"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "household-member-completed",
+                                "when": [
+                                    {
+                                        "id": "term-time-location-answer",
+                                        "condition": "equals",
+                                        "value": "at another address"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "country-of-birth"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "country-of-birth",
+                    "title": "country of birth",
+                    "sections": [
+                        {
+                            "id": "country-of-birth-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "country-of-birth-england-question",
+                                    "title": "Ym mha wlad y cawsoch eich geni?",
+                                    "number": "9",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "country-of-birth-england-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Lloegr",
+                                                    "value": "England"
+                                                },
+                                                {
+                                                    "label": "Cymru",
+                                                    "value": "Wales"
+                                                },
+                                                {
+                                                    "label": "Yr Alban",
+                                                    "value": "Scotland"
+                                                },
+                                                {
+                                                    "label": "Gogledd Iwerddon",
+                                                    "value": "Northern Ireland"
+                                                },
+                                                {
+                                                    "label": "Gweriniaeth Iwerddon",
+                                                    "value": "Republic of Ireland"
+                                                },
+                                                {
+                                                    "label": "Rhywle arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch enw presennol y wlad"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "id": "country-of-birth-wales-question",
+                                    "title": "Ym mha wlad y cawsoch eich geni?",
+                                    "number": "9",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "country-of-birth-wales-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Cymru",
+                                                    "value": "Wales"
+                                                },
+                                                {
+                                                    "label": "Lloegr",
+                                                    "value": "England"
+                                                },
+                                                {
+                                                    "label": "Yr Alban",
+                                                    "value": "Scotland"
+                                                },
+                                                {
+                                                    "label": "Gogledd Iwerddon",
+                                                    "value": "Northern Ireland"
+                                                },
+                                                {
+                                                    "label": "Gweriniaeth Iwerddon",
+                                                    "value": "Republic of Ireland"
+                                                },
+                                                {
+                                                    "label": "Rhywle arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch enw presennol y wlad"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "not equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "carer",
+                                "when": [
+                                    {
+                                        "id": "country-of-birth-england-answer",
+                                        "condition": "equals",
+                                        "value": "England"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "carer",
+                                "when": [
+                                    {
+                                        "id": "country-of-birth-england-answer",
+                                        "condition": "equals",
+                                        "value": "Wales"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "carer",
+                                "when": [
+                                    {
+                                        "id": "country-of-birth-england-answer",
+                                        "condition": "equals",
+                                        "value": "Scotland"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "carer",
+                                "when": [
+                                    {
+                                        "id": "country-of-birth-england-answer",
+                                        "condition": "equals",
+                                        "value": "Northern Ireland"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "carer",
+                                "when": [
+                                    {
+                                        "id": "country-of-birth-wales-answer",
+                                        "condition": "equals",
+                                        "value": "Wales"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "carer",
+                                "when": [
+                                    {
+                                        "id": "country-of-birth-wales-answer",
+                                        "condition": "equals",
+                                        "value": "England"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "carer",
+                                "when": [
+                                    {
+                                        "id": "country-of-birth-wales-answer",
+                                        "condition": "equals",
+                                        "value": "Scotland"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "carer",
+                                "when": [
+                                    {
+                                        "id": "country-of-birth-wales-answer",
+                                        "condition": "equals",
+                                        "value": "Northern Ireland"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "arrive-in-uk"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "arrive-in-uk",
+                    "title": "arrive in uk",
+                    "sections": [
+                        {
+                            "id": "arrive-in-uk-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "arrive-in-uk-question",
+                                    "title": "Os na chawsoch eich geni yn y Deyrnas Unedig, pryd y daethoch i fyw yma ddiwethaf?",
+                                    "number": "10",
+                                    "guidance": [
+                                        {
+                                            "description": "Peidiwch â chyfrif ymweliadau byr i ffwrdd o’r Deyrnas Unedig"
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "arrive-in-uk-answer",
+                                            "mandatory": false,
+                                            "type": "MonthYearDate",
+                                            "validation": {
+                                                "messages": {
+                                                    "INVALID_DATE": "Nid yw’r dyddiad a roddwyd yn ddilys. Cywirwch eich ateb"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "length-of-stay",
+                    "title": "length of stay",
+                    "sections": [
+                        {
+                            "id": "length-of-stay-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "length-of-stay-question",
+                                    "title": "Gan gynnwys yr amser yr ydych wedi’i dreulio yma’n barod, am faint yr ydych yn bwriadu aros yn y Deyrnas Unedig?",
+                                    "number": "12",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "length-of-stay-answer",
+                                            "mandatory": false,
+                                            "guidance": "Os gwnaethoch gyrraedd y Deyrnas Unedig cyn mis Mai 2016, dewiswch ‘12 mis neu fwy’",
+                                            "options": [
+                                                {
+                                                    "label": "Llai na 6 mis",
+                                                    "value": "Less than 6 months"
+                                                },
+                                                {
+                                                    "label": "6 mis neu fwy, ond llai na 12 mis",
+                                                    "value": "6 months or more but less than 12 months"
+                                                },
+                                                {
+                                                    "label": "12 mis neu fwy",
+                                                    "value": "12 months or more"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "carer",
+                    "title": "carer",
+                    "sections": [
+                        {
+                            "id": "carer-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "carer-question",
+                                    "title": "A ydych yn gofalu am aelodau o’r teulu, ffrindiau, cymdogion neu eraill, neu’n cynnig unrhyw help neu gefnogaeth i un neu i rai o’r rhain, oherwydd naill ai:",
+                                    "number": "13",
+                                    "description": "<div><ul><li>Salwch/anabledd corfforol neu feddyliol hirdymor?</li><li>Problemau sy’n gysylltiedig â henaint?</li></ul></div>",
+                                    "guidance": [
+                                        {
+                                            "description": "<strong>Peidiwch â chyfrif</strong> unrhyw beth y byddwch yn derbyn cyflog am ei wneud"
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "carer-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Nac ydw",
+                                                    "value": "No"
+                                                },
+                                                {
+                                                    "label": "Ydw, 1 - 19 awr yr wythnos",
+                                                    "value": "Yes, 1 -19 hours a week"
+                                                },
+                                                {
+                                                    "label": "Ydw, 20 - 49 awr yr wythnos",
+                                                    "value": "Yes, 20 - 49 hours a week"
+                                                },
+                                                {
+                                                    "label": "Ydw, 50 neu fwy o oriau’r wythnos",
+                                                    "value": "Yes, 50 or more hours a week"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "national-identity",
+                    "title": "national identity",
+                    "sections": [
+                        {
+                            "id": "national-identity-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "national-identity-england-question",
+                                    "title": "Sut byddech chi’n disgrifio’ch hunaniaeth genedlaethol?",
+                                    "number": "14",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "national-identity-england-answer",
+                                            "label": "Dewiswch bob un sy’n berthnasol",
+                                            "mandatory": false,
+                                            "guidance": "<p>Gallwch ddewis mwy nag un hunaniaeth genedlaethol.</p><p>Chi sy’n penderfynu sut i ddewis eich hunaniaeth genedlaethol neu hunaniaethau cenedlaethol. Er enghraifft, gallai ymwneud â‘r wlad neu’r gwledydd rydych yn teimlo eich bod yn perthyn iddi neu iddynt, neu’n ei hystyried neu’n eu hystyried yn gartref.</p><p>Nid yw’n ddibynnol ar eich grŵp ethnig na’ch cenedligrwydd cyfreithiol (dinasyddiaeth).</p><p>Dewiswch bob un sy’n berthnasol. Os nad yw eich hunaniaeth genedlaethol ar y rhestr, dewiswch ‘Arall’ a nodwch eich hunaniaeth genedlaethol.</p>",
+                                            "options": [
+                                                {
+                                                    "label": "Sais/Saesnes",
+                                                    "value": "English"
+                                                },
+                                                {
+                                                    "label": "Cymro/Cymraes",
+                                                    "value": "Welsh"
+                                                },
+                                                {
+                                                    "label": "Albanwr/Albanes",
+                                                    "value": "Scottish"
+                                                },
+                                                {
+                                                    "label": "Gwyddel/Gwyddeles o Ogledd Iwerddon",
+                                                    "value": "Northern Irish"
+                                                },
+                                                {
+                                                    "label": "Prydeiniwr/Prydeinwraig",
+                                                    "value": "British"
+                                                },
+                                                {
+                                                    "label": "Arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Disgrifiwch eich hunaniaeth genedlaethol"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "id": "national-identity-wales-question",
+                                    "title": "Sut byddech chi’n disgrifio’ch hunaniaeth genedlaethol?",
+                                    "number": "14",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "national-identity-wales-answer",
+                                            "label": "Dewiswch bob un sy’n berthnasol",
+                                            "mandatory": false,
+                                            "guidance": "<p>Gallwch ddewis mwy nag un hunaniaeth genedlaethol.<p><p>Chi sy’n penderfynu sut i ddewis eich hunaniaeth genedlaethol neu hunaniaethau cenedlaethol. Er enghraifft, gallai ymwneud â‘r wlad neu’r gwledydd rydych yn teimlo eich bod yn perthyn iddi neu iddynt, neu’n ei hystyried neu’n eu hystyried yn gartref.</p><p>Nid yw’n ddibynnol ar eich grŵp ethnig na’ch cenedligrwydd cyfreithiol (dinasyddiaeth).</p><p>Dewiswch bob un sy’n berthnasol. Os nad yw eich hunaniaeth genedlaethol ar y rhestr, dewiswch ‘Arall’ a nodwch eich hunaniaeth genedlaethol.</p>",
+                                            "options": [
+                                                {
+                                                    "label": "Cymro/Cymraes",
+                                                    "value": "Welsh"
+                                                },
+                                                {
+                                                    "label": "Sais/Saesnes",
+                                                    "value": "English"
+                                                },
+                                                {
+                                                    "label": "Albanwr/Albanes",
+                                                    "value": "Scottish"
+                                                },
+                                                {
+                                                    "label": "Gwyddel/Gwyddeles o Ogledd Iwerddon",
+                                                    "value": "Northern Irish"
+                                                },
+                                                {
+                                                    "label": "Prydeiniwr/Prydeinwraig",
+                                                    "value": "British"
+                                                },
+                                                {
+                                                    "label": "Arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Disgrifiwch eich hunaniaeth genedlaethol"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "not equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "ethnic-group",
+                    "title": "ethnic group",
+                    "sections": [
+                        {
+                            "id": "ethnic-group-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "ethnic-group-england-question",
+                                    "title": "Beth yw eich grŵp ethnig?",
+                                    "number": "15",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "ethnic-group-england-answer",
+                                            "mandatory": false,
+                                            "guidance": "<p>Chi sy’n dewis eich grŵp ethnig. Er enghraifft gallai adlewyrchu eich cefndir teuluol neu ddiwylliannol, neu sut y byddech yn disgrifio eich hun.</p><p>Dewiswch yr ateb mwyaf priodol yn eich barn chi.</p><p>Os nad ydych yn credu bod yr opsiynau yn berthnasol i chi, dewiswch ‘Grŵp ethnig arall’. Yna byddwch yn gallu ysgrifennu’r grŵp ethnig sydd orau gennych ar gyfer y cwestiwn nesaf.</p>",
+                                            "options": [
+                                                {
+                                                    "label": "Gwyn",
+                                                    "value": "White",
+                                                    "description": "Gan gynnwys Seisnig / Cymreig / Albanaidd / Gwyddelig Gogledd Iwerddon / Prydeinig, Sipsi neu Deithiwr Gwyddelig neu unrhyw gefndir Gwyn arall"
+                                                },
+                                                {
+                                                    "label": "Cymysg / grwpiau aml-ethnig",
+                                                    "value": "Mixed / multiple ethnic groups",
+                                                    "description": "Gan gynnwys Gwyn a Du Caribïaidd, Gwyn a Du Affricanaidd, Gwyn ac Asiaidd neu unrhyw gefndir Cymysg/aml-ethnig arall"
+                                                },
+                                                {
+                                                    "label": "Asiaidd / Asiaidd Prydeinig",
+                                                    "value": "Asian / Asian British",
+                                                    "description": "Gan gynnwys Indiaidd, Pacistanaidd, Bangladeshaidd, Tsieineaidd neu unrhyw gefndir Asiaidd arall"
+                                                },
+                                                {
+                                                    "label": "Du / Affricanaidd / Caribïaidd / Du Prydeinig",
+                                                    "value": "Black / African / Caribbean / Black British",
+                                                    "description": "Gan gynnwys Affricanaidd, Caribïaidd neu unrhyw gefndir Du / Affricanaidd / Caribïaidd arall"
+                                                },
+                                                {
+                                                    "label": "Grŵp ethnig arall",
+                                                    "value": "Other ethnic group",
+                                                    "description": "Gan gynnwys Arabaidd neu unrhyw grŵp ethnig arall"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "id": "ethnic-group-wales-question",
+                                    "title": "Beth yw eich grŵp ethnig?",
+                                    "number": "15",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "ethnic-group-wales-answer",
+                                            "mandatory": false,
+                                            "guidance": "<p>Chi sy’n dewis eich grŵp ethnig. Er enghraifft gallai adlewyrchu eich cefndir teuluol neu ddiwylliannol, neu sut y byddech yn disgrifio eich hun.</p><p>Dewiswch yr ateb mwyaf priodol yn eich barn chi.</p><p>Os nad ydych yn credu bod yr opsiynau yn berthnasol i chi, dewiswch ‘Grŵp ethnig arall’.  Yna byddwch yn gallu ysgrifennu’r grŵp ethnig sydd orau gennych ar gyfer y cwestiwn nesaf.</p>",
+                                            "options": [
+                                                {
+                                                    "label": "Gwyn",
+                                                    "value": "White",
+                                                    "description": "Gan gynnwys Cymreig / Seisnig / Albanaidd / Gwyddelig Gogledd Iwerddon / Prydeinig, Gwyddelig, Sipsi neu Deithiwr Gwyddelig neu unrhyw gefndir Gwyn arall"
+                                                },
+                                                {
+                                                    "label": "Cymysg / grwpiau aml-ethnig",
+                                                    "value": "Mixed / multiple ethnic groups",
+                                                    "description": "Gan gynnwys Gwyn a Du Caribïaidd, Gwyn a Du Affricanaidd, Gwyn ac Asiaidd neu unrhyw gefndir Cymysg/aml-ethnig arall"
+                                                },
+                                                {
+                                                    "label": "Asiaidd / Asiaidd Prydeinig",
+                                                    "value": "Asian / Asian British",
+                                                    "description": "Gan gynnwys Indiaidd, Pacistanaidd, Bangladeshaidd, Tsieineaidd neu unrhyw gefndir Asiaidd arall"
+                                                },
+                                                {
+                                                    "label": "Du / Affricanaidd / Caribïaidd / Du Prydeinig",
+                                                    "value": "Black / African / Caribbean / Black British",
+                                                    "description": "Gan gynnwys Affricanaidd, Caribïaidd neu unrhyw gefndir Du / Affricanaidd / Caribïaidd arall"
+                                                },
+                                                {
+                                                    "label": "Grŵp ethnig arall",
+                                                    "value": "Other ethnic group",
+                                                    "description": "Gan gynnwys Arabaidd neu unrhyw grŵp ethnig arall"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "not equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "white-ethnic-group",
+                                "when": [
+                                    {
+                                        "id": "ethnic-group-england-answer",
+                                        "condition": "equals",
+                                        "value": "White"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "mixed-ethnic-group",
+                                "when": [
+                                    {
+                                        "id": "ethnic-group-england-answer",
+                                        "condition": "equals",
+                                        "value": "Mixed / multiple ethnic groups"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "asian-ethnic-group",
+                                "when": [
+                                    {
+                                        "id": "ethnic-group-england-answer",
+                                        "condition": "equals",
+                                        "value": "Asian / Asian British"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "black-ethnic-group",
+                                "when": [
+                                    {
+                                        "id": "ethnic-group-england-answer",
+                                        "condition": "equals",
+                                        "value": "Black / African / Caribbean / Black British"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "other-ethnic-group",
+                                "when": [
+                                    {
+                                        "id": "ethnic-group-england-answer",
+                                        "condition": "equals",
+                                        "value": "Other ethnic group"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "white-ethnic-group",
+                                "when": [
+                                    {
+                                        "id": "ethnic-group-wales-answer",
+                                        "condition": "equals",
+                                        "value": "White"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "mixed-ethnic-group",
+                                "when": [
+                                    {
+                                        "id": "ethnic-group-wales-answer",
+                                        "condition": "equals",
+                                        "value": "Mixed / multiple ethnic groups"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "asian-ethnic-group",
+                                "when": [
+                                    {
+                                        "id": "ethnic-group-wales-answer",
+                                        "condition": "equals",
+                                        "value": "Asian / Asian British"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "black-ethnic-group",
+                                "when": [
+                                    {
+                                        "id": "ethnic-group-wales-answer",
+                                        "condition": "equals",
+                                        "value": "Black / African / Caribbean / Black British"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "other-ethnic-group",
+                                "when": [
+                                    {
+                                        "id": "ethnic-group-wales-answer",
+                                        "condition": "equals",
+                                        "value": "Other ethnic group"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "sexual-identity",
+                                "when": [
+                                    {
+                                        "id": "over-16-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "meta": "variant_flags.sexual_identity",
+                                        "condition": "equals",
+                                        "value": true
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "understand-welsh",
+                                "when": [
+                                    {
+                                        "meta": "region_code",
+                                        "condition": "equals",
+                                        "value": "GB-WLS"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "language"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "white-ethnic-group",
+                    "title": "white ethnic group",
+                    "sections": [
+                        {
+                            "id": "white-ethnic-group-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "white-ethnic-group-england-question",
+                                    "title": "Pa un sy’n disgrifio eich grŵp ethnig neu gefndir Gwyn orau?",
+                                    "number": "15a",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "white-ethnic-group-england-answer",
+                                            "guidance": "<p>Mae’r opsiynau’n seiliedig ar yr ateb i’r cwestiwn blaenorol. Dewiswch yr ateb sydd fwyaf priodol yn eich barn chi. </p><p> Os nad ydych yn credu bod yr opsiynau yn berthnasol i chi, dewiswch ‘Unrhyw un arall ...’ ac ysgrifennwch eich grŵp ethnig.</p>",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Cymreig / Seisnig / Albanaidd / Gwyddelig Gogledd Iwerddon / Prydeinig",
+                                                    "value": "English / Welsh / Scottish / Northern Irish / British"
+                                                },
+                                                {
+                                                    "label": "Gwyddelig",
+                                                    "value": "Irish"
+                                                },
+                                                {
+                                                    "label": "Sipsi neu Deithiwr Gwyddelig",
+                                                    "value": "Gypsy or Irish Traveller"
+                                                },
+                                                {
+                                                    "label": "Unrhyw gefndir Gwyn arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch gefndir Gwyn arall"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "id": "white-ethnic-group-wales-question",
+                                    "title": "Pa un sy’n disgrifio eich grŵp ethnig neu gefndir Gwyn orau?",
+                                    "number": "15a",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "white-ethnic-group-wales-answer",
+                                            "guidance": "<p>Mae’r opsiynau’n seiliedig ar yr ateb i’r cwestiwn blaenorol. Dewiswch yr ateb sydd fwyaf priodol yn eich barn chi. </p><p> Os nad ydych yn credu bod yr opsiynau yn berthnasol i chi, dewiswch ‘Unrhyw un arall ...’ ac ysgrifennwch eich grŵp ethnig.</p>",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Cymreig / Seisnig /Albanaidd / Gwyddelig Gogledd Iwerddon / Prydeinig",
+                                                    "value": "Welsh / English / Scottish / Northern Irish / British"
+                                                },
+                                                {
+                                                    "label": "Gwyddelig",
+                                                    "value": "Irish"
+                                                },
+                                                {
+                                                    "label": "Sipsi neu Deithiwr Gwyddelig",
+                                                    "value": "Gypsy or Irish Traveller"
+                                                },
+                                                {
+                                                    "label": "Unrhyw gefndir Gwyn arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch gefndir Gwyn arall"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "not equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "sexual-identity",
+                                "when": [
+                                    {
+                                        "id": "over-16-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "meta": "variant_flags.sexual_identity",
+                                        "condition": "equals",
+                                        "value": true
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "understand-welsh",
+                                "when": [
+                                    {
+                                        "meta": "region_code",
+                                        "condition": "equals",
+                                        "value": "GB-WLS"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "language"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "mixed-ethnic-group",
+                    "title": "mixed ethnic group",
+                    "sections": [
+                        {
+                            "id": "mixed-ethnic-group-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "mixed-ethnic-group-question",
+                                    "title": "Pa un sy’n disgrifio eich grŵp neu gefndir Cymysg / aml-ethnig orau?",
+                                    "number": "15a",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "mixed-ethnic-group-answer",
+                                            "guidance": "<p>Mae’r opsiynau’n seiliedig ar yr ateb i’r cwestiwn blaenorol. Dewiswch yr ateb sydd fwyaf priodol yn eich barn chi. </p><p> Os nad ydych yn credu bod yr opsiynau yn berthnasol i chi, dewiswch ‘Unrhyw un arall ...’ ac ysgrifennwch eich grŵp ethnig.</p>",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Gwyn a Du Caribïaidd",
+                                                    "value": "White and Black Caribbean"
+                                                },
+                                                {
+                                                    "label": "Gwyn a Du Affricanaidd",
+                                                    "value": "White and Black African"
+                                                },
+                                                {
+                                                    "label": "Gwyn ac Asiaidd",
+                                                    "value": "White and Asian"
+                                                },
+                                                {
+                                                    "label": "Unrhyw gefndir Cymysg / aml-ethnig arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch gefndir Cymysg / aml-ethnig arall"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "sexual-identity",
+                                "when": [
+                                    {
+                                        "id": "over-16-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "meta": "variant_flags.sexual_identity",
+                                        "condition": "equals",
+                                        "value": true
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "understand-welsh",
+                                "when": [
+                                    {
+                                        "meta": "region_code",
+                                        "condition": "equals",
+                                        "value": "GB-WLS"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "language"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "asian-ethnic-group",
+                    "title": "asian ethnic group",
+                    "sections": [
+                        {
+                            "id": "asian-ethnic-group-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "asian-ethnic-group-question",
+                                    "title": "Pa un sy’n disgrifio eich grŵp ethnig neu gefndir Asiaidd / Asiaidd Prydeinig orau?",
+                                    "number": "15a",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "asian-ethnic-group-answer",
+                                            "mandatory": false,
+                                            "guidance": "<p>Mae’r opsiynau’n seiliedig ar yr ateb i’r cwestiwn blaenorol. Dewiswch yr ateb sydd fwyaf priodol yn eich barn chi. </p><p> Os nad ydych yn credu bod yr opsiynau yn berthnasol i chi, dewiswch ‘Unrhyw un arall ...’ ac ysgrifennwch eich grŵp ethnig.</p>",
+                                            "options": [
+                                                {
+                                                    "label": "Indiaidd",
+                                                    "value": "Indian"
+                                                },
+                                                {
+                                                    "label": "Pacistanaidd",
+                                                    "value": "Pakistani"
+                                                },
+                                                {
+                                                    "label": "Bangladeshaidd",
+                                                    "value": "Bangladeshi"
+                                                },
+                                                {
+                                                    "label": "Tsieineaidd",
+                                                    "value": "Chinese"
+                                                },
+                                                {
+                                                    "label": "Unrhyw gefndir Asiaidd arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch unrhyw gefndir Asiaidd arall"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "sexual-identity",
+                                "when": [
+                                    {
+                                        "id": "over-16-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "meta": "variant_flags.sexual_identity",
+                                        "condition": "equals",
+                                        "value": true
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "understand-welsh",
+                                "when": [
+                                    {
+                                        "meta": "region_code",
+                                        "condition": "equals",
+                                        "value": "GB-WLS"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "language"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "black-ethnic-group",
+                    "title": "black ethnic group",
+                    "sections": [
+                        {
+                            "id": "black-ethnic-group-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "black-ethnic-group-question",
+                                    "title": "Pa un sy’n disgrifio eich grŵp ethnig neu gefndir Du / Affricanaidd / Caribïaidd / Du Prydeinig orau?",
+                                    "number": "15a",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "black-ethnic-group-answer",
+                                            "mandatory": false,
+                                            "guidance": "<p>Mae’r opsiynau’n seiliedig ar yr ateb i’r cwestiwn blaenorol. Dewiswch yr ateb sydd fwyaf priodol yn eich barn chi. </p><p> Os nad ydych yn credu bod yr opsiynau yn berthnasol i chi, dewiswch ‘Unrhyw un arall ...’ ac ysgrifennwch eich grŵp ethnig.</p>",
+                                            "options": [
+                                                {
+                                                    "label": "Affricanaidd",
+                                                    "value": "African"
+                                                },
+                                                {
+                                                    "label": "Caribïaidd",
+                                                    "value": "Caribbean"
+                                                },
+                                                {
+                                                    "label": "Unrhyw gefndir Du / Affricanaidd / Caribïaidd arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch gefndir Du / Affricanaidd / Caribïaidd arall"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "sexual-identity",
+                                "when": [
+                                    {
+                                        "id": "over-16-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "meta": "variant_flags.sexual_identity",
+                                        "condition": "equals",
+                                        "value": true
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "understand-welsh",
+                                "when": [
+                                    {
+                                        "meta": "region_code",
+                                        "condition": "equals",
+                                        "value": "GB-WLS"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "language"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "other-ethnic-group",
+                    "title": "other ethnic group",
+                    "sections": [
+                        {
+                            "id": "other-ethnic-group-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "other-ethnic-group-question",
+                                    "title": "Pa un sy’n disgrifio eich grŵp ethnig neu gefndir Arall orau?",
+                                    "number": "15a",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "other-ethnic-group-answer",
+                                            "mandatory": false,
+                                            "guidance": "<p>Mae’r opsiynau’n seiliedig ar yr ateb i’r cwestiwn blaenorol. Dewiswch yr ateb sydd fwyaf priodol yn eich barn chi. </p><p> Os nad ydych yn credu bod yr opsiynau yn berthnasol i chi, dewiswch ‘Unrhyw un arall ...’ ac ysgrifennwch eich grŵp ethnig.</p>",
+                                            "options": [
+                                                {
+                                                    "label": "Arabaidd",
+                                                    "value": "Arab"
+                                                },
+                                                {
+                                                    "label": "Unrhyw grŵp ethnig arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch grŵp ethnig Arall"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "sexual-identity",
+                                "when": [
+                                    {
+                                        "id": "over-16-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "meta": "variant_flags.sexual_identity",
+                                        "condition": "equals",
+                                        "value": true
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "understand-welsh",
+                                "when": [
+                                    {
+                                        "meta": "region_code",
+                                        "condition": "equals",
+                                        "value": "GB-WLS"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "language"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "sexual-identity",
+                    "title": "sexual identity",
+                    "sections": [
+                        {
+                            "id": "sexual-identity-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "sexual-identity-question",
+                                    "title": "Pa un o’r opsiynau canlynol sy’n disgrifio’r ffordd rydych yn meddwl am eich hun orau?",
+                                    "number": "17",
+                                    "description": "Mae’r cwestiwn hwn yn wirfoddol",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "sexual-identity-answer",
+                                            "mandatory": false,
+                                            "guidance": "<p>Chi sy’n penderfynu sut i ddewis ateb.</p><p>Os nad ydych yn siŵr beth yw ystyr unrhyw air a ddefnyddir, efallai y bydd y canlynol yn helpu:</p><ul><li>mae ‘Heterorywiol neu Strêt’ yn disgrifio rhywun sydd, er enghraifft, yn hoffi pobl o’r rhyw/rhywedd arall</li><li>mae ‘Hoyw neu Lesbiaidd’ yn disgrifio rhywun sy’n hoffi pobl o’r un rhyw/rhywedd</li><li>mae ‘Deurywiol’ yn disgrifio rhywun sydd, er enghraifft, yn hoffi pobl o’r ddau ryw/rhywedd</li></ul><p><strong>Hunaniaeth heb ei rhestru</strong></p><p>Os nad oes unrhyw un o’r tri opsiwn cyntaf yn berthnasol i chi, dewiswch ‘Arall’ a rhowch yr ateb sy’n well gennych.</p><p>Mae’r cwestiwn hwn yn wirfoddol; gallwch ei adael yn wag os yw’n well gennych wneud hynny.</p>",
+                                            "options": [
+                                                {
+                                                    "label": "Heterorywiol neu Strêt",
+                                                    "value": "Heterosexual or Straight"
+                                                },
+                                                {
+                                                    "label": "Hoyw neu Lesbiaidd",
+                                                    "value": "Gay or Lesbian"
+                                                },
+                                                {
+                                                    "label": "Deurywiol",
+                                                    "value": "Bisexual"
+                                                },
+                                                {
+                                                    "label": "Arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "understand-welsh",
+                                "when": [
+                                    {
+                                        "meta": "region_code",
+                                        "condition": "equals",
+                                        "value": "GB-WLS"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "language"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "understand-welsh",
+                    "title": "understand welsh",
+                    "sections": [
+                        {
+                            "id": "understand-welsh-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "understand-welsh-question",
+                                    "title": "A allwch ddeall, siarad, darllen neu ysgrifennu Cymraeg",
+                                    "number": "18",
+                                    "description": "Dewiswch bob un sy’n berthnasol",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "understand-welsh-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Deall Cymraeg llafar",
+                                                    "value": "Understand spoken Welsh"
+                                                },
+                                                {
+                                                    "label": "Siarad Cymraeg",
+                                                    "value": "Speak Welsh"
+                                                },
+                                                {
+                                                    "label": "Darllen Cymraeg",
+                                                    "value": "Read Welsh"
+                                                },
+                                                {
+                                                    "label": "Ysgrifennu Cymraeg",
+                                                    "value": "Write Welsh"
+                                                },
+                                                {
+                                                    "label": "Dim un o’r uchod",
+                                                    "value": "None of the above"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "language",
+                    "title": "language",
+                    "sections": [
+                        {
+                            "id": "language-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "language-england-question",
+                                    "title": "Beth yw eich prif iaith?",
+                                    "number": "19",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "language-england-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Saesneg",
+                                                    "value": "English"
+                                                },
+                                                {
+                                                    "label": "Arall (nodwch)",
+                                                    "value": "Other",
+                                                    "description": "Gan gynnwys Iaith Arwyddion Prydain",
+                                                    "other": {
+                                                        "label": "Nodwch eich prif iaith"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "id": "language-welsh-question",
+                                    "title": "Beth yw eich prif iaith?",
+                                    "number": "19",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "language-welsh-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Cymraeg neu Saesneg",
+                                                    "value": "English or Welsh"
+                                                },
+                                                {
+                                                    "label": "Arall (nodwch)",
+                                                    "value": "Other",
+                                                    "description": "Gan gynnwys Iaith Arwyddion Prydain",
+                                                    "other": {
+                                                        "label": "Nodwch eich prif iaith"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "not equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "religion",
+                                "when": [
+                                    {
+                                        "id": "language-england-answer",
+                                        "condition": "equals",
+                                        "value": "English"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "religion",
+                                "when": [
+                                    {
+                                        "id": "language-welsh-answer",
+                                        "condition": "equals",
+                                        "value": "English or Welsh"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "english"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "english",
+                    "title": "english",
+                    "sections": [
+                        {
+                            "id": "english-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "english-question",
+                                    "title": "Pa mor dda allwch chi siarad Saesneg?",
+                                    "number": "20",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "english-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Da iawn",
+                                                    "value": "Very well"
+                                                },
+                                                {
+                                                    "label": "Da",
+                                                    "value": "Well"
+                                                },
+                                                {
+                                                    "label": "Ddim yn dda",
+                                                    "value": "Not well"
+                                                },
+                                                {
+                                                    "label": "Ddim o gwbl",
+                                                    "value": "Not at all"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "religion",
+                    "title": "religion",
+                    "sections": [
+                        {
+                            "id": "religion-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "religion-question",
+                                    "title": "Beth yw eich crefydd?",
+                                    "description": "Mae’r cwestiwn hwn yn wirfoddol",
+                                    "number": "21",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "religion-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Dim crefydd",
+                                                    "value": "No religion"
+                                                },
+                                                {
+                                                    "label": "Cristnogaeth (gan gynnwys Eglwys Lloegr, Catholig, Protestannaidd a phob enwad Cristnogol arall)",
+                                                    "value": "Christian (Including Church of England, Catholic, Protestant and all other Christian denominations)"
+                                                },
+                                                {
+                                                    "label": "Bwdhaeth",
+                                                    "value": "Buddhist"
+                                                },
+                                                {
+                                                    "label": "Hindŵaeth",
+                                                    "value": "Hindu"
+                                                },
+                                                {
+                                                    "label": "Iddewiaeth",
+                                                    "value": "Jewish"
+                                                },
+                                                {
+                                                    "label": "Islam",
+                                                    "value": "Muslim"
+                                                },
+                                                {
+                                                    "label": "Siciaeth",
+                                                    "value": "Sikh"
+                                                },
+                                                {
+                                                    "label": "Unrhyw grefydd arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "id": "religion-welsh-question",
+                                    "title": "Beth yw eich crefydd?",
+                                    "description": "Mae’r cwestiwn hwn yn wirfoddol",
+                                    "number": "21",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "religion-welsh-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Dim crefydd",
+                                                    "value": "No religion"
+                                                },
+                                                {
+                                                    "label": "Cristnogaeth (pob enwad)",
+                                                    "value": "Christian (all denominations)"
+                                                },
+                                                {
+                                                    "label": "Bwdhaeth",
+                                                    "value": "Buddhist"
+                                                },
+                                                {
+                                                    "label": "Hindŵaeth",
+                                                    "value": "Hindu"
+                                                },
+                                                {
+                                                    "label": "Iddewiaeth",
+                                                    "value": "Jewish"
+                                                },
+                                                {
+                                                    "label": "Islam",
+                                                    "value": "Muslim"
+                                                },
+                                                {
+                                                    "label": "Siciaeth",
+                                                    "value": "Sikh"
+                                                },
+                                                {
+                                                    "label": "Unrhyw grefydd arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "not equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "past-usual-address",
+                    "title": "past usual address",
+                    "sections": [
+                        {
+                            "id": "past-usual-address-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "past-usual-address-question",
+                                    "title": "Flwyddyn yn ôl, beth oedd eich cyfeiriad arferol?",
+                                    "number": "22",
+                                    "description": "Os nad oedd gennych gyfeiriad arferol flwyddyn yn ôl, nodwch y cyfeiriad lle’r oeddech yn aros",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "past-usual-address-answer",
+                                            "mandatory": false,
+                                            "guidance": "Yn y rhan fwyaf o achosion eich cyfeiriad arferol fydd y cartref parhaol neu gartref y teulu roeddech yn byw ynddo.",
+                                            "options": [
+                                                {
+                                                    "label": "Y cyfeiriad hwn",
+                                                    "value": "This address"
+                                                },
+                                                {
+                                                    "label": "Cyfeiriad myfyriwr yn ystod y tymor neu gyfeiriad ysgol breswyl yn y Deyrnas Unedig",
+                                                    "value": "Student term time or boarding school address in the UK"
+                                                },
+                                                {
+                                                    "label": "Cyfeiriad arall yn y Deyrnas Unedig",
+                                                    "value": "Another address in the UK"
+                                                },
+                                                {
+                                                    "label": "Cyfeiriad y tu allan i’r Deyrnas Unedig (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch enw’r wlad"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "last-year-address",
+                                "when": [
+                                    {
+                                        "id": "past-usual-address-answer",
+                                        "condition": "equals",
+                                        "value": "Student term time or boarding school address in the UK"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "last-year-address",
+                                "when": [
+                                    {
+                                        "id": "past-usual-address-answer",
+                                        "condition": "equals",
+                                        "value": "Another address in the UK"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "passports"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "last-year-address",
+                    "title": "last year address",
+                    "sections": [
+                        {
+                            "id": "last-year-address-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "last-year-address-question",
+                                    "title": "Nodwch fanylion eich cyfeiriad flwyddyn yn ôl",
+                                    "number": "22a",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "last-year-address-answer-building",
+                                            "label": "Adeilad",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "last-year-address-answer-street",
+                                            "label": "Stryd",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "last-year-address-answer-city",
+                                            "label": "Tref neu ddinas",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "last-year-address-answer-county",
+                                            "label": "Sir (dewisol)",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "last-year-address-answer-postcode",
+                                            "label": "Cod post",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "passports",
+                    "title": "passports",
+                    "sections": [
+                        {
+                            "id": "passports-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "passports-question",
+                                    "title": "Pa basbortau sydd gennych?",
+                                    "number": "23",
+                                    "description": "Dewiswch bob un sy’n berthnasol",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "passports-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Y Deyrnas Unedig",
+                                                    "value": "United Kingdom"
+                                                },
+                                                {
+                                                    "label": "Gwyddelig",
+                                                    "value": "Irish"
+                                                },
+                                                {
+                                                    "label": "Arall",
+                                                    "value": "Other"
+                                                },
+                                                {
+                                                    "label": "Dim",
+                                                    "value": "None"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "other-passports",
+                                "when": [
+                                    {
+                                        "id": "passports-answer",
+                                        "condition": "contains",
+                                        "value": "Other"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "disability"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "other-passports",
+                    "title": "Other passports",
+                    "sections": [
+                        {
+                            "id": "other-passports-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "other-passports-question",
+                                    "title": "Nodwch y pasbortau eraill sydd gennych",
+                                    "number": "23a",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "other-passports-answer",
+                                            "label": "Pasbortau sydd gennych",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "disability",
+                    "title": "disability",
+                    "sections": [
+                        {
+                            "id": "disability-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "disability-question",
+                                    "title": "A oes gennych broblem iechyd neu anabledd sydd wedi para neu sy’n debygol o bara am o leiaf 12 mis, ac sy’n cyfyngu ar eich gallu i wneud gweithgareddau arferol?",
+                                    "number": "24",
+                                    "guidance": [
+                                        {
+                                            "description": "<strong>Dylech gynnwys</strong> Problemau sy’n gysylltiedig â henaint"
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "disability-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Oes, yn cyfyngu’n fawr",
+                                                    "value": "Yes, limited a lot"
+                                                },
+                                                {
+                                                    "label": "Oes, yn cyfyngu ychydig",
+                                                    "value": "Yes, limited a little"
+                                                },
+                                                {
+                                                    "label": "Nac oes",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "household-member-completed",
+                                "when": [
+                                    {
+                                        "id": "over-16-answer",
+                                        "condition": "equals",
+                                        "value": "No"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "qualifications"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "qualifications",
+                    "title": "qualifications",
+                    "sections": [
+                        {
+                            "id": "qualifications-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "qualifications-england-question",
+                                    "title": "Gan feddwl am unrhyw astudiaethau, arholiadau neu gymwysterau, pa rai o’r canlynol sydd gennych?",
+                                    "number": "26",
+                                    "description": "Dewiswch bob opsiwn sy’n berthnasol (boed yn y Deyrnas Unedig neu’r hyn sy’n cyfateb iddo dramor) os oes gennych unrhyw rai o’r cymwysterau a restrir",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "qualifications-england-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "5 TGAU neu fwy (graddau A* i C) neu Lefel O (llwyddo) neu TAU (gradd 1), Tystysgrif Ysgol, Un Safon Uwch, 2 - 3 Safon UG neu TAA, Diploma Lefel Uwch",
+                                                    "value": "5 or more  GCSEs (grades A-Star to C) or O-Levels (passes) or CSEs (grade 1), School Certificate, One A-Level, 2 to 3 AS-Levels or VCEs, Higher Diploma"
+                                                },
+                                                {
+                                                    "label": "1 - 4 TGAU neu Lefel O neu TAU (unrhyw radd), Lefel Mynediad, Diploma Sylfaen",
+                                                    "value": "1 to 4 GCSEs or O-Levels or CSEs (any grades), Entry level, Foundation Diploma"
+                                                },
+                                                {
+                                                    "label": "2 neu fwy Safon Uwch, 4 neu fwy Safon UG neu TAA, Tystysgrif Ysgol Uwch, Diploma Pellach",
+                                                    "value": "2 or more  A-Levels, 4 or more  AS-levels or VCEs, Higher School Certificate, Advanced Diploma"
+                                                },
+                                                {
+                                                    "label": "Prentisiaeth (masnach, uwch, sylfaen neu fodern)",
+                                                    "value": "Apprenticeship (trade, advanced, foundation or modern)"
+                                                },
+                                                {
+                                                    "label": "NVQ lefel un, GNVQ Sylfaen, Sgiliau Sylfaenol",
+                                                    "value": "NVQ level one, Foundation GNVQ, Basic Skills"
+                                                },
+                                                {
+                                                    "label": "NVQ lefel dau, GNVQ Canolradd, Crefft City and Guilds, Diploma Cyntaf BTEC, Diploma RSA",
+                                                    "value": "NVQ level two, Intermediate GNVQ, City and Guilds Craft, BTEC First, RSA Diploma"
+                                                },
+                                                {
+                                                    "label": "NVQ Lefel tri, GNVQ Uwch, Crefft Uwch City and Guilds, ONC, OND, Diploma Cenedlaethol BTEC, Diploma Pellach RSA",
+                                                    "value": "NVQ Level three, Advanced GNVQ, City and Guilds Advanced Craft, ONC, OND, BTEC National, RSA Advanced Diploma"
+                                                },
+                                                {
+                                                    "label": "NVQ Lefel 4 - 5, HNC, HND, Diploma Uwch RSA, Diploma Uwch BTEC, Gradd Sylfaen",
+                                                    "value": "NVQ Level four to five, HNC, HND, RSA Higher Diploma, BTEC Higher, Foundation degree"
+                                                },
+                                                {
+                                                    "label": "Cymwysterau galwedigaethol neu gymwysterau cysylltiedig â gwaith eraill",
+                                                    "value": "Other vocational or work-related qualifications"
+                                                },
+                                                {
+                                                    "label": "Gradd Israddedig",
+                                                    "value": "Undergraduate Degree"
+                                                },
+                                                {
+                                                    "label": "Tystysgrif / Diploma Ôl-raddedig",
+                                                    "value": "Postgraduate Certificate / Diploma"
+                                                },
+                                                {
+                                                    "label": "Gradd Meistr",
+                                                    "value": "Masters Degree"
+                                                },
+                                                {
+                                                    "label": "Doethuriaeth (er enghraifft PhD)",
+                                                    "value": "Doctorate Degree (for example PhD)"
+                                                },
+                                                {
+                                                    "label": "Cymhwyster proffesiynol (er enghraifft addysgu, nyrsio, cyfrifyddiaeth)",
+                                                    "value": "Professional qualification (for example teaching, nursing, accountancy)"
+                                                },
+                                                {
+                                                    "label": "Cymwysterau tramor (heb wybod beth sy’n cyfateb iddynt yn y Deyrnas Unedig)",
+                                                    "value": "Foreign qualifications (UK equivalent not known)"
+                                                },
+                                                {
+                                                    "label": "Dim cymwysterau",
+                                                    "value": "No qualifications"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "id": "qualifications-welsh-question",
+                                    "title": "Gan feddwl am unrhyw astudiaethau, arholiadau neu gymwysterau, pa rai o’r canlynol sydd gennych?",
+                                    "number": "26",
+                                    "description": "Dewiswch bob opsiwn sy’n berthnasol (boed yn y Deyrnas Unedig neu’r hyn sy’n cyfateb iddo dramor) os oes gennych unrhyw rai o’r cymwysterau a restrir",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "qualifications-welsh-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "5 TGAU neu fwy (graddau A* i C) neu Lefel O (llwyddo) neu TAU (gradd 1), Tystysgrif Ysgol, Un Safon Uwch, 2 - 3 Safon UG neu TAA,  Diploma Canolradd neu Genedlaethol Bagloriaeth Cymru (Lefel dau)",
+                                                    "value": "5 or more GCSEs (grades A-Star to C) or O Levels (passes) or CSEs (grade 1), School Certificate, One A-Level, 2 to 3 AS-Levels or VCEs,  Intermediate or National Welsh Baccalaureate (Level two)"
+                                                },
+                                                {
+                                                    "label": "1 - 4  TGAU neu Lefel O neu TAU (unrhyw radd), Lefel Mynediad, Diploma Sylfaen Bagloriaeth Cymru (lefel un)",
+                                                    "value": "1 to 4  GCSEs or O Levels or CSEs (any grades), Entry level, Foundation Welsh Baccalaureate (level one)"
+                                                },
+                                                {
+                                                    "label": "Mwy na 2 Safon Uwch, mwy na 4 Safon UG neu TAA, Tystysgrif Ysgol Uwch, Diploma Uwch Bagloriaeth Cymru (lefel tri)",
+                                                    "value": "More than 2 A-Levels, more than 4 AS-levels or VCEs, Higher School Certificate, Advanced Welsh Baccalaureate (level three)"
+                                                },
+                                                {
+                                                    "label": "Prentisiaeth (sylfaen, modern neu uwch)",
+                                                    "value": "Apprenticeship (foundation, modern or higher)"
+                                                },
+                                                {
+                                                    "label": "NVQ lefel un, GNVQ Sylfaen, Sgiliau Hanfodol neu Allweddol",
+                                                    "value": "NVQ level one, Foundation GNVQ, Essential or Key  Skills"
+                                                },
+                                                {
+                                                    "label": "NVQ lefel dau, GNVQ Canolradd, Crefft City and Guilds, Diploma Cyntaf BTEC, Diploma RSA",
+                                                    "value": "NVQ level two, Intermediate GNVQ, City and Guilds Craft, BTEC First, RSA Diploma"
+                                                },
+                                                {
+                                                    "label": "NVQ Lefel tri, GNVQ Uwch, Crefft Uwch City and Guilds, ONC, OND, Diploma Cenedlaethol BTEC, Diploma Pellach RSA",
+                                                    "value": "NVQ Level three, Advanced GNVQ, City and Guilds Advanced Craft, ONC, OND, BTEC National, RSA Advanced Diploma"
+                                                },
+                                                {
+                                                    "label": "NVQ Lefel 4 - 5, HNC, HND, Diploma Uwch RSA, Diploma Uwch BTEC",
+                                                    "value": "NVQ Level four to five, HNC, HND, RSA Higher Diploma, BTEC Higher"
+                                                },
+                                                {
+                                                    "label": "Cymwysterau galwedigaethol neu gymwysterau cysylltiedig â gwaith eraill",
+                                                    "value": "Other vocational or work-related qualifications"
+                                                },
+                                                {
+                                                    "label": "Gradd Israddedig",
+                                                    "value": "Undergraduate Degree"
+                                                },
+                                                {
+                                                    "label": "Tystysgrif / Diploma Ôl-raddedig",
+                                                    "value": "Postgraduate Certificate / Diploma"
+                                                },
+                                                {
+                                                    "label": "Gradd Meistr",
+                                                    "value": "Masters Degree"
+                                                },
+                                                {
+                                                    "label": "Doethuriaeth (er enghraifft PhD)",
+                                                    "value": "Doctorate Degree (for example PhD)"
+                                                },
+                                                {
+                                                    "label": "Cymhwyster proffesiynol (er enghraifft addysgu, nyrsio, cyfrifyddiaeth)",
+                                                    "value": "Professional qualification (for example teaching, nursing, accountancy)"
+                                                },
+                                                {
+                                                    "label": "Cymwysterau tramor (heb wybod beth sy’n cyfateb iddynt yn y Deyrnas Unedig)",
+                                                    "value": "Foreign qualifications (UK equivalent not known)"
+                                                },
+                                                {
+                                                    "label": "Dim cymwysterau",
+                                                    "value": "No qualifications"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "not equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "volunteering",
+                    "title": "volunteering",
+                    "sections": [
+                        {
+                            "id": "volunteering-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "volunteering-question",
+                                    "title": "Gan ystyried y 12 mis a aeth heibio, ydych chi wedi gwirfoddoli ar gyfer unrhyw grwpiau, clybiau neu sefydliadau?",
+                                    "number": "27",
+                                    "guidance": [
+                                        {
+                                            "description": "<strong>Ni ddylech gynnwys</strong> unrhyw weithgareddau a orchmynnwyd gan lys"
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "volunteering-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Nac ydw",
+                                                    "value": "No"
+                                                },
+                                                {
+                                                    "label": "Ydw, o leiaf unwaith yr wythnos",
+                                                    "value": "Yes, at least once a week"
+                                                },
+                                                {
+                                                    "label": "Ydw, llai nag unwaith yr wythnos ond o leiaf unwaith y mis",
+                                                    "value": "Yes, less than once a week but at least once a month"
+                                                },
+                                                {
+                                                    "label": "Ydw, yn llai aml",
+                                                    "value": "Yes, less often"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "employment-type",
+                    "title": "employment type",
+                    "sections": [
+                        {
+                            "id": "employment-type-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "employment-type-question",
+                                    "title": "Yr wythnos diwethaf a oeddech:",
+                                    "number": "28",
+                                    "description": "Dewiswch bob un sy’n berthnasol",
+                                    "guidance": [
+                                        {
+                                            "description": "<strong>Nodwch</strong> unrhyw waith am dâl, gan gynnwys gwaith achlysurol neu dros dro, hyd yn oed os oedd ond am awr"
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "employment-type-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "yn weithiwr cyflogedig?",
+                                                    "value": "working as an employee?"
+                                                },
+                                                {
+                                                    "label": "ar gynllun hyfforddi a noddir gan y llywodraeth?",
+                                                    "value": "on a government sponsored training scheme?"
+                                                },
+                                                {
+                                                    "label": "yn hunan-gyflogedig neu’n gweithio ar eich liwt eich hun?",
+                                                    "value": "self-employed or freelance?"
+                                                },
+                                                {
+                                                    "label": "yn gweithio am dâl neu’n ddi-dâl i’ch busnes eich hun neu i fusnes eich teulu?",
+                                                    "value": "working paid or unpaid for you own or your family’s business?"
+                                                },
+                                                {
+                                                    "label": "i ffwrdd o’ch gwaith yn sâl, ar gyfnod mamolaeth, ar eich gwyliau, neu wedi’ch cadw  o’ch gwaith dros dro am na all eich cyflogwr gynnig gwaith ar hyn o bryd?",
+                                                    "value": "away from work ill, on maternity leave, on holiday or temporarily laid off?"
+                                                },
+                                                {
+                                                    "label": "yn gwneud unrhyw fath arall o waith am dâl?",
+                                                    "value": "doing any other kind of paid work?"
+                                                },
+                                                {
+                                                    "label": "dim un o’r uchod?",
+                                                    "value": "none of the above?"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "main-job",
+                                "when": [
+                                    {
+                                        "id": "employment-type-answer",
+                                        "condition": "contains",
+                                        "value": "working as an employee?"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "main-job",
+                                "when": [
+                                    {
+                                        "id": "employment-type-answer",
+                                        "condition": "contains",
+                                        "value": "on a government sponsored training scheme?"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "main-job",
+                                "when": [
+                                    {
+                                        "id": "employment-type-answer",
+                                        "condition": "contains",
+                                        "value": "self-employed or freelance?"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "main-job",
+                                "when": [
+                                    {
+                                        "id": "employment-type-answer",
+                                        "condition": "contains",
+                                        "value": "working paid or unpaid for you own or your family’s business?"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "main-job",
+                                "when": [
+                                    {
+                                        "id": "employment-type-answer",
+                                        "condition": "contains",
+                                        "value": "away from work ill, on maternity leave, on holiday or temporarily laid off?"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "main-job",
+                                "when": [
+                                    {
+                                        "id": "employment-type-answer",
+                                        "condition": "contains",
+                                        "value": "doing any other kind of paid work?"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "jobseeker"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "jobseeker",
+                    "title": "jobseeker",
+                    "sections": [
+                        {
+                            "id": "jobseeker-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "jobseeker-question",
+                                    "title": "A oeddech wrthi’n chwilio am unrhyw fath o waith am dâl yn ystod y pedair wythnos diwethaf?",
+                                    "number": "29",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "jobseeker-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Oeddwn",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "Nac oeddwn",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "job-availability",
+                    "title": "job availability",
+                    "sections": [
+                        {
+                            "id": "job-availability-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "job-availability-question",
+                                    "title": "Petai swydd wedi bod ar gael yr wythnos diwethaf, a fyddech wedi gallu dechrau arni o fewn pythefnos?",
+                                    "number": "30",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "job-availability-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Byddwn",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "Na fyddwn",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "job-pending",
+                    "title": "job pending",
+                    "sections": [
+                        {
+                            "id": "job-pending-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "job-pending-question",
+                                    "title": "Yr wythnos diwethaf, a oeddech yn aros i ddechrau swydd yr oeddech eisoes wedi’i chael?",
+                                    "number": "31",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "job-pending-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Oeddwn",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "Nac oeddwn",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "occupation",
+                    "title": "occupation",
+                    "sections": [
+                        {
+                            "id": "occupation-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "occupation-question",
+                                    "title": "Yr wythnos diwethaf, a oeddech:",
+                                    "number": "32",
+                                    "description": "Dewiswch bob un sy’n berthnasol",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "occupation-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "wedi ymddeol (p’un a oeddech yn cael pensiwn ai peidio)?",
+                                                    "value": "retired (whether receiving a pension or not)?"
+                                                },
+                                                {
+                                                    "label": "yn fyfyriwr?",
+                                                    "value": "a student?"
+                                                },
+                                                {
+                                                    "label": "yn gofalu am y cartref neu am y teulu?",
+                                                    "value": "looking after home or family?"
+                                                },
+                                                {
+                                                    "label": "yn sâl neu wedi bod yn anabl am gyfnod hir?",
+                                                    "value": "long-term sick or disabled?"
+                                                },
+                                                {
+                                                    "label": "arall",
+                                                    "value": "other"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "ever-worked",
+                    "title": "ever worked",
+                    "sections": [
+                        {
+                            "id": "ever-worked-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "ever-worked-question",
+                                    "title": "A ydych wedi gweithio erioed?",
+                                    "number": "33",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "ever-worked-answer",
+                                            "mandatory": false,
+                                            "guidance": "<p>Os oedd gennych swydd llawn amser neu ran amser yn y gorffennol dewiswch ‘Ydw’</p><p>Mae hyn yn cynnwys gwaith y tu allan i’r Deyrnas Unedig.</p><p>Rhowch ateb hyd yn oed os ydych wedi ymddeol.</p><p>Os nad ydych wedi gweithio erioed, neu ond wedi gwneud gwaith gwirfoddol/di-dâl, dewiswch ‘Nac ydw’.</p>",
+                                            "options": [
+                                                {
+                                                    "label": "Ydw",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "Nac ydw",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "household-member-completed",
+                                "when": [
+                                    {
+                                        "id": "ever-worked-answer",
+                                        "condition": "equals",
+                                        "value": "No"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "main-job"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "main-job",
+                    "title": "main job",
+                    "sections": [
+                        {
+                            "id": "main-job-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "main-job-question",
+                                    "title": "Yn eich prif swydd, a ydych (oeddech):",
+                                    "number": "35",
+                                    "guidance": [
+                                        {
+                                            "description": "<p>Os nad ydych yn gweithio atebwch y cwestiynau sy’n weddill am eich prif swydd ddiwethaf.</p><p>Eich prif swydd yw’r swydd yr ydych (oeddech) fel arfer yn gweithio’r nifer fwyaf o oriau ynddi </p>"
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "main-job-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "yn weithiwr cyflogedig?",
+                                                    "value": "an employee?"
+                                                },
+                                                {
+                                                    "label": "yn hunan-gyflogedig neu’n llawrydd heb gyflogi gweithwyr eraill?",
+                                                    "value": "self-employed or freelance without employees?"
+                                                },
+                                                {
+                                                    "label": "yn hunan-gyflogedig ac yn cyflogi gweithwyr eraill?",
+                                                    "value": "self-employed with employees?"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "job-title",
+                    "title": "job title",
+                    "sections": [
+                        {
+                            "id": "job-title-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "job-title-question",
+                                    "title": "Beth yw (oedd) teitl llawn a phenodol eich swydd?",
+                                    "number": "36",
+                                    "guidance": [
+                                        {
+                                            "description": "<p>Er enghraifft, <b>athro ysgol gynradd, mecanydd ceir, nyrs ardal, peiriannydd strwythurol</b></p><p>Peidiwch â nodi eich gradd na’ch band cyflog</p>"
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "job-title-answer",
+                                            "label": "Teitl swydd",
+                                            "mandatory": false,
+                                            "guidance": "<p>Nodwch deitl eich swydd yn y man a ddarperir.</p><p>Peidiwch â nodi eich gradd na’ch band cyflog.</p><p>Os nad ydych yn siŵr beth yw teitl eich swydd rhowch y wybodaeth orau bosibl.</p>",
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "job-description",
+                    "title": "job description",
+                    "sections": [
+                        {
+                            "id": "job-description-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "job-description-question",
+                                    "title": "Beth ydych (oeddech) chi’n ei wneud yn eich prif swydd.",
+                                    "number": "37",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "job-description-answer",
+                                            "label": "Disgrifiad",
+                                            "mandatory": false,
+                                            "guidance": "<p>Rhowch ddisgrifiad byr o beth ydych (oeddech) chi’n ei wneud yn eich prif swydd. Eich prif swydd yw’r swydd yr ydych (oeddech) fel arfer yn gweithio’r nifer fwyaf o oriau ynddi.</p><p>Rhowch y wybodaeth orau bosibl hyd yn oed os nad ydych yn siŵr o’r holl fanylion neu’n methu â‘u cofio.</p>",
+                                            "type": "TextArea"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "employers-business",
+                    "title": "employers business",
+                    "sections": [
+                        {
+                            "id": "employers-business-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "employers-business-question",
+                                    "title": "Yn eich gweithle, beth yw (oedd) prif weithgarwch eich cyflogwr neu’ch busnes?",
+                                    "number": "38",
+                                    "guidance": [
+                                        {
+                                            "list": [
+                                                "Er enghraifft, <b>addysg gynradd, trwsio ceir, arlwyo cytundebol, trin cyfrifiaduron</b>",
+                                                "Os ydych (oeddech) yn was sifil, ysgrifennwch <b>llywodraeth</b>",
+                                                "Os ydych (oeddech) yn swyddog llywodraeth leol, ysgrifennwch <b>llywodraeth leol</b> a rhowch enw’r adran o fewn yr awdurdod lleol"
+                                            ]
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "employers-business-answer",
+                                            "label": "Disgrifiad",
+                                            "mandatory": false,
+                                            "guidance": "<p>Nodwch brif weithgarwch eich cyflogwr neu’ch busnes.</p><p>Ffordd arall o ddisgrifio’r prif weithgarwch yw’r diwydiant y mae’ch cyflogwr neu’ch busnes yn gweithio ynddo.</p><p>Os nad ydych yn siŵr beth yw prif weithgarwch eich cyflogwr neu’ch busnes rhowch y wybodaeth orau bosibl.</p><p>Os ydych wedi’ch cyflogi drwy asiantaeth nodwch brif weithgarwch y busnes rydych yn gweithio iddo, nid yr asiantaeth.</p>",
+                                            "type": "TextArea"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "main-job-type",
+                    "title": "main job type",
+                    "sections": [
+                        {
+                            "id": "main-job-type-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "main-job-type-question",
+                                    "title": "Yn eich prif swydd, a ydych (oeddech):",
+                                    "number": "39",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "main-job-type-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yn weithiwr cyflogedig mewn sefydliad neu fusnes",
+                                                    "value": "Employed by an organisation or business"
+                                                },
+                                                {
+                                                    "label": "Yn hunan-gyflogedig yn eich sefydliad neu’ch busnes eich hun",
+                                                    "value": "Self-employed in your own organisation or business"
+                                                },
+                                                {
+                                                    "label": "Ddim yn gweithio i sefydliad na busnes",
+                                                    "value": "Not working for an organisation or business",
+                                                    "description": "Er enghraifft yn hunan-gyflogedig, yn gweithio ar eich liwt eich hun neu’n (arfer) gweithio i unigolyn preifat"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "household-member-completed",
+                                "when": [
+                                    {
+                                        "id": "main-job-type-answer",
+                                        "condition": "equals",
+                                        "value": "Not working for an organisation or business"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "business-name"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "business-name",
+                    "title": "business name",
+                    "sections": [
+                        {
+                            "id": "business-name-section",
+                            "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "business-name-question",
+                                    "title": "Yn eich prif swydd, beth yw (oedd) enw’r sefydliad neu’r busnes yr ydych (oeddech) yn gweithio iddo?",
+                                    "number": "39a",
+                                    "guidance": [
+                                        {
+                                            "description": "Os ydych (oeddech) yn hunan-gyflogedig yn eich sefydliad neu’ch busnes eich hun, nodwch yr enw"
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "business-name-answer",
+                                            "label": "Enw’r sefydliad neu’r busnes",
+                                            "mandatory": false,
+                                            "guidance": "<p>Mae’r cwestiwn hwn yn gofyn am enw’r sefydliad neu’r busnes yr ydych (oeddech) yn gweithio iddo fel eich prif swydd.</p><p>Os na allwch gofio enw’r sefydliad, rhowch y wybodaeth orau bosibl.</p><p>Os ydych wedi’ch cyflogi drwy asiantaeth nodwch enw’r busnes rydych yn gweithio iddo, nid yr asiantaeth.</p>",
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "interstitial",
+                    "id": "household-member-completed",
+                    "title": "You have completed:",
+                    "sections": [
+                        {
+                            "title": "Nid oes rhagor o gwestiynau ar gyfer {{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                            "id": "household-member-completed-section",
+                            "questions": []
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "visitors",
+            "title": "Ymwelwyr",
+            "highlight_when": [
+                "visitors-interstitial"
+            ],
+            "completed_id": "visitors-completed",
+            "routing_rules": [
+                {
+                    "repeat": {
+                        "type": "answer_value",
+                        "answer_id": "overnight-visitors-answer"
+                    }
+                }
+            ],
+            "blocks": [
+                {
+                    "type": "interstitial",
+                    "id": "visitor-begin",
+                    "title": "Visitor begin",
+                    "sections": [
+                        {
+                            "id": "visitor-begin-section",
+                            "title": "Mae’r adran nesaf yn cynnwys cwestiynau ar gyfer Ymwelydd {{group_instance + 1}}",
+                            "questions": [
+                                {
+                                    "answers": [],
+                                    "id": "visitor-begin-question",
+                                    "title": "",
+                                    "type": "General"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "visitor-name",
+                    "title": "Visitors",
+                    "sections": [
+                        {
+                            "id": "visitor-name-section",
+                            "title": "Ymwelydd {{group_instance + 1}}",
+                            "questions": [
+                                {
+                                    "id": "visitor-name-question",
+                                    "title": "Beth yw enw ymwelydd {{group_instance + 1}}?",
+                                    "number": "1",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "visitor-first-name",
+                                            "label": "Enw cyntaf",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "visitor-last-name",
+                                            "label": "Cyfenw",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "visitor-sex",
+                    "title": "visitor sex",
+                    "sections": [
+                        {
+                            "id": "visitor-sex-section",
+                            "title": "Ymwelydd {{group_instance + 1}}",
+                            "questions": [
+                                {
+                                    "id": "visitor-sex-question",
+                                    "title": "Beth yw rhyw’r person hwn?",
+                                    "number": "2",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "visitor-sex-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Gwryw",
+                                                    "value": "Male"
+                                                },
+                                                {
+                                                    "label": "Benyw",
+                                                    "value": "Female"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "visitor-date-of-birth",
+                    "title": "Visitor {{group_instance + 1}}",
+                    "sections": [
+                        {
+                            "id": "visitor-date-of-birth-section",
+                            "title": "Ymwelydd {{group_instance + 1}}",
+                            "questions": [
+                                {
+                                    "id": "visitor-date-of-birth-question",
+                                    "title": "Beth yw dyddiad geni’r person hwn?",
+                                    "number": "3",
+                                    "description": "Er enghraifft 20 Mawrth 1980",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "visitor-date-of-birth-answer",
+                                            "mandatory": false,
+                                            "type": "Date",
+                                            "validation": {
+                                                "messages": {
+                                                    "INVALID_DATE": "Nid yw’r dyddiad a roddwyd yn ddilys. Cywirwch eich ateb"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "visitor-uk-resident",
+                    "title": "Visitor {{group_instance + 1}}",
+                    "sections": [
+                        {
+                            "id": "visitor-uk-resident-section",
+                            "title": "Ymwelydd {{group_instance + 1}}",
+                            "questions": [
+                                {
+                                    "id": "visitor-uk-resident-question",
+                                    "title": "A yw’r person hwn fel arfer yn byw yn y Deyrnas Unedig?",
+                                    "number": "4",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "visitor-uk-resident-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Ydy, mae fel arfer yn byw yn y Deyrnas Unedig",
+                                                    "value": "Yes, usually lives in the United Kingdom"
+                                                },
+                                                {
+                                                    "label": "Nac ydy, mae fel arfer yn byw y tu allan i’r Deyrnas Unedig (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch y wlad"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "visitor-address",
+                                "when": [
+                                    {
+                                        "id": "visitor-uk-resident-answer",
+                                        "condition": "equals",
+                                        "value": "Yes, usually lives in the United Kingdom"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "visitor-completed"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "visitor-address",
+                    "title": "Visitors",
+                    "sections": [
+                        {
+                            "id": "visitor-address-section",
+                            "title": "Ymwelydd {{group_instance + 1}}",
+                            "questions": [
+                                {
+                                    "id": "visitor-address-question",
+                                    "title": "Rhowch fanylion cyfeiriad arferol y person hwn yn y Deyrnas Unedig",
+                                    "number": "4a",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "visitor-address-answer-building",
+                                            "label": "Adeilad",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "visitor-address-answer-street",
+                                            "label": "Stryd",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "visitor-address-answer-city",
+                                            "label": "Tref neu ddinas",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "visitor-address-answer-county",
+                                            "label": "Sir (dewisol)",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "visitor-address-answer-postcode",
+                                            "label": "Cod post",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "interstitial",
+                    "id": "visitor-completed",
+                    "title": "Visitor completed",
+                    "sections": [
+                        {
+                            "title": "Rydych wedi cwblhau pob cwestiwn ar gyfer Ymwelydd {{group_instance + 1}}",
+                            "id": "visitor-completed-section",
+                            "questions": []
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "visitors-interstitial",
+            "title": "Ymwelwyr",
+            "hide_in_navigation": true,
+            "blocks": [
+                {
+                    "type": "interstitial",
+                    "id": "visitors-completed",
+                    "title": "",
+                    "sections": [
+                        {
+                            "id": "visitors-completed-section",
+                            "questions": [
+                                {
+                                    "description": "",
+                                    "answers": [],
+                                    "id": "visitors-completed-question",
+                                    "title": "",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Rydych wedi cwblhau’r adran ‘Ymwelwyr’ yn llwyddiannus"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "questionnaire-completed",
+            "title": "Questionnaire Completed",
+            "hide_in_navigation": true,
+            "blocks": [
+                {
+                    "type": "interstitial",
+                    "id": "confirmation",
+                    "title": "You’re ready to submit your 2017 Census Test",
+                    "sections": [
+                        {
+                            "title": "Rydych yn barod i gyflwyno Prawf Cyfrifiad 2017",
+                            "id": "questionnaire-completed-section",
+                            "description": "<p>Diolch am gymryd rhan ym Mhrawf Cyfrifiad 2017.</p>",
+                            "questions": [
+                                {
+                                    "answers": [],
+                                    "id": "questionnaire-completed-question",
+                                    "title": "",
+                                    "type": "General",
+                                    "guidance": [
+                                        {
+                                            "title": "Nodwch:",
+                                            "list": [
+                                                "Drwy gyflwyno’ch ymatebion, rydych yn datgan eich bod wedi cwblhau’r prawf hyd eithaf eich gwybodaeth a’ch cred.",
+                                                "Os na fyddwch yn cyflwyno’ch ymatebion, byddant yn cael eu cyflwyno’n awtomatig pan fydd Prawf Cyfrifiad 2017 yn cau.",
+                                                "Ar ôl eu cyflwyno cewch gyfle i roi adborth ar eich profiad."
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/app/data/cy/census_individual.json
+++ b/app/data/cy/census_individual.json
@@ -1,0 +1,3230 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "questionnaire_id": "",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "census",
+    "title": "Census England Individual Schema",
+    "description": "Census England Individual Schema",
+    "theme": "census",
+    "eq_id": "census",
+    "groups": [
+        {
+            "id": "household-member",
+            "title": "Household Member Details",
+            "blocks": [
+                {
+                    "type": "questionnaire",
+                    "id": "correct-name",
+                    "title": "Correct name",
+                    "sections": [
+                        {
+                            "id": "correct-name-section",
+                            "title": "",
+                            "questions": [
+                                {
+                                    "id": "correct-name-question",
+                                    "title": "Beth yw eich enw?",
+                                    "number": "1a",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "alias": "first_name",
+                                            "id": "first-name",
+                                            "label": "Enw cyntaf",
+                                            "mandatory": true,
+                                            "type": "TextField",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Nodwch enw"
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "alias": "middle_names",
+                                            "id": "middle-names",
+                                            "label": "Enwau canol",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "alias": "last_name",
+                                            "id": "last-name",
+                                            "label": "Cyfenw",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "sex",
+                    "title": "Sex",
+                    "sections": [
+                        {
+                            "id": "sex-section",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "sex-question",
+                                    "title": "Beth yw eich rhyw?",
+                                    "number": "2",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "sex-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Gwryw",
+                                                    "value": "Male"
+                                                },
+                                                {
+                                                    "label": "Benyw",
+                                                    "value": "Female"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "date-of-birth",
+                    "title": "Date of birth",
+                    "sections": [
+                        {
+                            "id": "date-of-birth-section",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "date-of-birth-question",
+                                    "title": "Beth yw dyddiad eich geni?",
+                                    "number": "3",
+                                    "description": "Er enghraifft 20 Mawrth 1980",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "date-of-birth-answer",
+                                            "mandatory": false,
+                                            "type": "Date",
+                                            "validation": {
+                                                "messages": {
+                                                    "INVALID_DATE": "Nid yw’r dyddiad a roddwyd yn ddilys.  Cywirwch eich ateb"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "marital-status",
+                    "title": "Marital status",
+                    "sections": [
+                        {
+                            "id": "marital-status-section",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "marital-status-question",
+                                    "title": "Ar 9 Ebrill 2017, beth, yn gyfreithiol, yw’ch statws priodasol neu statws eich partneriaeth sifil o’r un rhyw?",
+                                    "number": "4",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "marital-status-answer",
+                                            "mandatory": false,
+                                            "guidance": "<p>Atebwch yn ôl eich statws ar 9 Ebrill 2017.</p><p>Atebwch y cwestiwn hwn ar gyfer plant, er nad ydynt efallai yn ddigon hen i briodi nac i ffurfio partneriaeth sifil o’r un rhyw.</p><p>Os oeddech yn briod (neu wedi ffurfio partneriaeth gofrestredig o’r un rhyw) dramor, a bod hyn yn eich galluogi i gael eich cydnabod yn briod neu mewn partneriaeth sifil yn y Deyrnas Unedig, atebwch y cwestiwn gan adlewyrchu’r bartneriaeth gyfreithiol honno.</p>",
+                                            "options": [
+                                                {
+                                                    "label": "Erioed wedi priodi na chofrestru partneriaeth sifil o’r un rhyw",
+                                                    "value": "Never married and never registered a same-sex civil partnership"
+                                                },
+                                                {
+                                                    "label": "Priod",
+                                                    "value": "Married"
+                                                },
+                                                {
+                                                    "label": "Mewn partneriaeth sifil gofrestredig o’r un rhyw",
+                                                    "value": "In a registered same-sex civil partnership"
+                                                },
+                                                {
+                                                    "label": "Wedi gwahanu, ond yn gyfreithiol yn dal i fod yn briod",
+                                                    "value": "Separated, but still legally married"
+                                                },
+                                                {
+                                                    "label": "Wedi gwahanu, ond yn gyfreithiol yn dal i fod mewn partneriaeth sifil o’r un rhyw",
+                                                    "value": "Separated, but still legally in a same-sex civil partnership"
+                                                },
+                                                {
+                                                    "label": "Wedi ysgaru",
+                                                    "value": "Divorced"
+                                                },
+                                                {
+                                                    "label": "Wedi bod mewn partneriaeth sifil o’r un rhyw sydd bellach wedi’i diddymu’n gyfreithiol",
+                                                    "value": "Formerly in a same-sex civil partnership which is now legally dissolved"
+                                                },
+                                                {
+                                                    "label": "Gweddw",
+                                                    "value": "Widowed"
+                                                },
+                                                {
+                                                    "label": "Wedi colli partner sifil o’r un rhyw trwy farwolaeth",
+                                                    "value": "Surviving partner from a same-sex civil partnership"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "another-address",
+                    "title": "Another address",
+                    "sections": [
+                        {
+                            "id": "another-address-section",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "another-address-question",
+                                    "title": "A ydych yn aros mewn cyfeiriad arall am fwy na 30 diwrnod y flwyddyn?",
+                                    "number": "5",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "another-address-answer",
+                                            "mandatory": false,
+                                            "guidance": "<p>Gall yr enghreifftiau gynnwys cyfeiriad rhiant arall, cyfeiriad un o ganolfannau’r lluoedd arfog, tŷ gwyliau, neu gyfeiriad yn ystod y tymor.</p><p>Nid oes rhaid i’r diwrnodau rydych yn aros yn y cyfeiriad fod un ar ôl y llall.  Gallant fod ar unrhyw adeg o’r flwyddyn.</p>",
+                                            "options": [
+                                                {
+                                                    "label": "Nac ydw",
+                                                    "value": "No"
+                                                },
+                                                {
+                                                    "label": "Ydw, cyfeiriad yn y Deyrnas Unedig",
+                                                    "value": "Yes, an address within the UK"
+                                                },
+                                                {
+                                                    "label": "Ydw, cyfeiriad y tu allan i’r Deyrnas Unedig (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch enw’r wlad"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "in-education",
+                                "when": [
+                                    {
+                                        "id": "another-address-answer",
+                                        "condition": "equals",
+                                        "value": "No"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "other-address",
+                                "when": [
+                                    {
+                                        "id": "another-address-answer",
+                                        "condition": "equals",
+                                        "value": "Yes, an address within the UK"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "address-type",
+                                "when": [
+                                    {
+                                        "id": "another-address-answer",
+                                        "condition": "equals",
+                                        "value": "Other"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "address-type",
+                                "when": [
+                                    {
+                                        "id": "another-address-answer",
+                                        "condition": "not equals",
+                                        "value": "Other"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "in-education"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "other-address",
+                    "title": "Other address",
+                    "sections": [
+                        {
+                            "id": "other-address-section",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "other-address-question",
+                                    "title": "Rhowch fanylion y cyfeiriad arall yn y Deyrnas Unedig lle rydych yn aros am fwy na 30 diwrnod y flwyddyn",
+                                    "number": "5a",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "other-address-answer-building",
+                                            "label": "Adeilad",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "other-address-answer-street",
+                                            "label": "Stryd",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "other-address-answer-city",
+                                            "label": "Tref neu ddinas",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "other-address-answer-county",
+                                            "label": "Sir (dewisol)",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "other-address-answer-postcode",
+                                            "label": "Cod post",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "address-type",
+                    "title": "Address type",
+                    "sections": [
+                        {
+                            "id": "address-type-section",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "address-type-question",
+                                    "title": "Pa fath o gyfeiriad yw’r cyfeiriad hwnnw?",
+                                    "number": "6",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "address-type-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Cyfeiriad un o ganolfannau’r lluoedd arfog",
+                                                    "value": "Armed forces base address"
+                                                },
+                                                {
+                                                    "label": "Cyfeiriad arall wrth weithio oddi cartref",
+                                                    "value": "Another address when working away from home"
+                                                },
+                                                {
+                                                    "label": "Cyfeiriad cartref myfyriwr",
+                                                    "value": "Student’s home address"
+                                                },
+                                                {
+                                                    "label": "Cyfeiriad myfyriwr yn ystod y tymor",
+                                                    "value": "Student’s term time address"
+                                                },
+                                                {
+                                                    "label": "Cyfeiriad cartref rhiant neu warcheidwad arall",
+                                                    "value": "Another parent or guardian’s address"
+                                                },
+                                                {
+                                                    "label": "Cyfeiriad tŷ gwyliau",
+                                                    "value": "Holiday home"
+                                                },
+                                                {
+                                                    "label": "Arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch y math o gyfeiriad"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "in-education",
+                    "title": "In education",
+                    "sections": [
+                        {
+                            "id": "in-education-section",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "in-education-question",
+                                    "title": "A ydych yn blentyn ysgol neu’n fyfyriwr mewn addysg amser llawn?",
+                                    "number": "7",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "in-education-answer",
+                                            "mandatory": false,
+                                            "guidance": "<p>Ystyrir bod y canlynol mewn addysg amser llawn:</p><p>Plant o dan 16 oed</p><p>Pobl ifanc 16-18 oed os ydynt yn mynychu mwy na 12 awr yr wythnos o astudiaethau ar gwrs hyd at ac yn cynnwys Safon Uwch</p><p>Unrhyw un sydd ar gwrs uwchlaw Safon Uwch os yw’n astudio mewn sefydliad yn y Deyrnas Unedig, ar gwrs sydd</p><ul><li>yn para o leiaf un flwyddyn academaidd</li><li>yn cynnwys o leiaf 24 wythnos y flwyddyn, ac</li><li>yn cynnwys o leiaf 21 awr yr wythnos o astudiaethau, dosbarthiadau neu brofiad gwaith yn ystod y tymor (gan gynnwys astudiaethau distrwythur)</li></ul>",
+                                            "options": [
+                                                {
+                                                    "label": "Ydw",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "Nac ydw",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "term-time-location",
+                                "when": [
+                                    {
+                                        "id": "in-education-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "country-of-birth"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "term-time-location",
+                    "title": "Term time location",
+                    "sections": [
+                        {
+                            "id": "term-time-location-section",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "term-time-location-question",
+                                    "title": "Yn ystod y tymor a ydych yn byw:",
+                                    "number": "8",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "term-time-location-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "yma, yn y cyfeiriad hwn",
+                                                    "value": "here, at this address"
+                                                },
+                                                {
+                                                    "label": "mewn cyfeiriad arall",
+                                                    "value": "at another address"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "confirmation",
+                                "when": [
+                                    {
+                                        "id": "term-time-location-answer",
+                                        "condition": "equals",
+                                        "value": "at another address"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "country-of-birth"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "country-of-birth",
+                    "title": "Country of birth",
+                    "sections": [
+                        {
+                            "id": "country-of-birth-section",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "country-of-birth-england-question",
+                                    "title": "Ym mha wlad y cawsoch eich geni?",
+                                    "number": "9",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "country-of-birth-england-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Lloegr",
+                                                    "value": "England"
+                                                },
+                                                {
+                                                    "label": "Cymru",
+                                                    "value": "Wales"
+                                                },
+                                                {
+                                                    "label": "Yr Alban",
+                                                    "value": "Scotland"
+                                                },
+                                                {
+                                                    "label": "Gogledd Iwerddon",
+                                                    "value": "Northern Ireland"
+                                                },
+                                                {
+                                                    "label": "Gweriniaeth Iwerddon",
+                                                    "value": "Republic of Ireland"
+                                                },
+                                                {
+                                                    "label": "Arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch enw presennol y wlad"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "id": "country-of-birth-wales-question",
+                                    "title": "Ym mha wlad y cawsoch eich geni?",
+                                    "number": "9",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "country-of-birth-wales-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Cymru",
+                                                    "value": "Wales"
+                                                },
+                                                {
+                                                    "label": "Lloegr",
+                                                    "value": "England"
+                                                },
+                                                {
+                                                    "label": "Yr Alban",
+                                                    "value": "Scotland"
+                                                },
+                                                {
+                                                    "label": "Gogledd Iwerddon",
+                                                    "value": "Northern Ireland"
+                                                },
+                                                {
+                                                    "label": "Gweriniaeth Iwerddon",
+                                                    "value": "Republic of Ireland"
+                                                },
+                                                {
+                                                    "label": "Arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch enw presennol y wlad"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "not equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "carer",
+                                "when": [
+                                    {
+                                        "id": "country-of-birth-england-answer",
+                                        "condition": "equals",
+                                        "value": "England"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "carer",
+                                "when": [
+                                    {
+                                        "id": "country-of-birth-england-answer",
+                                        "condition": "equals",
+                                        "value": "Wales"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "carer",
+                                "when": [
+                                    {
+                                        "id": "country-of-birth-england-answer",
+                                        "condition": "equals",
+                                        "value": "Scotland"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "carer",
+                                "when": [
+                                    {
+                                        "id": "country-of-birth-england-answer",
+                                        "condition": "equals",
+                                        "value": "Northern Ireland"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "carer",
+                                "when": [
+                                    {
+                                        "id": "country-of-birth-wales-answer",
+                                        "condition": "equals",
+                                        "value": "Wales"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "carer",
+                                "when": [
+                                    {
+                                        "id": "country-of-birth-wales-answer",
+                                        "condition": "equals",
+                                        "value": "England"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "carer",
+                                "when": [
+                                    {
+                                        "id": "country-of-birth-wales-answer",
+                                        "condition": "equals",
+                                        "value": "Scotland"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "carer",
+                                "when": [
+                                    {
+                                        "id": "country-of-birth-wales-answer",
+                                        "condition": "equals",
+                                        "value": "Northern Ireland"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "arrive-in-uk"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "arrive-in-uk",
+                    "title": "Arrive in UK",
+                    "sections": [
+                        {
+                            "id": "arrive-in-uk-section",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "arrive-in-uk-question",
+                                    "title": "Os na chawsoch eich geni yn y Deyrnas Unedig, pryd y daethoch i fyw yma ddiwethaf?",
+                                    "number": "10",
+                                    "guidance": [
+                                        {
+                                            "description": "<strong>Peidiwch â chyfrif</strong> ymweliadau byr i ffwrdd o’r DU"
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "arrive-in-uk-answer",
+                                            "mandatory": false,
+                                            "type": "MonthYearDate",
+                                            "validation": {
+                                                "messages": {
+                                                    "INVALID_DATE": "Nid yw’r dyddiad a roddwyd yn ddilys. Cywirwch eich ateb"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "length-of-stay",
+                    "title": "Length of stay",
+                    "sections": [
+                        {
+                            "id": "length-of-stay-section",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "length-of-stay-question",
+                                    "title": "Gan gynnwys yr amser yr ydych wedi’i dreulio yma’n barod, am faint yr ydych yn bwriadu aros yn y Deyrnas Unedig?",
+                                    "number": "12",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "length-of-stay-answer",
+                                            "mandatory": false,
+                                            "guidance": "Os gwnaethoch gyrraedd y Deyrnas Unedig cyn mis Mai 2016, dewiswch ‘12 mis neu fwy’",
+                                            "options": [
+                                                {
+                                                    "label": "Llai na 6 mis",
+                                                    "value": "Less than 6 months"
+                                                },
+                                                {
+                                                    "label": "6 mis neu fwy, ond llai na 12 mis",
+                                                    "value": "6 months or more but less than 12 months"
+                                                },
+                                                {
+                                                    "label": "12 mis neu fwy",
+                                                    "value": "12 months or more"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "carer",
+                    "title": "Carer",
+                    "sections": [
+                        {
+                            "id": "carer-section",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "carer-question",
+                                    "title": "A ydych yn gofalu am aelodau o’r teulu, ffrindiau, cymdogion neu eraill, neu’n cynnig unrhyw help neu gefnogaeth i un neu i rai o’r rhain, oherwydd naill ai:",
+                                    "number": "13",
+                                    "description": "<div><ul><li>Salwch/anabledd corfforol neu feddyliol hirdymor?</li><li>Problemau sy’n gysylltiedig â henaint?</li></ul></div>",
+                                    "guidance": [
+                                        {
+                                            "description": "<strong>Peidiwch â chyfrif</strong> unrhyw beth y byddwch yn derbyn cyflog am ei wneud"
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "carer-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Nac ydw",
+                                                    "value": "No"
+                                                },
+                                                {
+                                                    "label": "Ydw, 1 - 19 awr yr wythnos",
+                                                    "value": "Yes, 1 -19 hours a week"
+                                                },
+                                                {
+                                                    "label": "Ydw, 20 - 49 awr yr wythnos",
+                                                    "value": "Yes, 20 - 49 hours a week"
+                                                },
+                                                {
+                                                    "label": "Ydw, 50 neu fwy o oriau’r wythnos",
+                                                    "value": "Yes, 50 or more hours a week"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "national-identity",
+                    "title": "national identity",
+                    "sections": [
+                        {
+                            "id": "national-identity-section",
+                            "title": "{{[answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "national-identity-england-question",
+                                    "title": "Sut fyddech chi’n disgrifio’ch hunaniaeth genedlaethol?",
+                                    "number": "14",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "national-identity-england-answer",
+                                            "label": "Dewiswch bob un sy’n berthnasol",
+                                            "mandatory": false,
+                                            "guidance": "<p>Gallwch ddewis mwy nag un hunaniaeth genedlaethol.</p><p>Chi sy’n penderfynu sut i ddewis eich hunaniaeth genedlaethol neu hunaniaethau cenedlaethol. Er enghraifft, gallai ymwneud â‘r wlad neu’r gwledydd rydych yn teimlo eich bod yn perthyn iddi neu iddynt, neu’n ei hystyried neu’n eu hystyried yn gartref.</p><p>Nid yw’n ddibynnol ar eich grŵp ethnig na’ch cenedligrwydd cyfreithiol (dinasyddiaeth).</p><p>Dewiswch bob un sy’n berthnasol. Os nad yw eich hunaniaeth genedlaethol ar y rhestr, dewiswch ‘Arall’ a nodwch eich hunaniaeth genedlaethol.</p>",
+                                            "options": [
+                                                {
+                                                    "label": "Sais/Saesnes",
+                                                    "value": "English"
+                                                },
+                                                {
+                                                    "label": "Cymro/Cymraes",
+                                                    "value": "Welsh"
+                                                },
+                                                {
+                                                    "label": "Albanwr/Albanes",
+                                                    "value": "Scottish"
+                                                },
+                                                {
+                                                    "label": "Gwyddel / Gwyddeles o Ogledd Iwerddon",
+                                                    "value": "Northern Irish"
+                                                },
+                                                {
+                                                    "label": "Prydeiniwr/Prydeinwraig",
+                                                    "value": "British"
+                                                },
+                                                {
+                                                    "label": "Arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Disgrifiwch eich hunaniaeth genedlaethol"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "id": "national-identity-wales-question",
+                                    "title": "Sut fyddech chi’n disgrifio’ch hunaniaeth genedlaethol?",
+                                    "number": "14",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "national-identity-wales-answer",
+                                            "label": "Dewiswch bob un sy’n berthnasol",
+                                            "mandatory": false,
+                                            "guidance": "<p>Gallwch ddewis mwy nag un hunaniaeth genedlaethol.</p><p>Chi sy’n penderfynu sut i ddewis eich hunaniaeth genedlaethol neu hunaniaethau cenedlaethol.  Er enghraifft, gallai ymwneud â‘r wlad neu’r gwledydd rydych yn teimlo eich bod yn perthyn iddi neu iddynt, neu’n ei hystyried neu’n eu hystyried yn gartref.</p><p>Nid yw’n ddibynnol ar eich grŵp ethnig na’ch cenedligrwydd cyfreithiol (dinasyddiaeth).</p><p>Dewiswch bob un sy’n berthnasol.  Os nad yw eich hunaniaeth genedlaethol ar y rhestr, dewiswch ‘Arall’ a nodwch eich hunaniaeth genedlaethol.</p>",
+                                            "options": [
+                                                {
+                                                    "label": "Cymro/Cymraes",
+                                                    "value": "Welsh"
+                                                },
+                                                {
+                                                    "label": "Sais/Saesnes",
+                                                    "value": "English"
+                                                },
+                                                {
+                                                    "label": "Albanwr/Albanes",
+                                                    "value": "Scottish"
+                                                },
+                                                {
+                                                    "label": "Gwyddel / Gwyddeles o Ogledd Iwerddon",
+                                                    "value": "Northern Irish"
+                                                },
+                                                {
+                                                    "label": "Prydeiniwr/Prydeinwraig",
+                                                    "value": "British"
+                                                },
+                                                {
+                                                    "label": "Arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Disgrifiwch eich hunaniaeth genedlaethol"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "not equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "ethnic-group",
+                    "title": "ethnic group",
+                    "sections": [
+                        {
+                            "id": "ethnic-group-section",
+                            "title": "{{[answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "ethnic-group-england-question",
+                                    "title": "Beth yw eich grŵp ethnig?",
+                                    "number": "15",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "ethnic-group-england-answer",
+                                            "mandatory": false,
+                                            "guidance": "<p>Chi sy’n dewis eich grŵp ethnig. Er enghraifft gallai adlewyrchu eich cefndir teuluol neu ddiwylliannol, neu sut y byddech yn disgrifio eich hun.</p><p>Dewiswch yr ateb mwyaf priodol yn eich barn chi.</p><p>os nad ydych yn credu bod yr opsiynau yn berthnasol i chi, dewiswch ‘Grŵp ethnig arall’. Yna byddwch yn gallu ysgrifennu’r grŵp ethnig sydd orau gennych ar gyfer y cwestiwn nesaf.</p>",
+                                            "options": [
+                                                {
+                                                    "label": "Gwyn",
+                                                    "value": "White",
+                                                    "description": "Gan gynnwys Seisnig / Cymreig / Albanaidd / Gwyddelig Gogledd Iwerddon / Prydeinig, Sipsi neu Deithiwr Gwyddelig neu unrhyw gefndir Gwyn arall"
+                                                },
+                                                {
+                                                    "label": "Cymysg / grwpiau aml-ethnig",
+                                                    "value": "Mixed / multiple ethnic groups",
+                                                    "description": "Gan gynnwys Gwyn a Du Caribïaidd, Gwyn a Du Affricanaidd, Gwyn ac Asiaidd neu unrhyw gefndir Cymysg/aml-ethnig arall"
+                                                },
+                                                {
+                                                    "label": "Asiaidd / Asiaidd Prydeinig",
+                                                    "value": "Asian / Asian British",
+                                                    "description": "Gan gynnwys Indiaidd, Pacistanaidd, Bangladeshaidd, Tsieineaidd neu unrhyw gefndir Asiaidd arall"
+                                                },
+                                                {
+                                                    "label": "Du / Affricanaidd / Caribïaidd / Du Prydeinig",
+                                                    "value": "Black / African / Caribbean / Black British",
+                                                    "description": "Gan gynnwys Affricanaidd, Caribïaidd neu unrhyw gefndir Du / Affricanaidd / Caribïaidd arall"
+                                                },
+                                                {
+                                                    "label": "Grŵp ethnig arall",
+                                                    "value": "Other ethnic group",
+                                                    "description": "Gan gynnwys Arabaidd neu unrhyw grŵp ethnig arall"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "id": "ethnic-group-wales-question",
+                                    "title": "Beth yw eich grŵp ethnig?",
+                                    "number": "15",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "ethnic-group-wales-answer",
+                                            "mandatory": false,
+                                            "guidance": "<p>Chi sy’n dewis eich grŵp ethnig.  Er enghraifft gallai adlewyrchu eich cefndir teuluol neu ddiwylliannol, neu sut y byddech yn disgrifio eich hun.</p><p>Dewiswch yr ateb mwyaf priodol yn eich barn chi.</p><p>os nad ydych yn credu bod yr opsiynau yn berthnasol i chi, dewiswch ‘Grŵp ethnig arall’.   Yna byddwch yn gallu ysgrifennu’r grŵp ethnig sydd orau gennych ar gyfer y cwestiwn nesaf.</p>",
+                                            "options": [
+                                                {
+                                                    "label": "Gwyn",
+                                                    "value": "White",
+                                                    "description": "Gan gynnwys Cymreig / Seisnig / Albanaidd / Gwyddelig Gogledd Iwerddon / Prydeinig, Gwyddelig, Sipsi neu Deithiwr Gwyddelig neu unrhyw gefndir Gwyn arall"
+                                                },
+                                                {
+                                                    "label": "Cymysg / grwpiau aml-ethnig",
+                                                    "value": "Mixed / multiple ethnic groups",
+                                                    "description": "Gan gynnwys Gwyn a Du Caribïaidd, Gwyn a Du Affricanaidd, Gwyn ac Asiaidd neu unrhyw gefndir Cymysg/aml-ethnig arall"
+                                                },
+                                                {
+                                                    "label": "Asiaidd / Asiaidd Prydeinig",
+                                                    "value": "Asian / Asian British",
+                                                    "description": "Gan gynnwys Indiaidd, Pacistanaidd, Bangladeshaidd, Tsieineaidd neu unrhyw gefndir Asiaidd arall"
+                                                },
+                                                {
+                                                    "label": "Du / Affricanaidd / Caribïaidd / Du Prydeinig",
+                                                    "value": "Black / African / Caribbean / Black British",
+                                                    "description": "Gan gynnwys Affricanaidd, Caribïaidd neu unrhyw gefndir Du / Affricanaidd / Caribïaidd arall"
+                                                },
+                                                {
+                                                    "label": "Grŵp ethnig arall",
+                                                    "value": "Other ethnic group",
+                                                    "description": "Gan gynnwys Arabaidd neu unrhyw grŵp ethnig arall"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "not equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "white-ethnic-group",
+                                "when": [
+                                    {
+                                        "id": "ethnic-group-england-answer",
+                                        "condition": "equals",
+                                        "value": "White"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "mixed-ethnic-group",
+                                "when": [
+                                    {
+                                        "id": "ethnic-group-england-answer",
+                                        "condition": "equals",
+                                        "value": "Mixed / multiple ethnic groups"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "asian-ethnic-group",
+                                "when": [
+                                    {
+                                        "id": "ethnic-group-england-answer",
+                                        "condition": "equals",
+                                        "value": "Asian / Asian British"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "black-ethnic-group",
+                                "when": [
+                                    {
+                                        "id": "ethnic-group-england-answer",
+                                        "condition": "equals",
+                                        "value": "Black / African / Caribbean / Black British"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "other-ethnic-group",
+                                "when": [
+                                    {
+                                        "id": "ethnic-group-england-answer",
+                                        "condition": "equals",
+                                        "value": "Other ethnic group"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "white-ethnic-group",
+                                "when": [
+                                    {
+                                        "id": "ethnic-group-wales-answer",
+                                        "condition": "equals",
+                                        "value": "White"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "mixed-ethnic-group",
+                                "when": [
+                                    {
+                                        "id": "ethnic-group-wales-answer",
+                                        "condition": "equals",
+                                        "value": "Mixed / multiple ethnic groups"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "asian-ethnic-group",
+                                "when": [
+                                    {
+                                        "id": "ethnic-group-wales-answer",
+                                        "condition": "equals",
+                                        "value": "Asian / Asian British"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "black-ethnic-group",
+                                "when": [
+                                    {
+                                        "id": "ethnic-group-wales-answer",
+                                        "condition": "equals",
+                                        "value": "Black / African / Caribbean / Black British"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "other-ethnic-group",
+                                "when": [
+                                    {
+                                        "id": "ethnic-group-wales-answer",
+                                        "condition": "equals",
+                                        "value": "Other ethnic group"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "sexual-identity",
+                                "when": [
+                                    {
+                                        "meta": "variant_flags.sexual_identity",
+                                        "condition": "equals",
+                                        "value": true
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "understand-welsh",
+                                "when": [
+                                    {
+                                        "meta": "region_code",
+                                        "condition": "equals",
+                                        "value": "GB-WLS"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "language"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "white-ethnic-group",
+                    "title": "white ethnic group",
+                    "sections": [
+                        {
+                            "id": "white-ethnic-group-section",
+                            "title": "{{[answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "white-ethnic-group-england-question",
+                                    "title": "Pa un sy’n disgrifio eich grŵp ethnig neu gefndir Gwyn orau?",
+                                    "number": "15a",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "white-ethnic-group-england-answer",
+                                            "guidance": "<p>Mae’r opsiynau’n seiliedig ar yr ateb i’r cwestiwn blaenorol. Dewiswch yr ateb sydd fwyaf priodol yn eich barn chi. </p><p> Os nad ydych yn credu bod yr opsiynau yn berthnasol i chi, dewiswch ‘Unrhyw un arall ...’ ac ysgrifennwch eich grŵp ethnig.</p>",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Cymreig / Seisnig / Albanaidd / Gwyddelig Gogledd Iwerddon / Prydeinig",
+                                                    "value": "English / Welsh / Scottish / Northern Irish / British"
+                                                },
+                                                {
+                                                    "label": "Gwyddelig",
+                                                    "value": "Irish"
+                                                },
+                                                {
+                                                    "label": "Sipsi neu Deithiwr Gwyddelig",
+                                                    "value": "Gypsy or Irish Traveller"
+                                                },
+                                                {
+                                                    "label": "Unrhyw gefndir Gwyn arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch gefndir Gwyn arall"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "id": "white-ethnic-group-wales-question",
+                                    "title": "Pa un sy’n disgrifio eich grŵp ethnig neu gefndir Gwyn orau?",
+                                    "number": "15a",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "white-ethnic-group-wales-answer",
+                                            "guidance": "<p>Mae’r opsiynau’n seiliedig ar yr ateb i’r cwestiwn blaenorol.  Dewiswch yr ateb sydd fwyaf priodol yn eich barn chi. </p><p> Os nad ydych yn credu bod yr opsiynau yn berthnasol i chi, dewiswch ‘Unrhyw un arall ...’ ac ysgrifennwch eich grŵp ethnig.</p>",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Cymreig / Seisnig / Albanaidd / Gwyddelig Gogledd Iwerddon / Prydeinig",
+                                                    "value": "Welsh / English / Scottish / Northern Irish / British"
+                                                },
+                                                {
+                                                    "label": "Gwyddelig",
+                                                    "value": "Irish"
+                                                },
+                                                {
+                                                    "label": "Sipsi neu Deithiwr Gwyddelig",
+                                                    "value": "Gypsy or Irish Traveller"
+                                                },
+                                                {
+                                                    "label": "Unrhyw gefndir Gwyn arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch gefndir Gwyn arall"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "not equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "sexual-identity",
+                                "when": [
+                                    {
+                                        "meta": "variant_flags.sexual_identity",
+                                        "condition": "equals",
+                                        "value": true
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "understand-welsh",
+                                "when": [
+                                    {
+                                        "meta": "region_code",
+                                        "condition": "equals",
+                                        "value": "GB-WLS"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "language"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "mixed-ethnic-group",
+                    "title": "mixed ethnic group",
+                    "sections": [
+                        {
+                            "id": "mixed-ethnic-group-section",
+                            "title": "{{[answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "mixed-ethnic-group-question",
+                                    "title": "Pa un sy’n disgrifio eich grŵp neu gefndir Cymysg / aml-ethnig orau?",
+                                    "number": "15a",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "mixed-ethnic-group-answer",
+                                            "guidance": "<p>Mae’r opsiynau’n seiliedig ar yr ateb i’r cwestiwn blaenorol. Dewiswch yr ateb sydd fwyaf priodol yn eich barn chi. </p><p> Os nad ydych yn credu bod yr opsiynau yn berthnasol i chi, dewiswch ‘Unrhyw un arall ...’ ac ysgrifennwch eich grŵp ethnig.</p>",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Gwyn a Du Caribïaidd",
+                                                    "value": "White and Black Caribbean"
+                                                },
+                                                {
+                                                    "label": "Gwyn a Du Affricanaidd",
+                                                    "value": "White and Black African"
+                                                },
+                                                {
+                                                    "label": "Gwyn ac Asiaidd",
+                                                    "value": "White and Asian"
+                                                },
+                                                {
+                                                    "label": "Unrhyw gefndir Cymysg / aml-ethnig arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch gefndir Cymysg / aml-ethnig arall"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "sexual-identity",
+                                "when": [
+                                    {
+                                        "meta": "variant_flags.sexual_identity",
+                                        "condition": "equals",
+                                        "value": true
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "understand-welsh",
+                                "when": [
+                                    {
+                                        "meta": "region_code",
+                                        "condition": "equals",
+                                        "value": "GB-WLS"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "language"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "asian-ethnic-group",
+                    "title": "asian ethnic group",
+                    "sections": [
+                        {
+                            "id": "asian-ethnic-group-section",
+                            "title": "{{[answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "asian-ethnic-group-question",
+                                    "title": "Pa un sy’n disgrifio eich grŵp ethnig neu gefndir Asiaidd / Asiaidd Prydeinig orau?",
+                                    "number": "15a",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "asian-ethnic-group-answer",
+                                            "mandatory": false,
+                                            "guidance": "<p>Mae’r opsiynau’n seiliedig ar yr ateb i’r cwestiwn blaenorol. Dewiswch yr ateb sydd fwyaf priodol yn eich barn chi. </p><p> Os nad ydych yn credu bod yr opsiynau yn berthnasol i chi, dewiswch ‘Unrhyw un arall ...’ ac ysgrifennwch eich grŵp ethnig.</p>",
+                                            "options": [
+                                                {
+                                                    "label": "Indiaidd",
+                                                    "value": "Indian"
+                                                },
+                                                {
+                                                    "label": "Pacistanaidd",
+                                                    "value": "Pakistani"
+                                                },
+                                                {
+                                                    "label": "Bangladeshaidd",
+                                                    "value": "Bangladeshi"
+                                                },
+                                                {
+                                                    "label": "Tsieineaidd",
+                                                    "value": "Chinese"
+                                                },
+                                                {
+                                                    "label": "Unrhyw gefndir Asiaidd arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Unrhyw gefndir Asiaidd arall"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "sexual-identity",
+                                "when": [
+                                    {
+                                        "meta": "variant_flags.sexual_identity",
+                                        "condition": "equals",
+                                        "value": true
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "understand-welsh",
+                                "when": [
+                                    {
+                                        "meta": "region_code",
+                                        "condition": "equals",
+                                        "value": "GB-WLS"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "language"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "black-ethnic-group",
+                    "title": "black ethnic group",
+                    "sections": [
+                        {
+                            "id": "black-ethnic-group-section",
+                            "title": "{{[answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "black-ethnic-group-question",
+                                    "title": "Pa un sy’n disgrifio eich grŵp ethnig neu gefndir Du / Affricanaidd / Caribïaidd / Du Prydeinig orau?",
+                                    "number": "15a",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "black-ethnic-group-answer",
+                                            "mandatory": false,
+                                            "guidance": "<p>Mae’r opsiynau’n seiliedig ar yr ateb i’r cwestiwn blaenorol. Dewiswch yr ateb sydd fwyaf priodol yn eich barn chi. </p><p> Os nad ydych yn credu bod yr opsiynau yn berthnasol i chi, dewiswch ‘Unrhyw un arall ...’ ac ysgrifennwch eich grŵp ethnig.</p>",
+                                            "options": [
+                                                {
+                                                    "label": "Affricanaidd",
+                                                    "value": "African"
+                                                },
+                                                {
+                                                    "label": "Caribïaidd",
+                                                    "value": "Caribbean"
+                                                },
+                                                {
+                                                    "label": "Unrhyw gefndir Du / Affricanaidd / Caribïaidd arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch gefndir Du / Affricanaidd / Caribïaidd arall"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "sexual-identity",
+                                "when": [
+                                    {
+                                        "meta": "variant_flags.sexual_identity",
+                                        "condition": "equals",
+                                        "value": true
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "understand-welsh",
+                                "when": [
+                                    {
+                                        "meta": "region_code",
+                                        "condition": "equals",
+                                        "value": "GB-WLS"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "language"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "other-ethnic-group",
+                    "title": "other ethnic group",
+                    "sections": [
+                        {
+                            "id": "other-ethnic-group-section",
+                            "title": "{{[answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "other-ethnic-group-question",
+                                    "title": "Pa un sy’n disgrifio eich grŵp ethnig neu gefndir Arall orau?",
+                                    "number": "15a",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "other-ethnic-group-answer",
+                                            "mandatory": false,
+                                            "guidance": "<p>Mae’r opsiynau’n seiliedig ar yr ateb i’r cwestiwn blaenorol. Dewiswch yr ateb sydd fwyaf priodol yn eich barn chi. </p><p> Os nad ydych yn credu bod yr opsiynau yn berthnasol i chi, dewiswch ‘Unrhyw un arall ...’ ac ysgrifennwch eich grŵp ethnig.</p>",
+                                            "options": [
+                                                {
+                                                    "label": "Arabaidd",
+                                                    "value": "Arab"
+                                                },
+                                                {
+                                                    "label": "Unrhyw grŵp ethnig arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch grŵp ethnig Arall"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "sexual-identity",
+                                "when": [
+                                    {
+                                        "meta": "variant_flags.sexual_identity",
+                                        "condition": "equals",
+                                        "value": true
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "understand-welsh",
+                                "when": [
+                                    {
+                                        "meta": "region_code",
+                                        "condition": "equals",
+                                        "value": "GB-WLS"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "language"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "sexual-identity",
+                    "title": "Sexual identity",
+                    "sections": [
+                        {
+                            "id": "sexual-identity-section",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "sexual-identity-question",
+                                    "title": "Pa un o’r opsiynau canlynol sy’n disgrifio’r ffordd rydych yn meddwl am eich hun orau?",
+                                    "number": "17",
+                                    "description": "Mae’r cwestiwn hwn yn wirfoddol",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "sexual-identity-answer",
+                                            "mandatory": false,
+                                            "guidance": "<p>Chi sy’n penderfynu sut i ddewis ateb.</p><p>Os nad ydych yn siŵr beth yw ystyr unrhyw air a ddefnyddir, efallai y bydd y canlynol yn helpu:</p><ul><li>mae ‘Heterorywiol neu Strêt’ yn disgrifio rhywun sydd, er enghraifft, yn hoffi pobl o’r rhyw/rhywedd arall</li><li>mae ‘Hoyw neu Lesbiaidd’ yn disgrifio rhywun sy’n hoffi pobl o’r un rhyw/rhywedd</li><li>mae ‘Deurywiol’ yn disgrifio rhywun sydd, er enghraifft, yn hoffi pobl o’r ddau ryw/rhywedd</li></ul><p><strong>Hunaniaeth heb ei rhestru</strong></p><p>Os nad oes unrhyw un o’r tri opsiwn cyntaf yn berthnasol i chi, dewiswch ‘Arall’ a rhowch yr ateb sy’n well gennych.</p><p>Mae’r cwestiwn hwn yn wirfoddol; gallwch ei adael yn wag os oes yn well gennych wneud hynny.</p>",
+                                            "options": [
+                                                {
+                                                    "label": "Heterorywiol neu Strêt",
+                                                    "value": "Heterosexual or Straight"
+                                                },
+                                                {
+                                                    "label": "Hoyw neu Lesbiaidd",
+                                                    "value": "Gay or Lesbian"
+                                                },
+                                                {
+                                                    "label": "Deurywiol",
+                                                    "value": "Bisexual"
+                                                },
+                                                {
+                                                    "label": "Arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "understand-welsh",
+                                "when": [
+                                    {
+                                        "meta": "region_code",
+                                        "condition": "equals",
+                                        "value": "GB-WLS"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "language"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "understand-welsh",
+                    "title": "Understand welsh",
+                    "sections": [
+                        {
+                            "id": "understand-welsh-section",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "understand-welsh-question",
+                                    "title": "A allwch ddeall, siarad, darllen neu ysgrifennu Cymraeg?",
+                                    "number": "18",
+                                    "description": "Dewiswch bob un sy’n berthnasol",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "understand-welsh-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Deall Cymraeg llafar",
+                                                    "value": "Understand spoken Welsh"
+                                                },
+                                                {
+                                                    "label": "Siarad Cymraeg",
+                                                    "value": "Speak Welsh"
+                                                },
+                                                {
+                                                    "label": "Darllen Cymraeg",
+                                                    "value": "Read Welsh"
+                                                },
+                                                {
+                                                    "label": "Ysgrifennu Cymraeg",
+                                                    "value": "Write Welsh"
+                                                },
+                                                {
+                                                    "label": "Dim un o’r uchod",
+                                                    "value": "None of the above"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "language",
+                    "title": "language",
+                    "sections": [
+                        {
+                            "id": "language-section",
+                            "title": "{{[answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "language-england-question",
+                                    "title": "Beth yw eich prif iaith?",
+                                    "number": "19",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "language-england-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Saesneg",
+                                                    "value": "English"
+                                                },
+                                                {
+                                                    "label": "Arall (nodwch)",
+                                                    "value": "Other",
+                                                    "description": "Gan gynnwys Iaith Arwyddion Prydain",
+                                                    "other": {
+                                                        "label": "Nodwch eich prif iaith"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "id": "language-welsh-question",
+                                    "title": "Beth yw eich prif iaith?",
+                                    "number": "19",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "language-welsh-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Cymraeg neu Saesneg",
+                                                    "value": "English or Welsh"
+                                                },
+                                                {
+                                                    "label": "Arall (nodwch)",
+                                                    "value": "Other",
+                                                    "description": "Gan gynnwys Iaith Arwyddion Prydain",
+                                                    "other": {
+                                                        "label": "Nodwch eich prif iaith"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "not equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "religion",
+                                "when": [
+                                    {
+                                        "id": "language-england-answer",
+                                        "condition": "equals",
+                                        "value": "English"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "religion",
+                                "when": [
+                                    {
+                                        "id": "language-welsh-answer",
+                                        "condition": "equals",
+                                        "value": "English or Welsh"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "english"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "english",
+                    "title": "english",
+                    "sections": [
+                        {
+                            "id": "english-section",
+                            "title": "{{[answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "english-question",
+                                    "title": "Pa mor dda allwch chi siarad Saesneg?",
+                                    "number": "20",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "english-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Da iawn",
+                                                    "value": "Very well"
+                                                },
+                                                {
+                                                    "label": "Da",
+                                                    "value": "Well"
+                                                },
+                                                {
+                                                    "label": "Ddim yn dda",
+                                                    "value": "Not well"
+                                                },
+                                                {
+                                                    "label": "Ddim o gwbl",
+                                                    "value": "Not at all"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "religion",
+                    "title": "Religion",
+                    "sections": [
+                        {
+                            "id": "religion-section",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "religion-question",
+                                    "title": "Beth yw eich crefydd?",
+                                    "number": "21",
+                                    "description": "Mae’r cwestiwn hwn yn wirfoddol",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "religion-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Dim crefydd",
+                                                    "value": "No religion"
+                                                },
+                                                {
+                                                    "label": "Cristnogaeth (gan gynnwys Eglwys Lloegr, Catholig, Protestannaidd a phob enwad Cristnogol arall)",
+                                                    "value": "Christian (Including Church of England, Catholic, Protestant and all other Christian denominations)"
+                                                },
+                                                {
+                                                    "label": "Bwdhaeth",
+                                                    "value": "Buddhist"
+                                                },
+                                                {
+                                                    "label": "Hindŵaeth",
+                                                    "value": "Hindu"
+                                                },
+                                                {
+                                                    "label": "Iddewiaeth",
+                                                    "value": "Jewish"
+                                                },
+                                                {
+                                                    "label": "Islam",
+                                                    "value": "Muslim"
+                                                },
+                                                {
+                                                    "label": "Siciaeth",
+                                                    "value": "Sikh"
+                                                },
+                                                {
+                                                    "label": "Unrhyw grefydd arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "id": "religion-welsh-question",
+                                    "title": "Beth yw eich crefydd?",
+                                    "number": "21",
+                                    "description": "Mae’r cwestiwn hwn yn wirfoddol",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "religion-welsh-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Dim crefydd",
+                                                    "value": "No religion"
+                                                },
+                                                {
+                                                    "label": "Cristnogaeth (pob enwad)",
+                                                    "value": "Christian (all denominations)"
+                                                },
+                                                {
+                                                    "label": "Bwdhaeth",
+                                                    "value": "Buddhist"
+                                                },
+                                                {
+                                                    "label": "Hindŵaeth",
+                                                    "value": "Hindu"
+                                                },
+                                                {
+                                                    "label": "Iddewiaeth",
+                                                    "value": "Jewish"
+                                                },
+                                                {
+                                                    "label": "Islam",
+                                                    "value": "Muslim"
+                                                },
+                                                {
+                                                    "label": "Siciaeth",
+                                                    "value": "Sikh"
+                                                },
+                                                {
+                                                    "label": "Unrhyw grefydd arall (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "not equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "past-usual-address",
+                    "title": "Past usual address",
+                    "sections": [
+                        {
+                            "id": "past-usual-address-section",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "past-usual-address-question",
+                                    "title": "Flwyddyn yn ôl, beth oedd eich cyfeiriad arferol?",
+                                    "number": "22",
+                                    "description": "Os nad oedd gennych gyfeiriad arferol flwyddyn yn ôl, nodwch y cyfeiriad lle’r oeddech yn aros",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "past-usual-address-answer",
+                                            "mandatory": false,
+                                            "guidance": "Yn y rhan fwyaf o achosion eich cyfeiriad arferol fydd y cartref parhaol neu gartref y teulu roeddech chi’n byw ynddo.",
+                                            "options": [
+                                                {
+                                                    "label": "Y cyfeiriad hwn",
+                                                    "value": "This address"
+                                                },
+                                                {
+                                                    "label": "Cyfeiriad myfyriwr yn ystod y tymor neu gyfeiriad ysgol breswyl yn y Deyrnas Unedig",
+                                                    "value": "Student term time or boarding school address in the UK"
+                                                },
+                                                {
+                                                    "label": "Cyfeiriad arall yn y Deyrnas Unedig",
+                                                    "value": "Another address in the UK"
+                                                },
+                                                {
+                                                    "label": "Cyfeiriad y tu allan i’r DU (nodwch)",
+                                                    "value": "Other",
+                                                    "other": {
+                                                        "label": "Nodwch enw’r wlad"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "last-year-address",
+                                "when": [
+                                    {
+                                        "id": "past-usual-address-answer",
+                                        "condition": "equals",
+                                        "value": "Student term time or boarding school address in the UK"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "last-year-address",
+                                "when": [
+                                    {
+                                        "id": "past-usual-address-answer",
+                                        "condition": "equals",
+                                        "value": "Another address in the UK"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "passports"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "last-year-address",
+                    "title": "Last year address",
+                    "sections": [
+                        {
+                            "id": "last-year-address-section",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "last-year-address-question",
+                                    "number": "22a",
+                                    "title": "Nodwch fanylion eich cyfeiriad flwyddyn yn ôl",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "last-year-address-answer-building",
+                                            "label": "Adeilad",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "last-year-address-answer-street",
+                                            "label": "Stryd",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "last-year-address-answer-city",
+                                            "label": "Tref neu ddinas",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "last-year-address-answer-county",
+                                            "label": "Sir (dewisol)",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "last-year-address-answer-postcode",
+                                            "label": "Cod post",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "passports",
+                    "title": "Passports",
+                    "sections": [
+                        {
+                            "id": "passports-section",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "passports-question",
+                                    "title": "Pa basportau sydd gennych?",
+                                    "number": "23",
+                                    "description": "Dewiswch bob un sy’n berthnasol",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "passports-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Y Deyrnas Unedig",
+                                                    "value": "United Kingdom"
+                                                },
+                                                {
+                                                    "label": "Gwyddelig",
+                                                    "value": "Irish"
+                                                },
+                                                {
+                                                    "label": "Arall",
+                                                    "value": "Other"
+                                                },
+                                                {
+                                                    "label": "Dim",
+                                                    "value": "None"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "other-passports",
+                                "when": [
+                                    {
+                                        "id": "passports-answer",
+                                        "condition": "contains",
+                                        "value": "Other"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "disability"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "other-passports",
+                    "title": "Other passports",
+                    "sections": [
+                        {
+                            "id": "other-passports-section",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "other-passports-question",
+                                    "title": "Nodwch y pasbortau eraill sydd gennych",
+                                    "number": "23a",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "other-passports-answer",
+                                            "label": "Pasbortau sydd gennych",
+                                            "mandatory": false,
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "disability",
+                    "title": "Disability",
+                    "sections": [
+                        {
+                            "id": "disability-section",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "disability-question",
+                                    "title": "A oes gennych broblem iechyd neu anabledd sydd wedi para neu sy’n debygol o bara am o leiaf 12 mis, ac sy’n cyfyngu ar eich gallu i wneud gweithgareddau arferol?",
+                                    "number": "24",
+                                    "guidance": [
+                                        {
+                                            "description": "<strong>Dylech gynnwys</strong> Problemau sy’n gysylltiedig â henaint"
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "disability-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Oes, yn cyfyngu’n fawr",
+                                                    "value": "Yes, limited a lot"
+                                                },
+                                                {
+                                                    "label": "Oes, yn cyfyngu ychydig",
+                                                    "value": "Yes, limited a little"
+                                                },
+                                                {
+                                                    "label": "Nac oes",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "qualifications"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "qualifications",
+                    "title": "qualifications",
+                    "sections": [
+                        {
+                            "id": "qualifications-section",
+                            "title": "{{[answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "qualifications-england-question",
+                                    "title": "Gan feddwl am unrhyw astudiaethau, arholiadau neu gymwysterau, pa rai o’r canlynol sydd gennych?",
+                                    "number": "26",
+                                    "description": "Dewiswch bob opsiwn sy’n berthnasol (boed yn y DU neu’r hyn sy’n cyfateb iddo dramor) os oes gennych unrhyw rai o’r cymwysterau a restrir",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "qualifications-england-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "5 TGAU neu fwy (graddau A* i C) neu Lefel O (llwyddo) neu TAU (gradd 1), Tystysgrif Ysgol, Un Safon Uwch, 2 - 3 Safon UG neu TAA, Diploma Lefel Uwch",
+                                                    "value": "5 or more  GCSEs (grades A-Star to C) or O-Levels (passes) or CSEs (grade 1), School Certificate, One A-Level, 2 to 3 AS-Levels or VCEs, Higher Diploma"
+                                                },
+                                                {
+                                                    "label": "1 - 4 TGAU neu Lefel O neu TAU (unrhyw radd), Lefel Mynediad, Diploma Sylfaen",
+                                                    "value": "1 to 4 GCSEs or O-Levels or CSEs (any grades), Entry level, Foundation Diploma"
+                                                },
+                                                {
+                                                    "label": "2 neu fwy Safon Uwch, 4 neu fwy Safon UG neu TAA, Tystysgrif Ysgol Uwch, Diploma Pellach",
+                                                    "value": "2 or more  A-Levels, 4 or more  AS-levels or VCEs, Higher School Certificate, Advanced Diploma"
+                                                },
+                                                {
+                                                    "label": "Prentisiaeth (masnach, uwch, sylfaen neu fodern)",
+                                                    "value": "Apprenticeship (trade, advanced, foundation or modern)"
+                                                },
+                                                {
+                                                    "label": "NVQ lefel un, GNVQ Sylfaen, Sgiliau Sylfaenol",
+                                                    "value": "NVQ level one, Foundation GNVQ, Basic Skills"
+                                                },
+                                                {
+                                                    "label": "NVQ lefel dau, GNVQ Canolradd, Crefft City and Guilds, Diploma Cyntaf BTEC, Diploma RSA",
+                                                    "value": "NVQ level two, Intermediate GNVQ, City and Guilds Craft, BTEC First, RSA Diploma"
+                                                },
+                                                {
+                                                    "label": "NVQ Lefel tri, GNVQ Uwch, Crefft Uwch City and Guilds, ONC, OND, Diploma Cenedlaethol BTEC, Diploma Pellach RSA",
+                                                    "value": "NVQ Level three, Advanced GNVQ, City and Guilds Advanced Craft, ONC, OND, BTEC National, RSA Advanced Diploma"
+                                                },
+                                                {
+                                                    "label": "NVQ Lefel 4 - 5, HNC, HND, Diploma Uwch RSA, Diploma Uwch BTEC, Gradd Sylfaen",
+                                                    "value": "NVQ Level four to five, HNC, HND, RSA Higher Diploma, BTEC Higher, Foundation degree"
+                                                },
+                                                {
+                                                    "label": "Cymwysterau galwedigaethol neu gymwysterau cysylltiedig â gwaith eraill",
+                                                    "value": "Other vocational or work-related qualifications"
+                                                },
+                                                {
+                                                    "label": "Gradd Israddedig",
+                                                    "value": "Undergraduate Degree"
+                                                },
+                                                {
+                                                    "label": "Tystysgrif / Diploma Ôl-raddedig",
+                                                    "value": "Postgraduate Certificate / Diploma"
+                                                },
+                                                {
+                                                    "label": "Gradd Meistr",
+                                                    "value": "Masters Degree"
+                                                },
+                                                {
+                                                    "label": "Doethuriaeth (er enghraifft PhD)",
+                                                    "value": "Doctorate Degree (for example PhD)"
+                                                },
+                                                {
+                                                    "label": "Cymhwyster proffesiynol (er enghraifft addysgu, nyrsio, cyfrifyddiaeth)",
+                                                    "value": "Professional qualification (for example teaching, nursing, accountancy)"
+                                                },
+                                                {
+                                                    "label": "Cymwysterau tramor (ddim yn gwybod beth sy’n cyfateb iddynt yn y DU)",
+                                                    "value": "Foreign qualifications (UK equivalent not known)"
+                                                },
+                                                {
+                                                    "label": "Dim cymwysterau",
+                                                    "value": "No qualifications"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "id": "qualifications-welsh-question",
+                                    "title": "Gan feddwl am unrhyw astudiaethau, arholiadau neu gymwysterau, pa rai o’r canlynol sydd gennych?",
+                                    "number": "26",
+                                    "description": "Dewiswch bob opsiwn sy’n berthnasol (boed yn y DU neu’r hyn sy’n cyfateb iddo dramor) os oes gennych unrhyw rai o’r cymwysterau a restrir",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "qualifications-welsh-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "5 TGAU neu fwy (graddau A* i C) neu Lefel O (llwyddo) neu TAU (gradd 1), Tystysgrif Ysgol, Un Safon Uwch, 2 - 3 Safon UG neu TAA,  Diploma Canolradd neu Genedlaethol Bagloriaeth Cymru (Lefel dau)",
+                                                    "value": "5 or more GCSEs (grades A-Star to C) or O Levels (passes) or CSEs (grade 1), School Certificate, One A-Level, 2 to 3 AS-Levels or VCEs,  Intermediate or National Welsh Baccalaureate (Level two)"
+                                                },
+                                                {
+                                                    "label": "1 - 4  TGAU neu Lefel O neu TAU (unrhyw radd), Lefel Mynediad, Diploma Sylfaen Bagloriaeth Cymru (lefel un)",
+                                                    "value": "1 to 4  GCSEs or O Levels or CSEs (any grades), Entry level, Foundation Welsh Baccalaureate (level one)"
+                                                },
+                                                {
+                                                    "label": "Mwy na 2 Safon Uwch, mwy na 4 Safon UG neu TAA, Tystysgrif Ysgol Uwch, Diploma Uwch Bagloriaeth Cymru (lefel tri)",
+                                                    "value": "More than 2 A-Levels, more than 4 AS-levels or VCEs, Higher School Certificate, Advanced Welsh Baccalaureate (level three)"
+                                                },
+                                                {
+                                                    "label": "Prentisiaeth (sylfaen, modern neu uwch)",
+                                                    "value": "Apprenticeship (foundation, modern or higher)"
+                                                },
+                                                {
+                                                    "label": "NVQ lefel un, GNVQ Sylfaen, Sgiliau Hanfodol neu Allweddol",
+                                                    "value": "NVQ level one, Foundation GNVQ, Essential or Key  Skills"
+                                                },
+                                                {
+                                                    "label": "NVQ lefel dau, GNVQ Canolradd, Crefft City and Guilds, Diploma Cyntaf BTEC, Diploma RSA",
+                                                    "value": "NVQ level two, Intermediate GNVQ, City and Guilds Craft, BTEC First, RSA Diploma"
+                                                },
+                                                {
+                                                    "label": "NVQ Lefel tri, GNVQ Uwch, Crefft Uwch City and Guilds, ONC, OND, Diploma Cenedlaethol BTEC, Diploma Pellach RSA",
+                                                    "value": "NVQ Level three, Advanced GNVQ, City and Guilds Advanced Craft, ONC, OND, BTEC National, RSA Advanced Diploma"
+                                                },
+                                                {
+                                                    "label": "NVQ Lefel 4 - 5, HNC, HND, Diploma Uwch RSA, Diploma Uwch BTEC",
+                                                    "value": "NVQ Level four to five, HNC, HND, RSA Higher Diploma, BTEC Higher"
+                                                },
+                                                {
+                                                    "label": "Cymwysterau galwedigaethol neu gymwysterau cysylltiedig â gwaith eraill",
+                                                    "value": "Other vocational or work-related qualifications"
+                                                },
+                                                {
+                                                    "label": "Gradd Israddedig",
+                                                    "value": "Undergraduate Degree"
+                                                },
+                                                {
+                                                    "label": "Tystysgrif / Diploma Ôl-raddedig",
+                                                    "value": "Postgraduate Certificate / Diploma"
+                                                },
+                                                {
+                                                    "label": "Gradd Meistr",
+                                                    "value": "Masters Degree"
+                                                },
+                                                {
+                                                    "label": "Doethuriaeth (er enghraifft PhD)",
+                                                    "value": "Doctorate Degree (for example PhD)"
+                                                },
+                                                {
+                                                    "label": "Cymhwyster proffesiynol (er enghraifft addysgu, nyrsio, cyfrifyddiaeth)",
+                                                    "value": "Professional qualification (for example teaching, nursing, accountancy)"
+                                                },
+                                                {
+                                                    "label": "Cymwysterau tramor (heb wybod beth sy’n cyfateb iddynt yn y Deyrnas Unedig)",
+                                                    "value": "Foreign qualifications (UK equivalent not known)"
+                                                },
+                                                {
+                                                    "label": "Dim cymwysterau",
+                                                    "value": "No qualifications"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "skip_condition": {
+                                        "when": [
+                                            {
+                                                "meta": "region_code",
+                                                "condition": "not equals",
+                                                "value": "GB-WLS"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "volunteering",
+                    "title": "Volunteering",
+                    "sections": [
+                        {
+                            "id": "volunteering-section",
+                            "title": "{{ [answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "volunteering-question",
+                                    "title": "Gan ystyried y 12 mis a aeth heibio, ydych chi wedi gwirfoddoli ar gyfer unrhyw grwpiau, clybiau neu sefydliadau?",
+                                    "number": "27",
+                                    "guidance": [
+                                        {
+                                            "description": "<strong>Ni ddylech gynnwys</strong> unrhyw weithgareddau a orchmynnwyd gan lys"
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "volunteering-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Naddo",
+                                                    "value": "No"
+                                                },
+                                                {
+                                                    "label": "Ydw, o leiaf unwaith yr wythnos",
+                                                    "value": "Yes, at least once a week"
+                                                },
+                                                {
+                                                    "label": "Ydw, llai nag unwaith yr wythnos ond o leiaf unwaith y mis",
+                                                    "value": "Yes, less than once a week but at least once a month"
+                                                },
+                                                {
+                                                    "label": "Ydw, yn llai aml",
+                                                    "value": "Yes, less often"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "employment-type",
+                    "title": "employment type",
+                    "sections": [
+                        {
+                            "id": "employment-type-section",
+                            "title": "{{[answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "employment-type-question",
+                                    "title": "Yr wythnos diwethaf a oeddech:",
+                                    "number": "28",
+                                    "description": "Dewiswch bob un sy’n berthnasol",
+                                    "guidance": [
+                                        {
+                                            "description": "<strong>Dylech gynnwys</strong> unrhyw waith am dâl, gan gynnwys gwaith achlysurol neu dros dro, hyd yn oed os oedd ond am awr"
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "employment-type-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "yn weithiwr cyflogedig?",
+                                                    "value": "working as an employee?"
+                                                },
+                                                {
+                                                    "label": "ar gynllun hyfforddi a noddir gan y llywodraeth?",
+                                                    "value": "on a government sponsored training scheme?"
+                                                },
+                                                {
+                                                    "label": "yn hunan-gyflogedig neu’n gweithio ar eich liwt eich hun?",
+                                                    "value": "self-employed or freelance?"
+                                                },
+                                                {
+                                                    "label": "yn gweithio am dâl neu’n ddi-dâl i’ch busnes eich hun neu i fusnes eich teulu?",
+                                                    "value": "working paid or unpaid for you own or your family’s business?"
+                                                },
+                                                {
+                                                    "label": "i ffwrdd o’ch gwaith yn sâl, ar gyfnod mamolaeth, ar eich gwyliau, neu wedi’ch cadw  o’ch gwaith dros dro am na all eich cyflogwr gynnig gwaith ar hyn o bryd?",
+                                                    "value": "away from work ill, on maternity leave, on holiday or temporarily laid off?"
+                                                },
+                                                {
+                                                    "label": "yn gwneud unrhyw fath arall o waith am dâl?",
+                                                    "value": "doing any other kind of paid work?"
+                                                },
+                                                {
+                                                    "label": "dim un o’r uchod?",
+                                                    "value": "none of the above?"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "main-job",
+                                "when": [
+                                    {
+                                        "id": "employment-type-answer",
+                                        "condition": "contains",
+                                        "value": "working as an employee?"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "main-job",
+                                "when": [
+                                    {
+                                        "id": "employment-type-answer",
+                                        "condition": "contains",
+                                        "value": "on a government sponsored training scheme?"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "main-job",
+                                "when": [
+                                    {
+                                        "id": "employment-type-answer",
+                                        "condition": "contains",
+                                        "value": "self-employed or freelance?"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "main-job",
+                                "when": [
+                                    {
+                                        "id": "employment-type-answer",
+                                        "condition": "contains",
+                                        "value": "working paid or unpaid for you own or your family’s business?"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "main-job",
+                                "when": [
+                                    {
+                                        "id": "employment-type-answer",
+                                        "condition": "contains",
+                                        "value": "away from work ill, on maternity leave, on holiday or temporarily laid off?"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "main-job",
+                                "when": [
+                                    {
+                                        "id": "employment-type-answer",
+                                        "condition": "contains",
+                                        "value": "doing any other kind of paid work?"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "jobseeker"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "jobseeker",
+                    "title": "jobseeker",
+                    "sections": [
+                        {
+                            "id": "jobseeker-section",
+                            "title": "{{[answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "jobseeker-question",
+                                    "title": "A oeddech wrthi’n chwilio am unrhyw fath o waith am dâl yn ystod y pedair wythnos diwethaf?",
+                                    "number": "29",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "jobseeker-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Oeddwn",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "Nac oeddwn",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "job-availability",
+                    "title": "job availability",
+                    "sections": [
+                        {
+                            "id": "job-availability-section",
+                            "title": "{{[answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "job-availability-question",
+                                    "title": "Petai swydd wedi bod ar gael yr wythnos diwethaf, a fyddech wedi gallu dechrau arni o fewn pythefnos?",
+                                    "number": "30",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "job-availability-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Byddwn",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "Na fyddwn",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "job-pending",
+                    "title": "job pending",
+                    "sections": [
+                        {
+                            "id": "job-pending-section",
+                            "title": "{{[answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "job-pending-question",
+                                    "title": "Yr wythnos diwethaf, a oeddech yn aros i ddechrau swydd yr oeddech eisoes wedi’i chael?",
+                                    "number": "31",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "job-pending-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Oeddwn",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "Nac oeddwn",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "occupation",
+                    "title": "occupation",
+                    "sections": [
+                        {
+                            "id": "occupation-section",
+                            "title": "{{[answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "occupation-question",
+                                    "title": "Yr wythnos diwethaf, a oeddech:",
+                                    "number": "32",
+                                    "description": "Dewiswch bob un sy’n berthnasol",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "occupation-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "wedi ymddeol (p’un a oeddech yn cael pensiwn ai peidio)?",
+                                                    "value": "retired (whether receiving a pension or not)?"
+                                                },
+                                                {
+                                                    "label": "myfyriwr?",
+                                                    "value": "a student?"
+                                                },
+                                                {
+                                                    "label": "yn gofalu am y cartref neu am y teulu?",
+                                                    "value": "looking after home or family?"
+                                                },
+                                                {
+                                                    "label": "yn sâl neu wedi bod yn anabl am gyfnod hir?",
+                                                    "value": "long-term sick or disabled?"
+                                                },
+                                                {
+                                                    "label": "arall",
+                                                    "value": "other"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "ever-worked",
+                    "title": "ever worked",
+                    "sections": [
+                        {
+                            "id": "ever-worked-section",
+                            "title": "{{[answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "ever-worked-question",
+                                    "title": "A ydych wedi gweithio erioed?",
+                                    "number": "33",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "ever-worked-answer",
+                                            "mandatory": false,
+                                            "guidance": "<p>Os oedd gennych swydd amser llawn neu ran amser yn y gorffennol dewiswch ‘Ydw’</p><p>Mae hyn yn cynnwys gwaith y tu allan i’r Deyrnas Unedig.</p><p>Rhowch ateb hyd yn oed os ydych wedi ymddeol.</p><p>Os nad ydych wedi gweithio erioed, neu ond wedi gwneud gwaith gwirfoddol/di-dâl, dewiswch ‘Nac ydw’.</p>",
+                                            "options": [
+                                                {
+                                                    "label": "Do",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "Naddo",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "confirmation",
+                                "when": [
+                                    {
+                                        "id": "ever-worked-answer",
+                                        "condition": "equals",
+                                        "value": "No"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "main-job"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "main-job",
+                    "title": "main job",
+                    "sections": [
+                        {
+                            "id": "main-job-section",
+                            "title": "{{[answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "main-job-question",
+                                    "title": "Yn eich prif swydd, a ydych (oeddech):",
+                                    "number": "35",
+                                    "guidance": [
+                                        {
+                                            "description": "<p>Os nad ydych yn gweithio atebwch y cwestiynau sy’n weddill am eich prif swydd ddiwethaf.</p><p>Eich prif swydd yw’r swydd yr ydych (oeddech) fel arfer yn gweithio’r nifer fwyaf o oriau ynddi </p>"
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "main-job-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "yn weithiwr cyflogedig?",
+                                                    "value": "an employee?"
+                                                },
+                                                {
+                                                    "label": "yn hunan-gyflogedig heb gyflogi gweithwyr eraill?",
+                                                    "value": "self-employed or freelance without employees?"
+                                                },
+                                                {
+                                                    "label": "yn hunan-gyflogedig ac yn cyflogi gweithwyr eraill?",
+                                                    "value": "self-employed with employees?"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "job-title",
+                    "title": "job title",
+                    "sections": [
+                        {
+                            "id": "job-title-section",
+                            "title": "{{[answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "job-title-question",
+                                    "title": "Beth yw (oedd) teitl llawn a phenodol eich swydd?",
+                                    "number": "36",
+                                    "guidance": [
+                                        {
+                                            "description": "<p>Er enghraifft, <b>athro ysgol gynradd, mecanydd ceir, nyrs ardal, peiriannydd strwythurol</b></p><p>Peidiwch â nodi eich gradd na’ch band cyflog</p>"
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "job-title-answer",
+                                            "label": "Teitl swydd",
+                                            "mandatory": false,
+                                            "guidance": "<p>Nodwch deitl eich swydd yn y man a ddarperir.</p><p>Peidiwch â nodi eich gradd na’ch band cyflog.</p><p>Os nad ydych yn siŵr beth yw teitl eich swydd rhowch y wybodaeth orau bosibl.</p>",
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "job-description",
+                    "title": "job description",
+                    "sections": [
+                        {
+                            "id": "job-description-section",
+                            "title": "{{[answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "job-description-question",
+                                    "title": "Beth ydych (oeddech) chi’n ei wneud yn eich prif swydd.",
+                                    "number": "37",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "job-description-answer",
+                                            "label": "Disgrifiad",
+                                            "mandatory": false,
+                                            "guidance": "<p>Rhowch ddisgrifiad byr o beth ydych (oeddech) chi’n ei wneud yn eich prif swydd.  Eich prif swydd yw’r swydd yr ydych (oeddech) fel arfer yn gweithio’r nifer fwyaf o oriau ynddi.</p><p>Rhowch y wybodaeth orau bosibl hyd yn oed os nad ydych yn siŵr o’r holl fanylion neu’n methu â‘u cofio.</p>",
+                                            "type": "TextArea"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "employers-business",
+                    "title": "employers business",
+                    "sections": [
+                        {
+                            "id": "employers-business-section",
+                            "title": "{{[answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "employers-business-question",
+                                    "title": "Yn eich gweithle, beth yw (oedd) prif weithgarwch eich cyflogwr neu’ch busnes?",
+                                    "number": "38",
+                                    "guidance": [
+                                        {
+                                            "list": [
+                                                "Er enghraifft, <b>addysg gynradd, trwsio ceir, arlwyo cytundebol, trin cyfrifiaduron</b>",
+                                                "Os ydych (oeddech) yn was sifil, ysgrifennwch <b>llywodraeth</b>",
+                                                "Os ydych (oeddech) yn swyddog llywodraeth leol, ysgrifennwch <b>llywodraeth leol</b> a rhowch enw’r adran o fewn yr awdurdod lleol"
+                                            ]
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "employers-business-answer",
+                                            "label": "Disgrifiad",
+                                            "mandatory": false,
+                                            "guidance": "<p>Nodwch brif weithgarwch eich cyflogwr neu’ch busnes.</p><p>Ffordd arall o ddisgrifio’r prif weithgarwch yw’r diwydiant y mae’ch cyflogwr neu’ch busnes yn gweithio ynddo.</p><p>Os nad ydych yn siŵr beth yw prif weithgarwch eich cyflogwr neu’ch busnes rhowch y wybodaeth orau bosibl.</p><p>Os ydych wedi’ch cyflogi drwy asiantaeth nodwch brif weithgarwch y busnes rydych yn gweithio iddo, nid yr asiantaeth.</p>",
+                                            "type": "TextArea"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "main-job-type",
+                    "title": "main job type",
+                    "sections": [
+                        {
+                            "id": "main-job-type-section",
+                            "title": "{{[answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "main-job-type-question",
+                                    "title": "Yn eich prif swydd, a ydych (oeddech):",
+                                    "number": "39",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "main-job-type-answer",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yn weithiwr cyflogedig mewn sefydliad neu fusnes",
+                                                    "value": "Employed by an organisation or business"
+                                                },
+                                                {
+                                                    "label": "Yn hunan-gyflogedig yn eich sefydliad neu’ch busnes eich hun",
+                                                    "value": "Self-employed in your own organisation or business"
+                                                },
+                                                {
+                                                    "label": "Ddim yn gweithio i sefydliad na busnes",
+                                                    "value": "Not working for an organisation or business",
+                                                    "description": "Er enghraifft yn hunan-gyflogedig, yn gweithio ar eich liwt eich hun neu’n (arfer) gweithio i unigolyn preifat"
+                                                }
+                                            ],
+                                            "type": "Radio"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "confirmation",
+                                "when": [
+                                    {
+                                        "id": "main-job-type-answer",
+                                        "condition": "equals",
+                                        "value": "Not working for an organisation or business"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "business-name"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "questionnaire",
+                    "id": "business-name",
+                    "title": "business name",
+                    "sections": [
+                        {
+                            "id": "business-name-section",
+                            "title": "{{[answers.first_name, answers.last_name] | format_household_name }}",
+                            "questions": [
+                                {
+                                    "id": "business-name-question",
+                                    "title": "Yn eich prif swydd, beth yw (oedd) enw’r sefydliad neu’r busnes yr ydych (oeddech) yn gweithio iddo?",
+                                    "number": "39a",
+                                    "guidance": [
+                                        {
+                                            "description": "Os ydych (oeddech) yn hunan-gyflogedig yn eich sefydliad neu’ch busnes eich hun, nodwch yr enw"
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "business-name-answer",
+                                            "label": "Enw’r sefydliad neu’r busnes",
+                                            "mandatory": false,
+                                            "guidance": "<p>Mae’r cwestiwn hwn yn gofyn am enw’r sefydliad neu’r busnes yr ydych (oeddech) yn gweithio iddo fel eich prif swydd.</p><p>Os na allwch gofio enw’r sefydliad, rhowch y wybodaeth orau bosibl.</p><p>Os ydych wedi’ch cyflogi drwy asiantaeth nodwch enw’r busnes rydych yn gweithio iddo, nid yr asiantaeth.</p>",
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "interstitial",
+                    "id": "confirmation",
+                    "title": "You are ready to submit your answers",
+                    "sections": [
+                        {
+                            "title": "Rydych yn barod i gyflwyno Prawf Cyfrifiad 2017",
+                            "id": "questionnaire-completed-section",
+                            "description": "<p><strong>Diolch am gymryd rhan ym Mhrawf Cyfrifiad 2017</strong></p>",
+                            "questions": [
+                                {
+                                    "answers": [],
+                                    "id": "questionnaire-completed-question",
+                                    "title": "",
+                                    "type": "General",
+                                    "guidance": [
+                                        {
+                                            "title": "Nodwch:",
+                                            "list": [
+                                                "Drwy gyflwyno’ch ymatebion, rydych yn datgan eich bod wedi cwblhau’r prawf hyd eithaf eich gwybodaeth a’ch cred.",
+                                                "Os na fyddwch yn cyflwyno’ch holiadur, bydd eich ymatebion yn cael eu cyflwyno’n awtomatig pan fydd yr holiadur ar-lein yn cau.",
+                                                "Ar ôl cyflwyno eich holiadur cewch gyfle i roi adborth ar eich profiad."
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/functional/helpers.js
+++ b/tests/functional/helpers.js
@@ -13,6 +13,12 @@ export const startCensusQuestionnaire = (schema, sexualIdentity = false, region 
     .setSchema(schema)
     .setRegionCode(region)
 
+  var language = 'en'
+  if(process.env.EQ_LANGUAGE_CODE) {
+    language = process.env.EQ_LANGUAGE_CODE
+  }
+  devPage.setLanguageCode(language)
+
   if (sexualIdentity) {
     devPage.checkSexualIdentity()
   }

--- a/tests/functional/pages/dev.page.js
+++ b/tests/functional/pages/dev.page.js
@@ -35,6 +35,11 @@ class DevPage {
     return this
   }
 
+  setLanguageCode(language) {
+    browser.selectByValue('.qa-language-code', language)
+    return this
+  }
+
   checkSexualIdentity() {
     browser.click('.qa-sexual-identity')
     return this

--- a/tests/functional/spec/census/issues/number-of-visitors-issue.spec.js
+++ b/tests/functional/spec/census/issues/number-of-visitors-issue.spec.js
@@ -9,13 +9,13 @@ import OvernightVisitors from '../../../pages/surveys/census/household/overnight
 const expect = chai.expect
 
 describe('Number of visitors', function () {
-  it('Given a census schema, When I dont enter any value for question: How many visitors are staying overnight here on 9th April 2017?, Then I should get an error message ', function () {
+  it('Given a census schema, When I don\'t enter any value for question: How many visitors are staying overnight here on 9th April 2017?, Then I should get an error message ', function () {
     startCensusQuestionnaire('census_household.json', true)
     PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
     HouseholdComposition.setFirstName('John').submit()
     EveryoneAtAddressConfirmation.clickEveryoneAtAddressConfirmationAnswerYes().submit()
     OvernightVisitors.submit()
 
-    expect(OvernightVisitors.getErrorMsg()).to.equal('Please enter a value even if that value is 0')
+    expect(OvernightVisitors.errorExists()).to.be.true
   })
 })

--- a/tests/functional/spec/census/routing/who-lives-here.spec.js
+++ b/tests/functional/spec/census/routing/who-lives-here.spec.js
@@ -97,7 +97,7 @@ describe('Who lives here routing Scenarios', function () {
   it('Given I am answering question 1 in the who lives here section, When I dont select any response, Then I a alert msg saying mandatory field must be displayed ', function () {
     startCensusQuestionnaire('census_household.json', true)
     PermanentOrFamilyHome.submit()
-    expect(PermanentOrFamilyHome.getAlertText()).to.contain('Please select an answer to continue')
+    expect(PermanentOrFamilyHome.errorExists()).to.be.true
   })
 
   it('Given I am answering question 1a in the who lives here section, When I select -yes- as the response, Then I am routed to Who lives here question 2 ', function () {
@@ -118,7 +118,7 @@ describe('Who lives here routing Scenarios', function () {
     startCensusQuestionnaire('census_household.json', true)
     PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerNo().submit()
     ElsePermanentOrFamilyHome.submit()
-    expect(ElsePermanentOrFamilyHome.getAlertText()).to.contain('Please select an answer to continue')
+    expect(ElsePermanentOrFamilyHome.errorExists()).to.be.true
   })
 
   it('Given I am answering question 3 in the who lives here section, When I select -yes- as the response, Then I am routed to Who lives here question 4 ', function () {
@@ -251,7 +251,7 @@ describe('Who lives here routing Scenarios', function () {
     PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
     HouseholdComposition.submit()
 
-    expect(HouseholdComposition.getErrorMsg()).to.contain('Please enter a name or remove the person to continue')
+    expect(HouseholdComposition.errorExists()).to.be.true
   })
 
   it('Given I enter a first name but no middle or surname, When I save and continue, Then I should not see any errors', function () {


### PR DESCRIPTION
### What is the context of this PR?
Adds a Welsh version of the Census Household and Individual survey JSON

**Note:** Not all screen text is translated, only text that comes from the survey JSON. This means any text that comes from the templates (e.g. 'Show further guidance' or 'Save and continue') is not translated.

### How to review 
- Select `census_household.json` or `census_individual.json` from Schemas list and `cy` from Language drop down on the dev page. 
- Verify translated version of Census is loaded and all screens have survey JSON text translated
- Run functional tests against the Welsh version by exporting `EQ_LANGAUGE_CODE='cy'` before running the tests