### PR TITLE
Fixes #782. Value of relationships changed from Welsh to English.

### DIFF
--- a/app/assets/js/app/modules/relationships.js
+++ b/app/assets/js/app/modules/relationships.js
@@ -41,11 +41,14 @@ class HouseholdRelationship extends EventEmitter {
 
     let selection = this.el.querySelector('input:checked')
     if (selection) {
-      this.setRelationship(selection.value)
+      this.setRelationship(selection.id)
     }
   }
 
-  setRelationship(relationship) {
+  setRelationship(relationshipId) {
+    var label = this.el.querySelector('label[for=' + relationshipId + ']')
+    var relationship = label.innerHTML
+
     this.legend.innerHTML = relationship.toLowerCase()
     this.answered = true
   }
@@ -67,7 +70,7 @@ class HouseholdRelationship extends EventEmitter {
   }, 100, { leading: true, trailing: false })
 
   onOptionChanged = (e) => {
-    this.setRelationship(e.target.getAttribute('value'))
+    this.setRelationship(e.target.getAttribute('id'))
   }
 
   onEditBtnClick = (e) => {


### PR DESCRIPTION
### What is the context of this PR?
Fixes #782.

Relationships page displays the value entered in the schema.
Since no routing is based on these values, should be able to change these to Welsh equivalent in the schema.

### How to review 
Re-test the issue.
All existing tests should pass.