### PR TITLE
Removing logic to load schemas from s3

### DIFF
--- a/app/schema_loader/schema_loader.py
+++ b/app/schema_loader/schema_loader.py
@@ -4,10 +4,6 @@ import os
 
 from app import settings
 
-import boto3
-
-import botocore
-
 
 class SchemaNotFound(Exception):
     pass
@@ -36,20 +32,6 @@ def load_schema(eq_id, form_type, language_code='en'):
     if form_type and form_type != "-1":
         return load_schema_file(filename_format.format(eq_id, form_type), language_code)
 
-    return load_s3_schema_file("{}.json".format(eq_id))
-
-
-def load_s3_schema_file(schema_file):
-    if settings.EQ_SCHEMA_BUCKET:
-        try:
-            s3 = boto3.resource('s3')
-            schema = s3.Object(settings.EQ_SCHEMA_BUCKET, schema_file)
-            jsn_schema = schema.get()['Body']
-            return json.loads(jsn_schema.read().decode("utf-8"))
-        except botocore.exceptions.ClientError as e:
-            logging.error("S3 error: %s", e.response['Error']['Code'])
-    return None
-
 
 def load_schema_file(schema_file, language_code='en'):
     try:
@@ -71,10 +53,7 @@ def load_schema_file(schema_file, language_code='en'):
 
 
 def available_schemas():
-    files = available_local_schemas()
-    if settings.EQ_SCHEMA_BUCKET:
-        files.extend(available_s3_schemas())
-    return sorted(files)
+    return sorted(available_local_schemas())
 
 
 def available_local_schemas():
@@ -84,16 +63,4 @@ def available_local_schemas():
             # ignore hidden file
             if file.endswith(".json"):
                 files.append(file)
-    return files
-
-
-def available_s3_schemas():
-    files = []
-    try:
-        s3 = boto3.resource('s3')
-        schemas_bucket = s3.Bucket(settings.EQ_SCHEMA_BUCKET)
-        for key in schemas_bucket.objects.all():
-            files.append(key.key)
-    except botocore.exceptions.ClientError as e:
-        logging.error("S3 error: %s", e.response['Error']['Code'])
     return files

--- a/app/schema_loader/schema_loader.py
+++ b/app/schema_loader/schema_loader.py
@@ -53,14 +53,10 @@ def load_schema_file(schema_file, language_code='en'):
 
 
 def available_schemas():
-    return sorted(available_local_schemas())
-
-
-def available_local_schemas():
     files = []
     for file in os.listdir(settings.EQ_SCHEMA_DIRECTORY):
         if os.path.isfile(os.path.join(settings.EQ_SCHEMA_DIRECTORY, file)):
             # ignore hidden file
             if file.endswith(".json"):
                 files.append(file)
-    return files
+    return sorted(files)

--- a/app/settings.py
+++ b/app/settings.py
@@ -48,7 +48,6 @@ EQ_SCHEMA_DIRECTORY = os.getenv('EQ_SCHEMA_DIRECTORY', 'app/data')
 EQ_SESSION_TIMEOUT = int(os.getenv('EQ_SESSION_TIMEOUT', '28800'))
 EQ_SECRET_KEY = os.getenv('EQ_SECRET_KEY', os.urandom(24))
 EQ_UA_ID = os.getenv('EQ_UA_ID', '')
-EQ_SCHEMA_BUCKET = os.getenv('EQ_SCHEMA_BUCKET', "eq-schema-files-" + os.getenv('USER', 'UNKNOWN'))
 EQ_MAX_REPLAY_COUNT = os.getenv('EQ_REPLAY_COUNT', 50)
 
 

--- a/tests/app/data/test_schema_validation.py
+++ b/tests/app/data/test_schema_validation.py
@@ -21,7 +21,7 @@ class TestSchemaValidation(unittest.TestCase):
 
         errors = []
 
-        files = schema_loader.available_local_schemas()
+        files = schema_loader.available_schemas()
 
         schema_file = open(os.path.join(settings.EQ_SCHEMA_DIRECTORY, "schema/schema-v1.json"), encoding="utf8")
         schema = json.load(schema_file)

--- a/tests/app/schema_loader/test_schema_loader.py
+++ b/tests/app/schema_loader/test_schema_loader.py
@@ -1,18 +1,13 @@
 import unittest
-import json
 
-from app.schema_loader.schema_loader import load_schema, load_s3_schema_file, available_s3_schemas
-from mock import patch, Mock
+from app.schema_loader.schema_loader import load_schema
 from app import settings
-
-import botocore
 
 
 class SchemaLoaderTest(unittest.TestCase):
 
     def setUp(self):
         self.original_bucket = settings.EQ_SCHEMA_BUCKET
-        settings.EQ_SCHEMA_BUCKET = "test-test-test"
 
     def tearDown(self):
         settings.EQ_SCHEMA_BUCKET = self.original_bucket
@@ -37,39 +32,3 @@ class SchemaLoaderTest(unittest.TestCase):
 
     def test_load_schema_with_language_code(self):
         self.assertIsNotNone(load_schema("test", "language", "cy"))
-
-    def test_available_s3_schemas(self):
-        mocked_keys = [Mock(key='test_schema_1.json'), Mock(key='test_schema_2.json')]
-        mocked_connection = Mock()
-        with patch('boto3.resource', Mock(return_value=mocked_connection)):
-            mocked_bucket = Mock()
-            mocked_connection.Bucket = Mock(return_value=mocked_bucket)
-            mocked_bucket.objects.all = Mock(return_value=mocked_keys)
-
-            expected = ['test_schema_1.json', 'test_schema_2.json']
-
-            self.assertEqual(expected, available_s3_schemas())
-
-    def test_load_s3_schema(self):
-        mocked_json = '{"survey": "some_survey"}'
-        mocked_connection = Mock()
-        with patch('boto3.resource', Mock(return_value=mocked_connection)):
-            mocked_file = Mock()
-            mocked_file.read = Mock(return_value=mocked_json.encode())
-            mocked_object = Mock()
-            mocked_connection.Object = Mock(return_value=mocked_object)
-            mocked_object.get.return_value = {"Body": mocked_file}
-
-            self.assertEqual(json.loads(mocked_json), load_s3_schema_file("ignored_filename.json"))
-
-    def test_load_invalid_s3_schema(self):
-
-        mocked_connection = Mock()
-        with patch('boto3.resource', Mock(return_value=mocked_connection)) as mocked_resource:
-            stubbed_error = {'Error': {'Code': '500', 'Message': "Couldn't find file"}}
-            mocked_resource.side_effect = botocore.exceptions.ClientError(stubbed_error, "Some operation")
-
-            self.assertIsNone(load_s3_schema_file("999999.json"))
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/app/schema_loader/test_schema_loader.py
+++ b/tests/app/schema_loader/test_schema_loader.py
@@ -1,16 +1,9 @@
 import unittest
 
 from app.schema_loader.schema_loader import load_schema
-from app import settings
 
 
 class SchemaLoaderTest(unittest.TestCase):
-
-    def setUp(self):
-        self.original_bucket = settings.EQ_SCHEMA_BUCKET
-
-    def tearDown(self):
-        settings.EQ_SCHEMA_BUCKET = self.original_bucket
 
     def test_load_schema(self):
         self.assertIsNotNone(load_schema("1", "0203"))


### PR DESCRIPTION
### What is the context of this PR?
The app fails to start up if you don't have the EQ_SCHEMA_BUCKET.
We don't currently utilise s3 for loading schemas therefore we can
remove the logic until the time it is needed.

### How to review 
All tests should still pass.
