### PR TITLE
Add Navigation class

### DIFF
--- a/app/helpers/schema_helper.py
+++ b/app/helpers/schema_helper.py
@@ -41,7 +41,7 @@ class SchemaHelper(object):
             yield group
 
     @staticmethod
-    def get_repeating_rule(group):
+    def get_repeat_rule(group):
         if 'routing_rules' in group:
             for rule in group['routing_rules']:
                 if 'repeat' in rule.keys():
@@ -67,7 +67,7 @@ class SchemaHelper(object):
     @classmethod
     def get_groups_that_repeat_with_answer_id(cls, survey_json, answer_id):
         for group in cls.get_groups(survey_json):
-            repeating_rule = cls.get_repeating_rule(group)
+            repeating_rule = cls.get_repeat_rule(group)
             if repeating_rule and repeating_rule['answer_id'] == answer_id:
                 yield group
 

--- a/app/questionnaire/navigation.py
+++ b/app/questionnaire/navigation.py
@@ -1,0 +1,170 @@
+import copy
+import logging
+
+from collections import defaultdict
+
+from app.helpers.schema_helper import SchemaHelper
+from app.questionnaire.location import Location
+from app.questionnaire.rules import evaluate_repeat
+
+logger = logging.getLogger(__name__)
+
+
+class Navigation(object):
+    """
+    Reads navigation config from the schema and returns collections of dicts that describe
+    completion status of each group
+    """
+    def __init__(self, survey_json, answer_store, metadata=None, completed_blocks=None):
+        self.survey_json = survey_json
+        self.metadata = metadata or {}
+        self.answer_store = answer_store
+        self.completed_blocks = completed_blocks or []
+
+    def build_navigation(self, current_group_id, current_group_instance):
+        """
+        Build navigation based on the current group/instance selected
+
+        :param current_group_id:
+        :param current_group_instance:
+        :return:
+        """
+        if 'navigation' not in self.survey_json:
+            return None
+
+        navigation = []
+
+        for group in filter(lambda x: 'hide_in_navigation' not in x, self.survey_json['groups']):
+            first_location = Location(group['id'], 0, group['blocks'][0]['id'])
+
+            logger.debug("Building frontend navigation for group %s", group)
+
+            repeating_rule = SchemaHelper.get_repeat_rule(group)
+
+            if repeating_rule:
+                navigation += self._build_repeating_navigation(repeating_rule, group, current_group_id,
+                                                               current_group_instance)
+            else:
+                navigation.append(self._build_single_navigation(group, current_group_id, first_location))
+
+        return navigation
+
+    def _build_repeating_navigation(self, repeating_rule, group, current_group_id, current_group_instance):
+        first_location = Location(group['id'], 0, group['blocks'][0]['id'])
+        no_of_repeats = evaluate_repeat(repeating_rule, self.answer_store)
+
+        repeating_nav = []
+
+        if repeating_rule['type'] == 'answer_count':
+            completed_id = group['completed_id'] if 'completed_id' in group else group['blocks'][-1]['id']
+            is_current_group = group['id'] == current_group_id
+            link_names = self._generate_link_names(repeating_rule)
+
+            repeating_nav = self._generate_repeated_items(link_names, first_location, completed_id, no_of_repeats,
+                                                          is_current_group, current_group_instance)
+
+        elif no_of_repeats > 0:
+            item = self._build_single_navigation(group, current_group_id, first_location)
+            repeating_nav.append(item)
+
+        return repeating_nav
+
+    def _build_single_navigation(self, group, current_group_id, first_location):
+        completed_id = group['completed_id'] if 'completed_id' in group else group['blocks'][-1]['id']
+        default_highlight = self._should_highlight(group, current_group_id)
+        is_completed = self._is_complete_non_repeating(completed_id)
+
+        return self._generate_item(group['title'], is_completed, first_location, default_highlight)
+
+    @staticmethod
+    def _should_highlight(group, current_group_id):
+        is_current_group = group['id'] == current_group_id
+        current_group_in_highlight = 'highlight_when' in group and current_group_id in group['highlight_when']
+
+        return (current_group_in_highlight and not is_current_group) or is_current_group
+
+    def _is_complete_non_repeating(self, completed_id):
+        """
+        Determines whether the non-repeating item can be marked as complete in navigation
+
+        :param completed_id: The block_id which indicates whether this group has been completed
+        :return:
+        """
+        for b in self.completed_blocks:
+            if b.block_id == completed_id:
+                return True
+        return False
+
+    def _is_complete_repeating(self, group_instance, completed_id):
+        """
+        Determines whether the repeating item can be marked as complete in navigation
+
+        :param group_instance:
+        :param completed_id: The block_id which indicates whether this group has been completed
+        :return:
+        """
+        for b in self.completed_blocks:
+            if b.group_instance == group_instance and b.block_id == completed_id:
+                return True
+        return False
+
+    def _generate_repeated_items(self, link_names, first_location, completed_id, no_of_repeats, is_current_group,
+                                 current_group_instance):
+        """
+        Generates a lists of navigation items
+
+        :param link_names: The list of titles to use for each link
+        :param first_location: The first group location
+        :param completed_id: The block_id which indicates whether this group has been completed
+        :param no_of_repeats: The number of times to repeat
+        :param is_current_group: Whether the repeated items are being generated for the current selected group
+        :param current_group_instance: The current selected group_instance
+        :return: A list of navigation items represented as dicts
+        """
+        nav_items = []
+
+        for i in range(no_of_repeats):
+            location = copy.copy(first_location)
+            location.group_instance = i
+            is_current_group_instance = is_current_group and i == current_group_instance
+
+            if link_names:
+                nav_item = self._generate_item(
+                    name=link_names.get(i),
+                    completed=self._is_complete_repeating(i, completed_id),
+                    location=location,
+                    highlight=is_current_group_instance,
+                    repeating=True,
+                )
+                nav_items.append(nav_item)
+
+        return nav_items
+
+    def _generate_item(self, name, completed, location, highlight, repeating=False):
+        return {
+            "link_name": name,
+            "link_url": location.url(self.metadata),
+            "completed": completed,
+            "highlight": highlight,
+            "repeating": repeating,
+        }
+
+    def _generate_link_names(self, repeating_rule):
+        logger.debug("Building frontend hyperlink names for %s", repeating_rule)
+
+        link_names = defaultdict(list)
+        if 'navigation_label_answer_ids' in repeating_rule:
+            label_answer_ids = repeating_rule['navigation_label_answer_ids']
+        else:
+            label_answer_ids = [repeating_rule['answer_id']]
+
+        for answer_id in label_answer_ids:
+            answers = self.answer_store.filter(answer_id=answer_id)
+            for answer in answers:
+                if answer['value']:
+                    link_names[answer['answer_instance']].append(answer['value'])
+
+        for link_name in link_names:
+            link_names[link_name] = " ".join(link_names[link_name])
+
+        return link_names

--- a/app/questionnaire/questionnaire_manager.py
+++ b/app/questionnaire/questionnaire_manager.py
@@ -1,7 +1,7 @@
 import logging
 
 from app.globals import get_answer_store, get_answers, get_metadata, get_questionnaire_store
-from app.questionnaire.navigator import Navigator
+from app.questionnaire.path_finder import PathFinder
 
 from app.templating.schema_context import build_schema_context
 from app.templating.template_renderer import renderer
@@ -44,7 +44,7 @@ class QuestionnaireManager(object):
 
     def validate_all_answers(self):
 
-        navigator = Navigator(self._json, get_metadata(current_user), get_answer_store(current_user))
+        navigator = PathFinder(self._json, get_answer_store(current_user), get_metadata(current_user))
 
         for location in navigator.get_location_path():
             answers = get_answers(current_user)

--- a/app/templating/summary_context.py
+++ b/app/templating/summary_context.py
@@ -1,6 +1,6 @@
 import logging
 
-from app.questionnaire.navigator import Navigator
+from app.questionnaire.path_finder import PathFinder
 from app.templating.summary.section import Section
 
 from flask import url_for
