### PR TITLE
Removing display configuration from schemas

### DIFF
--- a/app/data/0_rogue_one.json
+++ b/app/data/0_rogue_one.json
@@ -10,36 +10,22 @@
     "introduction": {
         "description": ""
     },
-    "display": {
-        "properties": {}
-    },
     "eq_id": "1",
     "groups": [
         {
             "blocks": [
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "f22b1ba4-d15f-48b8-a1f3-db62b6f34cc0",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "ed3e200a-0735-4e8d-9eea-627c1d908697",
                             "questions": [
                                 {
                                     "answers": [
                                         {
                                             "alias": "character",
-                                            "display": {
-                                                "properties": {
-                                                    "columns": true
-                                                }
-                                            },
                                             "guidance": "",
                                             "id": "ca3ce3a3-ae44-4e30-8f85-5b6a7a2fb23c",
                                             "label": "Who do you want to know more about?",
@@ -71,9 +57,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "4bfa0229-0ce8-4190-817b-535f55ad2817",
                                     "title": "",
                                     "type": "General",
@@ -143,26 +126,15 @@
                 },
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "26f2c4b3-28ac-4072-9f18-a6a6c6f660db",
                     "sections": [
                         {
                             "description": "Putting behind a checkered past by lending her skills to a greater cause, Jyn is impetuous, defiant, and eager to bring the battle to the Empire. Used to operating alone, she finds higher purpose by taking on a desperate mission for the Rebel Alliance.",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "b2b1eb6d-400f-452a-854f-be028600f862",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {
-                                                "properties": {
-                                                    "columns": true
-                                                }
-                                            },
                                             "guidance": "",
                                             "id": "a2c2649a-85ff-4a26-ba3c-e1880f7c807b",
                                             "label": "",
@@ -185,9 +157,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "574e5d5e-36b4-44ea-b8f6-09d744552241",
                                     "title": "Do you like this page?",
                                     "type": "General",
@@ -211,26 +180,15 @@
                 },
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "cbb1f973-7fbc-4e96-bd7b-47a8d8056a46",
                     "sections": [
                         {
                             "description": "An accomplished Rebel Alliance Intelligence Officer with combat field experience, Captain Andor commands respect from his Rebel troops with his ability to keep a cool head under fire and complete his missions with minimal resources",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "bcd67e48-7eec-4766-ab0c-acbaa3a3af01",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {
-                                                "properties": {
-                                                    "columns": true
-                                                }
-                                            },
                                             "guidance": "",
                                             "id": "3f1f1bb7-2452-4f8d-ac7a-735ea5d4517f",
                                             "label": "",
@@ -253,9 +211,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "b5c0c1fd-578c-436e-86a8-7d3b1786cb5f",
                                     "title": "Do you like this page?",
                                     "type": "General",
@@ -279,26 +234,15 @@
                 },
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "9b091307-e14c-4211-9104-91e3975d6910",
                     "sections": [
                         {
                             "description": "A former Imperial pilot, Bodhi has strong piloting and technical skills to use as the pilot of the Rebel squad. Ever practical, but highly anxious, Rook must gather his courage to bring the battle to the Empire.",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "95d5abef-d2c4-4a27-a89b-43f8bfe8f404",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {
-                                                "properties": {
-                                                    "columns": true
-                                                }
-                                            },
                                             "guidance": "",
                                             "id": "57ff0b3a-d66e-4f06-b6f8-00a4474e4ade",
                                             "label": "",
@@ -321,9 +265,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "ff1d8559-d5f7-4ba8-95fa-bf76178f4433",
                                     "title": "Do you like this page?",
                                     "type": "General",
@@ -347,26 +288,15 @@
                 },
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "b4f8e11a-dac9-4554-ba44-55fc5c5aebcb",
                     "sections": [
                         {
                             "description": "An Imperial Military Director who is obsessed with the completion of the long-delayed Death Star project. A cruel but brilliant man, Krennic has staked his reputation on the delivery of the functional battle station to the Emperor.",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "c37363d8-5a2d-479c-8b88-31c23e3f4d44",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {
-                                                "properties": {
-                                                    "columns": true
-                                                }
-                                            },
                                             "guidance": "",
                                             "id": "216d7f5b-e908-42d4-84b6-036a9f76512e",
                                             "label": "",
@@ -389,9 +319,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "15beab29-e3b3-42c5-a8ea-ce299504ce66",
                                     "title": "Do you like this page?",
                                     "type": "General",
@@ -415,26 +342,15 @@
                 },
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "5e633f04-073a-44c0-a9da-a7cc2116b937",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "c50124ac-79f5-40c9-8dc4-af8bef649981",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {
-                                            "properties": {
-                                                "columns": true
-                                            }
-                                        },
                                         "guidance": "",
                                         "id": "a04a516d-502d-4068-bbed-a43427c68cd9",
                                         "label": "",
@@ -452,9 +368,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "0ae9664b-601d-4428-8cd4-4738df48b685",
                                     "title": "In millions, how much do you think this film will take?",
                                     "type": "General",
@@ -469,9 +382,6 @@
                     "validation": []
                 }
             ],
-            "display": {
-                "properties": {}
-            },
             "id": "82504ab4-de5d-41fd-9a86-9ad5ea483296",
             "title": "",
             "validation": []

--- a/app/data/0_star_wars.json
+++ b/app/data/0_star_wars.json
@@ -14,9 +14,6 @@
             "Total Yearly cost of Rebel Alliance"
         ]
     },
-    "display": {
-        "properties": {}
-    },
     "eq_id": "0",
     "messages": {
       "INTEGER_TOO_LARGE": "Too big, that number is",
@@ -28,26 +25,15 @@
             "blocks": [
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "f22b1ba4-d15f-48b8-a1f3-db62b6f34cc0",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "ed3e200a-0735-4e8d-9eea-627c1d908697",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {
-                                                "properties": {
-                                                    "columns": false
-                                                }
-                                            },
                                             "guidance": "",
                                             "id": "ca3ce3a3-ae44-4e30-8f85-5b6a7a2fb23c",
                                             "label": "Choose a side",
@@ -83,9 +69,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "4bfa0229-0ce8-4190-817b-535f55ad2817",
                                     "title": "Which side of the force are you on?",
                                     "type": "General",
@@ -147,26 +130,15 @@
                 },
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "96682325-47ab-41e4-a56e-8315a19ffe2a",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "a7dcbb30-1187-4276-a49c-9284730ba4ed",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {
-                                                "properties": {
-                                                    "columns": true
-                                                }
-                                            },
                                             "guidance": "",
                                             "id": "91631df0-4356-4e9f-a9d9-ce8b08d26eb3",
                                             "label": "",
@@ -197,9 +169,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "680f2ff9-d5a5-4057-b1cd-9fde2660b244",
                                     "title": "A wise choice young Yedi. Pick your hero",
                                     "type": "General",
@@ -208,11 +177,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {
-                                                "properties": {
-                                                    "columns": true
-                                                }
-                                            },
                                             "guidance": "",
                                             "id": "2e0989b8-5185-4ba6-b73f-c126e3a06ba7",
                                             "label": "",
@@ -235,9 +199,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "5667e5eb-f9d3-4482-9257-edf752000708",
                                     "title": "Do you want to pick a ship?",
                                     "type": "General",
@@ -281,26 +242,15 @@
                 },
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "923ccc84-9d47-4a02-8ebc-1e9d14fcf10b",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "dcb42b6a-88b8-4258-bfe4-3e8b46db28b5",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {
-                                                "properties": {
-                                                    "columns": true
-                                                }
-                                            },
                                             "guidance": "",
                                             "id": "653e6407-43d6-4dfc-8b11-a673a73d602d",
                                             "label": "",
@@ -332,9 +282,6 @@
 
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "d9fd4a58-83a5-44df-a413-47ce41244124",
                                     "title": "Good! Your hate has made you powerful. Pick your baddie",
                                     "type": "General",
@@ -343,11 +290,6 @@
                               {
                                     "answers": [
                                         {
-                                            "display": {
-                                                "properties": {
-                                                    "columns": true
-                                                }
-                                            },
                                             "guidance": "",
                                             "id": "pel989b8-5185-4ba6-b73f-c126e3a06ba7",
                                             "label": "",
@@ -374,9 +316,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "8777e5eb-f9d3-4482-9257-edf752000708",
                                     "title": "Do you want to pick a ship?",
                                     "type": "General",
@@ -433,26 +372,15 @@
                 },
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "26f2c4b3-28ac-4072-9f18-a6a6c6f660db",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "b2b1eb6d-400f-452a-854f-be028600f862",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {
-                                                "properties": {
-                                                    "columns": true
-                                                }
-                                            },
                                             "guidance": "",
                                             "id": "a2c2649a-85ff-4a26-ba3c-e1880f7c807b",
                                             "label": "",
@@ -475,9 +403,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "574e5d5e-36b4-44ea-b8f6-09d744552241",
                                     "title": "Which ship do you want?",
                                     "type": "General",
@@ -500,26 +425,15 @@
                 },
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "fab02f02-6ce4-4f22-b61f-0c7880009f08",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "cc8ab489-4ad1-4d89-b60f-b13d550fa591",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {
-                                                "properties": {
-                                                    "columns": true
-                                                }
-                                            },
                                             "guidance": "",
                                             "id": "a5d5ca1a-cf58-4626-be35-dce81297688b",
                                             "label": "",
@@ -542,9 +456,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "cb8f691d-7925-4131-a19b-9eeef592ceea",
                                     "title": "Which ship do you want?",
                                     "type": "General",
@@ -567,22 +478,15 @@
                 },
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "cd3b74d1-b687-4051-9634-a8f9ce10a27d",
                     "sections": [
                         {
                             "description": "May the force be with you young EQ developer<br/><br/>",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "017880bc-752d-4a6b-83df-e130409ee660",
                             "questions": [
                               {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "cccfe681-9969-4175-8ac3-98184ab58423",
                                             "label": "Which species stole the plans to the second Death Star?",
@@ -593,9 +497,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "1054a0de-4878-4d24-b997-7965ad8e3e66",
                                     "title": "",
                                     "type": "General"
@@ -604,7 +505,6 @@
                                     "answers": [
                                         {
                                             "alias": "chewies_age",
-                                            "display": {},
                                             "guidance": "",
                                             "id": "6cf5c72a-c1bf-4d0c-af6c-d0f07bc5b65b",
                                             "label": "How old is Chewy?",
@@ -622,9 +522,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "88824eff-7bb6-443f-85cb-8c2db016d44c",
                                     "title": "",
                                     "type": "General"
@@ -632,7 +529,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "92e49d93-cbdc-4bcb-adb2-0e0af6c9a07c",
                                             "label": "How many Octillions do Nasa reckon it would cost to build a death star?",
@@ -650,9 +546,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "b8a803ba-2048-46dc-83cf-9ef9000d7a92",
                                     "title": "",
                                     "type": "General"
@@ -660,7 +553,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "pre49d93-cbdc-4bcb-adb2-0e0af6c9a07c",
                                             "label": "How hot is a lightsaber in degrees C?",
@@ -678,9 +570,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "d8a803ga-2048-46dc-83cf-9ef9000d7a92",
                                     "title": "",
                                     "type": "General"
@@ -688,11 +577,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {
-                                                "properties": {
-                                                    "columns": true
-                                                }
-                                            },
                                             "guidance": "",
                                             "id": "a5dc09e8-36f2-4bf4-97be-c9e6ca8cbe0d",
                                             "label": "",
@@ -720,9 +604,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "235f0930-47fb-4998-afed-d73167886d63",
                                     "title": "What animal was used to create the engine sound of the Empire's TIE fighters?",
                                     "type": "General"
@@ -730,11 +611,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {
-                                                "properties": {
-                                                    "columns": false
-                                                }
-                                            },
                                             "guidance": "",
                                             "id": "7587eb9b-f24e-4dc0-ac94-66118b896c10",
                                             "label": "",
@@ -762,9 +638,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "def61645-c231-4522-ba2f-273b25507e53",
                                     "title": "Which of these Darth Vader quotes is wrong?",
                                     "type": "General"
@@ -772,11 +645,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {
-                                                "properties": {
-                                                    "columns": true
-                                                }
-                                            },
                                             "guidance": "",
                                             "id": "9587eb9b-f24e-4dc0-ac94-66117b896c10",
                                             "label": "",
@@ -813,9 +681,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "def6r645-c231-4522-ba2f-273b25507e53",
                                     "title": "Which 3 have wielded a green lightsaber?",
                                     "type": "General"
@@ -823,11 +688,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {
-                                                "properties": {
-                                                    "columns": false
-                                                }
-                                            },
                                             "guidance": "",
                                             "id": "5587eb9b-f24e-4dc0-ac94-66117b896c10",
                                             "label": "",
@@ -863,9 +723,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "pef6r645-c231-4522-ba2f-273b25507e53",
                                     "title": "Which 3 appear in any of the opening crawlers?",
                                     "type": "General"
@@ -873,7 +730,6 @@
                               {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "6fd644b0-798e-4a58-a393-a438b32fe637",
                                             "label": "Period from",
@@ -889,7 +745,6 @@
                                             }
                                         },
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "06a6a4b7-6ce4-4687-879d-3443cd8e2ff0",
                                             "label": "Period to",
@@ -906,9 +761,6 @@
                                         }
                                     ],
                                     "description": "It could be between {{exercise.start_date|format_date}} and {{exercise.end_date|format_date}}. But that might just be a test",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "6cc86b54-330c-4465-99b2-34cc7073dc2c",
                                     "title": "When was The Empire Strikes Back released?",
                                     "type": "DateRange"
@@ -921,23 +773,16 @@
                 },
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "an3b74d1-b687-4051-9634-a8f9ce10ard",
                     "sections": [
                         {
                             "description": "If you didn't pick the right employment date for Return of the Jedi its your fault if this question makes no sense",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "12346782-08a6-4213-9dc9-0780c2996896",
                             "questions": [
 
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "5rr015b1-f87c-4740-9fd4-f01f707ef558",
                                             "label": "What was the total number of Ewokes?",
@@ -955,9 +800,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "rt4eedc2-d98c-4d4d-9a7c-997ce10c361f",
                                     "title": "",
                                     "type": "General"
@@ -967,15 +809,11 @@
                         },
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "94546782-08a6-4213-9dc9-0780c2996896",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "c8d9d66e-6c0a-439e-8ef9-e0d7038be009",
                                             "label": "What else did the Bothan spies steal for the Rebel Alliance?",
@@ -986,9 +824,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "048e40da-bca4-48e5-9885-0bb6413bef62",
                                     "title": "The force is strong with you, young Jedi!",
                                     "type": "General",
@@ -1005,11 +840,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {
-                                                "properties": {
-                                                    "max_length": "2000"
-                                                }
-                                            },
                                             "guidance": "",
                                             "id": "215015b1-f87c-4740-9fd4-f01f707ef558",
                                             "label": "Why doesn't Chewbacca receive a medal at the end of A New Hope?",
@@ -1020,9 +850,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "fef6edc2-d98c-4d4d-9a7c-997ce10c361f",
                                     "title": "",
                                     "type": "General"
@@ -1030,11 +857,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {
-                                                "properties": {
-                                                    "columns": false
-                                                }
-                                            },
                                             "guidance": "",
                                             "id": "7587qe9b-f24e-4dc0-ac94-66118b896c10",
                                             "label": "",
@@ -1054,9 +876,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "fef6qwc2-d98c-4d4d-9a7c-997ce10c361f",
                                     "title": "Do you really think that Chewbacca is {{answers.chewies_age}} years old?",
                                     "type": "General"
@@ -1064,7 +883,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "77e20f0e-cabb-4eac-8cb0-ac6e66f0e95f",
                                             "label": "",
@@ -1084,9 +902,6 @@
                                         }
                                     ],
                                     "description": "Episodes I-III",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "a3967576-e1a0-4930-9bb4-475157ca5f7c",
                                     "title": "What do you think of the prequel series?",
                                     "type": "General"
@@ -1099,22 +914,15 @@
                 },
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "846f8514-fed2-4bd7-8fb2-4b5fcb1622b1",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "d45aa634-fed7-42ab-a1d8-dca512b9d834",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "fcf636ff-7b3d-47b6-aaff-9a4b00aa888b",
                                             "label": "What is the name of Jar Jar Binks' home planet?",
@@ -1125,9 +933,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "f2ee7dd4-b63c-45f1-a883-9f89c937ad17",
                                     "title": "",
                                     "type": "General",
@@ -1144,7 +949,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "4a085fe5-6830-4ef6-96e6-2ea2b3caf0c1",
                                             "label": "",
@@ -1184,9 +988,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "9e104317-6a19-48a5-b70f-7aec92deb90e",
                                     "title": "Finally, which  is your favourite film?",
                                     "type": "General"
@@ -1198,9 +999,6 @@
                     "title": ""
                 }
             ],
-            "display": {
-                "properties": {}
-            },
             "id": "14ba4707-321d-441d-8d21-b8367366e766",
             "title": ""
         }

--- a/app/data/1_0102.json
+++ b/app/data/1_0102.json
@@ -15,31 +15,21 @@
           "reasons for changes to figures"
         ]
     },
-    "display": {
-        "properties": {}
-    },
     "eq_id": "1",
     "groups": [
         {
             "blocks": [
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "5bce8d8f-0af8-4d35-b77d-744e6179b406",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "2d5e6844-d1c0-4280-baa4-26ee68b81489",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "94f368e4-7c6c-4272-a780-8c46328626a2",
                                             "label": "Period from",
@@ -55,7 +45,6 @@
                                             }
                                         },
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "dc156715-3d48-4af3-afed-7a0a6bb65583",
                                             "label": "Period to",
@@ -72,9 +61,6 @@
                                         }
                                     ],
                                     "description": "If possible, this should be for the period {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}.",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "f5ef26e3-b22d-4689-9053-3eefac4504e8",
                                     "title": "What are the dates of the period that you will be reporting for?",
                                     "type": "DateRange",
@@ -90,22 +76,15 @@
                 },
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "7418732e-12fb-4270-8307-5682ac63bfae",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "5ed7e98a-146f-415d-9f4b-75c8d45e495e",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "ea08f977-33a8-4933-ad7b-c497997107cf",
                                             "label": "Total retail turnover",
