### PR TITLE
Support ‘or‘ rules for group skip_condition to fix visitors interstitial page being displayed when skipping sections via navigation

### DIFF
--- a/app/data/census_household.json
+++ b/app/data/census_household.json
@@ -4740,15 +4740,25 @@
             "id": "visitors-interstitial",
             "title": "Visitors",
             "hide_in_navigation": true,
-            "skip_condition": {
-               "when": [
-                   {
-                       "id" : "overnight-visitors-answer",
-                       "condition": "equals",
-                       "value": "0"
-                   }
-               ]
-            },
+            "skip_condition": [
+                {
+                    "when": [
+                        {
+                            "id": "overnight-visitors-answer",
+                            "condition": "equals",
+                            "value": "0"
+                        }
+                    ]
+                },
+                {
+                   "when": [
+                       {
+                           "id" : "overnight-visitors-answer",
+                           "condition": "not set"
+                       }
+                   ]
+                }
+            ],
             "blocks": [
                 {
                     "type": "interstitial",

--- a/app/data/schema/schema-v1.json
+++ b/app/data/schema/schema-v1.json
@@ -4,6 +4,7 @@
   "definitions": {
     "when": {
       "type": "array",
+      "description": "Configure conditional rules. By adding more than one `condition` element it will evaluate as an and rule.",
         "items" : {
             "type": "object",
             "properties": {
@@ -81,32 +82,6 @@
     },
     "groups": {
       "type": "array",
-      "completed_id": {
-          "type":"string"
-      },
-      "highlight_when": {
-            "type": "array",
-            "items": {
-                "type": "string"
-            },
-            "minItems": 1,
-            "uniqueItems": true
-      },
-      "hide_in_navigation": {
-          "type":"boolean"
-      },
-      "skip_condition": {
-        "description": "Allows a group to be skipped when a condition has been met.",
-        "type": "object",
-        "properties": {
-          "when": {
-            "$ref": "#/definitions/when"
-          }
-        },
-        "required": [
-          "when"
-        ]
-      },
       "items": {
         "type": "object",
         "properties": {
@@ -115,6 +90,34 @@
           },
           "title": {
             "type": "string"
+          },
+          "completed_id": {
+              "type":"string"
+          },
+          "highlight_when": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "minItems": 1,
+                "uniqueItems": true
+          },
+          "hide_in_navigation": {
+              "type":"boolean"
+          },
+          "skip_condition": {
+            "description": "Allows a group to be skipped when a condition has been met. By adding more than one `when` element it will evaluate as an or rule.",
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "properties": {
+              "when": {
+                "$ref": "#/definitions/when"
+              }
+            },
+            "required": [
+              "when"
+            ]
           },
           "blocks": {
             "type": "array",

--- a/app/data/test_skip_condition_group.json
+++ b/app/data/test_skip_condition_group.json
@@ -61,15 +61,17 @@
         {
             "id": "should-skip-group",
             "title": "This question may or may not be skipped",
-            "skip_condition": {
-               "when": [
-                   {
-                       "id" : "do-you-want-to-skip-answer",
-                       "condition": "equals",
-                       "value": "Yes"
-                   }
-               ]
-            },
+            "skip_condition": [
+                {
+                   "when": [
+                       {
+                           "id" : "do-you-want-to-skip-answer",
+                           "condition": "equals",
+                           "value": "Yes"
+                       }
+                   ]
+                }
+            ],
             "blocks": [
                 {
                     "type": "questionnaire",

--- a/app/questionnaire/navigator.py
+++ b/app/questionnaire/navigator.py
@@ -4,7 +4,8 @@ from collections import defaultdict
 
 from app.data_model.answer_store import AnswerStore
 from app.helpers.schema_helper import SchemaHelper
-from app.questionnaire.rules import evaluate_goto, evaluate_repeat, evaluate_when_rules, is_goto_rule
+from app.questionnaire.rules import evaluate_goto, evaluate_repeat, evaluate_skip_condition, is_goto_rule
+
 
 logger = logging.getLogger(__name__)
 
@@ -192,7 +193,7 @@ class Navigator:
 
         for group_index, group in enumerate(SchemaHelper.get_groups(self.survey_json)):
             if 'skip_condition' in group:
-                skip = evaluate_when_rules(group['skip_condition']['when'], self.metadata, self.answer_store)
+                skip = evaluate_skip_condition(group['skip_condition'], self.metadata, self.answer_store)
                 if skip:
                     continue
 

--- a/app/templates/partials/navigation.html
+++ b/app/templates/partials/navigation.html
@@ -6,7 +6,7 @@
       {% if group.current_location %}
         <div>{{group.link_name}}</div>
       {% else %}
-        <a class="nav__link" href="{{meta.survey|format_url(group.group_id, group.instance, group.block_id)}}">{{group.link_name}}</a>
+        <a class="nav__link" href="{{meta.survey|format_url(group.group_id, group.instance, group.block_id)}}" data-qa="navigate-to-{{group.group_id}}">{{group.link_name}}</a>
       {% endif %}
       </li>
     {% endfor %}

--- a/tests/functional/pages/surveys/census/household/navigation.js
+++ b/tests/functional/pages/surveys/census/household/navigation.js
@@ -1,0 +1,10 @@
+class Navigation {
+
+  navigateToHouseholdAndAccommodation() {
+    browser.element('[data-qa="navigate-to-household-and-accommodation"]').click()
+    return this
+  }
+
+}
+
+export default new Navigation()

--- a/tests/functional/spec/census/routing/visitors.spec.js
+++ b/tests/functional/spec/census/routing/visitors.spec.js
@@ -2,6 +2,7 @@ import chai from 'chai'
 import {startCensusQuestionnaire} from '../../../helpers'
 import {completeHouseholdAndAccommodation, completeVisitorSection, completeHouseholdAndAccommodationNoOneAtAddress} from '../complete-section'
 
+import Navigation from '../../../pages/surveys/census/household/navigation.js'
 import PermanentOrFamilyHome from '../../../pages/surveys/census/household/permanent-or-family-home.page.js'
 import ElsePermanentOrFamilyHome from '../../../pages/surveys/census/household/else-permanent-or-family-home.page.js'
 import HouseholdComposition from '../../../pages/surveys/census/household/household-composition.page.js'
@@ -82,6 +83,7 @@ import ThankYou from '../../../pages/thank-you.page'
 
 const expect = chai.expect
 
+
 describe('Visitors routing', function () {
 
     it('Given I have two visitors, When I complete the visitor details for person one, Then I should be asked visitor details for person two.', function () {
@@ -116,6 +118,19 @@ describe('Visitors routing', function () {
 
         // Then
         expect(Confirmation.isOpen()).to.equal(true, 'Expected to skip visitor questions')
+    })
+
+    it('Given I skip to the household and accommodation section, When I complete the section, Then I should the who lives here section.', function () {
+        // Given
+        startCensusQuestionnaire('census_household.json')
+        Navigation.navigateToHouseholdAndAccommodation()
+
+
+        // When
+        completeHouseholdAndAccommodationNoOneAtAddress()
+
+        // Then
+        expect(PermanentOrFamilyHome.isOpen()).to.equal(true, 'Expected to route to who lives here section')
     })
 
 })


### PR DESCRIPTION
### What is the context of this PR?
[trello card](https://trello.com/c/OIsxmKxW/816-eq-survey-runner-740-none-or-zero-visitors-answer-still-shows-visitor-section-complete-interstitial-issue)
Fixes #740
We need to be able to support `or` rules for the census visitors
interstitial page so that it is skipped when the number of visitors is 0
or skipped via navigation. We have changed the skip_condition
configuration to take an array of when elements. Adding more than one
when element creates a `or` rule like so.

```
"skip_condition": [
                {
                    "when": [
                        {
                            "id": "overnight-visitors-answer",
                            "condition": "equals",
                            "value": "0"
                        }
                    ]
                },
                {
                   "when": [
                       {
                           "id" : "overnight-visitors-answer",
                           "condition": "not set"
                       }
                   ]
                }
            ],
```
### How to review 
1. Load the census_household schema
1. Skip to the household and accommodation section
1. Complete the household and accommodation section

Expect to be routed to the `who lives here` section