@@ -16,7 +16,7 @@ def build_summary_rendering_context(schema_json, answer_store, metadata):
     :param metadata: all of the metadata
     :return: questionnaire summary context
     """
-    navigator = Navigator(schema_json, metadata, answer_store)
+    navigator = PathFinder(schema_json, answer_store, metadata)
     path = navigator.get_routing_path()
     sections = []
     for group in schema_json['groups']:

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -4,7 +4,8 @@ from app.authentication.session_manager import session_manager
 from app.globals import get_answer_store, get_completed_blocks, get_metadata, get_questionnaire_store
 from app.helpers.schema_helper import SchemaHelper
 from app.questionnaire.location import Location
-from app.questionnaire.navigator import Navigator
+from app.questionnaire.navigation import Navigation
+from app.questionnaire.path_finder import PathFinder
 from app.questionnaire.questionnaire_manager import get_questionnaire_manager
 from app.submitter.converter import convert_answers
 from app.submitter.submitter import SubmitterFactory
@@ -87,12 +88,12 @@ def get_block(eq_id, form_type, collection_id, group_id, group_instance, block_i
 @questionnaire_blueprint.route('<group_id>/<int:group_instance>/<block_id>', methods=["POST"])
 @login_required
 def post_block(eq_id, form_type, collection_id, group_id, group_instance, block_id):
-    navigator = Navigator(g.schema_json, get_metadata(current_user), get_answer_store(current_user))
+    path_finder = PathFinder(g.schema_json, get_answer_store(current_user), get_metadata(current_user))
     q_manager = get_questionnaire_manager(g.schema, g.schema_json)
 
     this_location = Location(group_id, group_instance, block_id)
 
-    valid_location = this_location in navigator.get_routing_path(group_id, group_instance)
+    valid_location = this_location in path_finder.get_routing_path(group_id, group_instance)
     valid_data = q_manager.validate(this_location, request.form)
 
     if not valid_location or not valid_data:
@@ -100,7 +101,8 @@ def post_block(eq_id, form_type, collection_id, group_id, group_instance, block_
     else:
         q_manager.update_questionnaire_store(this_location)
 
-    next_location = navigator.get_next_location(current_location=this_location)
+    next_location = path_finder.get_next_location(current_location=this_location)
+
     metadata = get_metadata(current_user)
 
     if next_location is None:
@@ -121,19 +123,19 @@ def get_introduction(eq_id, form_type, collection_id):
 @questionnaire_blueprint.route('<block_id>', methods=["POST"])
 @login_required
 def post_interstitial(eq_id, form_type, collection_id, block_id):
-    navigator = Navigator(g.schema_json, get_metadata(current_user), get_answer_store(current_user))
+    path_finder = PathFinder(g.schema_json, get_answer_store(current_user), get_metadata(current_user))
     q_manager = get_questionnaire_manager(g.schema, g.schema_json)
 
     this_location = Location(SchemaHelper.get_first_group_id(g.schema_json), 0, block_id)
 
-    valid_location = this_location in navigator.get_location_path()
+    valid_location = this_location in path_finder.get_location_path()
     q_manager.process_incoming_answers(this_location, request.form)
 
     # Don't care if data is valid because there isn't any for interstitial
     if not valid_location:
         return _render_template(q_manager.state, current_location=this_location, template='questionnaire')
 
-    next_location = navigator.get_next_location(current_location=this_location)
+    next_location = path_finder.get_next_location(current_location=this_location)
     metadata = get_metadata(current_user)
 
     if next_location is None:
@@ -149,8 +151,8 @@ def post_interstitial(eq_id, form_type, collection_id, block_id):
 def get_summary(eq_id, form_type, collection_id):
 
     answer_store = get_answer_store(current_user)
-    navigator = Navigator(g.schema_json, get_metadata(current_user), answer_store)
-    latest_location = navigator.get_latest_location(get_completed_blocks(current_user))
+    path_finder = PathFinder(g.schema_json, answer_store, get_metadata(current_user))
+    latest_location = path_finder.get_latest_location(get_completed_blocks(current_user))
     metadata = get_metadata(current_user)
 
     if latest_location.block_id is 'summary':
@@ -167,9 +169,9 @@ def get_summary(eq_id, form_type, collection_id):
 @login_required
 def get_confirmation(eq_id, form_type, collection_id):
     answer_store = get_answer_store(current_user)
-    navigator = Navigator(g.schema_json, get_metadata(current_user), answer_store)
+    path_finder = PathFinder(g.schema_json, answer_store, get_metadata(current_user))
 
-    latest_location = navigator.get_latest_location(get_completed_blocks(current_user))
+    latest_location = path_finder.get_latest_location(get_completed_blocks(current_user))
 
     if latest_location.block_id == 'confirmation':
 
@@ -203,9 +205,9 @@ def submit_answers(eq_id, form_type, collection_id):
 
     if is_valid:
         answer_store = get_answer_store(current_user)
-        navigator = Navigator(g.schema_json, metadata, answer_store)
+        path_finder = PathFinder(g.schema_json, answer_store, metadata)
         submitter = SubmitterFactory.get_submitter()
-        message = convert_answers(metadata, g.schema, answer_store, navigator.get_routing_path())
+        message = convert_answers(metadata, g.schema, answer_store, path_finder.get_routing_path())
         submitter.send_answers(message)
         logger.info("Responses submitted tx_id=%s", metadata["tx_id"])
         return redirect_to_thank_you(eq_id, form_type, collection_id)
@@ -216,7 +218,7 @@ def submit_answers(eq_id, form_type, collection_id):
 @questionnaire_blueprint.route('<group_id>/0/household-composition', methods=["POST"])
 @login_required
 def post_household_composition(eq_id, form_type, collection_id, group_id):
-    navigator = Navigator(g.schema_json, get_metadata(current_user), get_answer_store(current_user))
+    path_finder = PathFinder(g.schema_json, get_answer_store(current_user), get_metadata(current_user))
     questionnaire_manager = get_questionnaire_manager(g.schema, g.schema_json)
     answer_store = get_answer_store(current_user)
 
@@ -239,7 +241,7 @@ def post_household_composition(eq_id, form_type, collection_id, group_id):
     if not valid:
         return _render_template(questionnaire_manager.state, current_location=this_location, template='questionnaire')
 
-    next_location = navigator.get_next_location(current_location=this_location)
+    next_location = path_finder.get_next_location(current_location=this_location)
 
     metadata = get_metadata(current_user)
 
@@ -313,18 +315,18 @@ def _render_template(context, current_location=None, block_id=None, template=Non
     metadata = get_metadata(current_user)
     metadata_context = build_metadata_context(metadata)
 
+    answer_store = get_answer_store(current_user)
+    completed_blocks = get_completed_blocks(current_user)
+
+    path_finder = PathFinder(g.schema_json, answer_store, metadata)
+    navigation = Navigation(g.schema_json, answer_store, metadata, completed_blocks)
+
     if current_location is None:
         group_id = SchemaHelper.get_first_group_id(g.schema_json)
         current_location = Location(group_id, 0, block_id)
 
-    navigator = Navigator(g.schema_json, get_metadata(current_user), get_answer_store(current_user))
-    completed_blocks = get_completed_blocks(current_user)
-    front_end_navigation = navigator.get_front_end_navigation(
-        completed_blocks,
-        current_location.group_id,
-        current_location.group_instance,
-    )
-    previous_location = navigator.get_previous_location(current_location)
+    previous_location = path_finder.get_previous_location(current_location)
+    front_end_navigation = navigation.build_navigation(current_location.group_id, current_location.group_instance)
 
     previous_url = None
 

--- a/app/views/session.py
+++ b/app/views/session.py
@@ -3,7 +3,7 @@ import logging
 from app.authentication.authenticator import Authenticator
 
 from app.globals import get_answer_store, get_completed_blocks, get_metadata
-from app.questionnaire.navigator import Navigator
+from app.questionnaire.path_finder import PathFinder
 from app.utilities.schema import get_schema
 
 from flask import redirect
@@ -58,7 +58,7 @@ def login():
 
     json, _ = get_schema(metadata)
 
-    navigator = Navigator(json, metadata, get_answer_store(current_user))
+    navigator = PathFinder(json, get_answer_store(current_user), metadata)
     current_location = navigator.get_latest_location(get_completed_blocks(current_user))
 
     return redirect(current_location.url(metadata))

--- a/tests/app/confirmation_page/test_confirmation_page.py
+++ b/tests/app/confirmation_page/test_confirmation_page.py
@@ -1,4 +1,4 @@
-from app.questionnaire.navigator import Navigator
+from app.questionnaire.path_finder import PathFinder
 from app.data_model.answer_store import Answer, AnswerStore
 from app.helpers.schema_helper import SchemaHelper
 from app.schema_loader.schema_loader import load_schema_file
@@ -16,7 +16,7 @@ class TestConfirmationPage(unittest.TestCase):
         answer_store.add(answer)
 
         survey = load_schema_file("0_rogue_one.json")
-        navigator = Navigator(survey, {}, answer_store)
+        navigator = PathFinder(survey, answer_store)
         next_location = navigator.get_next_location(SchemaHelper.get_last_location(survey))
 
         self.assertEqual('summary', next_location.block_id)

--- a/tests/app/helpers/test_schema_helper.py
+++ b/tests/app/helpers/test_schema_helper.py
@@ -54,7 +54,7 @@ class TestSchemaHelper(unittest.TestCase):
     def test_get_repeating_rule(self):
         survey = load_schema_file("test_repeating_household.json")
         groups = [group for group in SchemaHelper.get_groups(survey)]
-        rule = SchemaHelper.get_repeating_rule(groups[1])
+        rule = SchemaHelper.get_repeat_rule(groups[1])
 
         self.assertEqual(
             {

--- a/tests/app/questionnaire/test_navigation.py
+++ b/tests/app/questionnaire/test_navigation.py
@@ -1,0 +1,520 @@
+import unittest
+
+from app.data_model.answer_store import AnswerStore, Answer
+
+from app.questionnaire.location import Location
+from app.questionnaire.navigation import Navigation
+
+from app import create_app
+
+from app.schema_loader.schema_loader import load_schema_file
+
+
+class TestNavigation(unittest.TestCase):
+
+    @staticmethod
+    def setUp():
+        app = create_app()
+        app.config['SERVER_NAME'] = "test"
+        app_context = app.app_context()
+        app_context.push()
+
+    def test_navigation_no_blocks_completed(self):
+        survey = load_schema_file("test_navigation.json")
+        metadata = {
+            "eq_id": '1',
+            "collection_exercise_sid": '999',
+            "form_type": "some_form"
+        }
+
+        navigation = Navigation(survey, AnswerStore(), metadata)
+
+        user_navigation = [
+            {
+                'link_name': 'Property Details',
+                'highlight': True,
+                'repeating': False,
+                'completed': False,
+                'link_url': Location('property-details', 0, 'insurance-type').url(metadata)
+            },
+            {
+                'link_name': 'Household Details',
+                'highlight': False,
+                'repeating': False,
+                'completed': False,
+                'link_url': Location('multiple-questions-group', 0, 'household-composition').url(metadata)
+            },
+            {
+                'link_name': 'Extra Cover',
+                'highlight': False,
+                'repeating': False,
+                'completed': False,
+                'link_url': Location('extra-cover', 0, 'extra-cover-block').url(metadata)
+            },
+            {
+                'link_name': 'Payment Details',
+                'highlight': False,
+                'repeating': False,
+                'completed': False,
+                'link_url': Location('payment-details', 0, 'credit-card').url(metadata)
+            }
+        ]
+
+        self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
+
+    def test_non_repeating_block_completed(self):
+        survey = load_schema_file("test_navigation.json")
+        metadata = {
+            "eq_id": '1',
+            "collection_exercise_sid": '999',
+            "form_type": "some_form"
+        }
+        completed_blocks = [
+            Location('property-details', 0, 'introduction'),
+            Location('property-details', 0, 'insurance-type'),
+            Location('property-details', 0, 'insurance-address'),
+            Location('property-details', 0, 'property-interstitial')
+        ]
+
+        navigation = Navigation(survey, AnswerStore(), metadata, completed_blocks=completed_blocks)
+
+        user_navigation = [
+            {
+                'completed': True,
+                'link_name': 'Property Details',
+                'highlight': True,
+                'repeating': False,
+                'link_url': Location('property-details', 0, 'insurance-type').url(metadata),
+            },
+            {
+                'completed': False,
+                'link_name': 'Household Details',
+                'highlight': False,
+                'repeating': False,
+                'link_url': Location('multiple-questions-group', 0, 'household-composition').url(metadata),
+            },
+            {
+                'completed': False,
+                'link_name': 'Extra Cover',
+                'highlight': False,
+                'repeating': False,
+                'link_url': Location('extra-cover', 0, 'extra-cover-block').url(metadata)
+            },
+            {
+                'completed': False,
+                'link_name': 'Payment Details',
+                'highlight': False,
+                'repeating': False,
+                'link_url': Location('payment-details', 0, 'credit-card').url(metadata)
+            }
+        ]
+        self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
+
+    def test_navigation_repeating_household_and_hidden_household_groups_completed(self):
+
+        survey = load_schema_file("test_navigation.json")
+        metadata = {
+            "eq_id": '1',
+            "collection_exercise_sid": '999',
+            "form_type": "some_form"
+        }
+
+        completed_blocks = [
+            Location('property-details', 0, 'introduction'),
+            Location('multiple-questions-group', 0, 'household-composition'),
+            Location('repeating-group', 0, 'repeating-block-1'),
+            Location('repeating-group', 0, 'repeating-block-2'),
+            Location('repeating-group', 1, 'repeating-block-1'),
+            Location('repeating-group', 1, 'repeating-block-2')
+        ]
+
+        navigation = Navigation(survey, AnswerStore(), metadata, completed_blocks=completed_blocks)
+
+        navigation.answer_store.answers = [
+            {
+                'group_instance': 0,
+                'answer_instance': 0,
+                'answer_id': 'household-full-name',
+                'value': 'Jim',
+                'group_id': 'multiple-questions-group',
+                'block_id': 'household-composition'
+            },
+            {
+                'group_instance': 0,
+                'answer_instance': 1,
+                'answer_id': 'household-full-name',
+                'value': 'Ben',
+                'group_id': 'multiple-questions-group',
+                'block_id': 'household-composition'
+            },
+            {
+                'group_instance': 0,
+                'answer_instance': 0,
+                'answer_id': 'what-is-your-age',
+                'value': None,
+                'group_id': 'repeating-group',
+                'block_id': 'repeating-block-1'
+            },
+            {
+                'group_instance': 0,
+                'answer_instance': 0,
+                'answer_id': 'what-is-your-shoe-size',
+                'value': None,
+                'group_id': 'repeating-group',
+                'block_id': 'repeating-block-2'
+            },
+            {
+                'group_instance': 1,
+                'answer_instance': 0,
+                'answer_id': 'what-is-your-age',
+                'value': None,
+                'group_id': 'repeating-group',
+                'block_id': 'repeating-block-1'
+            },
+            {
+                'group_instance': 1,
+                'answer_instance': 0,
+                'answer_id': 'what-is-your-shoe-size',
+                'value': None,
+                'group_id': 'repeating-group',
+                'block_id': 'repeating-block-2'
+            }
+        ]
+
+        user_navigation = [
+            {
+                'link_name': 'Property Details',
+                'repeating': False,
+                'completed': False,
+                'highlight': True,
+                'link_url': Location('property-details', 0, 'insurance-type').url(metadata)
+            },
+            {
+                'link_name': 'Household Details',
+                'repeating': False,
+                'completed': True,
+                'highlight': False,
+                'link_url': Location('multiple-questions-group', 0, 'household-composition').url(metadata)
+            },
+            {
+                'link_name': 'Jim',
+                'repeating': True,
+                'completed': True,
+                'highlight': False,
+                'link_url': Location('repeating-group', 0, 'repeating-block-1').url(metadata)
+            },
+            {
+                'link_name': 'Ben',
+                'repeating': True,
+                'completed': True,
+                'highlight': False,
+                'link_url': Location('repeating-group', 1, 'repeating-block-1').url(metadata)
+            },
+            {
+                'link_name': 'Extra Cover',
+                'repeating': False,
+                'completed': False,
+                'highlight': False,
+                'link_url': Location('extra-cover', 0, 'extra-cover-block').url(metadata)
+            },
+            {
+                'link_name': 'Payment Details',
+                'repeating': False,
+                'completed': False,
+                'highlight': False,
+                'link_url': Location('payment-details', 0, 'credit-card').url(metadata)
+            }
+        ]
+
+        self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
+
+    def test_navigation_repeating_group_extra_answered_not_completed(self):
+        survey = load_schema_file("test_navigation.json")
+        metadata = {
+            "eq_id": '1',
+            "collection_exercise_sid": '999',
+            "form_type": "some_form"
+        }
+
+        completed_blocks = [
+            Location('property-details', 0, 'introduction'),
+            Location('property-details', 0, 'insurance-type'),
+            Location('property-details', 0, 'cd6a5727-8cab-4737-aa4e-d666d98b3f92'),
+            Location('property-details', 0, 'personal-interstitial'),
+            Location('extra-cover', 0, 'extra-cover-block'),
+            Location('extra-cover', 0, 'ea651fa7-6b9d-4b6f-ba72-79133f312039'),
+        ]
+
+        answer_store = AnswerStore()
+
+        answer_1 = Answer(
+            answer_instance=0,
+            group_id='multiple-questions-group',
+            answer_id='household-full-name',
+            block_id='household-composition',
+            group_instance=0,
+            value='Person1'
+        )
+        answer_2 = Answer(
+            answer_instance=1,
+            group_id='multiple-questions-group',
+            answer_id='household-full-name',
+            block_id='household-composition',
+            group_instance=0,
+            value='Person2'
+        )
+        answer_3 = Answer(
+            answer_instance=1,
+            group_id='extra-cover',
+            answer_id='extra-cover-answer',
+            block_id='extra-cover-block',
+            group_instance=0,
+            value=2
+        )
+
+        answer_store.add(answer_1)
+        answer_store.add(answer_2)
+        answer_store.add(answer_3)
+
+        navigation = Navigation(survey, answer_store, metadata, completed_blocks)
+
+        user_navigation = [
+            {
+                'completed': False,
+                'highlight': True,
+                'repeating': False,
+                'link_name': 'Property Details',
+                'link_url': Location('property-details', 0, 'insurance-type').url(metadata)
+            },
+            {
+                'completed': False,
+                'highlight': False,
+                'repeating': False,
+                'link_name': 'Household Details',
+                'link_url': Location('multiple-questions-group', 0, 'household-composition').url(metadata),
+            },
+            {
+                'completed': False,
+                'highlight': False,
+                'repeating': True,
+                'link_name': 'Person1',
+                'link_url': Location('repeating-group', 0, 'repeating-block-1').url(metadata),
+            },
+            {
+                'completed': False,
+                'highlight': False,
+                'repeating': True,
+                'link_name': 'Person2',
+                'link_url': Location('repeating-group', 1, 'repeating-block-1').url(metadata),
+            },
+            {
+                'completed': False,
+                'highlight': False,
+                'repeating': False,
+                'link_name': 'Extra Cover',
+                'link_url': Location('extra-cover', 0, 'extra-cover-block').url(metadata),
+            },
+            {
+                'completed': False,
+                'highlight': False,
+                'repeating': False,
+                'link_name': 'Payment Details',
+                'link_url': Location('payment-details', 0, 'credit-card').url(metadata),
+            },
+            {
+                'completed': False,
+                'highlight': False,
+                'repeating': False,
+                'link_name': 'Extra Cover Items',
+                'link_url': Location('extra-cover-items-group', 0, 'extra-cover-items').url(metadata)
+            }
+        ]
+
+        self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
+
+    def test_navigation_repeating_group_extra_answered_completed(self):
+        survey = load_schema_file("test_navigation.json")
+        metadata = {
+            "eq_id": '1',
+            "collection_exercise_sid": '999',
+            "form_type": "some_form"
+        }
+
+        completed_blocks = [
+            Location('property-details', 0, 'introduction'),
+            Location('extra-cover', 0, 'extra-cover-block'),
+            Location('extra-cover', 0, 'extra-cover-interstitial'),
+            Location('extra-cover-items-group', 0, 'extra-cover-items'),
+            Location('extra-cover-items-group', 1, 'extra-cover-items'),
+        ]
+
+        answer_store = AnswerStore()
+
+        answer_1 = Answer(
+            value=2,
+            group_instance=0,
+            block_id='extra-cover-block',
+            group_id='extra-cover',
+            answer_instance=0,
+            answer_id='extra-cover-answer'
+        )
+        answer_2 = Answer(
+            value='2',
+            group_instance=0,
+            block_id='extra-cover-items',
+            group_id='extra-cover-items-group',
+            answer_instance=0,
+            answer_id='extra-cover-items-answer'
+        )
+        answer_3 = Answer(
+            value='2',
+            group_instance=1,
+            block_id='extra-cover-items',
+            group_id='extra-cover-items-group',
+            answer_id='extra-cover-items-answer',
+            answer_instance=0
+        )
+
+        answer_store.add(answer_1)
+        answer_store.add(answer_2)
+        answer_store.add(answer_3)
+
+        navigation = Navigation(survey, answer_store, metadata, completed_blocks=completed_blocks)
+
+        user_navigation = [
+            {
+                'repeating': False,
+                'highlight': True,
+                'completed': False,
+                'link_name': 'Property Details',
+                'link_url': Location('property-details', 0, 'insurance-type').url(metadata)
+            },
+            {
+                'repeating': False,
+                'highlight': False,
+                'completed': False,
+                'link_name': 'Household Details',
+                'link_url': Location('multiple-questions-group', 0, 'household-composition').url(metadata)
+            },
+            {
+                'repeating': False,
+                'highlight': False,
+                'completed': True,
+                'link_name': 'Extra Cover',
+                'link_url': Location('extra-cover', 0, 'extra-cover-block').url(metadata)
+            },
+            {
+                'repeating': False,
+                'highlight': False,
+                'completed': False,
+                'link_name': 'Payment Details',
+                'link_url': Location('payment-details', 0, 'credit-card').url(metadata)
+            },
+            {
+                'repeating': False,
+                'highlight': False,
+                'completed': True,
+                'link_name': 'Extra Cover Items',
+                'link_url': Location('extra-cover-items-group', 0, 'extra-cover-items').url(metadata)
+            }
+        ]
+        self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
+
+    def test_navigation_repeating_group_link_name_format(self):
+        survey = load_schema_file("test_repeating_household.json")
+        metadata = {
+            "eq_id": '1',
+            "collection_exercise_sid": '999',
+            "form_type": "some_form"
+        }
+
+        completed_blocks = [
+            Location('multiple-questions-group', 0, 'introduction'),
+            Location('multiple-questions-group', 0, 'household-composition'),
+        ]
+
+        answer_store = AnswerStore()
+
+        answer_1 = Answer(
+            block_id='household-composition',
+            answer_instance=0,
+            answer_id='first-name',
+            group_id='multiple-questions-group',
+            group_instance=0,
+            value='Joe'
+        )
+        answer_2 = Answer(
+            block_id='household-composition',
+            answer_instance=0,
+            answer_id='middle-names',
+            group_id='multiple-questions-group',
+            group_instance=0,
+            value=None
+        )
+        answer_3 = Answer(
+            block_id='household-composition',
+            answer_instance=0,
+            answer_id='last-name',
+            group_id='multiple-questions-group',
+            group_instance=0,
+            value='Bloggs'
+        )
+        answer_4 = Answer(
+            block_id='household-composition',
+            answer_instance=1,
+            answer_id='first-name',
+            group_id='multiple-questions-group',
+            group_instance=0,
+            value='Jim'
+        )
+        answer_5 = Answer(
+            block_id='household-composition',
+            answer_instance=1,
+            answer_id='last-name',
+            group_id='multiple-questions-group',
+            group_instance=0,
+            value=None
+        )
+        answer_6 = Answer(
+            block_id='household-composition',
+            answer_instance=1,
+            answer_id='middle-names',
+            group_id='multiple-questions-group',
+            group_instance=0,
+            value=None
+        )
+
+        answer_store.add(answer_1)
+        answer_store.add(answer_2)
+        answer_store.add(answer_3)
+        answer_store.add(answer_4)
+        answer_store.add(answer_5)
+        answer_store.add(answer_6)
+
+        navigation = Navigation(survey, answer_store, metadata, completed_blocks=completed_blocks)
+
+        user_navigation = [
+            {
+                'repeating': False,
+                'completed': True,
+                'highlight': False,
+                'link_name': '',
+                'link_url': Location('multiple-questions-group', 0, 'household-composition').url(metadata)
+            },
+            {
+                'repeating': True,
+                'link_name': 'Joe Bloggs',
+                'completed': False,
+                'highlight': False,
+                'link_url': Location('repeating-group', 0, 'repeating-block-1').url(metadata)
+            },
+            {
+                'repeating': True,
+                'link_name': 'Jim',
+                'completed': False,
+                'highlight': False,
+                'link_url': Location('repeating-group', 1, 'repeating-block-1').url(metadata)
+            }
+        ]
+
+        self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)

--- a/tests/app/questionnaire/test_path_finder.py
+++ b/tests/app/questionnaire/test_path_finder.py
@@ -2,16 +2,14 @@ import unittest
 
 import pytest
 
-from app import create_app
-
 from app.questionnaire.location import Location
-from app.questionnaire.navigator import Navigator
+from app.questionnaire.path_finder import PathFinder
 
 from app.schema_loader.schema_loader import load_schema_file
 from app.data_model.answer_store import Answer, AnswerStore
 
 
-class TestNavigator(unittest.TestCase):
+class TestPathFinder(unittest.TestCase):
 
     def test_next_block(self):
         survey = load_schema_file("1_0102.json")
@@ -28,8 +26,8 @@ class TestNavigator(unittest.TestCase):
             group_instance=0
         )
 
-        navigator = Navigator(survey)
-        self.assertEqual(navigator.get_next_location(current_location=current_location), next_location)
+        path_finder = PathFinder(survey)
+        self.assertEqual(path_finder.get_next_location(current_location=current_location), next_location)
 
     def test_previous_block(self):
         survey = load_schema_file("1_0102.json")
@@ -46,24 +44,24 @@ class TestNavigator(unittest.TestCase):
             group_instance=0
         )
 
-        navigator = Navigator(survey)
-        self.assertEqual(navigator.get_previous_location(current_location=current_location), previous_location)
+        path_finder = PathFinder(survey)
+        self.assertEqual(path_finder.get_previous_location(current_location=current_location), previous_location)
 
     def test_introduction_in_path_when_in_schema(self):
         survey = load_schema_file("1_0102.json")
 
-        navigator = Navigator(survey)
+        path_finder = PathFinder(survey)
 
-        blocks = [b.block_id for b in navigator.get_location_path()]
+        blocks = [b.block_id for b in path_finder.get_location_path()]
 
         self.assertIn('introduction', blocks)
 
     def test_introduction_not_in_path_when_not_in_schema(self):
         survey = load_schema_file("census_individual.json")
 
-        navigator = Navigator(survey)
+        path_finder = PathFinder(survey)
 
-        blocks = [b.block_id for b in navigator.get_location_path()]
+        blocks = [b.block_id for b in path_finder.get_location_path()]
 
         self.assertNotIn('introduction', blocks)
 
@@ -99,15 +97,15 @@ class TestNavigator(unittest.TestCase):
         current_location = expected_path[1]
         expected_next_location = expected_path[2]
 
-        navigator = Navigator(survey, answer_store=answers)
-        actual_next_block = navigator.get_next_location(current_location=current_location)
+        path_finder = PathFinder(survey, answer_store=answers)
+        actual_next_block = path_finder.get_next_location(current_location=current_location)
 
         self.assertEqual(actual_next_block, expected_next_location)
 
         current_location = expected_path[2]
         expected_next_location = expected_path[3]
 
-        actual_next_block = navigator.get_next_location(current_location=current_location)
+        actual_next_block = path_finder.get_next_location(current_location=current_location)
 
         self.assertEqual(actual_next_block, expected_next_location)
 
@@ -123,8 +121,8 @@ class TestNavigator(unittest.TestCase):
             Location("f74d1147-673c-497a-9616-763829d944ac", 0, "7e2d49eb-ffc7-4a61-a45d-eba336d1d0e6")
         ]
 
-        navigator = Navigator(survey)
-        routing_path = navigator.get_routing_path()
+        path_finder = PathFinder(survey)
+        routing_path = path_finder.get_routing_path()
 
         self.assertEqual(routing_path, expected_path)
 
@@ -157,19 +155,19 @@ class TestNavigator(unittest.TestCase):
         answers.add(answer_1)
         answers.add(answer_2)
 
-        navigator = Navigator(survey, answer_store=answers)
-        routing_path = navigator.get_routing_path()
+        path_finder = PathFinder(survey, answer_store=answers)
+        routing_path = path_finder.get_routing_path()
 
         self.assertEqual(routing_path, expected_path)
 
     def test_get_next_location_introduction(self):
         survey = load_schema_file("0_star_wars.json")
 
-        navigator = Navigator(survey)
+        path_finder = PathFinder(survey)
 
         introduction = Location('14ba4707-321d-441d-8d21-b8367366e766', 0, 'introduction')
 
-        next_location = navigator.get_next_location(current_location=introduction)
+        next_location = path_finder.get_next_location(current_location=introduction)
 
         self.assertEqual('f22b1ba4-d15f-48b8-a1f3-db62b6f34cc0', next_location.block_id)
 
@@ -193,11 +191,11 @@ class TestNavigator(unittest.TestCase):
         answers.add(answer_1)
         answers.add(answer_2)
 
-        navigator = Navigator(survey, answer_store=answers)
+        path_finder = PathFinder(survey, answer_store=answers)
 
         current_location = Location('14ba4707-321d-441d-8d21-b8367366e766', 0, 'an3b74d1-b687-4051-9634-a8f9ce10ard')
 
-        next_location = navigator.get_next_location(current_location=current_location)
+        next_location = path_finder.get_next_location(current_location=current_location)
 
         expected_next_location = Location("14ba4707-321d-441d-8d21-b8367366e766", 0, '846f8514-fed2-4bd7-8fb2-4b5fcb1622b1')
 
@@ -205,7 +203,7 @@ class TestNavigator(unittest.TestCase):
 
         current_location = expected_next_location
 
-        next_location = navigator.get_next_location(current_location=current_location)
+        next_location = path_finder.get_next_location(current_location=current_location)
 
         expected_next_location = Location("14ba4707-321d-441d-8d21-b8367366e766", 0, 'summary')
 
@@ -214,11 +212,11 @@ class TestNavigator(unittest.TestCase):
     def test_get_previous_location_introduction(self):
         survey = load_schema_file("0_star_wars.json")
 
-        navigator = Navigator(survey)
+        path_finder = PathFinder(survey)
 
         first_location = Location("14ba4707-321d-441d-8d21-b8367366e766", 0, 'f22b1ba4-d15f-48b8-a1f3-db62b6f34cc0')
 
-        previous_location = navigator.get_previous_location(current_location=first_location)
+        previous_location = path_finder.get_previous_location(current_location=first_location)
 
         self.assertEqual('introduction', previous_location.block_id)
 
@@ -254,15 +252,15 @@ class TestNavigator(unittest.TestCase):
         current_location = expected_path[3]
         expected_previous_location = expected_path[2]
 
-        navigator = Navigator(survey, answer_store=answers)
-        actual_previous_block = navigator.get_previous_location(current_location=current_location)
+        path_finder = PathFinder(survey, answer_store=answers)
+        actual_previous_block = path_finder.get_previous_location(current_location=current_location)
 
         self.assertEqual(actual_previous_block, expected_previous_location)
 
         current_location = expected_path[2]
         expected_previous_location = expected_path[1]
 
-        actual_previous_block = navigator.get_previous_location(current_location=current_location)
+        actual_previous_block = path_finder.get_previous_location(current_location=current_location)
 
         self.assertEqual(actual_previous_block, expected_previous_location)
 
@@ -297,9 +295,9 @@ class TestNavigator(unittest.TestCase):
         answers.add(answer_1)
         answers.add(answer_2)
 
-        navigator = Navigator(survey, answer_store=answers)
+        path_finder = PathFinder(survey, answer_store=answers)
 
-        self.assertEqual(navigator.get_previous_location(current_location=current_location), expected_previous_location)
+        self.assertEqual(path_finder.get_previous_location(current_location=current_location), expected_previous_location)
 
     def test_next_location_goto_summary(self):
         survey = load_schema_file("0_star_wars.json")
@@ -319,12 +317,12 @@ class TestNavigator(unittest.TestCase):
         )
         answers = AnswerStore()
         answers.add(answer)
-        navigator = Navigator(survey, answer_store=answers)
+        path_finder = PathFinder(survey, answer_store=answers)
 
         current_location = expected_path[1]
         expected_next_location = expected_path[2]
 
-        next_location = navigator.get_next_location(current_location=current_location)
+        next_location = path_finder.get_next_location(current_location=current_location)
 
         self.assertEqual(next_location, expected_next_location)
 
@@ -355,12 +353,12 @@ class TestNavigator(unittest.TestCase):
         answers.add(answer_1)
         answers.add(answer_2)
 
-        navigator = Navigator(survey, answer_store=answers)
+        path_finder = PathFinder(survey, answer_store=answers)
 
         current_location = expected_path[1]
         expected_next_location = expected_path[2]
 
-        next_location = navigator.get_next_location(current_location=current_location)
+        next_location = path_finder.get_next_location(current_location=current_location)
 
         self.assertEqual(next_location, expected_next_location)
 
@@ -377,9 +375,9 @@ class TestNavigator(unittest.TestCase):
         answers = AnswerStore()
         answers.add(answer)
 
-        navigator = Navigator(survey, answer_store=answers)
+        path_finder = PathFinder(survey, answer_store=answers)
 
-        self.assertFalse(Location("14ba4707-321d-441d-8d21-b8367366e766", 0, 'summary') in navigator.get_location_path())
+        self.assertFalse(Location("14ba4707-321d-441d-8d21-b8367366e766", 0, 'summary') in path_finder.get_location_path())
 
     def test_repeating_groups(self):
         survey = load_schema_file("test_repeating_household.json")
@@ -405,9 +403,9 @@ class TestNavigator(unittest.TestCase):
         answers = AnswerStore()
         answers.add(answer)
 
-        navigator = Navigator(survey, answer_store=answers)
+        path_finder = PathFinder(survey, answer_store=answers)
 
-        self.assertEqual(expected_path, navigator.get_routing_path())
+        self.assertEqual(expected_path, path_finder.get_routing_path())
 
     def test_should_not_show_block_for_zero_repeats(self):
         survey = load_schema_file("test_repeating_household.json")
@@ -429,9 +427,9 @@ class TestNavigator(unittest.TestCase):
         answers = AnswerStore()
         answers.add(answer)
 
-        navigator = Navigator(survey, answer_store=answers)
+        path_finder = PathFinder(survey, answer_store=answers)
 
-        self.assertEqual(expected_path, navigator.get_routing_path())
+        self.assertEqual(expected_path, path_finder.get_routing_path())
 
     def test_repeating_groups_no_of_answers(self):
         survey = load_schema_file("test_repeating_household.json")
@@ -479,9 +477,9 @@ class TestNavigator(unittest.TestCase):
         answers.add(answer_2)
         answers.add(answer_3)
 
-        navigator = Navigator(survey, answer_store=answers)
+        path_finder = PathFinder(survey, answer_store=answers)
 
-        self.assertEqual(expected_path, navigator.get_routing_path())
+        self.assertEqual(expected_path, path_finder.get_routing_path())
 
     def test_repeating_groups_no_of_answers_minus_one(self):
         survey = load_schema_file("test_repeating_household.json")
@@ -518,9 +516,9 @@ class TestNavigator(unittest.TestCase):
         answers.add(answer)
         answers.add(answer_2)
 
-        navigator = Navigator(survey, answer_store=answers)
+        path_finder = PathFinder(survey, answer_store=answers)
 
-        self.assertEqual(expected_path, navigator.get_routing_path())
+        self.assertEqual(expected_path, path_finder.get_routing_path())
 
     def test_repeating_groups_previous_location_introduction(self):
         survey = load_schema_file("test_repeating_household.json")
@@ -530,9 +528,9 @@ class TestNavigator(unittest.TestCase):
             Location('multiple-questions-group', 0, 'household-composition'),
         ]
 
-        navigator = Navigator(survey)
+        path_finder = PathFinder(survey)
 
-        self.assertEqual(navigator.get_previous_location(current_location=expected_path[1]), expected_path[0])
+        self.assertEqual(path_finder.get_previous_location(current_location=expected_path[1]), expected_path[0])
 
     def test_repeating_groups_previous_location(self):
         survey = load_schema_file("test_repeating_household.json")
@@ -570,9 +568,9 @@ class TestNavigator(unittest.TestCase):
         answers.add(answer)
         answers.add(answer_2)
 
-        navigator = Navigator(survey, answer_store=answers)
+        path_finder = PathFinder(survey, answer_store=answers)
 
-        self.assertEqual(expected_previous_location, navigator.get_previous_location(current_location=current_location))
+        self.assertEqual(expected_previous_location, path_finder.get_previous_location(current_location=current_location))
 
     def test_repeating_groups_next_location(self):
         survey = load_schema_file("test_repeating_household.json")
@@ -607,11 +605,11 @@ class TestNavigator(unittest.TestCase):
         answers.add(answer)
         answers.add(answer_2)
 
-        navigator = Navigator(survey, answer_store=answers)
+        path_finder = PathFinder(survey, answer_store=answers)
 
         summary_location = Location("repeating-group", 0, 'summary')
 
-        self.assertEqual(summary_location, navigator.get_next_location(current_location=current_location))
+        self.assertEqual(summary_location, path_finder.get_next_location(current_location=current_location))
 
     def test_repeating_groups_conditional_location_path(self):
         survey = load_schema_file("test_repeating_and_conditional_routing.json")
@@ -656,9 +654,9 @@ class TestNavigator(unittest.TestCase):
         answers.add(answer_2)
         answers.add(answer_3)
 
-        navigator = Navigator(survey, answer_store=answers)
+        path_finder = PathFinder(survey, answer_store=answers)
 
-        self.assertEqual(expected_path, navigator.get_location_path())
+        self.assertEqual(expected_path, path_finder.get_location_path())
 
     def test_next_with_conditional_path_based_on_metadata(self):
         survey = load_schema_file("test_metadata_routing.json")
@@ -678,9 +676,9 @@ class TestNavigator(unittest.TestCase):
             }
         }
 
-        navigator = Navigator(survey, metadata=metadata)
+        path_finder = PathFinder(survey, metadata=metadata)
 
-        self.assertEqual(expected_next_location, navigator.get_next_location(current_location=current_location))
+        self.assertEqual(expected_next_location, path_finder.get_next_location(current_location=current_location))
 
     def test_next_with_conditional_path_when_value_not_in_metadata(self):
         survey = load_schema_file("test_metadata_routing.json")
@@ -699,9 +697,9 @@ class TestNavigator(unittest.TestCase):
             }
         }
 
-        navigator = Navigator(survey, metadata=metadata)
+        path_finder = PathFinder(survey, metadata=metadata)
 
-        self.assertEqual(expected_next_location, navigator.get_next_location(current_location=current_location))
+        self.assertEqual(expected_next_location, path_finder.get_next_location(current_location=current_location))
 
     def test_routing_backwards_loops_to_previous_block(self):
         survey = load_schema_file("test_household_question.json")
@@ -750,9 +748,9 @@ class TestNavigator(unittest.TestCase):
         answers.add(answer_2)
         answers.add(answer_3)
 
-        navigator = Navigator(survey, answer_store=answers)
+        path_finder = PathFinder(survey, answer_store=answers)
 
-        self.assertEqual(expected_next_location, navigator.get_next_location(current_location=current_location))
+        self.assertEqual(expected_next_location, path_finder.get_next_location(current_location=current_location))
 
     def test_routing_backwards_continues_to_summary_when_complete(self):
         survey = load_schema_file("test_household_question.json")
@@ -801,113 +799,9 @@ class TestNavigator(unittest.TestCase):
         answers.add(answer_2)
         answers.add(answer_3)
 
-        navigator = Navigator(survey, answer_store=answers)
+        path_finder = PathFinder(survey, answer_store=answers)
 
-        self.assertEqual(expected_next_location, navigator.get_next_location(current_location=current_location))
-
-    def test_navigation_no_blocks_completed(self):
-        app = create_app()
-        app.config['SERVER_NAME'] = "test"
-        app_context = app.app_context()
-        app_context.push()
-
-        survey = load_schema_file("test_navigation.json")
-        metadata = {
-            "eq_id": '1',
-            "collection_exercise_sid": '999',
-            "form_type": "some_form"
-        }
-
-        navigator = Navigator(survey, metadata)
-
-        completed_blocks = []
-
-        user_navigation = [
-            {
-                'link_name': 'Property Details',
-                'highlight': True,
-                'repeating': False,
-                'completed': False,
-                'link_url': Location('property-details', 0, 'insurance-type').url(metadata)
-            },
-            {
-                'link_name': 'Household Details',
-                'highlight': False,
-                'repeating': False,
-                'completed': False,
-                'link_url': Location('multiple-questions-group', 0, 'household-composition').url(metadata)
-            },
-            {
-                'link_name': 'Extra Cover',
-                'highlight': False,
-                'repeating': False,
-                'completed': False,
-                'link_url': Location('extra-cover', 0, 'extra-cover-block').url(metadata)
-            },
-            {
-                'link_name': 'Payment Details',
-                'highlight': False,
-                'repeating': False,
-                'completed': False,
-                'link_url': Location('payment-details', 0, 'credit-card').url(metadata)
-            }
-        ]
-
-        self.assertEqual(navigator.get_front_end_navigation(completed_blocks, 'property-details', 0), user_navigation)
-
-    def test_non_repeating_block_completed(self):
-        app = create_app()
-        app.config['SERVER_NAME'] = "test"
-        app_context = app.app_context()
-        app_context.push()
-
-        survey = load_schema_file("test_navigation.json")
-        metadata = {
-            "eq_id": '1',
-            "collection_exercise_sid": '999',
-            "form_type": "some_form"
-        }
-
-        navigator = Navigator(survey, metadata)
-
-        completed_blocks = [
-            Location('property-details', 0, 'introduction'),
-            Location('property-details', 0, 'insurance-type'),
-            Location('property-details', 0, 'insurance-address'),
-            Location('property-details', 0, 'property-interstitial')
-        ]
-
-        user_navigation = [
-            {
-                'completed': True,
-                'link_name': 'Property Details',
-                'highlight': True,
-                'repeating': False,
-                'link_url': Location('property-details', 0, 'insurance-type').url(metadata),
-            },
-            {
-                'completed': False,
-                'link_name': 'Household Details',
-                'highlight': False,
-                'repeating': False,
-                'link_url': Location('multiple-questions-group', 0, 'household-composition').url(metadata),
-            },
-            {
-                'completed': False,
-                'link_name': 'Extra Cover',
-                'highlight': False,
-                'repeating': False,
-                'link_url': Location('extra-cover', 0, 'extra-cover-block').url(metadata)
-            },
-            {
-                'completed': False,
-                'link_name': 'Payment Details',
-                'highlight': False,
-                'repeating': False,
-                'link_url': Location('payment-details', 0, 'credit-card').url(metadata)
-            }
-        ]
-        self.assertEqual(navigator.get_front_end_navigation(completed_blocks, 'property-details', 0), user_navigation)
+        self.assertEqual(expected_next_location, path_finder.get_next_location(current_location=current_location))
 
     def test_get_next_location_should_skip_group(self):
         # Given
@@ -917,12 +811,12 @@ class TestNavigator(unittest.TestCase):
         answer_store.add(Answer(group_id='do-you-want-to-skip-group', block_id='do-you-want-to-skip', answer_id='do-you-want-to-skip-answer', value='Yes'))
 
         # When
-        navigator = Navigator(survey, answer_store=answer_store)
+        path_finder = PathFinder(survey, answer_store=answer_store)
 
         # Then
-        next_location = Location('last-group', 0, 'last-group-block')
+        expected_next_location = Location('last-group', 0, 'last-group-block')
 
-        self.assertEqual(navigator.get_next_location(current_location), next_location)
+        self.assertEqual(path_finder.get_next_location(current_location=current_location), expected_next_location)
 
     def test_get_next_location_should_not_skip_group(self):
         # Given
@@ -933,12 +827,12 @@ class TestNavigator(unittest.TestCase):
                                 answer_id='do-you-want-to-skip-answer', value='No'))
 
         # When
-        navigator = Navigator(survey, answer_store=answer_store)
+        path_finder = PathFinder(survey, answer_store=answer_store)
 
         # Then
-        next_location = Location('should-skip-group', 0, 'should-skip')
+        expected_location = Location('should-skip-group', 0, 'should-skip')
 
-        self.assertEqual(navigator.get_next_location(current_location), next_location)
+        self.assertEqual(path_finder.get_next_location(current_location=current_location), expected_location)
 
     def test_get_next_location_should_not_skip_when_no_answers(self):
         # Given
@@ -947,12 +841,12 @@ class TestNavigator(unittest.TestCase):
         answer_store = AnswerStore()
 
         # When
-        navigator = Navigator(survey, answer_store=answer_store)
+        path_finder = PathFinder(survey, answer_store=answer_store)
 
         # Then
-        next_location = Location('should-skip-group', 0, 'should-skip')
+        expected_location = Location('should-skip-group', 0, 'should-skip')
 
-        self.assertEqual(navigator.get_next_location(current_location), next_location)
+        self.assertEqual(path_finder.get_next_location(current_location=current_location), expected_location)
 
     @pytest.mark.xfail(reason="Known bug when skipping last group due to summary bundled into it", strict=True, raises=StopIteration)
     def test_get_routing_path_when_first_block_in_group_skipped(self):
@@ -963,7 +857,7 @@ class TestNavigator(unittest.TestCase):
                                 answer_id='do-you-want-to-skip-answer', value='Yes'))
 
         # When
-        navigator = Navigator(survey, answer_store=answer_store)
+        path_finder = PathFinder(survey, answer_store=answer_store)
 
         # Then
         expected_route = [
@@ -978,431 +872,17 @@ class TestNavigator(unittest.TestCase):
                 'group_instance': 0
             }
         ]
-        self.assertEqual(navigator.get_routing_path('should-skip-group'), expected_route)
+        self.assertEqual(path_finder.get_routing_path('should-skip-group'), expected_route)
 
-    def test_navigation_repeating_household_and_hidden_household_groups_completed(self):
+    def test_build_path_with_invalid_location(self):
+        path_finder = PathFinder(survey_json={})
 
-        app = create_app()
-        app.config['SERVER_NAME'] = "test"
-        app_context = app.app_context()
-        app_context.push()
-
-        survey = load_schema_file("test_navigation.json")
-        metadata = {
-            "eq_id": '1',
-            "collection_exercise_sid": '999',
-            "form_type": "some_form"
-        }
-
-        navigator = Navigator(survey, metadata)
-
-        navigator.answer_store.answers = [
-            {
-                'group_instance': 0,
-                'answer_instance': 0,
-                'answer_id': 'household-full-name',
-                'value': 'Jim',
-                'group_id': 'multiple-questions-group',
-                'block_id': 'household-composition'
-            },
-            {
-                'group_instance': 0,
-                'answer_instance': 1,
-                'answer_id': 'household-full-name',
-                'value': 'Ben',
-                'group_id': 'multiple-questions-group',
-                'block_id': 'household-composition'
-            },
-            {
-                'group_instance': 0,
-                'answer_instance': 0,
-                'answer_id': 'what-is-your-age',
-                'value': None,
-                'group_id': 'repeating-group',
-                'block_id': 'repeating-block-1'
-            },
-            {
-                'group_instance': 0,
-                'answer_instance': 0,
-                'answer_id': 'what-is-your-shoe-size',
-                'value': None,
-                'group_id': 'repeating-group',
-                'block_id': 'repeating-block-2'
-            },
-            {
-                'group_instance': 1,
-                'answer_instance': 0,
-                'answer_id': 'what-is-your-age',
-                'value': None,
-                'group_id': 'repeating-group',
-                'block_id': 'repeating-block-1'
-            },
-            {
-                'group_instance': 1,
-                'answer_instance': 0,
-                'answer_id': 'what-is-your-shoe-size',
-                'value': None,
-                'group_id': 'repeating-group',
-                'block_id': 'repeating-block-2'
-            }
-        ]
-
-        completed_blocks = [
-            Location('property-details', 0, 'introduction'),
-            Location('multiple-questions-group', 0, 'household-composition'),
-            Location('repeating-group', 0, 'repeating-block-1'),
-            Location('repeating-group', 0, 'repeating-block-2'),
-            Location('repeating-group', 1, 'repeating-block-1'),
-            Location('repeating-group', 1, 'repeating-block-2')
-        ]
-
-        user_navigation = [
-            {
-                'link_name': 'Property Details',
-                'repeating': False,
-                'completed': False,
-                'highlight': True,
-                'link_url': Location('property-details', 0, 'insurance-type').url(metadata)
-            },
-            {
-                'link_name': 'Household Details',
-                'repeating': False,
-                'completed': True,
-                'highlight': False,
-                'link_url': Location('multiple-questions-group', 0, 'household-composition').url(metadata)
-            },
-            {
-                'link_name': 'Jim',
-                'repeating': True,
-                'completed': True,
-                'highlight': False,
-                'link_url': Location('repeating-group', 0, 'repeating-block-1').url(metadata)
-            },
-            {
-                'link_name': 'Ben',
-                'repeating': True,
-                'completed': True,
-                'highlight': False,
-                'link_url': Location('repeating-group', 1, 'repeating-block-1').url(metadata)
-            },
-            {
-                'link_name': 'Extra Cover',
-                'repeating': False,
-                'completed': False,
-                'highlight': False,
-                'link_url': Location('extra-cover', 0, 'extra-cover-block').url(metadata)
-            },
-            {
-                'link_name': 'Payment Details',
-                'repeating': False,
-                'completed': False,
-                'highlight': False,
-                'link_url': Location('payment-details', 0, 'credit-card').url(metadata)
-            }
-        ]
-
-        self.assertEqual(navigator.get_front_end_navigation(completed_blocks, 'property-details', 0), user_navigation)
-
-    def test_navigation_repeating_group_extra_answered_not_completed(self):
-        app = create_app()
-        app.config['SERVER_NAME'] = "test"
-        app_context = app.app_context()
-        app_context.push()
-
-        survey = load_schema_file("test_navigation.json")
-        metadata = {
-            "eq_id": '1',
-            "collection_exercise_sid": '999',
-            "form_type": "some_form"
-        }
-
-        navigator = Navigator(survey, metadata)
-
-        navigator.answer_store.answers = [
-            {
-                'answer_instance': 0,
-                'group_id': 'multiple-questions-group',
-                'answer_id': 'household-full-name',
-                'block_id': 'household-composition',
-                'group_instance': 0,
-                'value': 'Person1'
-            },
-            {
-                'answer_instance': 1,
-                'group_id': 'multiple-questions-group',
-                'answer_id': 'household-full-name',
-                'block_id': 'household-composition',
-                'group_instance': 0,
-                'value': 'Person2'
-            },
-            {
-                'answer_instance': 1,
-                'group_id': 'extra-cover',
-                'answer_id': 'extra-cover-answer',
-                'block_id': 'extra-cover-block',
-                'group_instance': 0,
-                'value': 2
-            }
-        ]
-
-        completed_blocks = [
-            Location('property-details', 0, 'introduction'),
-            Location('property-details', 0, 'insurance-type'),
-            Location('property-details', 0, 'cd6a5727-8cab-4737-aa4e-d666d98b3f92'),
-            Location('property-details', 0, 'personal-interstitial'),
-            Location('extra-cover', 0, 'extra-cover-block'),
-            Location('extra-cover', 0, 'ea651fa7-6b9d-4b6f-ba72-79133f312039'),
-        ]
-
-        user_navigation = [
-            {
-                'completed': False,
-                'highlight': True,
-                'repeating': False,
-                'link_name': 'Property Details',
-                'link_url': Location('property-details', 0, 'insurance-type').url(metadata)
-            },
-            {
-                'completed': False,
-                'highlight': False,
-                'repeating': False,
-                'link_name': 'Household Details',
-                'link_url': Location('multiple-questions-group', 0, 'household-composition').url(metadata),
-            },
-            {
-                'completed': False,
-                'highlight': False,
-                'repeating': True,
-                'link_name': 'Person1',
-                'link_url': Location('repeating-group', 0, 'repeating-block-1').url(metadata),
-            },
-            {
-                'completed': False,
-                'highlight': False,
-                'repeating': True,
-                'link_name': 'Person2',
-                'link_url': Location('repeating-group', 1, 'repeating-block-1').url(metadata),
-            },
-            {
-                'completed': False,
-                'highlight': False,
-                'repeating': False,
-                'link_name': 'Extra Cover',
-                'link_url': Location('extra-cover', 0, 'extra-cover-block').url(metadata),
-            },
-            {
-                'completed': False,
-                'highlight': False,
-                'repeating': False,
-                'link_name': 'Payment Details',
-                'link_url': Location('payment-details', 0, 'credit-card').url(metadata),
-            },
-            {
-                'completed': False,
-                'highlight': False,
-                'repeating': False,
-                'link_name': 'Extra Cover Items',
-                'link_url': Location('extra-cover-items-group', 0, 'extra-cover-items').url(metadata)
-            }
-        ]
-
-        self.assertEqual(navigator.get_front_end_navigation(completed_blocks, 'property-details', 0), user_navigation)
-
-    def test_navigation_repeating_group_extra_answered_completed(self):
-        app = create_app()
-        app.config['SERVER_NAME'] = "test"
-        app_context = app.app_context()
-        app_context.push()
-
-        survey = load_schema_file("test_navigation.json")
-        metadata = {
-            "eq_id": '1',
-            "collection_exercise_sid": '999',
-            "form_type": "some_form"
-        }
-
-        navigator = Navigator(survey, metadata)
-
-        navigator.answer_store.answers = [
-            {
-                'value': 2,
-                'group_instance': 0,
-                'block_id': 'extra-cover-block',
-                'group_id': 'extra-cover',
-                'answer_instance': 0,
-                'answer_id': 'extra-cover-answer'
-            },
-            {
-                'value': '2',
-                'group_instance': 0,
-                'block_id': 'extra-cover-items',
-                'group_id': 'extra-cover-items-group',
-                'answer_instance': 0,
-                'answer_id': 'extra-cover-items-answer'
-            },
-            {
-                'value': '2',
-                'group_instance': 1,
-                'block_id': 'extra-cover-items',
-                'group_id': 'extra-cover-items-group',
-                'answer_id': 'extra-cover-items-answer',
-                'answer_instance': 0
-            }
-        ]
-
-        completed_blocks = [
-            Location('property-details', 0, 'introduction'),
-            Location('extra-cover', 0, 'extra-cover-block'),
-            Location('extra-cover', 0, 'extra-cover-interstitial'),
-            Location('extra-cover-items-group', 0, 'extra-cover-items'),
-            Location('extra-cover-items-group', 1, 'extra-cover-items'),
-        ]
-
-        user_navigation = [
-            {
-                'repeating': False,
-                'highlight': True,
-                'completed': False,
-                'link_name': 'Property Details',
-                'link_url': Location('property-details', 0, 'insurance-type').url(metadata)
-            },
-            {
-                'repeating': False,
-                'highlight': False,
-                'completed': False,
-                'link_name': 'Household Details',
-                'link_url': Location('multiple-questions-group', 0, 'household-composition').url(metadata)
-            },
-            {
-                'repeating': False,
-                'highlight': False,
-                'completed': True,
-                'link_name': 'Extra Cover',
-                'link_url': Location('extra-cover', 0, 'extra-cover-block').url(metadata)
-            },
-            {
-                'repeating': False,
-                'highlight': False,
-                'completed': False,
-                'link_name': 'Payment Details',
-                'link_url': Location('payment-details', 0, 'credit-card').url(metadata)
-            },
-            {
-                'repeating': False,
-                'highlight': False,
-                'completed': True,
-                'link_name': 'Extra Cover Items',
-                'link_url': Location('extra-cover-items-group', 0, 'extra-cover-items').url(metadata)
-            }
-        ]
-
-        self.assertEqual(navigator.get_front_end_navigation(completed_blocks, 'property-details', 0), user_navigation)
-
-    def test_navigation_repeating_group_link_name_format(self):
-        app = create_app()
-        app.config['SERVER_NAME'] = "test"
-        app_context = app.app_context()
-        app_context.push()
-
-        survey = load_schema_file("test_repeating_household.json")
-        metadata = {
-            "eq_id": '1',
-            "collection_exercise_sid": '999',
-            "form_type": "some_form"
-        }
-
-        navigator = Navigator(survey, metadata)
-
-        navigator.answer_store.answers = [
-            {
-                'block_id': 'household-composition',
-                'answer_instance': 0,
-                'answer_id': 'first-name',
-                'group_id': 'multiple-questions-group',
-                'group_instance': 0,
-                'value': 'Joe'
-            },
-            {
-                'block_id': 'household-composition',
-                'answer_instance': 0,
-                'answer_id': 'middle-names',
-                'group_id': 'multiple-questions-group',
-                'group_instance': 0,
-                'value': None
-            },
-            {
-                'block_id': 'household-composition',
-                'answer_instance': 0,
-                'answer_id': 'last-name',
-                'group_id': 'multiple-questions-group',
-                'group_instance': 0,
-                'value': 'Bloggs'
-            },
-            {
-                'block_id': 'household-composition',
-                'answer_instance': 1,
-                'answer_id': 'first-name',
-                'group_id': 'multiple-questions-group',
-                'group_instance': 0,
-                'value': 'Jim'
-            },
-            {
-                'block_id': 'household-composition',
-                'answer_instance': 1,
-                'answer_id': 'last-name',
-                'group_id': 'multiple-questions-group',
-                'group_instance': 0,
-                'value': None
-            },
-            {
-                'block_id': 'household-composition',
-                'answer_instance': 1,
-                'answer_id': 'middle-names',
-                'group_id': 'multiple-questions-group',
-                'group_instance': 0,
-                'value': None
-            }
-        ]
-
-        completed_blocks = [
-            Location('multiple-questions-group', 0, 'introduction'),
-            Location('multiple-questions-group', 0, 'household-composition'),
-        ]
-
-        user_navigation = [
-            {
-                'repeating': False,
-                'completed': True,
-                'highlight': False,
-                'link_name': '',
-                'link_url': Location('multiple-questions-group', 0, 'household-composition').url(metadata)
-            },
-            {
-                'repeating': True,
-                'link_name': 'Joe Bloggs',
-                'completed': False,
-                'highlight': False,
-                'link_url': Location('repeating-group', 0, 'repeating-block-1').url(metadata)
-            },
-            {
-                'repeating': True,
-                'link_name': 'Jim',
-                'completed': False,
-                'highlight': False,
-                'link_url': Location('repeating-group', 1, 'repeating-block-1').url(metadata)
-            }
-        ]
-
-        self.assertEqual(navigator.get_front_end_navigation(completed_blocks, 'property-details', 0), user_navigation)
-
-    def test_block_index_for_location_with_invalid_location(self):
         blocks = [
             {
                 "group_id": 'first-valid-group-id',
                 "group_instance": 0,
                 "block": {"id": 'first-valid-block-id'}
-            },
-            {
+            }, {
                 "group_id": 'second-valid-group-id',
                 "group_instance": 0,
                 "block": {"id": 'second-valid-block-id'}
@@ -1416,13 +896,13 @@ class TestNavigator(unittest.TestCase):
         )
 
         with self.assertRaises(StopIteration):
-            Navigator._block_index_for_location(blocks, invalid_group_location)
+            path_finder.build_path(blocks, invalid_group_location)
 
         invalid_block_location = Location(
             group_instance=0,
             group_id='second-valid-group-id',
-            block_id= 'this-block-id-doesnt-exist-in-the-list-of-blocks'
+            block_id='this-block-id-doesnt-exist-in-the-list-of-blocks'
         )
 
         with self.assertRaises(StopIteration):
-            Navigator._block_index_for_location(blocks, invalid_block_location)
+            path_finder.build_path(blocks, invalid_block_location)

--- a/tests/app/templating/test_summary_context.py
+++ b/tests/app/templating/test_summary_context.py
@@ -42,7 +42,7 @@ class TestSummaryContext(unittest.TestCase):
         navigator = Mock()
         navigator.get_routing_path = Mock(return_value=routing_path)
 
-        with patch('app.templating.summary_context.Navigator', return_value=navigator):
+        with patch('app.templating.summary_context.PathFinder', return_value=navigator):
             context = build_summary_rendering_context(self.schema_json, answer_store, self.metadata)
 
         self.assertEqual(len(context), 1)


### PR DESCRIPTION
### What is the context of this PR?

Depends on the addition of the location class in https://github.com/ONSdigital/eq-survey-runner/pull/759.

Move the navigation methods from current navigator to a new Navigation class. Both frontend sidebar navigation and path navigation can be generated independently from one another and this split allows for separation of concerns. Refactor current methods to make behaviour clearer.
    
Rename the current Navigator to PathFinder to prevent confusion and migrate tests.

### How to review 
Check if tests pass and you agree with approach.