@@ -143,9 +122,6 @@
                                             ]
                                         }
                                     ],
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "7a4b1aee-d6b9-4581-ab18-1191e5ebb94d",
                                     "title": "For the reporting period, what was the value of the business’s total retail turnover?",
                                     "type": "General",
@@ -161,22 +137,15 @@
                 },
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "02ed26ad-4cfc-4e29-a946-630476228b2c",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "fdd9dc60-59f2-475e-af1e-9bfe30010e36",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "66612bbb-bc06-4d38-b32c-e2a113641c8a",
                                             "label": "Internet sales",
@@ -201,9 +170,6 @@
                                             "list": [ "VAT" ]
                                         }
                                     ],
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "eb40935b-b771-4082-adc4-37e4c0b04208",
                                     "title": "Of the business's total retail turnover, what was the value of internet sales?",
                                     "type": "General",
@@ -219,26 +185,15 @@
                 },
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "f55cccc6-0755-455d-9f9e-085f1bf55399",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "2a7f1c20-8a10-4fe4-96ff-b9356e32302f",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {
-                                                "properties": {
-                                                    "max_length": "2000"
-                                                }
-                                            },
                                             "guidance": "<div><p>Examples of commentary:</p><p><strong>'In-store promotion'</strong></p> <p>Offer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales.</p><strong> 'Special events (for example, sporting events)'</strong></p><p>This was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online.</p><p><strong>‘Weather'</strong></p><p>The bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month.</div>",
                                             "id": "568e2c81-b11d-4682-bd89-f170481c9a48",
                                             "label": "Comments",
