### PR TITLE
eq-787 Legends not wrapping in IE11

### DIFF
--- a/app/assets/styles/partials/base/_global.scss
+++ b/app/assets/styles/partials/base/_global.scss
@@ -45,3 +45,9 @@ main,
     outline: none;
   }
 }
+
+legend {
+  // http://www.456bereastreet.com/archive/201210/how_to_line_wrap_text_in_legend_elements_even_in_ie/
+  white-space: normal;
+  display: table;
+}


### PR DESCRIPTION
### What is the context of this PR?

Fixes #787 by adding some CSS to `legend` that forces wrapping of legends in IE.

### How to review 

As per #787. This does affect both English and Welsh so I recommend doing in English for ease.
