### PR TITLE
eq-595 Mobile numeric keypad on date inputs

### DIFF
--- a/app/assets/styles/partials/components/_buttons.scss
+++ b/app/assets/styles/partials/components/_buttons.scss
@@ -61,7 +61,10 @@
 
 .btn--lg {
   font-weight: $font-weight-semibold;
-  padding: 0.9rem 5rem;
+  padding: 0.9rem 1rem;
+  @include mq(s) {
+    padding: 0.9rem 5rem;
+  }
 }
 
 .btn--link {

--- a/app/assets/styles/partials/components/_input.scss
+++ b/app/assets/styles/partials/components/_input.scss
@@ -118,10 +118,6 @@ $input-width: 20rem;
   }
 }
 
-.input--number {
-  padding-right: 0.3rem;
-}
-
 .input--block {
   display: block;
   width: 100%;

--- a/app/schema/widgets/date_widget.py
+++ b/app/schema/widgets/date_widget.py
@@ -36,7 +36,7 @@ class DateWidget(Widget):
                 'text': 'Day',
             },
             'input': {
-                'type': 'text',
+                'type': 'number',
                 'value': day,
                 'placeholder': 'DD',
                 'name': self.name + '-day',
@@ -70,7 +70,7 @@ class DateWidget(Widget):
             },
             'input': {
                 'value': year,
-                'type': 'text',
+                'type': 'number',
                 'placeholder': 'YYYY',
                 'name': self.name + '-year',
                 'id': self.name + '-year',

--- a/app/templates/partials/forms/input.html
+++ b/app/templates/partials/forms/input.html
@@ -1,13 +1,16 @@
+{% set type = "text" if input.type == "number" else input.type %}
+
 {% set attr = {
   "class": "input input--" ~ input.type ~ " " ~ input.classes,
-  "type": input.type,
+  "type": type,
   "value": input.value,
   "name": input.name,
   "id": "input-" ~ input.id,
   "placeholder": input.placeholder,
   "checked": "checked" if input.checked,
   "data-qa": "input-" ~ input.type,
-  "maxlength": input.maxlength
+  "maxlength": input.maxlength,
+  "pattern": ("[0-9]*" if input.type == "number"),
 } %}
 
 <input {{attr|xmlattr}} />


### PR DESCRIPTION
### What is the context of this PR?

Fixes #594.

- Adds numeric keypad for date (day/year) inputs.

#### Bonus

- Fixed issue with button padding on mobile

### How to review 

- Using an iOS device `test_dates` schema
- Check numeric keypad is used

![screenshot 2016-12-20 13 30 37](https://cloud.githubusercontent.com/assets/930398/21352253/90ca8d82-c6b8-11e6-9613-0332d3cfe9ab.png)