@@ -261,9 +216,6 @@
                                             ]
                                         }
                                     ],
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "d434cea3-00ac-4954-8ad8-ef6bb9e85041",
                                     "title": "Indicate the reasons for any changes in the business's total retail turnover",
                                     "type": "General",
@@ -278,9 +230,6 @@
                     "validation": []
                 }
             ],
-            "display": {
-                "properties": {}
-            },
             "id": "07f40cd2-0704-4804-9f32-19309089a51b",
             "title": "",
             "validation": []

--- a/app/data/1_0112.json
+++ b/app/data/1_0112.json
@@ -16,31 +16,21 @@
           "reasons for changes to figures"
         ]
     },
-    "display": {
-        "properties": {}
-    },
     "eq_id": "1",
     "groups": [
         {
             "blocks": [
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "980b148e-0856-4e50-9afe-67a4fa6ae13b",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "b3c2e966-77ec-4373-b3dd-fdafb5a05cbd",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "fad63234-1083-4f6a-826a-20b5df6e4baa",
                                             "label": "Period from",
@@ -56,7 +46,6 @@
                                             }
                                         },
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "c8c4bd92-fd45-4fd1-83b6-18c813de2df2",
                                             "label": "Period to",
@@ -73,9 +62,6 @@
                                         }
                                     ],
                                     "description": "If possible, this should be for the period {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}.",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "1ce1e40e-64e1-4f9a-bb56-85f04c9e7e5d",
                                     "title": "What are the dates of the period that you will be reporting for?",
                                     "type": "DateRange",
@@ -91,22 +77,15 @@
                 },
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "6c8a2f39-e0d8-406f-b463-2151225abea2",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "fc71d2a7-e5b3-4409-bb66-902efbbf7e20",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "fe88fa9a-3c49-4fbc-9408-a91c0a1cc6d5",
                                             "label": "Total retail turnover",
@@ -144,9 +123,6 @@
                                             ]
                                         }
                                     ],
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "61c5a553-3ba7-4cd2-bdf0-cd67f011ea6c",
                                     "title": "For the reporting period, what was the value of the business’s total retail turnover?",
                                     "type": "General",
@@ -162,22 +138,15 @@
                 },
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "0c7c8876-6a63-4251-ac29-b821b3e9b1bc",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "5355deab-0b1e-495d-b4ab-f3e1f7c0c6f1",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "78774493-5b64-45c4-8072-22f1a9638095",
                                             "label": "Internet sales",
@@ -202,9 +171,6 @@
                                             "list": [ "VAT" ]
                                         }
                                     ],
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "449774d1-7969-4282-bbce-bceb7e8ba374",
                                     "title": "Of the business's total retail turnover, what was the value of internet sales?",
                                     "type": "General",
@@ -220,26 +186,15 @@
                 },
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "a42b5752-1896-4f52-9d58-320085be92a7",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "a04ed3cc-ddbc-48e0-83c2-630d2b0cb063",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {
-                                                "properties": {
-                                                    "max_length": "2000"
-                                                }
-                                            },
                                             "guidance": "<div><p>Examples of commentary:</p><p><strong>'In-store promotion'</strong></p> <p>Offer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales.</p><strong> 'Special events (for example, sporting events)'</strong></p><p>This was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online.</p><p><strong>‘Weather'</strong></p><p>The bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month.</div>",
                                             "id": "287e8c33-9d52-4589-9c1c-3db11d0eec20",
                                             "label": "Comments",
@@ -262,9 +217,6 @@
                                             ]
                                         }
                                     ],
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "fe06b609-5200-404b-bd94-da94843e1b8c",
                                     "title": "Indicate the reasons for any changes in the business's total retail turnover",
                                     "type": "General",
@@ -280,21 +232,14 @@
                 },
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "0b29d3f7-5905-43d8-9921-5b353db68104",
                     "sections": [
                         {
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "2f73e574-2178-4415-afcd-6c07adb75864",
                             "questions": [
                                 {
                                     "answers": [
                                       {
-                                          "display": {},
                                           "guidance": "",
                                           "id": "dc309fdf-eeaf-4f1d-85df-1f5569749ea8",
                                           "label": "Male employees working more than 30 hours per week",
@@ -311,7 +256,6 @@
                                           }
                                       },
                                       {
-                                          "display": {},
                                           "guidance": "",
                                           "id": "06909776-3238-4e8b-9a3f-97e5a6b2182f",
                                           "label": "Male employees working 30 hours or less per week",
@@ -328,7 +272,6 @@
                                           }
                                       },
                                       {
-                                          "display": {},
                                           "guidance": "",
                                           "id": "a7e2cd8f-54e5-427b-b9e2-ce90613a5dba",
                                           "label": "Female employees working more than 30 hours per week",
@@ -345,7 +288,6 @@
                                           }
                                       },
                                       {
-                                          "display": {},
                                           "guidance": "",
                                           "id": "bf73b3bc-4d8d-4472-8c1b-ca7680a39469",
                                           "label": "Female employees working 30 hours or less per week",
@@ -362,7 +304,6 @@
                                           }
                                       },
                                       {
-                                          "display": {},
                                           "guidance": "",
                                           "id": "c6881970-98ff-4005-af4a-60bfd9b6179f",
                                           "label": "Total number of employees",
@@ -380,9 +321,6 @@
                                           }
                                       }
                                     ],
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "17136377-f52e-4a00-a1d6-039972fc26ab",
                                     "title": "On {{exercise.employment_date|format_date}} what was the number of employees?",
                                     "description": "<p>An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.</p>",
@@ -418,26 +356,15 @@
                 },
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "7e2d49eb-ffc7-4a61-a45d-eba336d1d0e6",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "edb9d0f9-effa-46b2-a35b-889394f6e755",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {
-                                                "properties": {
-                                                    "max_length": "2000"
-                                                }
-                                            },
                                             "id": "414699da-1667-44fd-8e98-7606966884db",
                                             "label": "Comments",
                                             "mandatory": false,
@@ -459,9 +386,6 @@
                                             ]
                                         }
                                     ],
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "a30d5bdd-72e6-43ab-91fc-4e63c5174cbb",
                                     "title": "Explain any significant changes in the number of employees",
                                     "type": "General",
@@ -476,9 +400,6 @@
                     "validation": []
                 }
             ],
-            "display": {
-                "properties": {}
-            },
             "id": "f74d1147-673c-497a-9616-763829d944ac",
             "title": "",
             "validation": []

--- a/app/data/1_0203.json
+++ b/app/data/1_0203.json
@@ -15,31 +15,21 @@
           "reasons for changes to figures"
         ]
     },
