### PR TITLE
Adding postgres instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ If using virtualenvwrapper (if not, you should be), create a new virtual env for
 mkvirtual --python=`which python3` <your env name>
 ```
 
+Install postgres using homebrew or an alternative package manager
+
+```
+brew install postgres
+```
+
 Install dependencies using pip
 
 ```


### PR DESCRIPTION
### What is the context of this PR?
If postgres isn't install when running `pip install -r requirements.txt` you will see
Collecting psycopg2==2.6.1 (from -r requirements.txt (line 203))
  Using cached psycopg2-2.6.1.tar.gz
    Complete output from command python setup.py egg_info:
    running egg_info
    creating pip-egg-info/psycopg2.egg-info
    writing top-level names to pip-egg-info/psycopg2.egg-info/top_level.txt
    writing dependency_links to pip-egg-info/psycopg2.egg-info/dependency_links.txt
    writing pip-egg-info/psycopg2.egg-info/PKG-INFO
    writing manifest file 'pip-egg-info/psycopg2.egg-info/SOURCES.txt'
    warning: manifest_maker: standard file '-c' not found
    Error: pg_config executable not found.

### How to review 
Validate build instructions are correct
