### PR TITLE
eq-633 Add emphasis styling

### DIFF
--- a/app/assets/styles/partials/base/_typography.scss
+++ b/app/assets/styles/partials/base/_typography.scss
@@ -38,3 +38,7 @@ ul {
 li {
   margin-bottom: 0.3rem;
 }
+
+em {
+  @extend .highlight;
+}

--- a/app/assets/styles/partials/components/_highlight.scss
+++ b/app/assets/styles/partials/components/_highlight.scss
@@ -1,5 +1,6 @@
 .highlight {
-  background-color: tint($color-secondary, 90);
+  background-color: $color-emphasis;
   margin: 0 -2px;
   padding: 0 2px;
+  font-style: normal;
 }

--- a/app/assets/styles/partials/vars/_colors.scss
+++ b/app/assets/styles/partials/vars/_colors.scss
@@ -28,5 +28,6 @@ $color-links-hover: $color-secondary;
 $color-focus: $color-blue;
 $color-borders: $color-dark-grey;
 $color-placeholder: lighten($color-text-light, 40%);
+$color-emphasis: #dce5b0;
 
 $color-errors: $color-red;

--- a/app/assets/styles/themes/census/_theme_vars.scss
+++ b/app/assets/styles/themes/census/_theme_vars.scss
@@ -1,3 +1,3 @@
 $color-purple: #6e2585;
-
 $color-secondary: $color-purple;
+$color-emphasis: tint($color-secondary, 90);

--- a/app/data/test_markup.json
+++ b/app/data/test_markup.json
@@ -1,0 +1,47 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "questionnaire_id": "0",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "survey_id": "0",
+    "title": "Markup test",
+    "theme": "default",
+    "description": "A questionnaire to test rendering of markup in questionnaires",
+    "groups": [
+        {
+            "id": "markup-group",
+            "title": "Markup",
+            "blocks": [
+                {
+                    "id": "emphasis-block",
+                    "sections": [
+                        {
+                            "title": "Emphasis",
+                            "id": "emphasis-section",
+                            "questions": [
+                                {
+                                      "answers": [
+                                          {
+                                              "guidance": "Lorem ipsum dolor sit amet, <em>consectetur adipiscing elit</em>. Nulla vitae elit libero, a pharetra augue. Vestibulum id ligula porta felis euismod semper. Integer posuere erat a ante venenatis dapibus posuere velit aliquet.",
+                                              "id": "answer",
+                                              "label": "What is the thing?",
+                                              "mandatory": false,
+                                              "options": [],
+                                              "q_code": "0",
+                                              "type": "TextField"
+                                          }
+                                      ],
+                                      "description": "Cum sociis natoque penatibus et <em>magnis dis parturient montes</em>, nascetur ridiculus mus. Curabitur blandit tempus porttitor.",
+                                      "id": "question",
+                                      "title": "This is a title <em>with emphasis</em>",
+                                      "type": "General"
+                                }
+                            ]
+                        }
+                    ],
+                    "title": ""
+                }
+            ]
+        }
+    ]
+}

--- a/app/templates/partials/question.html
+++ b/app/templates/partials/question.html
@@ -13,11 +13,11 @@
       {%- if question_number -%}
         <span>{{question_number}}. </span>
       {% endif %}
-      {{question_title}}
+      {{question_title|safe}}
     </h2>
   {%- endif %}
   {%- if question_subtitle -%}
-    <h3 class="question__subtitle mars">{{question_subtitle}}</h3>
+    <h3 class="question__subtitle mars">{{question_subtitle|safe}}</h3>
   {%- endif -%}
 {% endset %}
 

--- a/app/templates/summary.html
+++ b/app/templates/summary.html
@@ -22,14 +22,14 @@
       {% for question in section.questions %}
 
         <div class="summary__question" id="{{question.id}}">
-          {{question.title|safe}}
+          {{question.title|striptags|safe}}
         </div>
 
         {% for answer in question.answers %}
 
           {% if question.answers|length > 1 %}
             <div class="summary__question summary__question--sub">
-              {{answer.label|safe}}
+              {{answer.label|striptags|safe}}
             </div>
           {% endif %}
 


### PR DESCRIPTION

### What is the context of this PR?

[Trello](https://trello.com/c/FCKCOSR5/633-2-emphasise-key-words-to-help-respondents-answer-questions-highlight)

Adds global styling for emphasis tag: `<em/>`

![screenshot 2017-01-05 15 32 46](https://cloud.githubusercontent.com/assets/930398/21686142/3af77856-d35c-11e6-99dd-5cf53eb3a26b.png)

### How to review 

- `test_markup`
- Confirm question title, description and guidance are styled with emphasis in correct place.