-    "display": {
-        "properties": {}
-    },
     "eq_id": "1",
     "groups": [
         {
             "blocks": [
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "cd3b74d1-b687-4051-9634-a8f9ce10a27d",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "f11bc7dc-3940-4c7d-9d0e-faa6acb23eeb",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "6fd644b0-798e-4a58-a393-a438b32fe637",
                                             "label": "Period from",
@@ -55,7 +45,6 @@
                                             }
                                         },
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "06a6a4b7-6ce4-4687-879d-3443cd8e2ff0",
                                             "label": "Period to",
@@ -72,9 +61,6 @@
                                         }
                                     ],
                                     "description": "If possible, this should be for the period {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}.",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "6cc86b54-330c-4465-99b2-34cc7073dc2c",
                                     "title": "What are the dates of the sales period you are reporting for?",
                                     "type": "DateRange",
@@ -86,9 +72,6 @@
                         },
                         {
                             "description": "<p>- You should enter figures for the reporting period stated above<br>- You should round your figures to the nearest (\u00a3) pound</p>",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "d9d25a21-41b8-42b2-ac7b-fb21b1036d71",
                             "questions": [
                                 {
@@ -103,7 +86,6 @@
                                     ],
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "<div> <h4>Include</h4> <ul> <li>all fresh food</li> <li>other food for human consumption (except chocolate and sugar confectionery)</li> <li>soft drinks</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>sales from catering facilities used by customers</li> </ul> </div>",
                                             "id": "bb8168e6-2272-450d-b5a7-d3170508efb2",
                                             "label": "What was the value of the business's total sales of food?",
@@ -121,9 +103,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "eedb9f9f-2f2e-41f4-9186-ba7110d9e6a4",
                                     "title": "",
                                     "type": "General",
@@ -132,7 +111,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "<div> <h4>Include</h4> <ul> <li>alcoholic drink</li> <li>chocolate and sugar confectionery</li> <li>tobacco and smokers\u2019 requisites</li></ul> </div>",
                                             "id": "fee0b9fe-4c3a-4c14-9611-4fa9e2e9578a",
                                             "label": "What was the value of the business's total sales of alcohol, confectionery and tobacco?",
@@ -150,9 +128,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "5743fe04-e9a3-491f-b475-ea5be662eff3",
                                     "title": "",
                                     "type": "General",
@@ -161,7 +136,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "<div> <h4>Include</h4><ul> <li>clothing and footwear</li> <li>clothing fabrics</li> <li>haberdashery and furs</li> <li>leather and travel goods</li> <li>handbags</li> <li>umbrellas</li></ul></div>",
                                             "id": "01ac2ebf-d49d-45e8-8f7a-0f847aa7cf25",
                                             "label": "What was the value of the business's total sales of clothing and footwear?",
@@ -179,9 +153,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "475471a1-7be0-4a7a-82b3-2b803d3935ed",
                                     "title": "",
                                     "type": "General",
@@ -190,7 +161,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "<div> <h4>Include</h4><ul> <li>carpets, rugs and other floor coverings</li> <li>furniture</li> <li>household textiles and soft furnishings</li> <li>prints and picture frames</li> <li>antiques and works of art</li> <li>domestic electrical and gas appliances, audio/visual equipment and home computers</li> <li>lighting and minor electrical supplies</li> <li>records, compact discs, audio and video tapes</li> <li>musical instruments and goods</li> <li>decorators\u2019 and DIY supplies</li> <li>lawn-mowers</li> <li>hardware</li> <li>china, glassware and cutlery</li> <li>novelties, souvenirs and gifts</li> <li>e-cigarettes</li> </ul></div>",
                                             "id": "7605c4a9-2c3a-483c-908b-e07244105ac4",
                                             "label": "What was the value of the business's total sales of household goods?",
@@ -208,9 +178,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "656eaad2-67ed-4413-93dd-06d66c954a22",
                                     "title": "",
                                     "type": "General",
@@ -219,7 +186,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "<div> <h4>Include</h4> <ul>  <li>toiletries and medications (except NHS receipts)</li> <li>newspapers and periodicals</li> <li>books, stationery and office supplies</li> <li>photographic and optical goods</li> <li>spectacles, contact lenses and sunglasses</li> <li>toys and games</li> <li>cycles and cycle accessories</li> <li>sport and camping equipment</li> <li>jewellery</li> <li>silverware and plate, clocks and watches</li> <li>household cleaning products and kitchen paper products</li> <li>pets, pets\u2019 requisites and pet foods</li> <li>cut flowers, plants, seeds and other garden sundries</li> <li>other new and second hand goods</li> <li>Mobile phones</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>revenue from mobile phone network commission and top up </li> <li>lottery sales and commission from lottery sales</li> <li>sales of car accessories and motor vehicles</li> <li>NHS receipts</li> </ul> </div>",
                                             "id": "5843e26e-a139-4645-baa9-51bdb0aba27b",
                                             "label": "What was the value of the business\u2019s total sales of other goods?",
@@ -237,9 +203,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "d7144593-8899-434a-8630-c622df1689b2",
                                     "title": "",
                                     "type": "General",
@@ -248,7 +211,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "<div> <h4>Include</h4> <ul> <li>VAT</li> <li>internet sales</li> <li>retail sale from outlets in Great Britain to customers abroad</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>revenue from mobile phone network commission and top up </li> <li>sales from catering facilities used by customers</li>  <li>lottery sales and commission from lottery sales</li> <li>sales of car accessories and motor vehicles</li> <li>NHS receipts</li> </ul> </div>",
                                             "id": "e81adc6d-6fb0-4155-969c-d0d646f15345",
                                             "label": "What was the value of the business\u2019s total retail turnover?",
@@ -267,9 +229,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "6c302f72-cf9d-4f42-8a35-cb258c3f807c",
                                     "title": "",
                                     "type": "General",
@@ -278,7 +237,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "<div> <h4>Include</h4><ul> <li>VAT</li> <li>sales from orders received over the internet, irrespective of the payment or delivery method</li> </ul></div>",
                                             "id": "4b75a6f7-9774-4b2b-82dc-976561189a99",
                                             "label": "Of your total retail turnover, how much were from internet sales?",
@@ -296,9 +254,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "c9902a3b-7dbb-48ff-8d3f-dce6fef322c7",
                                     "title": "",
                                     "type": "General",
@@ -310,19 +265,11 @@
                         },
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "94546782-08a6-4213-9dc9-0780c2996896",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {
-                                                "properties": {
-                                                    "max_length": "2000"
-                                                }
-                                            },
                                             "guidance": "",
                                             "id": "215015b1-f87c-4740-9fd4-f01f707ef558",
                                             "label": "Comments",
@@ -336,9 +283,6 @@
                                         }
                                     ],
                                     "description": "Please explain any movements in your data, for example, sale held, branches opened or sold, extreme weather, or temporary closure of shop",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "fef6edc2-d98c-4d4d-9a7c-997ce10c361f",
                                     "title": "",
                                     "type": "General",
@@ -353,9 +297,6 @@
                     "validation": []
                 }
             ],
-            "display": {
-                "properties": {}
-            },
             "id": "14ba4707-321d-441d-8d21-b8367366e766",
             "title": "",
             "validation": []

--- a/app/data/1_0205.json
+++ b/app/data/1_0205.json
@@ -213,12 +213,7 @@
 							"guidance": "",
 							"type": "TextArea",
 							"options": [],
-							"mandatory": false,
-							"display": {
-								"properties": {
-									"max_length": "2000"
-								}
-							}
+							"mandatory": false
 						}]
 					}]
 				}

--- a/app/data/1_0213.json
+++ b/app/data/1_0213.json
@@ -16,31 +16,21 @@
           "reasons for changes to figures"
         ]
     },
-    "display": {
-        "properties": {}
-    },
     "eq_id": "1",
     "groups": [
         {
             "blocks": [
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "cd3b74d1-b687-4051-9634-a8f9ce10a27d",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "f11bc7dc-3940-4c7d-9d0e-faa6acb23eeb",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "6fd644b0-798e-4a58-a393-a438b32fe637",
                                             "label": "Period from",
@@ -56,7 +46,6 @@
                                             }
                                         },
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "06a6a4b7-6ce4-4687-879d-3443cd8e2ff0",
                                             "label": "Period to",
@@ -73,9 +62,6 @@
                                         }
                                     ],
                                     "description": "If possible, this should be for the period {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}.",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "6cc86b54-330c-4465-99b2-34cc7073dc2c",
                                     "title": "What are the dates of the sales period you are reporting for?",
                                     "type": "DateRange",
