### PR TITLE
Initial UKIS schema content, generated from Google Slides

### DIFF
--- a/app/data/1_0001.json
+++ b/app/data/1_0001.json
@@ -1,0 +1,5137 @@
+{
+    "data_version": "0.0.1",
+    "description": "UK Innovation Survey",
+    "groups": [
+        {
+            "blocks": [
+                {
+                    "id": "geographic-markets",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "geographic-markets-section",
+                            "number": "1",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "geographic-markets-answer",
+                                            "label": "Pleases select all that apply",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "UK regional within approximately 100 miles of this business",
+                                                    "q_code": "0210",
+                                                    "value": "UK regional within approximately 100 miles of this business"
+                                                },
+                                                {
+                                                    "label": "UK national",
+                                                    "q_code": "0220",
+                                                    "value": "UK national"
+                                                },
+                                                {
+                                                    "label": "European countries",
+                                                    "q_code": "0230",
+                                                    "value": "European countries"
+                                                },
+                                                {
+                                                    "label": "All other countries",
+                                                    "q_code": "0240",
+                                                    "value": "All other countries"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "id": "geographic-markets-question",
+                                    "number": "1.1",
+                                    "title": "In which geographic markets did {{respondent.ru_name}} sell goods and/or services?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "General Business Information"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "significant-events",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "significant-events-section",
+                            "number": "1",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "significant-events-established-answer",
+                                            "label": "{{respondent.ru_name}} was established",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "0410",
+                                            "type": "Radio"
+                                        },
+                                        {
+                                            "description": "",
+                                            "id": "significant-events-turnover-increase-answer",
+                                            "label": "Turnover increased by at least 10% due to merger with another business or part of it",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "0420",
+                                            "type": "Radio"
+                                        },
+                                        {
+                                            "description": "",
+                                            "id": "significant-events-turnover-decrease-answer",
+                                            "label": "Turnover decreased by at least 10% due to merger with another business or part of it",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "0430",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "id": "significant-events-question",
+                                    "number": "1.2",
+                                    "title": "Did any of the following significant events or changes occur to {{respondent.ru_name}}?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "General Business Information"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "general-business-information-completed",
+                    "sections": [
+                        {
+                            "description": "<p>You have successfully completed this section</p><p>The next section covers changes in <em>business strategy and practices</em>, for example, implementing changes to marketing concepts or strategies.</p>",
+                            "id": "general-business-information-completed-section",
+                            "number": "1",
+                            "questions": [
+                                {
+                                    "answers": [],
+                                    "description": "",
+                                    "id": "general-business-information-completed-question",
+                                    "title": "",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "General Business Information"
+                        }
+                    ],
+                    "type": "interstitial"
+                }
+            ],
+            "id": "general-business-information",
+            "title": "General Business Information"
+        },
+        {
+            "blocks": [
+                {
+                    "id": "business-changes",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "business-changes-section",
+                            "number": "2",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "For example first use of supply chain management, business re-engineering, knowledge management, lean production or quality management",
+                                            "id": "business-changes-business-practices-answer",
+                                            "label": "New <em>business practices</em> for organising procedures",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "2310",
+                                            "type": "Radio"
+                                        },
+                                        {
+                                            "description": "For example first use of a new system of employee responsibilities, team work, decentralisation, integration or de-integration of departments or education / training systems",
+                                            "id": "business-changes-organising-answer",
+                                            "label": "New methods of <em>organising work responsibilities and decision making</em>",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "2320",
+                                            "type": "Radio"
+                                        },
+                                        {
+                                            "description": "For example first use of alliances, partnerships, outsourcing or subcontracting",
+                                            "id": "business-changes-external-relationships-answer",
+                                            "label": "New methods of <em>organising external relationships</em> with other firms or public institutions",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "2330",
+                                            "type": "Radio"
+                                        },
+                                        {
+                                            "description": "For example a <em>marketing concept or strategy</em> that differs significantly from your enterprise’s existing marketing methods and which has not been used before",
+                                            "id": "business-changes-answer",
+                                            "label": "Implementation of significant  changes to marketing concepts or strategies.",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "2340",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "guidance": [
+                                        {
+                                            "description": "",
+                                            "list": [
+                                                "all <em>new</em> and <em>significantly improved</em> forms of organisation, business structures or practices aimed at raising internal efficiency or the effectiveness of approaching markets and customers.",
+                                                "changes that have been implemented during the 3 year period"
+                                            ],
+                                            "title": "Include:"
+                                        },
+                                        {
+                                            "description": "",
+                                            "list": [
+                                                "ongoing changes"
+                                            ],
+                                            "title": "Exclude:"
+                                        }
+                                    ],
+                                    "id": "business-changes-question",
+                                    "number": "2.1",
+                                    "title": "Did {{respondent.ru_name}} make changes in the following areas?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Business Strategy and Practices"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "business-strategy-practices-completed",
+                    "sections": [
+                        {
+                            "description": "<p>You have successfully completed this section </p><p>The next section covers  <em>investments in innovation</em>.</p><p> </p><p>You will be asked to provide figures for expenditure on innovation activities in the calendar year 2016.</p>",
+                            "id": "business-strategy-practices-completed-section",
+                            "number": "2",
+                            "questions": [
+                                {
+                                    "answers": [],
+                                    "description": "",
+                                    "id": "business-strategy-practices-completed-question",
+                                    "title": "",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Business Strategy & Practices"
+                        }
+                    ],
+                    "type": "interstitial"
+                }
+            ],
+            "id": "business-strategy-practices",
+            "title": "Business Strategy & Practices"
+        },
+        {
+            "blocks": [
+                {
+                    "id": "internal-investment-r-d",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "internal-investment-r-d-section",
+                            "number": "3",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "internal-investment-r-d-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "1310",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "guidance": [
+                                        {
+                                            "description": "",
+                                            "list": [
+                                                "Creative work undertaken within your business that increases knowledge for developing new and improved goods or services and processes."
+                                            ],
+                                            "title": "Definition of ‘internal Research and Development’:"
+                                        }
+                                    ],
+                                    "id": "internal-investment-r-d-question",
+                                    "number": "3.1",
+                                    "title": "Did {{respondent.ru_name}} invest in <em>internal Research and Development</em> for the purposes of current or future innovation?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Innovation Investment"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "years-internal-investment-r-d",
+                    "sections": [
+                        {
+                            "description": "",
+                            "id": "years-internal-investment-r-d-section",
+                            "number": "3",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "years-internal-investment-r-d-answer",
+                                            "label": "Select all that apply",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "2014",
+                                                    "q_code": "2675",
+                                                    "value": "2014"
+                                                },
+                                                {
+                                                    "label": "2015",
+                                                    "q_code": "2676",
+                                                    "value": "2015"
+                                                },
+                                                {
+                                                    "label": "2016",
+                                                    "q_code": "2677",
+                                                    "value": "2016"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "id": "years-internal-investment-r-d-question",
+                                    "number": "3.2",
+                                    "title": "In which of the following years did {{respondent.ru_name}} invest in <em>internal Research & Development</em>?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Innovation Investment"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "expenditure-internal-investment-r-d",
+                    "sections": [
+                        {
+                            "description": "<p>1 year period 1 January 2016 to 31 December 2016.</p>",
+                            "id": "expenditure-internal-investment-r-d-section",
+                            "number": "3",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "Round to the nearest £ thousand, for example enter £1,702,800 as 1703000",
+                                            "id": "expenditure-internal-investment-r-d-answer",
+                                            "label": "Total internal Research and Development",
+                                            "mandatory": false,
+                                            "options": [],
+                                            "q_code": "1410",
+                                            "type": "Currency"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "guidance": [
+                                        {
+                                            "description": "",
+                                            "list": [
+                                                "Internal costs and purchases from outside the business"
+                                            ],
+                                            "title": "Include:"
+                                        }
+                                    ],
+                                    "id": "expenditure-internal-investment-r-d-question",
+                                    "number": "3.3",
+                                    "title": "Please estimate the amount of expenditure on internal Research & Development  the <em>calendar  year 2016 only</em>?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Innovation Investment"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "acquisition-internal-investment-r-d",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "acquisition-internal-investment-r-d-section",
+                            "number": "3",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "acquisition-internal-investment-r-d-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "1320",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "guidance": [
+                                        {
+                                            "description": "",
+                                            "list": [
+                                                "Creative work undertaken  by companies, including other businesses within your group, or by public or private research organisations and purchased by your business"
+                                            ],
+                                            "title": "Include:"
+                                        }
+                                    ],
+                                    "id": "acquisition-internal-investment-r-d-question",
+                                    "number": "3.4",
+                                    "title": "Did {{respondent.ru_name}} invest in the <em>acquisition of</em><em> Research and Development</em> for the purposes of current or future innovation?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Innovation Investment"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "amount-acquisition-internal-investment-r-d",
+                    "sections": [
+                        {
+                            "description": "<p>1 year period 1 January 2016 to 31 December 2016.</p>",
+                            "id": "amount-acquisition-internal-investment-r-d-section",
+                            "number": "3",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "Round to the nearest £ thousand, for example enter £1,702,800 as 1703000",
+                                            "id": "amount-acquisition-internal-investment-r-d-answer",
+                                            "label": "Total acquisition of Research and Development",
+                                            "mandatory": false,
+                                            "options": [],
+                                            "q_code": "1420",
+                                            "type": "Currency"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "guidance": [
+                                        {
+                                            "description": "",
+                                            "list": [
+                                                "Internal costs and purchases from outside the business"
+                                            ],
+                                            "title": "Include:"
+                                        }
+                                    ],
+                                    "id": "amount-acquisition-internal-investment-r-d-question",
+                                    "number": "3.5",
+                                    "title": "Please estimate the amount of expenditure on acquisition of Research & Development in  the <em>calendar  year 2016 only</em>?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Innovation Investment"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "investment-advanced-machinery",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "investment-advanced-machinery-section",
+                            "number": "3",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "investment-advanced-machinery-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "10000",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "id": "investment-advanced-machinery-question",
+                                    "number": "3.6",
+                                    "title": "Did {{respondent.ru_name}}  invest in <em>acquisition of advanced machinery, equipment or software</em> for the purposes of current or future innovation?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Innovation Investment"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "investment-purposes-innovation",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "investment-purposes-innovation-section",
+                            "number": "3",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "investment-purposes-innovation-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Advanced machinery and equipment",
+                                                    "q_code": "1331",
+                                                    "value": "Advanced machinery and equipment"
+                                                },
+                                                {
+                                                    "label": "Computer hardware",
+                                                    "q_code": "1332",
+                                                    "value": "Computer hardware"
+                                                },
+                                                {
+                                                    "label": "Computer software",
+                                                    "q_code": "1333",
+                                                    "value": "Computer software"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "id": "investment-purposes-innovation-question",
+                                    "number": "3.7",
+                                    "title": "Which of the following did {{respondent.ru_name}} invest in for the purposes of current or future innovation?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Innovation Investment"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "amount-acquisition-advanced-machinery",
+                    "sections": [
+                        {
+                            "description": "<p>1 year period 1 January 2016 to 31 December 2016.</p>",
+                            "id": "amount-acquisition-advanced-machinery-section",
+                            "number": "3",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "Round to the nearest £ thousand, for example enter £1,702,800 as 1703000",
+                                            "id": "amount-acquisition-advanced-machinery-answer",
+                                            "label": "Total acquisition of advanced machinery, equipment and software",
+                                            "mandatory": false,
+                                            "options": [],
+                                            "q_code": "1430",
+                                            "type": "Currency"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "guidance": [
+                                        {
+                                            "description": "",
+                                            "list": [
+                                                "Internal costs and purchase from outside the business"
+                                            ],
+                                            "title": "Include:"
+                                        }
+                                    ],
+                                    "id": "amount-acquisition-advanced-machinery-question",
+                                    "number": "3.8",
+                                    "title": "Please estimate the amount of expenditure for the total acquisition of advanced machinery, equipment and software for  the <em>calendar year 2016 only</em>?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Innovation Investment"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "investment-existing-knowledge-innovation",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "investment-existing-knowledge-innovation-section",
+                            "number": "3",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "investment-existing-knowledge-innovation-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "1340",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "guidance": [
+                                        {
+                                            "description": "",
+                                            "list": [
+                                                "Purchase or licensing of patents and non-patented inventions, know-how and other types of knowledge from other businesses or organisations"
+                                            ],
+                                            "title": "Include:"
+                                        }
+                                    ],
+                                    "id": "investment-existing-knowledge-innovation-question",
+                                    "number": "3.9",
+                                    "title": "Did {{respondent.ru_name}} invest in the <em>acquisition of existing knowledge</em> for the purposes of current or future innovation?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Innovation Investment"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "expenditure-existing-2016",
+                    "sections": [
+                        {
+                            "description": "<p>1 year period 1 January 2016 to 31 December 2016.</p>",
+                            "id": "expenditure-existing-2016-section",
+                            "number": "3",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "Round to the nearest £ thousand, for example enter £1,702,800 as 1703000",
+                                            "id": "expenditure-existing-2016-answer",
+                                            "label": "Total acquisition of existing knowledge",
+                                            "mandatory": false,
+                                            "options": [],
+                                            "q_code": "1440",
+                                            "type": "Currency"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "guidance": [
+                                        {
+                                            "description": "",
+                                            "list": [
+                                                "Internal costs and purchase from outside {{respondent.ru_name}}"
+                                            ],
+                                            "title": "Include:"
+                                        }
+                                    ],
+                                    "id": "expenditure-existing-2016-question",
+                                    "number": "3.10",
+                                    "title": "Please estimate the amount of expenditure for acquisition of existing knowledge for the <em>calendar year 2016 only</em>?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Innovation Investment"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "investment-training-innovative",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "investment-training-innovative-section",
+                            "number": "3",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "investment-training-innovative-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "1350",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "guidance": [
+                                        {
+                                            "description": "",
+                                            "list": [
+                                                "Internal or external training for your personnel, specifically for the development or implementation of new or improved goods, services and processes."
+                                            ],
+                                            "title": "Include:"
+                                        }
+                                    ],
+                                    "id": "investment-training-innovative-question",
+                                    "number": "3.11",
+                                    "title": "Did {{respondent.ru_name}} invest in <em>training for innovative activities</em> for the purposes of current or future innovation?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Innovation Investment"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "expenditure-training-innovative-2016",
+                    "sections": [
+                        {
+                            "description": "<p>1 year period 1 January 2016 to 31 December 2016.</p>",
+                            "id": "expenditure-training-innovative-2016-section",
+                            "number": "3",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "Round to the nearest £ thousand, for example enter £1,702,800 as 1703000",
+                                            "id": "expenditure-training-innovative-2016-answer",
+                                            "label": "Total training for innovative activities",
+                                            "mandatory": false,
+                                            "options": [],
+                                            "q_code": "1450",
+                                            "type": "Currency"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "guidance": [
+                                        {
+                                            "description": "",
+                                            "list": [
+                                                "Internal costs and purchase from outside the business"
+                                            ],
+                                            "title": "Include:"
+                                        }
+                                    ],
+                                    "id": "expenditure-training-innovative-2016-question",
+                                    "number": "3.12",
+                                    "title": "Please estimate the amount of expenditure for training for innovative activities for the <em>calendar year 2016 only</em>?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Innovation Investment"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "investment-design-future-innovation",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "investment-design-future-innovation-section",
+                            "number": "3",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "investment-design-future-innovation-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "1360",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "guidance": [
+                                        {
+                                            "description": "",
+                                            "list": [
+                                                "Engagement in all design activities, including strategic, for the development or implementation of new or improved goods, services and processes."
+                                            ],
+                                            "title": "Include:"
+                                        }
+                                    ],
+                                    "id": "investment-design-future-innovation-question",
+                                    "number": "3.13",
+                                    "title": "Did {{respondent.ru_name}} invest in <em>all forms of design</em> for the purposes of current or future innovation?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Innovation Investment"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "expenditure-design-2016",
+                    "sections": [
+                        {
+                            "description": "<p>1 year period 1 January 2016 to 31 December 2016.</p>",
+                            "id": "expenditure-design-2016-section",
+                            "number": "3",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "Round to the nearest £ thousand, for example enter £1,702,800 as 1703000",
+                                            "id": "expenditure-design-2016-answer",
+                                            "label": "Total training for all forms of design",
+                                            "mandatory": false,
+                                            "options": [],
+                                            "q_code": "1460",
+                                            "type": "Currency"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "guidance": [
+                                        {
+                                            "description": "",
+                                            "list": [
+                                                "Internal costs and purchase from outside the business"
+                                            ],
+                                            "title": "Include:"
+                                        }
+                                    ],
+                                    "id": "expenditure-design-2016-question",
+                                    "number": "3.14",
+                                    "title": "Please estimate the amount of expenditure for all forms of design for the <em>calendar year 2016 only</em>?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Innovation Investment"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "investment-introduction-innovations",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "investment-introduction-innovations-section",
+                            "number": "3",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "investment-introduction-innovations-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "10001",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "id": "investment-introduction-innovations-question",
+                                    "number": "3.15",
+                                    "title": "Did {{respondent.ru_name}} invest in <em>market introduction of innovations</em> for the purposes of current or future innovation?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Innovation Investment"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "investment-purposes-innovation-2",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "investment-purposes-innovation-section-2",
+                            "number": "3",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "investment-purposes-innovation-answer-2",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Changes to product or service design",
+                                                    "q_code": "1371",
+                                                    "value": "Changes to product or service design"
+                                                },
+                                                {
+                                                    "label": "Market research",
+                                                    "q_code": "1372",
+                                                    "value": "Market research"
+                                                },
+                                                {
+                                                    "label": "Changes to marketing methods",
+                                                    "q_code": "1373",
+                                                    "value": "Changes to marketing methods"
+                                                },
+                                                {
+                                                    "label": "Launch advertising",
+                                                    "q_code": "1374",
+                                                    "value": "Launch advertising"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "id": "investment-purposes-innovation-question-2",
+                                    "number": "3.16",
+                                    "title": "Which of the following did {{respondent.ru_name}} invest in for the purposes of current or future innovation?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Innovation Investment"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "expenditure-introduction-innovations-2016",
+                    "sections": [
+                        {
+                            "description": "<p>1 year period 1 January 2016 to 31 December 2016.</p>",
+                            "id": "expenditure-introduction-innovations-2016-section",
+                            "number": "3",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "Round to the nearest £ thousand, for example enter £1,702,800 as 1703000",
+                                            "id": "expenditure-introduction-innovations-2016-answer",
+                                            "label": "Total market introduction of innovations",
+                                            "mandatory": false,
+                                            "options": [],
+                                            "q_code": "1470",
+                                            "type": "Currency"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "guidance": [
+                                        {
+                                            "description": "",
+                                            "list": [
+                                                "Internal costs and purchase from outside the business"
+                                            ],
+                                            "title": "Include:"
+                                        }
+                                    ],
+                                    "id": "expenditure-introduction-innovations-2016-question",
+                                    "number": "3.17",
+                                    "title": "Please estimate the amount of expenditure for market introduction of innovations for the <em>calendar year 2016 only</em>?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Innovation Investment"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "innovation-investment-completed",
+                    "sections": [
+                        {
+                            "description": "<p> </p><p>You have successfully completed this section</p><p>The next section covers innovation relating to <em>goods and services</em>.</p><p> </p><p>You will first be asked to provide information about any new or significantly improved goods introduced by your business; and second to provide information relating to any new or significantly improved services.</p><p> </p><p>You will also be asked to provide estimates for turnover in the calendar year 2016 relating to new or improved goods or services introduced during the period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "innovation-investment-completed-section",
+                            "number": "3",
+                            "questions": [
+                                {
+                                    "answers": [],
+                                    "description": "",
+                                    "id": "innovation-investment-completed-question",
+                                    "title": "Innovation Investment",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Innovation Investment"
+                        }
+                    ],
+                    "type": "interstitial"
+                }
+            ],
+            "id": "innovation-investment",
+            "title": "Innovation Investment"
+        },
+        {
+            "blocks": [
+                {
+                    "id": "introducing-significantly-improved-goods",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "introducing-significantly-improved-goods-section",
+                            "number": "4",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "introducing-significantly-improved-goods-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "0510",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "guidance": [
+                                        {
+                                            "description": "",
+                                            "list": [
+                                                "all <em>new</em> or <em>significantly improved</em> goods (for example, improvement in quality or distinct user benefits)",
+                                                "goods innovations that are new to the business, even if they are not new to the market",
+                                                "all product innovations, regardless of their origin"
+                                            ],
+                                            "title": "Include:"
+                                        },
+                                        {
+                                            "description": "",
+                                            "list": [
+                                                "the simple resale of goods purchased from other businesses and changes of a solely aesthetic nature"
+                                            ],
+                                            "title": "Exclude:"
+                                        }
+                                    ],
+                                    "id": "introducing-significantly-improved-goods-question",
+                                    "number": "4.1",
+                                    "title": "Did {{respondent.ru_name}} introduce new or significantly improved <em>goods</em>?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Goods and Services Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "entity-developed-these-goods",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "entity-developed-these-goods-section",
+                            "number": "4",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "gentity-developed-these-goods-answer",
+                                            "label": "Select all that apply",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "This business or enterprise group",
+                                                    "q_code": "0610",
+                                                    "value": "This business or enterprise group"
+                                                },
+                                                {
+                                                    "label": "This business with other businesses or organisations",
+                                                    "q_code": "0620",
+                                                    "value": "This business with other businesses or organisations"
+                                                },
+                                                {
+                                                    "label": "Other businesses or organisations",
+                                                    "q_code": "0630",
+                                                    "value": "Other businesses or organisations"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "id": "entity-developed-these-goods-question",
+                                    "number": "4.2",
+                                    "title": "Which entity mainly developed these <em>goods</em>?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Goods and Services Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "introduce-significantly-improvement",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "introduce-significantly-improvement-section",
+                            "number": "4",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "introduce-significantly-improvement-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "0520",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "guidance": [
+                                        {
+                                            "description": "",
+                                            "list": [
+                                                "all <em>new</em> or <em>significantly improved</em> services (for example, improvement in quality or distinct user benefits)",
+                                                "services innovations that are new to the business, even if they are not new to the market"
+                                            ],
+                                            "title": "Include:"
+                                        }
+                                    ],
+                                    "id": "introduce-significantly-improvement-question",
+                                    "number": "4.3",
+                                    "title": "Did {{respondent.ru_name}} introduce new or significantly improved <em>services</em>?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Goods and Services Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "entity-mainly-developed-these",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "entity-mainly-developed-these-section",
+                            "number": "4",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "entity-mainly-developed-these-answer",
+                                            "label": "Select all that apply",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "This business or enterprise group",
+                                                    "q_code": "0601",
+                                                    "value": "This business or enterprise group"
+                                                },
+                                                {
+                                                    "label": "This business with other businesses or organisations",
+                                                    "q_code": "0602",
+                                                    "value": "This business with other businesses or organisations"
+                                                },
+                                                {
+                                                    "label": "Other businesses or organisations",
+                                                    "q_code": "0603",
+                                                    "value": "Other businesses or organisations"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "id": "entity-mainly-developed-these-question",
+                                    "number": "4.4",
+                                    "title": "Which entity mainly developed these <em>services</em>?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Goods and Services Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "new-goods-services-innovations",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "new-goods-services-innovations-section",
+                            "number": "4",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "new-goods-services-innovations-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "0710",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "guidance": [
+                                        {
+                                            "description": "",
+                                            "list": [
+                                                "Goods or services this business introduced to the market before competitors"
+                                            ],
+                                            "title": "Include:"
+                                        }
+                                    ],
+                                    "id": "new-goods-services-innovations-question",
+                                    "number": "4.5",
+                                    "title": "Were any of your <em>goods and services innovations</em> new to the <em>market</em>?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Goods and Services Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "goods-services-innovations-new",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "goods-services-innovations-new-section",
+                            "number": "4",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "goods-services-innovations-new-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "0720",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "guidance": [
+                                        {
+                                            "description": "",
+                                            "list": [
+                                                "New goods or services that were essentially the same as a good or service already available from competitors"
+                                            ],
+                                            "title": "Include:"
+                                        }
+                                    ],
+                                    "id": "goods-services-innovations-new-question",
+                                    "number": "4.6",
+                                    "title": "Were any of your <em>goods and services innovations</em> only new to  <em>{{respondent.ru_name}}</em>?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Goods and Services Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "percentage-turnover-2016",
+                    "sections": [
+                        {
+                            "description": "<p>The following question refers to turnover for the <em>calendar year 1st January to 31st December 2016</em>, based on goods or services introduced during the period 1st January 2014 to 31st December 2016.</p><p>If <em>{{respondent.ru_name}}</em> did not introduce any new or significantly improved goods or services, please enter 100% in the ‘Unchanged or only marginally modified’ answer field. </p><p>Please note that estimates are acceptable and percentages must total 100%.</p>",
+                            "id": "percentage-turnover-2016-section",
+                            "number": "4",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "percentage-turnover-2016-market-new-answer",
+                                            "label": "New to the market in 2014-2016",
+                                            "mandatory": false,
+                                            "options": [],
+                                            "q_code": "0810",
+                                            "type": "Percentage"
+                                        },
+                                        {
+                                            "description": "",
+                                            "id": "percentage-turnover-2016-business-new-answer",
+                                            "label": "Only new to this business in 2014-2016",
+                                            "mandatory": false,
+                                            "options": [],
+                                            "q_code": "0820",
+                                            "type": "Percentage"
+                                        },
+                                        {
+                                            "description": "",
+                                            "id": "percentage-turnover-2016-improvement-answer",
+                                            "label": "Significantly improved in 2014-2016",
+                                            "mandatory": false,
+                                            "options": [],
+                                            "q_code": "0830",
+                                            "type": "Percentage"
+                                        },
+                                        {
+                                            "description": "Include the resale of goods and services purchased from other business",
+                                            "id": "percentage-turnover-2016-modified-answer",
+                                            "label": "Unchanged or only marginally modified",
+                                            "mandatory": false,
+                                            "options": [],
+                                            "q_code": "0840",
+                                            "type": "Percentage"
+                                        },
+                                        {
+                                            "description": "Total should add up to 100% - Please use this format",
+                                            "id": "percentage-turnover-2016-total-answer",
+                                            "label": "Total Turnover",
+                                            "mandatory": false,
+                                            "options": [],
+                                            "q_code": "10002",
+                                            "type": "Percentage"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "guidance": [
+                                        {
+                                            "description": "",
+                                            "list": [
+                                                "The market sales of goods and services (including all taxes except VAT)"
+                                            ],
+                                            "title": "Definition of ‘turnover’:"
+                                        }
+                                    ],
+                                    "id": "percentage-turnover-2016-question",
+                                    "number": "4.7",
+                                    "title": "Please <em>ESTIMATE</em> the percentage of {{respondent.ru_name}}’s <em>total</em> turnover in <em>calendar year 2016 only</em> from goods and services that were:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Goods and Services Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "goods-and-services-innovation-completed",
+                    "sections": [
+                        {
+                            "description": "<p>You have successfully completed this section</p><p>The next section covers innovation relating to <em>processes</em> for the production or supply of goods or services including all <em>new</em> or <em>significantly improved</em> methods of production.</p><p> </p><p>You will be asked to provide general information about process innovation for your business. </p>",
+                            "id": "goods-and-services-innovation-completed-section",
+                            "number": "4",
+                            "questions": [
+                                {
+                                    "answers": [],
+                                    "description": "",
+                                    "id": "goods-and-services-innovation-completed-question",
+                                    "title": "",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Goods and Services Innovation"
+                        }
+                    ],
+                    "type": "interstitial"
+                }
+            ],
+            "id": "goods-services-innovation",
+            "title": "Goods and Services Innovation"
+        },
+        {
+            "blocks": [
+                {
+                    "id": "process-improved",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "process-improved-section",
+                            "number": "5",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "process-improved-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "0900",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "guidance": [
+                                        {
+                                            "description": "",
+                                            "list": [
+                                                "all new or significantly improved methods for the production or supply of goods or services",
+                                                "process innovations that are new to {{respondent.ru_name}}, even if they are not new to your industry",
+                                                "all process innovations, regardless of their origin"
+                                            ],
+                                            "title": "Include:"
+                                        }
+                                    ],
+                                    "id": "process-improved-question",
+                                    "number": "5.1",
+                                    "title": "Did {{respondent.ru_name}} introduce any new or significantly improved <em>processes</em> for producing or supplying goods or services?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Process Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "developed-processes",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "developed-processes-section",
+                            "number": "5",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "developed-processes-answer",
+                                            "label": "Select all that apply",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "This business or enterprise group",
+                                                    "q_code": "1010",
+                                                    "value": "This business or enterprise group"
+                                                },
+                                                {
+                                                    "label": "This business with other businesses or organisations",
+                                                    "q_code": "1020",
+                                                    "value": "This business with other businesses or organisations"
+                                                },
+                                                {
+                                                    "label": "Other businesses or organisations",
+                                                    "q_code": "1030",
+                                                    "value": "Other businesses or organisations"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "id": "developed-processes-question",
+                                    "number": "5.2",
+                                    "title": "Which entity mainly developed these processes?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Process Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "improved-processes",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "improved-processes-section",
+                            "number": "5",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "improved-processes-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "1100",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "id": "improved-processes-question",
+                                    "number": "5.3",
+                                    "title": "Did {{respondent.ru_name}} introduce any new or significantly improved processes for producing or supplying goods or services which were new to your industry?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Process Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "process-innovation-completed",
+                    "sections": [
+                        {
+                            "description": "<p>You have successfully completed this section</p><p>The next section covers <em>constraining factors on innovation</em>. You will be asked to provide information on the importance of factors constraining innovation.</p>",
+                            "id": "process-innovation-completed-section",
+                            "number": "5",
+                            "questions": [
+                                {
+                                    "answers": [],
+                                    "description": "",
+                                    "id": "process-innovation-completed-question",
+                                    "title": "",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Process Innovation"
+                        }
+                    ],
+                    "type": "interstitial"
+                }
+            ],
+            "id": "process-innovation",
+            "title": "Process Innovation"
+        },
+        {
+            "blocks": [
+                {
+                    "id": "constraints-innovation-activities",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "constraints-innovation-activities-section",
+                            "number": "6",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "constraints-innovation-activities-abandoned-answser",
+                                            "label": "abandoned?",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "1510",
+                                            "type": "Radio"
+                                        },
+                                        {
+                                            "description": "",
+                                            "id": "constraints-innovation-activities-scaled-back-answser",
+                                            "label": "scaled back?",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "1530",
+                                            "type": "Radio"
+                                        },
+                                        {
+                                            "description": "",
+                                            "id": "constraints-innovation-activities-ongoing-2016-answser",
+                                            "label": "still ongoing at the end of 2016?",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "1520",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "id": "constraints-innovation-activities-question",
+                                    "number": "6.1",
+                                    "title": "Did {{respondent.ru_name}} have any innovation activities that were:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Constraints on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "constraining-innovation-economic",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "constraining-innovation-economic-section",
+                            "number": "6",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "constraining-innovation-economic-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "2657",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>Excessive perceived economic risk</p>",
+                                    "guidance": [
+                                        {
+                                            "description": "what constitutes an answer of 'high', 'medium', 'low', or ‘not important’ is dependent on your own interpretation in relation to {{respondent.ru_name}}",
+                                            "list": [],
+                                            "title": "Please note:"
+                                        }
+                                    ],
+                                    "id": "constraining-innovation-economic-question",
+                                    "number": "6.2",
+                                    "title": "How important were the following factors in constraining innovation activities?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Constraints on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "constraining-innovation-costs",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "constraining-innovation-costs-section",
+                            "number": "6",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "constraining-innovation-costs-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "2658",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>Direct innovation costs too high</p>",
+                                    "id": "constraining-innovation-costs-question",
+                                    "number": "6.3",
+                                    "title": "How important were the following factors in constraining innovation activities?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Constraints on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "constraining-innovation-finance",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "constraining-innovation-finance-section",
+                            "number": "6",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "constraining-innovation-finance-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "2659",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>Cost of finance</p>",
+                                    "id": "constraining-innovation-finance-question",
+                                    "number": "6.4",
+                                    "title": "How important were the following factors in constraining innovation activities?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Constraints on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "constraining-innovation-available-finance",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "constraining-innovation-available-finance-section",
+                            "number": "6",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "constraining-innovation-available-finance-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "2660",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>Availability of finance</p>",
+                                    "id": "constraining-innovation-available-finance-question",
+                                    "number": "6.5",
+                                    "title": "How important were the following factors in constraining innovation activities?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Constraints on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "constraining-innovation-lack-qualified",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "constraining-innovation-lack-qualified-section",
+                            "number": "6",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "constraining-innovation-lack-qualified-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "2661",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>Lack of qualified personnel</p>",
+                                    "id": "constraining-innovation-lack-qualified-question",
+                                    "number": "6.6",
+                                    "title": "How important were the following factors in constraining innovation activities?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Constraints on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "constraining-innovation-lack-technology",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "constraining-innovation-lack-technology-section",
+                            "number": "6",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "constraining-innovation-lack-technology-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "2662",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>Lack of information on technology</p>",
+                                    "id": "constraining-innovation-lack-technology-question",
+                                    "number": "6.7",
+                                    "title": "How important were the following factors in constraining innovation activities?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Constraints on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "constraining-innovation-lack-information",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "constraining-innovation-lack-information-section",
+                            "number": "6",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "constraining-innovation-lack-information-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "2663",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>Lack of information on markets</p>",
+                                    "id": "constraining-innovation-lack-information-question",
+                                    "number": "6.8",
+                                    "title": "How important were the following factors in constraining innovation activities?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Constraints on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "constraining-innovation-dominated",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "constraining-innovation-dominated-section",
+                            "number": "6",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "constraining-innovation-dominated-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "2664",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>Market dominated by established businesses</p>",
+                                    "id": "constraining-innovation-dominated-question",
+                                    "number": "6.9",
+                                    "title": "How important were the following factors in constraining innovation activities?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Constraints on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "constraining-innovation-uncertain",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "constraining-innovation-uncertain-section",
+                            "number": "6",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "constraining-innovation-uncertain-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "2665",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>Uncertain demand for innovative goods or services</p>",
+                                    "id": "constraining-innovation-uncertain-question",
+                                    "number": "6.10",
+                                    "title": "How important were the following factors in constraining innovation activities?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Constraints on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "constraining-innovation-government",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "constraining-innovation-government-section",
+                            "number": "6",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "constraining-innovation-government-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "2666",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>UK government regulations</p>",
+                                    "id": "constraining-innovation-government-question",
+                                    "number": "6.11",
+                                    "title": "How important were the following factors in constraining innovation activities?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Constraints on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "constraining-innovation-eu",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "constraining-innovation-eu-section",
+                            "number": "6",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "constraining-innovation-eu-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "2667",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>EU regulations (including standards)</p>",
+                                    "id": "constraining-innovation-eu-question",
+                                    "number": "6.12",
+                                    "title": "How important were the following factors in constraining innovation activities?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Constraints on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "constraining-innovation-referendum",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "constraining-innovation-referendum-section",
+                            "number": "6",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "constraining-innovation-referendum-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "2678",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>Outcome of the EU Referendum</p>",
+                                    "id": "constraining-innovation-referendum-question",
+                                    "number": "6.13",
+                                    "title": "How important were the following factors in constraining innovation activities?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Constraints on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "constraints-on-innovation-completed",
+                    "sections": [
+                        {
+                            "description": "<p>You have successfully completed this section</p><p>The next section covers <em>factors affecting innovation</em>.  You will be asked to provide information on factors deemed important when deciding to initiate or terminate innovation.</p>",
+                            "id": "constraints-on-innovation-completed-section",
+                            "number": "6",
+                            "questions": [
+                                {
+                                    "answers": [],
+                                    "description": "",
+                                    "id": "constraints-on-innovation-completed-question",
+                                    "title": "",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Constraints on Innovation "
+                        }
+                    ],
+                    "type": "interstitial"
+                }
+            ],
+            "id": "constraints-on-innovation",
+            "title": "Constraints on Innovation "
+        },
+        {
+            "blocks": [
+                {
+                    "id": "factors-affecting-increasing-range",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "factors-affecting-increasing-range-section",
+                            "number": "7",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "factors-affecting-increasing-range-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "1210",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>Increasing range of goods or services</p>",
+                                    "id": "factors-affecting-increasing-range-question",
+                                    "number": "7.1",
+                                    "title": "How important were the following factors in your decision to innovate in goods or services and/or processes?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Factors Affecting Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "factors-affecting-new-markets",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "factors-affecting-new-markets-section",
+                            "number": "7",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "factors-affecting-new-markets-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "1211",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>Entering new markets</p>",
+                                    "id": "factors-affecting-new-markets-question",
+                                    "number": "7.2",
+                                    "title": "How important were the following factors in your decision to innovate in goods or services and/or processes?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Factors Affecting Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "factors-affecting-market-share",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "factors-affecting-market-share-section",
+                            "number": "7",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "factors-affecting-market-share-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "1220",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>Increasing market share</p>",
+                                    "id": "factors-affecting-market-share-question",
+                                    "number": "7.3",
+                                    "title": "How important were the following factors in your decision to innovate in goods or services and/or processes?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Factors Affecting Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "factors-affecting-quality",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "factors-affecting-quality-section",
+                            "number": "7",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "factors-affecting-quality-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "1230",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>Improving quality of goods or services</p>",
+                                    "id": "factors-affecting-quality-question",
+                                    "number": "7.4",
+                                    "title": "How important were the following factors in your decision to innovate in goods or services and/or processes?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Factors Affecting Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "factors-affecting-flexibility",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "factors-affecting-flexibility-section",
+                            "number": "7",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "factors-affecting-flexibility-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "1240",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>Improving flexibility for producing goods or services</p>",
+                                    "id": "factors-affecting-flexibility-question",
+                                    "number": "7.5",
+                                    "title": "How important were the following factors in your decision to innovate in goods or services and/or processes?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Factors Affecting Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "factors-affecting-capacity",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "factors-affecting-capacity-section",
+                            "number": "7",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "factors-affecting-capacity-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "1250",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>Improving capacity for producing goods or services</p>",
+                                    "id": "factors-affecting-capacity-question",
+                                    "number": "7.6",
+                                    "title": "How important were the following factors in your decision to innovate in goods or services and/or processes?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Factors Affecting Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "factors-affecting-value",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "factors-affecting-value-section",
+                            "number": "7",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "factors-affecting-value-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "1290",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>Increasing value added</p>",
+                                    "id": "factors-affecting-value-question",
+                                    "number": "7.7",
+                                    "title": "How important were the following factors in your decision to innovate in goods or services and/or processes?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Factors Affecting Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "factors-affecting-reducing-cost",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "factors-affecting-reducing-cost-section",
+                            "number": "7",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "factors-affecting-reducing-cost-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "1260",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>Reducing costs per unit produced or provided</p>",
+                                    "id": "factors-affecting-reducing-cost-question",
+                                    "number": "7.8",
+                                    "title": "How important were the following factors in your decision to innovate in goods or services and/or processes?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Factors Affecting Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "factors-affecting-health-safety",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "factors-affecting-health-safety-section",
+                            "number": "7",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "factors-affecting-health-safety-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "1270",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>Improving health and safety</p>",
+                                    "id": "factors-affecting-health-safety-question",
+                                    "number": "7.9",
+                                    "title": "How important were the following factors in your decision to innovate in goods or services and/or processes?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Factors Affecting Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "factors-affecting-environmental",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "factors-affecting-environmental-section",
+                            "number": "7",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "factors-affecting-environmental-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "1212",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>Reducing environmental impacts</p>",
+                                    "id": "factors-affecting-environmental-question",
+                                    "number": "7.10",
+                                    "title": "How important were the following factors in your decision to innovate in goods or services and/or processes?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Factors Affecting Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "factors-affecting-replacing",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "factors-affecting-replacing-section",
+                            "number": "7",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "factors-affecting-replacing-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "1213",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>Replacing outdated products or processes</p>",
+                                    "id": "factors-affecting-replacing-question",
+                                    "number": "7.11",
+                                    "title": "How important were the following factors in your decision to innovate in goods or services and/or processes?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Factors Affecting Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "factors-affecting-regulatory",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "factors-affecting-regulatory-section",
+                            "number": "7",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "factors-affecting-regulatory-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "1280",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>Meeting regulatory requirements (including standards)</p>",
+                                    "id": "factors-affecting-regulatory-question",
+                                    "number": "7.12",
+                                    "title": "How important were the following factors in your decision to innovate in goods or services and/or processes?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Factors Affecting Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "factors-affecting-completed",
+                    "sections": [
+                        {
+                            "description": "<p>You have successfully completed this section</p><p>The next section covers <em>information needed for innovation</em>. You will be asked to provide information about the importance of various information sources to your business’s innovation activities.</p>",
+                            "id": "factors-affecting-completed-section",
+                            "number": "7",
+                            "questions": [
+                                {
+                                    "answers": [],
+                                    "description": "",
+                                    "id": "factors-affecting-completed-question",
+                                    "title": "",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Factors Affecting Innovation"
+                        }
+                    ],
+                    "type": "interstitial"
+                }
+            ],
+            "id": "factors-affecting-innovation",
+            "title": "Factors Affecting Innovation"
+        },
+        {
+            "blocks": [
+                {
+                    "id": "importances-information-innovation",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "importances-information-innovation-section",
+                            "number": "8",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "importances-information-innovation-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "1601",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>within your business or enterprise group?</p>",
+                                    "id": "importances-information-innovation-question",
+                                    "number": "8.1",
+                                    "title": "How important to {{respondent.ru_name}}’s innovation activities was information from:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Information Needed for Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "importances-information-suppliers",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "importances-information-suppliers-section",
+                            "number": "8",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "importances-information-suppliers-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "1620",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>suppliers of equipment, materials, services or software?</p>",
+                                    "id": "importances-information-suppliers-question",
+                                    "number": "8.2",
+                                    "title": "How important to {{respondent.ru_name}}’s innovation activities was information from:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Information Needed for Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "importances-information-client",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "importances-information-client-section",
+                            "number": "8",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "importances-information-client-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "1631",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>clients or customers from the private sector?</p>",
+                                    "id": "importances-information-client-question",
+                                    "number": "8.3",
+                                    "title": "How important to {{respondent.ru_name}}’s innovation activities was information from:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Information Needed for Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "importances-information-public-sector",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "importances-information-public-sector-section",
+                            "number": "8",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "importances-information-public-sector-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "1632",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>clients or customers from the public sector?</p>",
+                                    "guidance": [
+                                        {
+                                            "description": "",
+                                            "list": [
+                                                "The public sector includes government owned organisations such as local, regional and national administrations and agencies, schools, hospitals and government providers of services such as security, transport, housing and energy etc."
+                                            ],
+                                            "title": "Definition of ‘public sector’"
+                                        }
+                                    ],
+                                    "id": "importances-information-public-sector-question",
+                                    "number": "8.4",
+                                    "title": "How important to {{respondent.ru_name}}’s innovation activities was information from:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Information Needed for Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "importances-information-competitors",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "importances-information-competitors-section",
+                            "number": "8",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "importances-information-competitors-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "1640",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>competitors or other businesses in your industry?</p>",
+                                    "id": "importances-information-competitors-question",
+                                    "number": "8.5",
+                                    "title": "How important to {{respondent.ru_name}}’s innovation activities was information from:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Information Needed for Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "importances-information-consultants",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "importances-information-consultants-section",
+                            "number": "8",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "importances-information-consultants-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "1650",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>consultants, commercial labs or private Research and Development institutes?</p>",
+                                    "id": "importances-information-consultants-question",
+                                    "number": "8.6",
+                                    "title": "How important to {{respondent.ru_name}}’s innovation activities was information from:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Information Needed for Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "importances-information-universities",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "importances-information-universities-section",
+                            "number": "8",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "importances-information-universities-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "1660",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>universities or other higher education institutes?</p>",
+                                    "id": "importances-information-universities-question",
+                                    "number": "8.7",
+                                    "title": "How important to {{respondent.ru_name}}’s innovation activities was information from:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Information Needed for Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "importances-information-government",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "importances-information-government-section",
+                            "number": "8",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "importances-information-government-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "1670",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>government or public research institutes?</p>",
+                                    "id": "importances-information-government-question",
+                                    "number": "8.8",
+                                    "title": "How important to {{respondent.ru_name}}’s innovation activities was information from:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Information Needed for Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "importances-information-conferences",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "importances-information-conferences-section",
+                            "number": "8",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "importances-information-conferences-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "1680",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>conferences, trade fairs or exhibitions?</p>",
+                                    "id": "importances-information-conferences-question",
+                                    "number": "8.9",
+                                    "title": "How important to {{respondent.ru_name}}’s innovation activities was information from:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Information Needed for Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "importances-information-associations",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "importances-information-associations-section",
+                            "number": "8",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "importances-information-associations-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "1610",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>professional and industry associations?</p>",
+                                    "id": "importances-information-associations-question",
+                                    "number": "8.10",
+                                    "title": "How important to {{respondent.ru_name}}’s innovation activities was information from:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Information Needed for Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "importances-information-standards",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "importances-information-standards-section",
+                            "number": "8",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "importances-information-standards-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "1611",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>technical, industry or service standards?</p>",
+                                    "id": "importances-information-standards-question",
+                                    "number": "8.11",
+                                    "title": "How important to {{respondent.ru_name}}’s innovation activities was information from:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Information Needed for Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "importances-information-publications",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "importances-information-publications-section",
+                            "number": "8",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "importances-information-publications-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "High",
+                                                    "value": "High"
+                                                },
+                                                {
+                                                    "label": "Medium",
+                                                    "value": "Medium"
+                                                },
+                                                {
+                                                    "label": "Low",
+                                                    "value": "Low"
+                                                },
+                                                {
+                                                    "label": "Not Important",
+                                                    "value": "Not Important"
+                                                }
+                                            ],
+                                            "q_code": "1690",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>scientific journals and trade or technical publications?</p>",
+                                    "id": "importances-information-publications-question",
+                                    "number": "8.12",
+                                    "title": "How important to {{respondent.ru_name}}’s innovation activities was information from:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Information Needed for Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "information-needed-for-innovation-completed",
+                    "sections": [
+                        {
+                            "description": "<p>You have successfully completed this section</p><p>The next section covers <em>co-operation on innovation activities</em>. You will be asked to provide information about co-operation on innovation activities and protection of your innovations, for example, trademarks or patents.</p>",
+                            "id": "information-needed-for-innovation-completed-section",
+                            "number": "8",
+                            "questions": [
+                                {
+                                    "answers": [],
+                                    "description": "",
+                                    "id": "information-needed-for-innovation-completed-question",
+                                    "title": "Information Needed for Innovation",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Information Needed for Innovation"
+                        }
+                    ],
+                    "type": "interstitial"
+                }
+            ],
+            "id": "information-needed-for-innovation",
+            "title": "Information Needed for Innovation"
+        },
+        {
+            "blocks": [
+                {
+                    "id": "co-operation-other-businesses",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "co-operation-other-businesses-section",
+                            "number": "9",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "co-operation-other-businesses-answer",
+                                            "label": "Please select all that apply",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "UK Regional",
+                                                    "q_code": "1811",
+                                                    "value": "UK Regional"
+                                                },
+                                                {
+                                                    "label": "UK National",
+                                                    "q_code": "1812",
+                                                    "value": "UK National"
+                                                },
+                                                {
+                                                    "label": "European Countries",
+                                                    "q_code": "1813",
+                                                    "value": "European Countries"
+                                                },
+                                                {
+                                                    "label": "Other Countries",
+                                                    "q_code": "1814",
+                                                    "value": "Other Countries"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "description": "<p>other businesses within your enterprise group?</p>",
+                                    "id": "co-operation-other-businesses-question",
+                                    "number": "9.1",
+                                    "title": "Did {{respondent.ru_name}} co-operate on any innovation activities with:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Co-operation on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "co-operation-suppliers",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "co-operation-suppliers-section",
+                            "number": "9",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "co-operation-suppliers-answer",
+                                            "label": "Please select all that apply",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "UK Regional",
+                                                    "q_code": "1821",
+                                                    "value": "UK Regional"
+                                                },
+                                                {
+                                                    "label": "UK National",
+                                                    "q_code": "1822",
+                                                    "value": "UK National"
+                                                },
+                                                {
+                                                    "label": "European Countries",
+                                                    "q_code": "1823",
+                                                    "value": "European Countries"
+                                                },
+                                                {
+                                                    "label": "Other Countries",
+                                                    "q_code": "1824",
+                                                    "value": "Other Countries"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "description": "<p>suppliers of equipment, materials, services or software?</p>",
+                                    "id": "co-operation-suppliers-question",
+                                    "number": "9.2",
+                                    "title": "Did {{respondent.ru_name}} co-operate on any innovation activities with:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Co-operation on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "co-operation-private-sector",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "co-operation-private-sector-section",
+                            "number": "9",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "co-operation-private-sector-answer",
+                                            "label": "Please select all that apply",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "UK Regional",
+                                                    "q_code": "1881",
+                                                    "value": "UK Regional"
+                                                },
+                                                {
+                                                    "label": "UK National",
+                                                    "q_code": "1882",
+                                                    "value": "UK National"
+                                                },
+                                                {
+                                                    "label": "European Countries",
+                                                    "q_code": "1883",
+                                                    "value": "European Countries"
+                                                },
+                                                {
+                                                    "label": "Other Countries",
+                                                    "q_code": "1884",
+                                                    "value": "Other Countries"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "description": "<p>clients or customers from the private sector?</p>",
+                                    "id": "co-operation-private-sector-question",
+                                    "number": "9.3",
+                                    "title": "Did {{respondent.ru_name}} co-operate on any innovation activities with:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Co-operation on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "co-operation-public-sector",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "co-operation-public-sector-section",
+                            "number": "9",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "co-operation-public-sector-answer",
+                                            "label": "Please select all that apply",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "UK Regional",
+                                                    "q_code": "1891",
+                                                    "value": "UK Regional"
+                                                },
+                                                {
+                                                    "label": "UK National",
+                                                    "q_code": "1892",
+                                                    "value": "UK National"
+                                                },
+                                                {
+                                                    "label": "European Countries",
+                                                    "q_code": "1893",
+                                                    "value": "European Countries"
+                                                },
+                                                {
+                                                    "label": "Other Countries",
+                                                    "q_code": "1894",
+                                                    "value": "Other Countries"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "description": "<p>clients or customers from the public sector?</p>",
+                                    "guidance": [
+                                        {
+                                            "description": "The public sector includes government owned organisations such as local, regional and national administrations and agencies, schools, hospitals and government providers of services such as security, transport, housing and energy.",
+                                            "list": [],
+                                            "title": "Definition of ‘public sector’"
+                                        }
+                                    ],
+                                    "id": "co-operation-public-sector-question",
+                                    "number": "9.4",
+                                    "title": "Did {{respondent.ru_name}} co-operate on any innovation activities with:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Co-operation on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "co-operation-competitors",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "co-operation-competitors-section",
+                            "number": "9",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "co-operation-competitors-answer",
+                                            "label": "Please select all that apply",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "UK Regional",
+                                                    "q_code": "1841",
+                                                    "value": "UK Regional"
+                                                },
+                                                {
+                                                    "label": "UK National",
+                                                    "q_code": "1842",
+                                                    "value": "UK National"
+                                                },
+                                                {
+                                                    "label": "European Countries",
+                                                    "q_code": "1843",
+                                                    "value": "European Countries"
+                                                },
+                                                {
+                                                    "label": "Other Countries",
+                                                    "q_code": "1844",
+                                                    "value": "Other Countries"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "description": "<p>competitors or other businesses in your industry?</p>",
+                                    "id": "co-operation-competitors-question",
+                                    "number": "9.5",
+                                    "title": "Did {{respondent.ru_name}} co-operate on any innovation activities with:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Co-operation on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "co-operation-consultants",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "co-operation-consultants-section",
+                            "number": "9",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "co-operation-consultants-answer",
+                                            "label": "Please select all that apply",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "UK Regional",
+                                                    "q_code": "1851",
+                                                    "value": "UK Regional"
+                                                },
+                                                {
+                                                    "label": "UK National",
+                                                    "q_code": "1852",
+                                                    "value": "UK National"
+                                                },
+                                                {
+                                                    "label": "European Countries",
+                                                    "q_code": "1853",
+                                                    "value": "European Countries"
+                                                },
+                                                {
+                                                    "label": "Other Countries",
+                                                    "q_code": "1854",
+                                                    "value": "Other Countries"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "description": "<p>consultants, commercial labs or private Research and Development institutes?</p>",
+                                    "id": "co-operation-consultants-question",
+                                    "number": "9.6",
+                                    "title": "Did {{respondent.ru_name}} co-operate on any innovation activities with:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Co-operation on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "co-operation-institutions",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "co-operation-institutions-section",
+                            "number": "9",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "co-operation-institutions-answer",
+                                            "label": "Please select all that apply",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "UK Regional",
+                                                    "q_code": "1861",
+                                                    "value": "UK Regional"
+                                                },
+                                                {
+                                                    "label": "UK National",
+                                                    "q_code": "1862",
+                                                    "value": "UK National"
+                                                },
+                                                {
+                                                    "label": "European Countries",
+                                                    "q_code": "1863",
+                                                    "value": "European Countries"
+                                                },
+                                                {
+                                                    "label": "Other Countries",
+                                                    "q_code": "1864",
+                                                    "value": "Other Countries"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "description": "<p>universities or other higher education institutions?</p>",
+                                    "id": "co-operation-institutions-question",
+                                    "number": "9.7",
+                                    "title": "Did {{respondent.ru_name}} co-operate on any innovation activities with:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Co-operation on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "co-operation-government",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "co-operation-government-section",
+                            "number": "9",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "co-operation-government-answer",
+                                            "label": "Please select all that apply",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "UK Regional",
+                                                    "q_code": "1871",
+                                                    "value": "UK Regional"
+                                                },
+                                                {
+                                                    "label": "UK National",
+                                                    "q_code": "1872",
+                                                    "value": "UK National"
+                                                },
+                                                {
+                                                    "label": "European Countries",
+                                                    "q_code": "1873",
+                                                    "value": "European Countries"
+                                                },
+                                                {
+                                                    "label": "Other Countries",
+                                                    "q_code": "1874",
+                                                    "value": "Other Countries"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "description": "<p>government or public research institutes?</p>",
+                                    "id": "co-operation-government-question",
+                                    "number": "9.8",
+                                    "title": "Did {{respondent.ru_name}} co-operate on any innovation activities with:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Co-operation on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "not-necessary-possible",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "not-necessary-possible-section",
+                            "number": "9",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "not-necessary-possible-answer",
+                                            "label": "Select all that apply",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "No need due to previous innovations",
+                                                    "q_code": "2011",
+                                                    "value": "No need due to previous innovations"
+                                                },
+                                                {
+                                                    "label": "No need due to market conditions",
+                                                    "q_code": "2020",
+                                                    "value": "No need due to market conditions"
+                                                },
+                                                {
+                                                    "label": "The UK does not have a business environment which encourages companies to innovate",
+                                                    "q_code": "2030",
+                                                    "value": "The UK does not have a business environment which encourages companies to innovate"
+                                                },
+                                                {
+                                                    "label": "Other",
+                                                    "q_code": "2040",
+                                                    "value": "Other"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "id": "not-necessary-possible-question",
+                                    "number": "9.9",
+                                    "title": "If {{respondent.ru_name}} had no innovation activity, please indicate why it has not been necessary or possible to innovate",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Co-operation on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "innovations-protected-patents",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "innovations-protected-patents-section",
+                            "number": "9",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "innovations-protected-patents-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "None",
+                                                    "value": "None"
+                                                },
+                                                {
+                                                    "label": "Less than 40%",
+                                                    "value": "Less than 40%"
+                                                },
+                                                {
+                                                    "label": "40-90%",
+                                                    "value": "40-90%"
+                                                },
+                                                {
+                                                    "label": "Over 90%",
+                                                    "value": "Over 90%"
+                                                }
+                                            ],
+                                            "q_code": "2650",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>patents?</p>",
+                                    "id": "innovations-protected-patents-question",
+                                    "number": "9.10",
+                                    "title": "What proportions of your innovations were protected by:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Co-operation on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "innovations-protected-design",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "innovations-protected-design-section",
+                            "number": "9",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "innovations-protected-design-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "None",
+                                                    "value": "None"
+                                                },
+                                                {
+                                                    "label": "Less than 40%",
+                                                    "value": "Less than 40%"
+                                                },
+                                                {
+                                                    "label": "40-90%",
+                                                    "value": "40-90%"
+                                                },
+                                                {
+                                                    "label": "Over 90%",
+                                                    "value": "Over 90%"
+                                                }
+                                            ],
+                                            "q_code": "2651",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>design registration?</p>",
+                                    "id": "innovations-protected-design-question",
+                                    "number": "9.11",
+                                    "title": "What proportions of your innovations were protected by:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Co-operation on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "innovations-protected-copyright",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "innovations-protected-copyright-section",
+                            "number": "9",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "innovations-protected-copyright-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "None",
+                                                    "value": "None"
+                                                },
+                                                {
+                                                    "label": "Less than 40%",
+                                                    "value": "Less than 40%"
+                                                },
+                                                {
+                                                    "label": "40-90%",
+                                                    "value": "40-90%"
+                                                },
+                                                {
+                                                    "label": "Over 90%",
+                                                    "value": "Over 90%"
+                                                }
+                                            ],
+                                            "q_code": "2652",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>copyright?</p>",
+                                    "id": "innovations-protected-copyright-question",
+                                    "number": "9.12",
+                                    "title": "What proportions of your innovations were protected by:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Co-operation on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "innovations-protected-trademark",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "innovations-protected-trademark-section",
+                            "number": "9",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "innovations-protected-trademark-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "None",
+                                                    "value": "None"
+                                                },
+                                                {
+                                                    "label": "Less than 40%",
+                                                    "value": "Less than 40%"
+                                                },
+                                                {
+                                                    "label": "40-90%",
+                                                    "value": "40-90%"
+                                                },
+                                                {
+                                                    "label": "Over 90%",
+                                                    "value": "Over 90%"
+                                                }
+                                            ],
+                                            "q_code": "2653",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>trademarks?</p>",
+                                    "id": "innovations-protected-trademark-question",
+                                    "number": "9.13",
+                                    "title": "What proportions of your innovations  were protected by:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Co-operation on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "innovations-protected-lead-time",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "innovations-protected-lead-time-section",
+                            "number": "9",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "innovations-protected-lead-time-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "None",
+                                                    "value": "None"
+                                                },
+                                                {
+                                                    "label": "Less than 40%",
+                                                    "value": "Less than 40%"
+                                                },
+                                                {
+                                                    "label": "40-90%",
+                                                    "value": "40-90%"
+                                                },
+                                                {
+                                                    "label": "Over 90%",
+                                                    "value": "Over 90%"
+                                                }
+                                            ],
+                                            "q_code": "2654",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>lead time advantages?</p>",
+                                    "id": "innovations-protected-lead-time-question",
+                                    "number": "9.14",
+                                    "title": "What proportions of your innovations were protected by:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Co-operation on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "innovations-protected-services",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "innovations-protected-services-section",
+                            "number": "9",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "innovations-protected-services-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "None",
+                                                    "value": "None"
+                                                },
+                                                {
+                                                    "label": "Less than 40%",
+                                                    "value": "Less than 40%"
+                                                },
+                                                {
+                                                    "label": "40-90%",
+                                                    "value": "40-90%"
+                                                },
+                                                {
+                                                    "label": "Over 90%",
+                                                    "value": "Over 90%"
+                                                }
+                                            ],
+                                            "q_code": "2655",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>complexity of goods or services?</p>",
+                                    "id": "innovations-protected-services-question",
+                                    "number": "9.15",
+                                    "title": "What proportions of your innovations were protected by:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Co-operation on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "innovations-protected-secrecy",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "innovations-protected-secrecy-section",
+                            "number": "9",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "innovations-protected-secrecy-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "None",
+                                                    "value": "None"
+                                                },
+                                                {
+                                                    "label": "Less than 40%",
+                                                    "value": "Less than 40%"
+                                                },
+                                                {
+                                                    "label": "40-90%",
+                                                    "value": "40-90%"
+                                                },
+                                                {
+                                                    "label": "Over 90%",
+                                                    "value": "Over 90%"
+                                                }
+                                            ],
+                                            "q_code": "2656",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "<p>secrecy?</p>",
+                                    "guidance": [
+                                        {
+                                            "description": "",
+                                            "list": [
+                                                "non-disclosure agreements"
+                                            ],
+                                            "title": "Include:"
+                                        }
+                                    ],
+                                    "id": "innovations-protected-secrecy-question",
+                                    "number": "9.16",
+                                    "title": "What proportions of your innovations were protected by:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Co-operation on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "co-operation-on-innovation-completed",
+                    "sections": [
+                        {
+                            "description": "<p>You have successfully completed this section</p><p>The next section covers <em>Public Financial Support for Innovation</em> received from government. </p><p>You will be asked to provide information specifying the type, if any, of public financial support your business received and the source; for example, Research & Development tax credits received from UK central government.</p>",
+                            "id": "co-operation-on-innovation-completed-section",
+                            "number": "9",
+                            "questions": [
+                                {
+                                    "answers": [],
+                                    "description": "",
+                                    "id": "co-operation-on-innovation-completed-question",
+                                    "title": "",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Co-operation on Innovation"
+                        }
+                    ],
+                    "type": "interstitial"
+                }
+            ],
+            "id": "co-operation-on-innovation",
+            "title": "Co-operation on Innovation"
+        },
+        {
+            "blocks": [
+                {
+                    "id": "public-financial-support",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "public-financial-support-section",
+                            "number": "10",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "public-financial-support-authorities-answer",
+                                            "label": "UK local or regional authorities",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "2668",
+                                            "type": "Radio"
+                                        },
+                                        {
+                                            "description": "<p>Include:</p><p>UK government’s agencies or funding bodies for example Innovate UK, formerly known as TSB</p>",
+                                            "id": "public-financial-support-central-government-answer",
+                                            "label": "UK central government",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "2669",
+                                            "type": "Radio"
+                                        },
+                                        {
+                                            "description": "",
+                                            "id": "public-financial-support-eu-answer",
+                                            "label": "European Union (EU) institutions or programmes",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "2670",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "guidance": [
+                                        {
+                                            "list": [
+                                                "financial support via tax credits or deductions, grants, subsidised loans and loan guarantees"
+                                            ],
+                                            "title": "Include:"
+                                        },
+                                        {
+                                            "list": [
+                                                "Research and Development and other innovations activities conducted entirely for the <em>public sector</em> under contract."
+                                            ],
+                                            "title": "Exclude:"
+                                        },
+                                        {
+                                            "description": "The public sector includes government owned organisations such as local, regional and national administrations and agencies, schools, hospitals and government providers of services such as security, transport, housing and energy"
+                                        }
+                                    ],
+                                    "id": "public-financial-support-question",
+                                    "number": "10.1",
+                                    "title": "Did {{respondent.ru_name}} receive public financial support for innovation activities from the following levels of government?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Public Financial Support for Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "kind-financial-central-government-support",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "kind-financial-central-government-support-section",
+                            "number": "10",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "For example Smart or Collaborative Research and Development grants, work with Catapult centres, Innovation vouchers",
+                                            "id": "kind-financial-central-government-support-direct-answer",
+                                            "label": "Direct financial support",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                },
+                                                {
+                                                    "label": "Don’t know",
+                                                    "value": "Don’t know"
+                                                }
+                                            ],
+                                            "q_code": "2672",
+                                            "type": "Radio"
+                                        },
+                                        {
+                                            "description": "For example Research and Development tax credits, Patent box",
+                                            "id": "kind-financial-central-government-support-indirect-answer",
+                                            "label": "Indirect financial support",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                },
+                                                {
+                                                    "label": "Don’t know",
+                                                    "value": "Don’t know"
+                                                }
+                                            ],
+                                            "q_code": "2673",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "id": "kind-financial-central-government-support-question",
+                                    "number": "10.2",
+                                    "title": "What kind of financial support was received by {{respondent.ru_name}} from UK <em>central government</em>? ",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Public Financial Support for Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "public-financial-support-for-innovation-completed",
+                    "sections": [
+                        {
+                            "description": "<p>You have successfully completed this section</p><p>The next section section covers <em>Turnover and Exports</em> for your business. You will be asked to provide total turnover excluding VAT for calendar years 2014 and 2016 as well as an estimate of your business’s total value of exports for the calendar year 2016.</p>",
+                            "id": "public-financial-support-for-innovation-completed-section",
+                            "number": "10",
+                            "questions": [
+                                {
+                                    "answers": [],
+                                    "description": "",
+                                    "id": "public-financial-support-for-innovation-completed-question",
+                                    "title": "",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Public Financial Support for Innovation"
+                        }
+                    ],
+                    "type": "interstitial"
+                }
+            ],
+            "id": "public-financial-support-for-innovation",
+            "title": "Public Financial Support for Innovation"
+        },
+        {
+            "blocks": [
+                {
+                    "id": "turnover-2014",
+                    "sections": [
+                        {
+                            "description": "<p>1 year period 1 January 2014 to 31 December 2014.</p>",
+                            "id": "turnover-2014-section",
+                            "number": "11",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "Round to the nearest £ thousand, for example enter £1,702,800 as 1703000",
+                                            "id": "turnover-2014-answer",
+                                            "label": "Total turnover for 2014, excluding VAT",
+                                            "mandatory": false,
+                                            "options": [],
+                                            "q_code": "2410",
+                                            "type": "Currency"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "id": "turnover-2014-question",
+                                    "number": "11.1",
+                                    "title": "Please <em>estimate</em> {{respondent.ru_name}}’s total turnover for the <em>calendar year 2014 only</em>, excluding VAT",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Turnover and Exports"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "turnover-2016",
+                    "sections": [
+                        {
+                            "description": "<p>1 year period 1 January 2016 to 31 December 2016.</p>",
+                            "id": "turnover-2016-section",
+                            "number": "11",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "Round to the nearest £ thousand, for example enter £1,702,800 as 1703000",
+                                            "id": "turnover-2016-answer",
+                                            "label": "Total turnover for 2016, excluding VAT",
+                                            "mandatory": false,
+                                            "options": [],
+                                            "q_code": "2420",
+                                            "type": "Currency"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "id": "turnover-2016-question",
+                                    "number": "11.2",
+                                    "title": "Please<em> estimate</em> {{respondent.ru_name}}’s total turnover for the <em>calendar year 2016 only</em>, excluding VAT",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Turnover and Exports"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "exports-2016",
+                    "sections": [
+                        {
+                            "description": "<p>1 year period 1 January 2016 to 31 December 2016.</p>",
+                            "id": "exports-2016-section",
+                            "number": "11",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "Round to the nearest £ thousand, for example enter £1,702,800 as 1703000",
+                                            "id": "exports-2016-answer",
+                                            "label": "Total value of exports for 2016",
+                                            "mandatory": false,
+                                            "options": [],
+                                            "q_code": "2440",
+                                            "type": "Currency"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "id": "exports-2016-question",
+                                    "number": "11.3",
+                                    "title": "Please <em>estimate</em> {{respondent.ru_name}}’s total value of exports for the <em>calendar year 2016 only</em>, excluding VAT",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Turnover and Exports"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "turnover-and-exports-completed",
+                    "sections": [
+                        {
+                            "description": "<p>You have successfully completed this section</p><p>The next section covers information relating to persons employed by your business. You will be asked to provide estimates for the total number of employees for the calendar years 2014 and 2016, an estimate of the proportion of your workforce who hold a degree or higher qualification and information regarding the skills possessed by employees, for example, mathematics or statistics.</p>",
+                            "id": "turnover-and-exports-completed-section",
+                            "number": "11",
+                            "questions": [
+                                {
+                                    "answers": [],
+                                    "description": "",
+                                    "id": "turnover-and-exports-completed-question",
+                                    "title": "",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Turnover and Exports"
+                        }
+                    ],
+                    "type": "interstitial"
+                }
+            ],
+            "id": "turnover-and-exports",
+            "title": "Turnover and Exports"
+        },
+        {
+            "blocks": [
+                {
+                    "id": "employees-2014",
+                    "sections": [
+                        {
+                            "description": "<p>1 year period 1 January 2014 to 31 December 2014.</p>",
+                            "id": "employees-2014-section",
+                            "number": "12",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "employees-2014-answer",
+                                            "label": "Total number of employees for 2014",
+                                            "mandatory": false,
+                                            "options": [],
+                                            "q_code": "2510",
+                                            "type": "PositiveInteger"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "id": "employees-2014-question",
+                                    "number": "12.1",
+                                    "title": "Please<em> estimate</em> {{respondent.ru_name}}’s average number of employees for the <em>calendar year 2014 only</em>",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Employees and Skills"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "employees-2016",
+                    "sections": [
+                        {
+                            "description": "<p>1 year period 1 January 2016 to 31 December 2016.</p>",
+                            "id": "employees-2016-section",
+                            "number": "12",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "employees-2016-answer",
+                                            "label": "Total number of employees for 2016",
+                                            "mandatory": false,
+                                            "options": [],
+                                            "q_code": "2520",
+                                            "type": "PositiveInteger"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "id": "employees-2016-question",
+                                    "number": "12.2",
+                                    "title": "Please <em>estimate</em> {{respondent.ru_name}}’s average number of employees for the <em>calendar year 2016 only</em>",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Employees and Skills"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "employees-qualifications-2016",
+                    "sections": [
+                        {
+                            "description": "<p>1 year period 1 January 2016 to 31 December 2016.</p>",
+                            "id": "employees-qualifications-2016-section",
+                            "number": "12",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "employees-qualifications-2016-science-answer",
+                                            "label": "Science or engineering subjects",
+                                            "mandatory": false,
+                                            "options": [],
+                                            "q_code": "2610",
+                                            "type": "Percentage"
+                                        },
+                                        {
+                                            "description": "",
+                                            "id": "employees-qualifications-other-2016-answer",
+                                            "label": "Other subjects",
+                                            "mandatory": false,
+                                            "options": [],
+                                            "q_code": "2620",
+                                            "type": "Percentage"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "guidance": [
+                                        {
+                                            "description": "",
+                                            "list": [
+                                                "BA, BSc, MA, PhD, PGCE"
+                                            ],
+                                            "title": "For example:"
+                                        }
+                                    ],
+                                    "id": "employees-qualifications-2016-question",
+                                    "number": "12.3",
+                                    "title": "Please <em>estimate</em> the proportion of employees that hold a degree or higher qualification in the following areas for the <em>calendar year 2016 only</em>:",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Employees and Skills"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "employees-in-house-skills",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "employees-in-house-skills-section",
+                            "number": "12",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "employees-in-house-skills-answer",
+                                            "label": "Select all that apply",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Graphic arts, layout, advertising",
+                                                    "q_code": "2631",
+                                                    "value": "Graphic arts, layout, advertising"
+                                                },
+                                                {
+                                                    "label": "Design of objects or services",
+                                                    "q_code": "2632",
+                                                    "value": "Design of objects or services"
+                                                },
+                                                {
+                                                    "label": "Multimedia, web design (for example audio, graphics, text, still pictures, animation, video)",
+                                                    "q_code": "2633",
+                                                    "value": "Multimedia, web design (for example audio, graphics, text, still pictures, animation, video)"
+                                                },
+                                                {
+                                                    "label": "Software development, database management",
+                                                    "q_code": "2634",
+                                                    "value": "Software development, database management"
+                                                },
+                                                {
+                                                    "label": "Engineering, applied sciences",
+                                                    "q_code": "2635",
+                                                    "value": "Engineering, applied sciences"
+                                                },
+                                                {
+                                                    "label": "Mathematics, statistics",
+                                                    "q_code": "2636",
+                                                    "value": "Mathematics, statistics"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "id": "employees-in-house-skills-question",
+                                    "number": "12.4",
+                                    "title": "Did {{respondent.ru_name}} employ individuals in-house with the following skills at any level, or obtain these skills from external sources?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Employees and Skills"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "employees-and-skills-completed",
+                    "sections": [
+                        {
+                            "description": "<p>You have successfully completed this section</p><p>The next section covers <em>General Information</em> about this survey.</p>",
+                            "id": "employees-and-skills-completed-section",
+                            "number": "12",
+                            "questions": [
+                                {
+                                    "answers": [],
+                                    "description": "",
+                                    "id": "employees-and-skills-completed-question",
+                                    "title": "",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Employees and Skills"
+                        }
+                    ],
+                    "type": "interstitial"
+                }
+            ],
+            "id": "employees-and-skills",
+            "title": "Employees and Skills"
+        },
+        {
+            "blocks": [
+                {
+                    "id": "additional-comments",
+                    "sections": [
+                        {
+                            "description": "",
+                            "id": "additional-comments-section",
+                            "number": "13",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "additional-comments-answer",
+                                            "label": "Comments",
+                                            "mandatory": false,
+                                            "options": [],
+                                            "q_code": "2700",
+                                            "type": "TextArea"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "id": "additional-comments-question",
+                                    "number": "13.1",
+                                    "title": "Please write any additional comments you would like to make on the information you have provided.",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "General Information"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "how-long",
+                    "sections": [
+                        {
+                            "description": "",
+                            "id": "how-long-section",
+                            "number": "13",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "general-information-hours-answer",
+                                            "label": "Hours",
+                                            "mandatory": false,
+                                            "options": [],
+                                            "q_code": "2801",
+                                            "type": "PositiveInteger"
+                                        },
+                                        {
+                                            "description": "",
+                                            "id": "how-long-minutes-answer",
+                                            "label": "Minutes",
+                                            "mandatory": false,
+                                            "options": [],
+                                            "q_code": "2800",
+                                            "type": "PositiveInteger"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "guidance": [
+                                        {
+                                            "description": "",
+                                            "list": [
+                                                "Any time spent extracting information from your accounting systems and collating data over and above normal accounting operations"
+                                            ],
+                                            "title": "Include:"
+                                        }
+                                    ],
+                                    "id": "how-long-question",
+                                    "number": "13.2",
+                                    "title": "How long has it taken you to complete this questionnaire?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "General Information"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                {
+                    "id": "approached-telephone",
+                    "sections": [
+                        {
+                            "description": "",
+                            "id": "approached-telephone-section",
+                            "number": "13",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "approached-telephone-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "q_code": "2900",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "id": "approached-telephone-question",
+                                    "number": "13.3",
+                                    "title": "Would {{respondent.ru_name}} be willing to be approached by telephone by the Department for Business, Energy and Industrial Strategy or its appointed agents, to ask some further questions about innovation?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "General Information"
+                        }
+                    ],
+                    "type": "questionnaire"
+                }
+            ],
+            "id": "general-information",
+            "title": "General Information"
+        },
+        {
+            "blocks": [
+                {
+                    "id": "ready-to-submit-completed",
+                    "sections": [
+                        {
+                            "description": "<p>Submission</p><p>You will not be able to access or change your answers on submitting the questionnaire</p><p>If you wish to review your answers please select the relevant Completed sections</p><p>If you do not submit your questionnaire, your responses will be collected when the online questionnaire closes</p>",
+                            "id": "ready-to-submit-completed-section",
+                            "questions": [
+                                {
+                                    "answers": [],
+                                    "description": "",
+                                    "id": "ready-to-submit-completed-question",
+                                    "title": "",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "You are now ready to submit this survey"
+                        }
+                    ],
+                    "type": "interstitial"
+                }
+            ],
+            "hide_in_navigation": true,
+            "id": "ready-to-submit",
+            "title": "You are now ready to submit this survey"
+        }
+    ],
+    "mime_type": "application/json/ons/eq",
+    "navigation": true,
+    "questionnaire_id": "0001",
+    "schema_version": "0.0.1",
+    "survey_id": "144",
+    "theme": "default",
+    "title": "UK Innovation Survey"
+}

--- a/app/data/schema/schema-v1.json
+++ b/app/data/schema/schema-v1.json
@@ -315,12 +315,16 @@
                                     "$ref": "#/definitions/id"
                                   },
                                   "q_code": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "pattern": "[0-9]+"
                                   },
                                   "label": {
                                     "type": "string"
                                   },
                                   "guidance": {
+                                    "type": "string"
+                                  },
+                                  "description": {
                                     "type": "string"
                                   },
                                   "type": {
@@ -341,15 +345,23 @@
                                   "options": {
                                     "type": "array",
                                     "items": {
-                                         "label": {
-                                            "type": "string"
-                                         },
-                                         "value": {
-                                             "type": "string"
+                                      "type": "object",
+                                      "properties": {
+                                        "label": {
+                                          "type": "string"
                                         },
-                                         "q_code": {
-                                            "type": "string"
+                                        "value": {
+                                          "type": "string"
+                                        },
+                                        "q_code": {
+                                          "type": "string",
+                                          "pattern": "[0-9]+"
                                         }
+                                      },
+                                      "required": [
+                                        "label",
+                                        "value"
+                                      ]
                                     }
                                   },
                                   "mandatory": {
@@ -403,7 +415,6 @@
               "additionalProperties": false,
               "required": [
                 "id",
-                "title",
                 "sections"
               ]
             }

--- a/app/data/test_checkbox.json
+++ b/app/data/test_checkbox.json
@@ -41,39 +41,38 @@
                                                 {
                                                     "label": "Cheese",
                                                     "value": "Cheese",
-                                                    "q_code": 1
+                                                    "q_code": "1"
                                                 },
                                                 {
                                                     "label": "Ham",
                                                     "value": "Ham",
-                                                    "q_code": 2
+                                                    "q_code": "2"
                                                 },
                                                 {
                                                     "label": "Pineapple",
                                                     "value": "Pineapple",
-                                                    "q_code": 3
+                                                    "q_code": "3"
                                                 },
                                                 {
                                                     "label": "Tuna",
                                                     "value": "Tuna",
-                                                    "q_code": 4
+                                                    "q_code": "4"
                                                 },
                                                 {
                                                     "label": "Pepperoni",
                                                     "value": "Pepperoni",
-                                                    "q_code": 5
+                                                    "q_code": "5"
                                                 },
                                                 {
                                                     "label": "Other",
                                                     "value": "other",
-                                                    "q_code": 6,
+                                                    "q_code": "6",
                                                     "description": "Choose any other topping",
                                                     "other": {
                                                       "label": "Please specify other"
                                                     }
                                                 }
                                             ],
-                                            "q_code": "",
                                             "type": "Checkbox",
                                             "validation": {
                                                 "messages": {}

--- a/app/parser/v0_0_1/schema_parser.py
+++ b/app/parser/v0_0_1/schema_parser.py
@@ -254,6 +254,7 @@ class SchemaParser(AbstractSchemaParser):
         answer.type = answer_type
         answer.code = ParserUtils.get_optional_string(schema, 'q_code')
         answer.label = ParserUtils.get_optional_string(schema, 'label')
+        answer.description = ParserUtils.get_optional_string(schema, 'description')
         answer.guidance = ParserUtils.get_optional_string(schema, 'guidance')
         answer.mandatory = ParserUtils.get_required_boolean(schema, 'mandatory')
         answer.options = ParserUtils.get_optional_array(schema, 'options')

--- a/app/schema/answer.py
+++ b/app/schema/answer.py
@@ -14,13 +14,14 @@ class Answer(Item):
     def __init__(self, answer_id=None):
         super().__init__(answer_id)
         self.label = ""
+        self.description = ""
         self.guidance = ""
         self.type = None
         self.code = None
         self.container = None
         self.mandatory = False
         self.messages = {}
-        self.templatable_properties = []
+        self.templatable_properties = ['label']
         self.options = []
         self.alias = None
         self.type_checkers = []

--- a/app/schema/question.py
+++ b/app/schema/question.py
@@ -12,7 +12,7 @@ class Question(Item):
         self.answers = []
         self.children = self.answers
         self.container = None
-        self.templatable_properties = ['title', 'description']
+        self.templatable_properties = ['title', 'description', 'guidance']
         self.type = None
         self.messages = {}
 

--- a/app/schema/widgets/currency_widget.py
+++ b/app/schema/widgets/currency_widget.py
@@ -14,6 +14,7 @@ class CurrencyWidget(Widget):
                 'name': self.name,
                 'id': self.id,
                 'label': state.schema_item.label,
+                'description': state.schema_item.description,
                 'value': state.value if state.value is not None else '',
                 'placeholder': '',
             },

--- a/app/schema/widgets/multiple_choice_widget.py
+++ b/app/schema/widgets/multiple_choice_widget.py
@@ -34,7 +34,8 @@ class MultipleChoiceWidget(Widget, metaclass=ABCMeta):
             'answer': {
                 'name': self.name,
                 'id': self.id,
-                'label': answer_state.schema_item.label or 'Label',
+                'label': answer_state.schema_item.label,
+                'description': answer_state.schema_item.description,
             },
             'debug': {
                 'state': answer_state.__dict__,

--- a/app/schema/widgets/text_widget.py
+++ b/app/schema/widgets/text_widget.py
@@ -14,6 +14,7 @@ class TextWidget(Widget):
                 'name': self.name,
                 'id': self.id,
                 'label': state.schema_item.label or '',
+                'description': state.schema_item.description,
                 'value': state.value if state.value is not None else '',
             },
         }

--- a/app/templates/layouts/_twocol.html
+++ b/app/templates/layouts/_twocol.html
@@ -2,8 +2,12 @@
 
 {% block content %}
 
-<div class="grid">
-  <div class="grid__col col-8@m">
+<div class="grid grid--reverse">
+  <div class="grid__col col-4@m">
+    {% block sidebar %}{% endblock %}
+  </div>
+
+  <div class="grid__col col-7@m pull-1@m">
     <div role="main" id="main" class="page__main">
       {% block main %}{% endblock %}
     </div>

--- a/app/templates/partials/forms/label.html
+++ b/app/templates/partials/forms/label.html
@@ -6,7 +6,7 @@
 
 <label {{attr|xmlattr}}>
   <div class="label__inner">
-    {{label.text}}
+    {{label.text|safe}}
     {% if label.description %}
       <br />
       <span class="label__description pluto">{{label.description|safe}}</span>

--- a/app/templates/partials/widgets/currency_widget.html
+++ b/app/templates/partials/widgets/currency_widget.html
@@ -1,7 +1,8 @@
 <!-- BEGIN CurrencyWidget -->
 {% set label = {
   'for': answer.id,
-  'text': answer.label
+  'text': answer.label,
+  'description': answer.description
 } %}
 
 {% include 'partials/forms/label.html' %}

--- a/app/templates/partials/widgets/multiple_choice_widget.html
+++ b/app/templates/partials/widgets/multiple_choice_widget.html
@@ -1,3 +1,10 @@
+{% set label = {
+  'for': answer.id,
+  'text': answer.label,
+  'description': answer.description
+} %}
+{% include 'partials/forms/label.html' %}
+
 {% for option in widget.options %}
 
   {% set option_id = answer.id ~ "-" ~ loop.index %}

--- a/app/templates/partials/widgets/text_widget.html
+++ b/app/templates/partials/widgets/text_widget.html
@@ -1,7 +1,8 @@
 <!-- BEGIN TextWidget -->
 {% set label = {
   'for': answer.id,
-  'text': answer.label
+  'text': answer.label,
+  'description': answer.description
 } %}
 {% include 'partials/forms/label.html' %}
 

--- a/app/templating/schema_context.py
+++ b/app/templating/schema_context.py
@@ -12,6 +12,7 @@ def build_schema_context(metadata, aliases, answer_store, group_instance=0):
     """
     return {
         "exercise": _build_exercise(metadata),
+        "respondent": _build_respondent(metadata),
         "answers": _map_alias_to_answers(aliases, answer_store),
         "group_instance": group_instance,
     }
@@ -44,4 +45,11 @@ def _build_exercise(metadata):
         "employment_date": to_date(metadata["employment_date"]),
         "return_by": to_date(metadata["return_by"]),
         "region_code": metadata["region_code"],
+    }
+
+
+def _build_respondent(metadata):
+    return {
+        "ru_name": metadata["ru_name"],
+        "trad_as": metadata["trad_as"],
     }

--- a/tests/app/templating/test_template_renderer.py
+++ b/tests/app/templating/test_template_renderer.py
@@ -76,7 +76,6 @@ class TestTemplateRenderer(unittest.TestCase):
 
             }
         ]
-        question.templatable_properties = ['guidance']
         context = {'yourself': 'Joe Bloggs', 'someone': 'Jane Bloggs', 'someone_else': 'John Doe'}
 
         schema = TemplateRenderer().render_schema_items(question, context)

--- a/tests/integration/downstream/test_downstream_data_typing.py
+++ b/tests/integration/downstream/test_downstream_data_typing.py
@@ -57,7 +57,7 @@ class TestDownstreamDataTyping(DownstreamTestCase, StarWarsTestCase):
         self.assertRegexpMatches(content, 'On 2 June 1983 how many were employed?')
 
         # Textarea question
-        self.assertRegexpMatches(content, 'Why doesn&#39;t Chewbacca receive a medal at the end of A New Hope?')
+        self.assertRegexpMatches(content, 'Why doesn\'t Chewbacca receive a medal at the end of A New Hope?')
         self.assertRegexpMatches(content, '215015b1-f87c-4740-9fd4-f01f707ef558')
 
         # Our answers

--- a/tests/integration/star_wars/star_wars_tests.py
+++ b/tests/integration/star_wars/star_wars_tests.py
@@ -211,7 +211,7 @@ class StarWarsTestCase(IntegrationTestCase):
         self.assertRegexpMatches(content, 'On 2 June 1983 how many were employed?')
 
         # Textarea question
-        self.assertRegexpMatches(content, 'Why doesn&#39;t Chewbacca receive a medal at the end of A New Hope?')
+        self.assertRegexpMatches(content, 'Why doesn\'t Chewbacca receive a medal at the end of A New Hope?')
         self.assertRegexpMatches(content, '215015b1-f87c-4740-9fd4-f01f707ef558')
 
     def submit_page(self, page, form_data):

--- a/tests/integration/star_wars/test_empty_submission_fails.py
+++ b/tests/integration/star_wars/test_empty_submission_fails.py
@@ -65,7 +65,7 @@ class TestEmptySubmissionFails(StarWarsTestCase):
         self.assertRegexpMatches(content, 'On 2 June 1983 how many were employed?')
 
         # Textarea question
-        self.assertRegexpMatches(content, 'Why doesn&#39;t Chewbacca receive a medal at the end of A New Hope?')
+        self.assertRegexpMatches(content, 'Why doesn\'t Chewbacca receive a medal at the end of A New Hope?')
         self.assertRegexpMatches(content, '215015b1-f87c-4740-9fd4-f01f707ef558')
 
         # Our answers

--- a/tests/integration/star_wars/test_light_side_path.py
+++ b/tests/integration/star_wars/test_light_side_path.py
@@ -52,7 +52,7 @@ class TestLightSidePath(StarWarsTestCase):
         self.assertRegexpMatches(content, 'On 2 June 1983 how many were employed?')
 
         # Textarea question
-        self.assertRegexpMatches(content, 'Why doesn&#39;t Chewbacca receive a medal at the end of A New Hope?')
+        self.assertRegexpMatches(content, 'Why doesn\'t Chewbacca receive a medal at the end of A New Hope?')
         self.assertRegexpMatches(content, '215015b1-f87c-4740-9fd4-f01f707ef558')
 
         # Our answers

--- a/tests/integration/star_wars/test_piping.py
+++ b/tests/integration/star_wars/test_piping.py
@@ -85,7 +85,7 @@ class TestPiping(StarWarsTestCase):
         self.assertRegexpMatches(content, 'On 2 June 1983 how many were employed?')
 
         # Textarea question
-        self.assertRegexpMatches(content, 'Why doesn&#39;t Chewbacca receive a medal at the end of A New Hope?')
+        self.assertRegexpMatches(content, 'Why doesn\'t Chewbacca receive a medal at the end of A New Hope?')
         self.assertRegexpMatches(content, '215015b1-f87c-4740-9fd4-f01f707ef558')
 
         # Check Cheewies Age has been correctly piped into the question text

--- a/tests/integration/star_wars/test_radio_boxes.py
+++ b/tests/integration/star_wars/test_radio_boxes.py
@@ -78,4 +78,4 @@ class TestEmptyRadioBoxes(StarWarsTestCase):
 
         # Check we are on the next page
         content = resp.get_data(True)
-        self.assertRegexpMatches(content, 'Why doesn&#39;t Chewbacca receive a medal at the end of A New Hope?')
+        self.assertRegexpMatches(content, 'Why doesn\'t Chewbacca receive a medal at the end of A New Hope?')


### PR DESCRIPTION
### What is the context of this PR?
See https://trello.com/c/vNz6tJD5

- Generated initial schema using https://github.com/ONSdigital/eq-google-slides-to-schema
- Schema doesn't contain routing rules, validation messages or highlighted text (see https://trello.com/c/FCKCOSR5)
- The schema doesn't have block titles so fails schema validation (what should they be, they aren't used?)
- Added description to answers to match prototype (was already in front-end but not piped through from schema) -needs frontend review/update.
- Added piping of ru_name into question text support

- Note: schema will need to be re-named to match 1_###.json once form type is known

### How to review 
- The display of `description` for answers needs a frontend review and checking in terms of accessibility.
- The schema generator has a go at generating some id values; are they appropriate?
- Does the rest of the schema look correct?