### PR TITLE
Add q_codes into checkbox options and update converter

### DIFF
--- a/app/data/schema/schema-v1.json
+++ b/app/data/schema/schema-v1.json
@@ -239,7 +239,17 @@
                                   },
                                   "options": {
                                     "type": "array",
-                                    "items": {}
+                                    "items": {
+                                         "label": {
+                                            "type": "string"
+                                         },
+                                         "value": {
+                                             "type": "string"
+                                        },
+                                         "q_code": {
+                                            "type": "string"
+                                        }
+                                    }
                                   },
                                   "mandatory": {
                                     "type": "boolean"

--- a/app/data/test_checkbox.json
+++ b/app/data/test_checkbox.json
@@ -41,34 +41,40 @@
                                             "options": [
                                                 {
                                                     "label": "Cheese",
-                                                    "value": "Cheese"
+                                                    "value": "Cheese",
+                                                    "q_code": 1
                                                 },
                                                 {
                                                     "label": "Ham",
-                                                    "value": "Ham"
+                                                    "value": "Ham",
+                                                    "q_code": 2
                                                 },
                                                 {
                                                     "label": "Pineapple",
-                                                    "value": "Pineapple"
+                                                    "value": "Pineapple",
+                                                    "q_code": 3
                                                 },
                                                 {
                                                     "label": "Tuna",
-                                                    "value": "Tuna"
+                                                    "value": "Tuna",
+                                                    "q_code": 4
                                                 },
                                                 {
                                                     "label": "Pepperoni",
-                                                    "value": "Pepperoni"
+                                                    "value": "Pepperoni",
+                                                    "q_code": 5
                                                 },
                                                 {
                                                     "label": "Other",
                                                     "value": "other",
+                                                    "q_code": 6,
                                                     "description": "Choose any other topping",
                                                     "other": {
                                                       "label": "Please specify other"
                                                     }
                                                 }
                                             ],
-                                            "q_code": "20",
+                                            "q_code": "",
                                             "type": "Checkbox",
                                             "validation": {
                                                 "messages": {}

--- a/app/helpers/multiple_choice_helper.py
+++ b/app/helpers/multiple_choice_helper.py
@@ -1,0 +1,15 @@
+class MultipleChoiceHelper(object):
+
+    @staticmethod
+    def find_other_value(posted_data, options):
+        """
+        Compare the posted_data with the options in the schema, if there is a value which doesn't match
+        the options it must be the other value
+        """
+        if posted_data and 'other' in (value.lower() for value in posted_data):
+            for answer in posted_data:
+                answer_in_options = any(option['value'] == answer for option in options)
+                if answer and not answer.isspace() and not answer_in_options and answer.lower() != 'other':
+                    return answer
+
+        return None

--- a/app/schema/answers/checkbox_answer.py
+++ b/app/schema/answers/checkbox_answer.py
@@ -1,8 +1,10 @@
 import logging
 
+from app.helpers.multiple_choice_helper import MultipleChoiceHelper
 from app.questionnaire_state.exceptions import StateException
 from app.schema.answer import Answer
 from app.schema.widgets.checkbox_group_widget import CheckboxGroupWidget
+
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +32,7 @@ class CheckboxAnswer(Answer):
                     super(CheckboxAnswer, self).mandatory_error(state)
                 elif 'other' not in state.input and not self._valid_option_selected(state.input, options):
                     super(CheckboxAnswer, self).mandatory_error(state)
-                elif 'other' in state.input and not self.widget.find_other_value(state.input, options):
+                elif 'other' in state.input and not MultipleChoiceHelper.find_other_value(state.input, options):
                     super(CheckboxAnswer, self).mandatory_error(state)
 
             # Here we just report on whether the answer has passed type checking

--- a/app/schema/widgets/multiple_choice_widget.py
+++ b/app/schema/widgets/multiple_choice_widget.py
@@ -2,6 +2,8 @@ import logging
 
 from abc import ABCMeta, abstractmethod
 
+from app.helpers.multiple_choice_helper import MultipleChoiceHelper
+
 from app.schema.widget import Widget
 
 from flask import render_template
@@ -54,18 +56,4 @@ class MultipleChoiceWidget(Widget, metaclass=ABCMeta):
         else:
             posted_data = post_vars.get(self.name)
 
-        return self.find_other_value(posted_data, options)
-
-    @staticmethod
-    def find_other_value(posted_data, options):
-        """
-        Compare the posted_data with the options in the schema, if there is a value which doesn't match
-        the options it must be the other value
-        """
-        if posted_data and 'other' in (value.lower() for value in posted_data):
-            for answer in posted_data:
-                answer_in_options = any(option['value'] == answer for option in options)
-                if answer and not answer.isspace() and not answer_in_options and answer.lower() != 'other':
-                    return answer
-
-        return None
+        return MultipleChoiceHelper.find_other_value(posted_data, options)

--- a/app/submitter/converter.py
+++ b/app/submitter/converter.py
@@ -4,6 +4,8 @@ from collections import OrderedDict
 from datetime import datetime, timezone
 
 from app import settings
+from app.helpers.multiple_choice_helper import MultipleChoiceHelper
+from app.schema.answers.checkbox_answer import CheckboxAnswer
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +21,6 @@ class DataVersionError(Exception):
 def convert_answers(metadata, questionnaire, answer_store, routing_path):
     """
     Create the JSON answer format for down stream processing
-
     :param metadata: metadata for the questionnaire
     :param questionnaire: the questionnaire schema
     :param answer_store: the users answers
@@ -82,15 +83,45 @@ def convert_answers_to_data(answer_store, questionnaire_schema):
     for answer in answer_store.answers:
         item = questionnaire_schema.get_item_by_id(answer['answer_id'])
         value = answer['value']
+
         if item is not None and value is not None:
-            if item.code not in data:
-                data[item.code] = _encode_value(value)
+            if not isinstance(item, CheckboxAnswer) or any('q_code' not in option for option in item.options):
+                data[item.code] = _get_answer_data(data, item.code, value)
             else:
-                if not isinstance(data[item.code], list):
-                    list_answers = [data[item.code]]
-                    data[item.code] = list_answers
-                data[item.code].append(_encode_value(value))
+                data.update(_get_checkbox_answer_data(item, value))
     return data
+
+
+def _get_answer_data(original_data, item_code, value):
+
+    if item_code in original_data:
+        data_to_return = original_data[item_code]
+        if not isinstance(data_to_return, list):
+            data_to_return = [data_to_return]
+        data_to_return.append(_encode_value(value))
+
+        return data_to_return
+    return _encode_value(value)
+
+
+def _get_checkbox_answer_data(checkboxes_with_qcode, value):
+
+    checkbox_answer_data = OrderedDict()
+
+    for user_answer in value:
+        # find the option in the schema which matches the users answer
+        option = next((option for option in checkboxes_with_qcode.options if option['value'] == user_answer), None)
+
+        if option:
+            if option['value'].lower() == 'other':
+                # if the user has selected 'other' we need to find the value it refers to.
+                # when non-mandatory, the other box value can be empty, in this case we just use its value
+                checkbox_answer_data[option['q_code']] = MultipleChoiceHelper.find_other_value(value, checkboxes_with_qcode.options) \
+                                         or option['value']
+            else:
+                checkbox_answer_data[option['q_code']] = user_answer
+
+    return checkbox_answer_data
 
 
 def convert_answers_to_census_data(answer_store, routing_path):

--- a/tests/app/submitter/test_converter.py
+++ b/tests/app/submitter/test_converter.py
@@ -6,6 +6,7 @@ from app.data_model.answer_store import AnswerStore
 from app.parser.metadata_parser import parse_metadata
 from app.questionnaire.location import Location
 from app.schema.answer import Answer
+from app.schema.answers.checkbox_answer import CheckboxAnswer
 from app.schema.block import Block
 from app.schema.group import Group
 from app.schema.question import Question
@@ -234,6 +235,136 @@ class TestConverter(SurveyRunnerTestCase):
                 convert_answers(metadata, questionnaire, AnswerStore(), {})
 
             self.assertEqual(str(err.exception), 'Data version -0.0.1 not supported')
+
+    def test_converter_checkboxes_with_q_codes(self):
+        with self.application.test_request_context():
+            routing_path = [Location(group_id='favourite food', group_instance=0, block_id='crisps')]
+            answers = [create_answer('crisps-answer', ['Ready salted', 'Sweet chilli'], group_id='favourite food', block_id='crisps')]
+
+            answer = CheckboxAnswer()
+            answer.id = "crisps-answer"
+            answer.code = ""
+            answer.options = [
+                                {
+                                    "label": "Ready salted",
+                                    "value": "Ready salted",
+                                    "q_code": "1"
+                                },
+                                {
+                                    "label": "Sweet chilli",
+                                    "value": "Sweet chilli",
+                                    "q_code": "2"
+                                },
+                                {
+                                    "label": "Cheese and onion",
+                                    "value": "Cheese and onion",
+                                    "q_code": "3"
+                                },
+                                {
+                                    "label": "Other",
+                                    "value": "other",
+                                    "q_code": "4",
+                                    "description": "Choose any other flavour",
+                                    "other": {
+                                      "label": "Please specify other"
+                                    }
+                                }
+                            ]
+
+            question = Question()
+            question.id = 'crisps-question'
+            question.add_answer(answer)
+
+            section = Section()
+            section.add_question(question)
+
+            block = Block()
+            block.id = 'crisps'
+            block.add_section(section)
+
+            group = Group()
+            group.id = 'favourite food'
+            group.add_block(block)
+
+            questionnaire = Questionnaire()
+            questionnaire.survey_id = "999"
+            questionnaire.data_version = "0.0.1"
+            questionnaire.add_group(group)
+            questionnaire.register(question)
+            questionnaire.register(answer)
+
+            # When
+            answer_object = convert_answers(metadata, questionnaire, AnswerStore(answers), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 2)
+            self.assertEqual(answer_object['data']['1'], 'Ready salted')
+            self.assertEqual(answer_object['data']['2'], 'Sweet chilli')
+
+    def test_converter_checkboxes_with_q_codes_and_other_value(self):
+        with self.application.test_request_context():
+            routing_path = [Location(group_id='favourite food', group_instance=0, block_id='crisps')]
+            answers = [create_answer('crisps-answer', ['Ready salted', 'other', 'Bacon'], group_id='favourite food', block_id='crisps')]
+
+            answer = CheckboxAnswer()
+            answer.id = "crisps-answer"
+            answer.code = ""
+            answer.options = [
+                                {
+                                    "label": "Ready salted",
+                                    "value": "Ready salted",
+                                    "q_code": "1"
+                                },
+                                {
+                                    "label": "Sweet chilli",
+                                    "value": "Sweet chilli",
+                                    "q_code": "2"
+                                },
+                                {
+                                    "label": "Cheese and onion",
+                                    "value": "Cheese and onion",
+                                    "q_code": "3"
+                                },
+                                {
+                                    "label": "Other",
+                                    "value": "other",
+                                    "q_code": "4",
+                                    "description": "Choose any other flavour",
+                                    "other": {
+                                      "label": "Please specify other"
+                                    }
+                                }
+                            ]
+
+            question = Question()
+            question.id = 'crisps-question'
+            question.add_answer(answer)
+
+            section = Section()
+            section.add_question(question)
+
+            block = Block()
+            block.id = 'crisps'
+            block.add_section(section)
+
+            group = Group()
+            group.id = 'favourite food'
+            group.add_block(block)
+
+            questionnaire = Questionnaire()
+            questionnaire.survey_id = "999"
+            questionnaire.data_version = "0.0.1"
+            questionnaire.add_group(group)
+            questionnaire.register(question)
+            questionnaire.register(answer)
+
+            # When
+            answer_object = convert_answers(metadata, questionnaire, AnswerStore(answers), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 2)
+            self.assertEqual(answer_object['data']['1'], 'Ready salted')
+            self.assertEqual(answer_object['data']['4'], 'Bacon')
 
 
 def create_answer(answer_id, value, group_id=None, block_id=None, answer_instance=0, group_instance=0):


### PR DESCRIPTION
### What is the context of this PR?
To add q_codes into the options of checkboxes so the converter can map the form data to the right q_code before sending to SDX. Needed for UKIS

### How to review 
Using test_checkbox.json, put in debug statement in converter.py just above the data return, to expose the data

i.e
```
  if option:
      if option['value'] == 'other':
           data[option['q_code']] = CheckboxHelper.find_other_value(value, item.options) or 'other'
      else:
          data[option['q_code']] = user_answer
  
  logger.error(data)
  return data
```

Run the application and fill out the form as normal, check your console to see what data is being produced. It should map your answers to the correct q_codes for the first questions checkboxes, if you use 'other' it will map the answer you provided to the q_code of other.