@@ -87,9 +73,6 @@
                         },
                         {
                             "description": "<p>- You should enter figures for the reporting period stated above<br>- You should round your figures to the nearest (\u00a3) pound</p>",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "d9d25a21-41b8-42b2-ac7b-fb21b1036d71",
                             "questions": [
                                 {
@@ -104,7 +87,6 @@
                                     ],
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "<div> <h4>Include</h4> <ul> <li>all fresh food</li> <li>other food for human consumption (except chocolate and sugar confectionery)</li> <li>soft drinks</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>sales from catering facilities used by customers</li> </ul> </div>",
                                             "id": "bb8168e6-2272-450d-b5a7-d3170508efb2",
                                             "label": "What was the value of the business's total sales of food?",
@@ -122,9 +104,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "eedb9f9f-2f2e-41f4-9186-ba7110d9e6a4",
                                     "title": "",
                                     "type": "General",
@@ -133,7 +112,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "<div> <h4>Include</h4> <ul> <li>alcoholic drink</li> <li>chocolate and sugar confectionery</li> <li>tobacco and smokers\u2019 requisites</li></ul> </div>",
                                             "id": "fee0b9fe-4c3a-4c14-9611-4fa9e2e9578a",
                                             "label": "What was the value of the business's total sales of alcohol, confectionery and tobacco?",
@@ -151,9 +129,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "5743fe04-e9a3-491f-b475-ea5be662eff3",
                                     "title": "",
                                     "type": "General",
@@ -162,7 +137,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "<div> <h4>Include</h4><ul> <li>clothing and footwear</li> <li>clothing fabrics</li> <li>haberdashery and furs</li> <li>leather and travel goods</li> <li>handbags</li> <li>umbrellas</li></ul></div>",
                                             "id": "01ac2ebf-d49d-45e8-8f7a-0f847aa7cf25",
                                             "label": "What was the value of the business's total sales of clothing and footwear?",
@@ -180,9 +154,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "475471a1-7be0-4a7a-82b3-2b803d3935ed",
                                     "title": "",
                                     "type": "General",
@@ -191,7 +162,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "<div> <h4>Include</h4><ul> <li>carpets, rugs and other floor coverings</li> <li>furniture</li> <li>household textiles and soft furnishings</li> <li>prints and picture frames</li> <li>antiques and works of art</li> <li>domestic electrical and gas appliances, audio/visual equipment and home computers</li> <li>lighting and minor electrical supplies</li> <li>records, compact discs, audio and video tapes</li> <li>musical instruments and goods</li> <li>decorators\u2019 and DIY supplies</li> <li>lawn-mowers</li> <li>hardware</li> <li>china, glassware and cutlery</li> <li>novelties, souvenirs and gifts</li> <li>e-cigarettes</li> </ul></div>",
                                             "id": "7605c4a9-2c3a-483c-908b-e07244105ac4",
                                             "label": "What was the value of the business's total sales of household goods?",
@@ -209,9 +179,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "656eaad2-67ed-4413-93dd-06d66c954a22",
                                     "title": "",
                                     "type": "General",
@@ -220,7 +187,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "<div> <h4>Include</h4> <ul>  <li>toiletries and medications (except NHS receipts)</li> <li>newspapers and periodicals</li> <li>books, stationery and office supplies</li> <li>photographic and optical goods</li> <li>spectacles, contact lenses and sunglasses</li> <li>toys and games</li> <li>cycles and cycle accessories</li> <li>sport and camping equipment</li> <li>jewellery</li> <li>silverware and plate, clocks and watches</li> <li>household cleaning products and kitchen paper products</li> <li>pets, pets\u2019 requisites and pet foods</li> <li>cut flowers, plants, seeds and other garden sundries</li> <li>other new and second hand goods</li> <li>Mobile phones</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>revenue from mobile phone network commission and top up </li> <li>lottery sales and commission from lottery sales</li> <li>sales of car accessories and motor vehicles</li> <li>NHS receipts</li> </ul> </div>",
                                             "id": "5843e26e-a139-4645-baa9-51bdb0aba27b",
                                             "label": "What was the value of the business\u2019s total sales of other goods?",
@@ -238,9 +204,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "d7144593-8899-434a-8630-c622df1689b2",
                                     "title": "",
                                     "type": "General",
@@ -249,7 +212,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "<div> <h4>Include</h4> <ul> <li>VAT</li> <li>internet sales</li> <li>retail sale from outlets in Great Britain to customers abroad</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>revenue from mobile phone network commission and top up </li> <li>sales from catering facilities used by customers</li>  <li>lottery sales and commission from lottery sales</li> <li>sales of car accessories and motor vehicles</li> <li>NHS receipts</li> </ul> </div>",
                                             "id": "e81adc6d-6fb0-4155-969c-d0d646f15345",
                                             "label": "What was the value of the business\u2019s total retail turnover?",
@@ -268,9 +230,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "6c302f72-cf9d-4f42-8a35-cb258c3f807c",
                                     "title": "",
                                     "type": "General",
@@ -279,7 +238,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "<div> <h4>Include</h4><ul> <li>VAT</li> <li>sales from orders received over the internet, irrespective of the payment or delivery method</li> </ul></div>",
                                             "id": "4b75a6f7-9774-4b2b-82dc-976561189a99",
                                             "label": "Of your total retail turnover, how much were from internet sales?",
@@ -297,9 +255,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "c9902a3b-7dbb-48ff-8d3f-dce6fef322c7",
                                     "title": "",
                                     "type": "General",
@@ -311,19 +266,11 @@
                         },
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "94546782-08a6-4213-9dc9-0780c2996896",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {
-                                                "properties": {
-                                                    "max_length": "2000"
-                                                }
-                                            },
                                             "guidance": "",
                                             "id": "215015b1-f87c-4740-9fd4-f01f707ef558",
                                             "label": "Comments",
@@ -337,9 +284,6 @@
                                         }
                                     ],
                                     "description": "Please explain any movements in your data, for example, sale held, branches opened or sold, extreme weather, or temporary closure of shop",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "fef6edc2-d98c-4d4d-9a7c-997ce10c361f",
                                     "title": "",
                                     "type": "General",
@@ -355,16 +299,10 @@
                 },
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "2d24cb72-5598-4c3e-bd53-1d21bb12455f",
                     "sections": [
                         {
                             "description": "<p>An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.</p>",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "c528d24b-d0dd-45cd-91af-380b61a5725d",
                             "questions": [
                                 {
@@ -389,7 +327,6 @@
                                     ],
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "cffbbca5-1162-44d8-bbfb-3bc733d80239",
                                             "label": "What was the number of male employees working more than 30 hours per week?",
@@ -407,9 +344,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "59ccb6e3-4a0a-4c32-b798-aafbf6b9e481",
                                     "title": "",
                                     "type": "General",
@@ -418,7 +352,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "c5908b75-d63d-4518-b00e-a60919aa63cd",
                                             "label": "What was the number of male employees working 30 hours or less per week?",
@@ -436,9 +369,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "fdafbc19-25b0-4985-a676-100df5bf25d3",
                                     "title": "",
                                     "type": "General",
@@ -447,7 +377,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "0ac86568-2e33-420c-9dfe-f47a95132a5a",
                                             "label": "What was the number of female employees working more than 30 hours per week?",
@@ -465,9 +394,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "e10d5a63-ac30-4031-8c71-20eb04196978",
                                     "title": "",
                                     "type": "General",
@@ -476,7 +402,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "ed675602-9696-49ba-b3b9-2ea582ffe171",
                                             "label": "What was the number of female employees working 30 hours or less per week?",
@@ -494,9 +419,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "87f52d2a-b0e4-47f2-b884-ce94df109ed9",
                                     "title": "",
                                     "type": "General",
@@ -505,7 +427,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "42ee21a7-c050-49f7-9cdc-647596f22317",
                                             "label": "What was the total number of employees?",
@@ -524,9 +445,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "b08ffc0f-c148-462e-a988-0a8ca259436a",
                                     "title": "",
                                     "type": "General",
@@ -541,9 +459,6 @@
                     "validation": []
                 }
             ],
-            "display": {
-                "properties": {}
-            },
             "id": "14ba4707-321d-441d-8d21-b8367366e766",
             "title": "",
             "validation": []

--- a/app/data/1_0215.json
+++ b/app/data/1_0215.json
@@ -16,31 +16,21 @@
           "reasons for changes to figures"
         ]
     },
-    "display": {
-        "properties": {}
-    },
     "eq_id": "1",
     "groups": [
         {
             "blocks": [
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "cd3b74d1-b687-4051-9634-a8f9ce10a27d",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "f11bc7dc-3940-4c7d-9d0e-faa6acb23eeb",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "6fd644b0-798e-4a58-a393-a438b32fe637",
                                             "label": "Period from",
@@ -56,7 +46,6 @@
                                             }
                                         },
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "06a6a4b7-6ce4-4687-879d-3443cd8e2ff0",
                                             "label": "Period to",
@@ -73,9 +62,6 @@
                                         }
                                     ],
                                     "description": "If possible, this should be for the period {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}.",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "6cc86b54-330c-4465-99b2-34cc7073dc2c",
                                     "title": "What are the dates of the sales period you are reporting for?",
                                     "type": "DateRange",
