### PR TITLE
fixed guidance alignment issue

### DIFF
--- a/app/assets/styles/partials/components/_guidance.scss
+++ b/app/assets/styles/partials/components/_guidance.scss
@@ -55,6 +55,7 @@
   opacity: 0;
   transition: all 0;
   max-height: 0;
+  margin-left: 0.5rem;
   .no-js &,
   .is-expanded & {
     max-height: 10000em;


### PR DESCRIPTION
### What is the context of this PR?

Fixes regressed CSS on guidance.

### How to review 

Make sure alignment of border is as below:

<img width="645" alt="screenshot 2016-12-21 16 05 54" src="https://cloud.githubusercontent.com/assets/930398/21396271/8b2c3ecc-c797-11e6-949b-120fa580c1e9.png">