@@ -87,9 +73,6 @@
                         },
                         {
                             "description": "<p>- You should enter figures for the reporting period stated above<br>- You should round your figures to the nearest (\u00a3) pound</p>",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "d9d25a21-41b8-42b2-ac7b-fb21b1036d71",
                             "questions": [
                                 {
@@ -104,7 +87,6 @@
                                     ],
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "<div> <h4>Include</h4> <ul> <li>all fresh food</li> <li>other food for human consumption (except chocolate and sugar confectionery)</li> <li>soft drinks</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>sales from catering facilities used by customers</li> </ul> </div>",
                                             "id": "bb8168e6-2272-450d-b5a7-d3170508efb2",
                                             "label": "What was the value of the business's total sales of food?",
@@ -122,9 +104,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "eedb9f9f-2f2e-41f4-9186-ba7110d9e6a4",
                                     "title": "",
                                     "type": "General",
@@ -133,7 +112,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "<div> <h4>Include</h4> <ul> <li>alcoholic drink</li> <li>chocolate and sugar confectionery</li> <li>tobacco and smokers\u2019 requisites</li></ul> </div>",
                                             "id": "fee0b9fe-4c3a-4c14-9611-4fa9e2e9578a",
                                             "label": "What was the value of the business's total sales of alcohol, confectionery and tobacco?",
@@ -151,9 +129,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "5743fe04-e9a3-491f-b475-ea5be662eff3",
                                     "title": "",
                                     "type": "General",
@@ -162,7 +137,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "<div> <h4>Include</h4><ul> <li>clothing and footwear</li> <li>clothing fabrics</li> <li>haberdashery and furs</li> <li>leather and travel goods</li> <li>handbags</li> <li>umbrellas</li></ul></div>",
                                             "id": "01ac2ebf-d49d-45e8-8f7a-0f847aa7cf25",
                                             "label": "What was the value of the business's total sales of clothing and footwear?",
@@ -180,9 +154,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "475471a1-7be0-4a7a-82b3-2b803d3935ed",
                                     "title": "",
                                     "type": "General",
@@ -191,7 +162,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "<div> <h4>Include</h4><ul> <li>carpets, rugs and other floor coverings</li> <li>furniture</li> <li>household textiles and soft furnishings</li> <li>prints and picture frames</li> <li>antiques and works of art</li> <li>domestic electrical and gas appliances, audio/visual equipment and home computers</li> <li>lighting and minor electrical supplies</li> <li>records, compact discs, audio and video tapes</li> <li>musical instruments and goods</li> <li>decorators\u2019 and DIY supplies</li> <li>lawn-mowers</li> <li>hardware</li> <li>china, glassware and cutlery</li> <li>novelties, souvenirs and gifts</li> <li>e-cigarettes</li> </ul></div>",
                                             "id": "7605c4a9-2c3a-483c-908b-e07244105ac4",
                                             "label": "What was the value of the business's total sales of household goods?",
@@ -209,9 +179,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "656eaad2-67ed-4413-93dd-06d66c954a22",
                                     "title": "",
                                     "type": "General",
@@ -220,7 +187,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "<div> <h4>Include</h4> <ul>  <li>toiletries and medications (except NHS receipts)</li> <li>newspapers and periodicals</li> <li>books, stationery and office supplies</li> <li>photographic and optical goods</li> <li>spectacles, contact lenses and sunglasses</li> <li>toys and games</li> <li>cycles and cycle accessories</li> <li>sport and camping equipment</li> <li>jewellery</li> <li>silverware and plate, clocks and watches</li> <li>household cleaning products and kitchen paper products</li> <li>pets, pets\u2019 requisites and pet foods</li> <li>cut flowers, plants, seeds and other garden sundries</li> <li>other new and second hand goods</li> <li>Mobile phones</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>revenue from mobile phone network commission and top up </li> <li>lottery sales and commission from lottery sales</li> <li>sales of car accessories and motor vehicles</li> <li>NHS receipts</li> </ul> </div>",
                                             "id": "5843e26e-a139-4645-baa9-51bdb0aba27b",
                                             "label": "What was the value of the business\u2019s total sales of other goods?",
@@ -238,9 +204,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "d7144593-8899-434a-8630-c622df1689b2",
                                     "title": "",
                                     "type": "General",
@@ -249,7 +212,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "<div> <h4>Include</h4> <ul> <li>VAT</li> <li>internet sales</li> <li>retail sale from outlets in Great Britain to customers abroad</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>revenue from mobile phone network commission and top up </li> <li>sales from catering facilities used by customers</li>  <li>lottery sales and commission from lottery sales</li> <li>sales of car accessories and motor vehicles</li> <li>NHS receipts</li> </ul> </div>",
                                             "id": "e81adc6d-6fb0-4155-969c-d0d646f15345",
                                             "label": "What was the value of the business\u2019s total retail turnover?",
@@ -268,9 +230,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "6c302f72-cf9d-4f42-8a35-cb258c3f807c",
                                     "title": "",
                                     "type": "General",
@@ -279,7 +238,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "<div> <h4>Include</h4><ul> <li>VAT</li> <li>sales from orders received over the internet, irrespective of the payment or delivery method</li> </ul></div>",
                                             "id": "4b75a6f7-9774-4b2b-82dc-976561189a99",
                                             "label": "Of your total retail turnover, how much were from internet sales?",
@@ -297,9 +255,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "c9902a3b-7dbb-48ff-8d3f-dce6fef322c7",
                                     "title": "",
                                     "type": "General",
@@ -308,7 +263,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "<div><h4>Include</h4><ul> <li>VAT</li> <li>sales of fuel owned by you</li> <li>sales of other items not paid a commission for</li>  </ul></div><div> <h4>Exclude</h4> <ul> <li>sales of fuel not owned by you</li> <li>any commissions</li> </ul></div>",
                                             "id": "b2bac3ed-5504-43ef-a883-f9ca8496aca3",
                                             "label": "What was the value of the business\u2019s total sales of automotive fuel?",
@@ -326,9 +280,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "96984134-1863-4450-b314-c44cf48d2bcd",
                                     "title": "",
                                     "type": "General",
@@ -340,19 +291,11 @@
                         },
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "94546782-08a6-4213-9dc9-0780c2996896",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {
-                                                "properties": {
-                                                    "max_length": "2000"
-                                                }
-                                            },
                                             "guidance": "",
                                             "id": "215015b1-f87c-4740-9fd4-f01f707ef558",
                                             "label": "Comments",
@@ -366,9 +309,6 @@
                                         }
                                     ],
                                     "description": "Please explain any movements in your data, for example, sale held, branches opened or sold, extreme weather, or temporary closure of shop",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "fef6edc2-d98c-4d4d-9a7c-997ce10c361f",
                                     "title": "",
                                     "type": "General",
@@ -384,16 +324,10 @@
                 },
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "2d24cb72-5598-4c3e-bd53-1d21bb12455f",
                     "sections": [
                         {
                             "description": "<p>An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.</p>",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "c528d24b-d0dd-45cd-91af-380b61a5725d",
                             "questions": [
                                 {
@@ -418,7 +352,6 @@
                                     ],
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "cffbbca5-1162-44d8-bbfb-3bc733d80239",
                                             "label": "What was the number of male employees working more than 30 hours per week?",
@@ -436,9 +369,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "59ccb6e3-4a0a-4c32-b798-aafbf6b9e481",
                                     "title": "",
                                     "type": "General",
@@ -447,7 +377,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "c5908b75-d63d-4518-b00e-a60919aa63cd",
                                             "label": "What was the number of male employees working 30 hours or less per week?",
@@ -465,9 +394,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "fdafbc19-25b0-4985-a676-100df5bf25d3",
                                     "title": "",
                                     "type": "General",
@@ -476,7 +402,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "0ac86568-2e33-420c-9dfe-f47a95132a5a",
                                             "label": "What was the number of female employees working more than 30 hours per week?",
@@ -494,9 +419,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "e10d5a63-ac30-4031-8c71-20eb04196978",
                                     "title": "",
                                     "type": "General",
@@ -505,7 +427,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "ed675602-9696-49ba-b3b9-2ea582ffe171",
                                             "label": "What was the number of female employees working 30 hours or less per week?",
@@ -523,9 +444,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "87f52d2a-b0e4-47f2-b884-ce94df109ed9",
                                     "title": "",
                                     "type": "General",
@@ -534,7 +452,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "42ee21a7-c050-49f7-9cdc-647596f22317",
                                             "label": "What was the total number of employees?",
@@ -553,9 +470,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "b08ffc0f-c148-462e-a988-0a8ca259436a",
                                     "title": "",
                                     "type": "General",
@@ -570,9 +484,6 @@
                     "validation": []
                 }
             ],
-            "display": {
-                "properties": {}
-            },
             "id": "14ba4707-321d-441d-8d21-b8367366e766",
             "title": "",
             "validation": []

--- a/app/data/multiple_answers.json
+++ b/app/data/multiple_answers.json
@@ -13,9 +13,6 @@
           "Personal details"
         ]
     },
-    "display": {
-        "properties": {}
-    },
     "eq_id": "1",
     "groups": [
         {
@@ -23,21 +20,14 @@
 
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "personal_details_block",
                     "sections": [
                         {
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "personal_details_section",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "first_name_answer",
                                             "label": "What is your first name",
@@ -49,7 +39,6 @@
                                               }
                                         },
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "surname_answer",
                                             "label": "What is your surname",
@@ -62,9 +51,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "personal_details_question",
                                     "title": "Tell me about yourself",
                                     "description" : "Answer the question with multiple answers",
@@ -80,9 +66,6 @@
                     "validation": []
                 }
             ],
-            "display": {
-                "properties": {}
-            },
             "id": "multiple_questions_group",
             "title": "",
             "validation": []

--- a/app/data/test_checkbox.json
+++ b/app/data/test_checkbox.json
@@ -14,9 +14,6 @@
             "Other info"
         ]
     },
-    "display": {
-        "properties": {}
-    },
     "eq_id": "0",
     "messages": {
       "INTEGER_TOO_LARGE": "Number is too large",
@@ -28,26 +25,15 @@
             "blocks": [
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "f22b1ba4-d15f-48b8-a1f3-db62b6f34cc0",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "ed3e200a-0735-4e8d-9eea-627c1d908697",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {
-                                                "properties": {
-                                                    "columns": false
-                                                }
-                                            },
                                             "guidance": "",
                                             "id": "ca3ce3a3-ae44-4e30-8f85-5b6a7a2fb23c",
                                             "label": "",
@@ -90,9 +76,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "4bfa0229-0ce8-4190-817b-535f55ad2817",
                                     "title": "Which pizza toppings would you like?",
                                     "type": "General",
@@ -109,26 +92,15 @@
                     "validation": []
                 }, {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "f22b1ba4-d15f-48b8-a1f3-db62b6f34cc1",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "ed3e200a-0735-4e8d-9eea-627c1d908696",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {
-                                                "properties": {
-                                                    "columns": false
-                                                }
-                                            },
                                             "guidance": "",
                                             "id": "ca3ce3a3-ae44-4e30-8f85-5b6a7a2fb23",
                                             "label": "",
@@ -171,9 +143,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "4bfa0229-0ce8-4190-817b-535f55ad2811",
                                     "title": "What extra toppings would you like?",
                                     "type": "General",
@@ -189,9 +158,6 @@
                     "title": "",
                     "validation": []
                 }],
-            "display": {
-                "properties": {}
-            },
             "id": "14ba4707-321d-441d-8d21-b8367366e761",
             "title": ""
         }

--- a/app/data/test_conditional_routing.json
+++ b/app/data/test_conditional_routing.json
@@ -95,7 +95,6 @@
                     "description": "",
                     "type": "General",
                     "answers": [{
-                        "display": {},
                         "id": "response-yes-number-of-cups",
                         "label": "Number of cups",
                         "mandatory": true,
@@ -129,7 +128,6 @@
                     "description": "",
                     "type": "General",
                     "answers": [{
-                        "display": {},
                         "id": "response-no-number-of-cups",
                         "label": "Number of cups",
                         "mandatory": true,

--- a/app/data/test_currency.json
+++ b/app/data/test_currency.json
@@ -11,9 +11,6 @@
         "description": "",
         "information_to_provide": []
     },
-    "display": {
-        "properties": {}
-    },
     "eq_id": "0",
     "messages": {
       "INTEGER_TOO_LARGE": "Number is too large",
@@ -25,22 +22,15 @@
             "blocks": [
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "block",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "section",
                             "questions": [
                               {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "answer",
                                             "label": "How much did you spend?",
@@ -51,9 +41,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "question",
                                     "title": "",
                                     "type": "General"
@@ -68,9 +55,6 @@
                     "title": "",
                     "validation": []
                 }],
-            "display": {
-                "properties": {}
-            },
             "id": "group",
             "title": ""
         }

--- a/app/data/test_dates.json
+++ b/app/data/test_dates.json
@@ -13,31 +13,21 @@
             "dates"
         ]
     },
-    "display": {
-        "properties": {}
-    },
     "eq_id": "0",
     "groups": [
         {
             "blocks": [
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "b10c8c7a-97fe-4bee-a4fb-e75f3a6f56c0",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "7352fd10-bb24-407a-9f13-23cc8b1cb51d",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "5b12aea2-ae3b-467d-9291-4d803a444d25",
                                             "label": "Period from",
@@ -53,7 +43,6 @@
                                             }
                                         },
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "ce42c1f7-a32a-46d5-8183-f54e38616617",
                                             "label": "Period to",
@@ -70,9 +59,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "e9130586-f72a-4b68-8373-885ad51d6cd5",
                                     "title": "Date range",
                                     "type": "DateRange",
@@ -81,7 +67,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "eade17ef-3ec6-46c2-afc7-dffeb07e2e5e",
                                             "label": "Date",
@@ -98,9 +83,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "9858220e-0514-4868-984f-8bb2481fde8f",
                                     "title": "Date with month and year",
                                     "type": "General",
@@ -109,7 +91,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "a51b1c7b-3f25-49dd-9275-2ea742eee510",
                                             "label": "Date",
@@ -126,9 +107,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "3b7d43d1-8e0e-499d-928e-7cd78be8525e",
                                     "title": "Single date type",
                                     "type": "General",
@@ -137,7 +115,6 @@
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "98fa9cec-e0bb-471e-80e3-1ff3d9242ef8",
                                             "label": "Date",
@@ -154,9 +131,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "cb2c75b7-6a2c-4e47-9303-ff6246d8f752",
                                     "title": "Non Mandatory",
                                     "type": "General",
@@ -171,9 +145,6 @@
                     "validation": []
                 }
             ],
-            "display": {
-                "properties": {}
-            },
             "id": "a23d36db-6b07-4ce0-94b2-a843369511e3",
             "title": "",
             "validation": []

--- a/app/data/test_final_confirmation.json
+++ b/app/data/test_final_confirmation.json
@@ -10,9 +10,6 @@
     "introduction": {
         "description": ""
     },
-    "display": {
-        "properties": {}
-    },
     "eq_id": "0",
     "messages": {
         "INTEGER_TOO_LARGE": "Number is too large",
@@ -24,22 +21,15 @@
             "blocks": [
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "f22b1ba4-d15f-48b8-a1f3-db62b6f34cc0",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "ed3e200a-0735-4e8d-9eea-627c1d908697",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "ca3ce3a3-ae44-4e30-8f85-5b6a7a2fb23c",
                                             "label": "What is your favourite breakfast food",
@@ -50,9 +40,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "4bfa0229-0ce8-4190-817b-535f55ad2817",
                                     "title": "",
                                     "type": "General",
@@ -70,9 +57,6 @@
                 },
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "sections": [],
                     "id": "confirmation",
                     "title": "Thank you for your answers, do you wish to submit",
@@ -86,9 +70,6 @@
                     ]
                 }
             ],
-            "display": {
-                "properties": {}
-            },
             "id": "14ba4707-321d-441d-8d21-b8367366e766",
             "title": ""
         }

--- a/app/data/test_household_question.json
+++ b/app/data/test_household_question.json
@@ -40,7 +40,6 @@
                                   "validation": [],
                                   "answers": [
                                     {
-                                        "display": {},
                                         "id": "first-name",
                                         "alias": "first_name",
                                         "label": "First Name",
@@ -51,7 +50,6 @@
                                         "validation": {}
                                     },
                                     {
-                                        "display": {},
                                         "id": "middle-names",
                                         "alias": "middle_names",
                                         "label": "Middle Names",
@@ -62,7 +60,6 @@
                                         "validation": {}
                                     },
                                     {
-                                        "display": {},
                                         "id": "last-name",
                                         "alias": "last_name",
                                         "label": "Last Name",

--- a/app/data/test_interstitial_page.json
+++ b/app/data/test_interstitial_page.json
@@ -11,9 +11,6 @@
         "description": "",
         "information_to_provide": []
     },
-    "display": {
-        "properties": {}
-    },
     "eq_id": "0",
     "messages": {
         "INTEGER_TOO_LARGE": "Number is too large",
@@ -25,22 +22,15 @@
             "blocks": [
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "breakfast-block",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "breakfast-section",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "favourite-breakfast",
                                             "label": "What is your favourite breakfast food",
@@ -51,9 +41,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "favourite-breakfast-question",
                                     "title": "",
                                     "type": "General",
@@ -73,22 +60,13 @@
                     "type": "interstitial",
                     "id": "breakfast-interstitial",
                     "title": "Breakfast Interstitial Page",
-                    "display": {
-                        "properties": {}
-                    },
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "interstitial-section",
                             "questions": [
                                 {
                                     "description": "You have successfully completed the breakfast section. Next we want to know about your lunch.",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "answers": [],
                                     "id": "interstitial-question",
                                     "title": "Breakfast Interstitial Page",
@@ -103,22 +81,15 @@
                 },
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "lunch-block",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "lunch-section",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "favourite-lunch",
                                             "label": "What is your favourite lunchtime food",
@@ -129,9 +100,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "favourite-lunch-question",
                                     "title": "",
                                     "type": "General",
@@ -148,9 +116,6 @@
                     "validation": []
                 }
             ],
-            "display": {
-                "properties": {}
-            },
             "id": "favourite-foods",
             "title": ""
         }

--- a/app/data/test_question_guidance.json
+++ b/app/data/test_question_guidance.json
@@ -63,7 +63,6 @@
                                     "type": "General",
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "answer-test-guidance-all",
                                             "label": "Text question",
@@ -104,7 +103,6 @@
                                     "type": "General",
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "answer-test-guidance-title",
                                             "label": "Text question",
@@ -150,7 +148,6 @@
                                     "type": "General",
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "answer-test-guidance-description",
                                             "label": "Text question",
@@ -200,7 +197,6 @@
                                     "type": "General",
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "answer-test-guidance-lists",
                                             "label": "Text question",

--- a/app/data/test_radio.json
+++ b/app/data/test_radio.json
@@ -11,9 +11,6 @@
         "description": "",
         "information_to_provide": []
     },
-    "display": {
-        "properties": {}
-    },
     "eq_id": "0",
     "messages": {
       "INTEGER_TOO_LARGE": "Number is too large",
@@ -25,27 +22,16 @@
             "blocks": [
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "f22b1ba4-d15f-48b8-a1f3-db62b6f34cc0",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "ed3e200a-0735-4e8d-9eea-627c1d908697",
                             "questions": [
                                 {
                                     "answers": [
                                         {
                                             "alias" : "othervalue",
-                                            "display": {
-                                                "properties": {
-                                                    "columns": false
-                                                }
-                                            },
                                             "guidance": "",
                                             "id": "ca3ce3a3-ae44-4e30-8f85-5b6a7a2fb23c",
                                             "label": "What is your favourite breakfast food",
@@ -80,9 +66,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "4bfa0229-0ce8-4190-817b-535f55ad2817",
                                     "title": "",
                                     "type": "General",
@@ -100,27 +83,16 @@
                 },
             {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "an3b74d1-b687-4051-9634-a8f9ce10ard",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "94546782-08a6-4213-9dc9-0780c2996896",
                             "questions": [
                                 {
                                     "answers": [
                                         {
                                             "alias" : "",
-                                            "display": {
-                                                "properties": {
-                                                    "columns": false
-                                                }
-                                            },
                                             "guidance": "",
                                             "id": "7587qe9b-f24e-4dc0-ac94-66118b896c10",
                                             "label": "What is your favourite breakfast food",
@@ -155,9 +127,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "fef6qwc2-d98c-4d4d-9a7c-997ce10c361f",
                                         "title": "Do you really want {{answers.othervalue}} for breakfast?",
                                     "type": "General"
@@ -167,9 +136,6 @@
                     ],
                     "title": ""
                 }],
-            "display": {
-                "properties": {}
-            },
             "id": "14ba4707-321d-441d-8d21-b8367366e766",
             "title": ""
         }

--- a/app/data/test_relationship_household.json
+++ b/app/data/test_relationship_household.json
@@ -36,7 +36,6 @@
                                   "validation": [],
                                   "answers": [
                                     {
-                                        "display": {},
                                         "id": "first-name",
                                         "label": "First Name",
                                         "mandatory": false,
@@ -46,7 +45,6 @@
                                         "validation": {}
                                     },
                                     {
-                                        "display": {},
                                         "id": "middle-names",
                                         "label": "Middle Names",
                                         "mandatory": false,
@@ -56,7 +54,6 @@
                                         "validation": {}
                                     },
                                     {
-                                        "display": {},
                                         "id": "last-name",
                                         "label": "Last Name",
                                         "mandatory": false,
@@ -105,7 +102,6 @@
                                         {
                                             "id": "who-is-related",
                                             "label": "%(current_person)s is the &hellip; of %(other_person)s",
-                                            "display": {},
                                             "guidance": "",
                                             "mandatory": false,
                                             "q_code": "2",

--- a/app/data/test_repeating_household.json
+++ b/app/data/test_repeating_household.json
@@ -17,22 +17,13 @@
 
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "household-composition",
                     "sections": [
                         {
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "section",
                             "questions": [
                                 {
                                   "description": "",
-                                  "display": {
-                                      "properties": {}
-                                  },
                                   "id": "household-composition-question",
                                   "title": "Who usually lives here?",
                                   "description": "<br> <div> <h3>Include:</h3> <ul> <li>Yourself, if this is your permanent or family home </li> <li>Family members including partners, children and babies born on or before 9 April 2017</li> <li>Students and/or school children who live away from home during term time</li> <li>Housemates, tenants or lodgers</li> </ul> </div>",
@@ -41,7 +32,6 @@
                                   "answers": [
                                     {
                                         "alias": "first_name",
-                                        "display": {},
                                         "id": "first-name",
                                         "label": "First Name",
                                         "mandatory": false,
@@ -52,7 +42,6 @@
                                     },
                                     {
                                         "alias": "middle_names",
-                                        "display": {},
                                         "id": "middle-names",
                                         "label": "Middle Names",
                                         "mandatory": false,
@@ -63,7 +52,6 @@
                                     },
                                     {
                                         "alias": "last_name",
-                                        "display": {},
                                         "id": "last-name",
                                         "label": "Last Name",
                                         "mandatory": false,
@@ -84,9 +72,6 @@
                     "validation": []
                 }
             ],
-            "display": {
-                "properties": {}
-            },
             "id": "multiple-questions-group",
             "title": "",
             "validation": []

--- a/app/data/test_skip_condition_group.json
+++ b/app/data/test_skip_condition_group.json
@@ -93,7 +93,6 @@
                                     "type": "General",
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "should-skip-answer",
                                             "label": "Why didn't you skip the group?",
@@ -133,7 +132,6 @@
                                     "type": "General",
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "last-group-answer",
                                             "label": "This group is required as a skipped group can't be the last group",

--- a/app/data/test_textarea.json
+++ b/app/data/test_textarea.json
@@ -11,9 +11,6 @@
         "description": "",
         "information_to_provide": []
     },
-    "display": {
-        "properties": {}
-    },
     "eq_id": "0",
     "messages": {
       "INTEGER_TOO_LARGE": "Number is too large",
@@ -25,22 +22,15 @@
             "blocks": [
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "block",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "section",
                             "questions": [
                               {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "answer",
                                             "label": "Enter your comments",
@@ -51,9 +41,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "question",
                                     "title": "",
                                     "type": "General"
@@ -68,9 +55,6 @@
                     "title": "",
                     "validation": []
                 }],
-            "display": {
-                "properties": {}
-            },
             "id": "group",
             "title": ""
         }

--- a/app/data/test_textfield.json
+++ b/app/data/test_textfield.json
@@ -11,9 +11,6 @@
         "description": "",
         "information_to_provide": []
     },
-    "display": {
-        "properties": {}
-    },
     "eq_id": "0",
     "messages": {
       "INTEGER_TOO_LARGE": "Number is too large",
@@ -25,22 +22,15 @@
             "blocks": [
                 {
                     "type": "questionnaire",
-                    "display": {
-                        "properties": {}
-                    },
                     "id": "block",
                     "sections": [
                         {
                             "description": "",
-                            "display": {
-                                "properties": {}
-                            },
                             "id": "section",
                             "questions": [
                               {
                                     "answers": [
                                         {
-                                            "display": {},
                                             "guidance": "",
                                             "id": "answer",
                                             "label": "What is your name?",
@@ -51,9 +41,6 @@
                                         }
                                     ],
                                     "description": "",
-                                    "display": {
-                                        "properties": {}
-                                    },
                                     "id": "question",
                                     "title": "",
                                     "type": "General"
@@ -68,9 +55,6 @@
                     "title": "",
                     "validation": []
                 }],
-            "display": {
-                "properties": {}
-            },
             "id": "group",
             "title": ""
         }


### PR DESCRIPTION
### What is the context of this PR?
* Displaying answers in columns is not supported in any schema other
  than test schema so removing.
* max_length display property is no longer supported

If we need display property related configuration this can easily be added in when we fully support it in the future by looking back in the git history.

### How to review 
All tests should pass.