### PR TITLE
Add save and come back functionality

### DIFF
--- a/app/assets/js/app/modules/household.js
+++ b/app/assets/js/app/modules/household.js
@@ -44,6 +44,7 @@ class HouseholdMember extends EventEmitter {
     this.removeBtn.innerHTML = this.removeTxt
     this.removeBtn.classList.add('btn')
     this.removeBtn.classList.add('btn--link')
+    this.removeBtn.classList.add('pluto')
     this.removeBtn.setAttribute('type', 'button')
     this.node.classList.add('is-hidden')
     this.actionNode.innerHTML = ''

--- a/app/assets/styles/partials/components/_buttons.scss
+++ b/app/assets/styles/partials/components/_buttons.scss
@@ -74,7 +74,6 @@
   color: $color-links;
   background: transparent;
   cursor: pointer;
-  font-size: 0.8rem;
   text-decoration: underline;
   width: auto;
   &:hover {

--- a/app/questionnaire/location.py
+++ b/app/questionnaire/location.py
@@ -61,6 +61,8 @@ class Location(object):
                 return url_for('questionnaire.get_summary', **path_params)
             elif self.block_id == 'introduction':
                 return url_for('questionnaire.get_introduction', **path_params)
+            elif self.block_id == 'sign-out':
+                return url_for('questionnaire.get_sign_out', **path_params)
             elif self.block_id == 'thank-you':
                 return url_for('questionnaire.get_thank_you', **path_params)
         elif self.block_id == 'confirmation':

--- a/app/questionnaire/rules.py
+++ b/app/questionnaire/rules.py
@@ -44,15 +44,24 @@ def evaluate_repeat(repeat_rule, answer_store):
     :return: The number of times to repeat
     """
     repeat_functions = {
-        'answer_value': lambda filtered_answers: int(filtered_answers[0]['value'] if len(filtered_answers) == 1 else 0),
+        'answer_value': _get_answer_value(),
         'answer_count': len,
-        'answer_count_minus_one': lambda filtered_answers: len(filtered_answers) - 1 if len(filtered_answers) > 0 else 0,
+        'answer_count_minus_one': _get_answer_count_minus_one(),
     }
     if 'answer_id' in repeat_rule and 'type' in repeat_rule:
         repeat_index = repeat_rule['answer_id']
         filtered = answer_store.filter(answer_id=repeat_index)
         repeat_function = repeat_functions[repeat_rule['type']]
         return repeat_function(filtered)
+
+
+def _get_answer_value():
+    return lambda filtered_answers: int(
+        filtered_answers[0]['value'] if len(filtered_answers) == 1 and filtered_answers[0]['value'] else 0)
+
+
+def _get_answer_count_minus_one():
+    return lambda filtered_answers: len(filtered_answers) - 1 if len(filtered_answers) > 0 else 0
 
 
 def evaluate_skip_condition(skip_condition, metadata, answer_store, group_instance=0):

--- a/app/schema/answer.py
+++ b/app/schema/answer.py
@@ -68,15 +68,15 @@ class Answer(Item):
     def _cast_user_input(user_input):
         return user_input
 
-    def validate(self, state):
+    def validate(self, state, skip_mandatory_validation):
         if isinstance(state, self.get_state_class()):
             question = state.parent
             if question.skipped:
                 # if the question is skipped then its always valid
                 state.is_valid = True
-            elif self.mandatory and state.input is None:
+            elif not skip_mandatory_validation and self.mandatory and state.input is None:
                 self.mandatory_error(state)
-            elif self.mandatory and self.type == 'Radio' and state.input == 'other' and state.other is None:
+            elif not skip_mandatory_validation and self.mandatory and self.type == 'Radio' and state.input == 'other' and state.other is None:
                 self.mandatory_error(state)
 
             # Try and get the typed value

--- a/app/schema/answers/checkbox_answer.py
+++ b/app/schema/answers/checkbox_answer.py
@@ -18,7 +18,7 @@ class CheckboxAnswer(Answer):
         # We cannot type cast a list of values, so just return the user_input
         return self.get_user_input(post_vars)
 
-    def validate(self, state):
+    def validate(self, state, skip_mandatory_validation):
         if isinstance(state, self.get_state_class()):
             question = state.parent
             options = state.schema_item.options
@@ -27,7 +27,7 @@ class CheckboxAnswer(Answer):
 
             if question.skipped:
                 state.is_valid = True
-            elif self.mandatory:
+            elif self.mandatory and not skip_mandatory_validation:
                 if not state.input:
                     super(CheckboxAnswer, self).mandatory_error(state)
                 elif 'other' not in state.input and not self._valid_option_selected(state.input, options):

--- a/app/schema/item.py
+++ b/app/schema/item.py
@@ -31,13 +31,13 @@ class Item(metaclass=ABCMeta):
     def get_state_class(self):
         raise NotImplementedError
 
-    def validate(self, state):
+    def validate(self, state, skip_mandatory_validation):
 
         if isinstance(state, self.get_state_class()):
             is_valid = True
             for child_state in state.children:
                 child_schema = self.questionnaire.get_item_by_id(child_state.id)
-                child_valid = child_schema.validate(child_state)
+                child_valid = child_schema.validate(child_state, skip_mandatory_validation)
 
                 if child_valid is not None and child_valid is False:
                     is_valid = False

--- a/app/schema/questions/date_range_question.py
+++ b/app/schema/questions/date_range_question.py
@@ -7,22 +7,25 @@ class DateRangeQuestion(Question):
     def __init__(self):
         super().__init__()
 
-    def validate(self, state):
-        is_valid = super().validate(state)
+    def validate(self, state, skip_mandatory_validation):
+
+        is_valid = super().validate(state, skip_mandatory_validation)
         if is_valid:
             state.errors = []
             state.is_valid = True
-            from_date = datetime.strptime(state.children[0].value, "%d/%m/%Y")
-            to_date = datetime.strptime(state.children[1].value, "%d/%m/%Y")
 
-            if to_date == from_date:
-                state.is_valid = False
-                state.errors.append(self.questionnaire.get_error_message("INVALID_DATE_RANGE_TO_FROM_SAME", self.id))
-                return False
+            if len(state.children) == 2 and state.children[0].value and state.children[1].value:
+                from_date = datetime.strptime(state.children[0].value, "%d/%m/%Y")
+                to_date = datetime.strptime(state.children[1].value, "%d/%m/%Y")
 
-            if to_date < from_date:
-                state.is_valid = False
-                state.errors.append(self.questionnaire.get_error_message("INVALID_DATE_RANGE_TO_BEFORE_FROM", self.id))
-                return False
+                if to_date == from_date:
+                    state.is_valid = False
+                    state.errors.append(self.questionnaire.get_error_message("INVALID_DATE_RANGE_TO_FROM_SAME", self.id))
+                    return False
+
+                if to_date < from_date:
+                    state.is_valid = False
+                    state.errors.append(self.questionnaire.get_error_message("INVALID_DATE_RANGE_TO_BEFORE_FROM", self.id))
+                    return False
 
         return is_valid

--- a/app/templates/partials/questions/repeatinganswer.html
+++ b/app/templates/partials/questions/repeatinganswer.html
@@ -20,7 +20,7 @@
           {%- if loop.index == 1 -%}
              <span class="js-household-action">{{ _('You') }}</span>
           {%- else -%}
-            <button class="btn btn--link js-btn-remove" name="action[remove_answer]" value="{{ loop.index0 }}" type="submit">{{ _('Remove') }}
+            <button class="btn btn--link pluto js-btn-remove" name="action[remove_answer]" value="{{ loop.index0 }}" type="submit">{{ _('Remove') }}
               <span class="u-vh">{{ _('Person') }} {{loop.index0}}</span>
             </button>
           {%- endif -%}

--- a/app/templates/partials/widgets/relationship_widget.html
+++ b/app/templates/partials/widgets/relationship_widget.html
@@ -5,7 +5,7 @@
 
   <fieldset class="field field--selectionbtn field--multiplechoice relationship__field" ]>
 
-    <button class="btn btn--link relationship__edit js-relationship-editbtn u-hidden" data-close="{{_('Close')}}" data-qa="relationship-close-btn">
+    <button class="btn btn--link pluto relationship__edit js-relationship-editbtn u-hidden" data-close="{{_('Close')}}" data-qa="relationship-close-btn">
       {{_('Edit')}}
     </button>
 

--- a/app/templates/questionnaire.html
+++ b/app/templates/questionnaire.html
@@ -19,7 +19,7 @@
 
     {% if navigation %}
       <div class="page__menubtn">
-        <button class="btn btn--link btn--menu js-menu-btn" data-close-label="{{_('Hide sections')}}" type="button" id="menu-btn">{{_('View sections')}}</button>
+        <button class="btn btn--link pluto btn--menu js-menu-btn" data-close-label="{{_('Hide sections')}}" type="button" id="menu-btn">{{_('View sections')}}</button>
       </div>
     {% endif %}
   </div>
@@ -79,7 +79,9 @@
       </div>
 
       <button class="btn btn--primary btn--lg qa-btn-submit venus" type="submit" name="action[save_continue]">{% block submit_button_text %}Save and continue{% endblock %}</button>
-
+      <div>
+        <button class="btn btn--link mars" type="submit" name="action[save_sign_out]">{% block save_sign_out_button_text %}Save and complete later{% endblock %}</button>
+      </div>
     </form>
 
 {% endblock main %}

--- a/app/templates/signed-out.html
+++ b/app/templates/signed-out.html
@@ -1,0 +1,15 @@
+{% extends theme('layouts/_twocol.html') %}
+
+{% block page_title %}Save Successful{% endblock %}
+
+{% block main %}
+
+  <div class="u-mb-s">
+    <h1 class="saturn">Your survey has been saved</h1>
+  </div>
+
+  <div class="panel panel--simple panel--success panel--spacious">
+    <p>You have been signed out of the survey, to complete the survey you will need to sign back in.</p>
+  </div>
+
+{% endblock %}

--- a/tests/app/schema/answers/test_checkbox_answer.py
+++ b/tests/app/schema/answers/test_checkbox_answer.py
@@ -16,6 +16,8 @@ class TestCheckBoxAnswer(TestCase):
         question.type = "General"
         question_state = StateQuestion('2', question)
 
+        self.skip_mandatory_validation = False
+
         self.check_box_answer = CheckboxAnswer('1234')
         self.check_box_answer.type = "Checkbox"
         self.check_box_answer.mandatory = True
@@ -28,24 +30,24 @@ class TestCheckBoxAnswer(TestCase):
 
     def test_mandatory_check_box_answer_other_with_valid_other(self):
         self.answer_state.input = ['other', 'Option3']
-        is_valid = self.check_box_answer.validate(self.answer_state)
+        is_valid = self.check_box_answer.validate(self.answer_state, self.skip_mandatory_validation)
         self.assertEquals(is_valid, True)
 
     def test_mandatory_check_box_answer_other_with_no_valid_other(self):
         self.answer_state.input = ['other']
-        is_valid = self.check_box_answer.validate(self.answer_state)
+        is_valid = self.check_box_answer.validate(self.answer_state, self.skip_mandatory_validation)
         self.assertEquals(is_valid, False)
         self.check_box_answer.questionnaire.get_error_message.assert_called_with('MANDATORY', '1234')
 
     def test_mandatory_check_box_answer_without_other_identifier(self):
         self.answer_state.input = ['Option3']
-        is_valid = self.check_box_answer.validate(self.answer_state)
+        is_valid = self.check_box_answer.validate(self.answer_state, self.skip_mandatory_validation)
         self.assertEquals(is_valid, False)
         self.check_box_answer.questionnaire.get_error_message.assert_called_with('MANDATORY', '1234')
 
     def test_mandatory_check_box_answer_without_input(self):
         self.answer_state.input = None
-        is_valid = self.check_box_answer.validate(self.answer_state)
+        is_valid = self.check_box_answer.validate(self.answer_state, self.skip_mandatory_validation)
         self.assertEquals(is_valid, False)
         self.check_box_answer.questionnaire.get_error_message.assert_called_with('MANDATORY', '1234')
 
@@ -53,18 +55,18 @@ class TestCheckBoxAnswer(TestCase):
         self.answer_state.input = None
         self.answer_state.is_valid = True
         self.check_box_answer.mandatory = False
-        is_valid = self.check_box_answer.validate(self.answer_state)
+        is_valid = self.check_box_answer.validate(self.answer_state, self.skip_mandatory_validation)
         self.assertEquals(is_valid, True)
 
     def test_non_mandatory_check_box_answer_non_valid_other_value(self):
         self.answer_state.input = ['other'] # other doesn't need an associated value if non_mandatory
         self.answer_state.is_valid = True
         self.check_box_answer.mandatory = False
-        is_valid = self.check_box_answer.validate(self.answer_state)
+        is_valid = self.check_box_answer.validate(self.answer_state, self.skip_mandatory_validation)
         self.assertEquals(is_valid, True)
 
     def test_check_box_answer_skipped(self):
         self.answer_state.is_valid = True
         self.answer_state.parent.skipped = True
-        is_valid = self.check_box_answer.validate(self.answer_state)
+        is_valid = self.check_box_answer.validate(self.answer_state, self.skip_mandatory_validation)
         self.assertEquals(is_valid, True)

--- a/tests/functional/pages/sign-out.page.js
+++ b/tests/functional/pages/sign-out.page.js
@@ -1,0 +1,8 @@
+class SignOut {
+
+  isOpen() {
+    const url = browser.url().value
+    return url.indexOf('signed-out') > -1
+  }
+}
+export default new SignOut()

--- a/tests/functional/pages/surveys/rsi/0102/retail-turnover.page.js
+++ b/tests/functional/pages/surveys/rsi/0102/retail-turnover.page.js
@@ -6,6 +6,19 @@ class RetailTurnoverPage extends QuestionPage {
     browser.setValue('[name="total-retail-turnover-answer"]', turnover)
     return this
   }
+  getRetailTurnover() {
+    return browser.element('[name="total-retail-turnover-answer"]').getValue()
+  }
+
+  saveSignOut() {
+    browser.click('button[name="action[save_sign_out]"]')
+    return this
+  }
+
+  isOpen() {
+    const url = browser.url().value
+    return url.indexOf('total-retail-turnover') > -1
+  }
 
 }
 

--- a/tests/functional/spec/save-sign-out.spec.js
+++ b/tests/functional/spec/save-sign-out.spec.js
@@ -1,0 +1,73 @@
+import assert from 'assert'
+import chai from 'chai'
+import {getRandomString, startQuestionnaire, openQuestionnaire} from '../helpers'
+import devPage from '../pages/dev.page'
+import landingPage from '../pages/landing.page'
+import thankYou from '../pages/thank-you.page'
+import signOut from '../pages/sign-out.page'
+import reportingPeriod from '../pages/surveys/rsi/0102/reporting-period.page'
+import retailTurnoverPage from '../pages/surveys/rsi/0102/retail-turnover.page'
+import internetSalesPage from '../pages/surveys/rsi/0102/internet-sales.page'
+import changeInRetailTurnover from '../pages/surveys/rsi/0102/changes-in-retail-turnover.page'
+import SummaryPage from '../pages/summary.page'
+
+const expect = chai.expect
+
+describe('RSI - Save and restore test', function() {
+
+  it('Given I am completing survey 0102, when I select save and complete later, then I am redirected to sign out page and my session is cleared', function() {
+
+    // Given I am completing survey 0102
+    const collectionId = getRandomString(5)
+    startQuestionnaire('1_0102.json', 'test_user', collectionId)
+    const url = browser.getUrl();
+    reportingPeriod.setFromReportingPeriodDay('01')
+      .setFromReportingPeriodMonth(5)
+      .setFromReportingPeriodYear('2016')
+      .setToReportingPeriodDay('01')
+      .setToReportingPeriodMonth(5)
+      .setToReportingPeriodYear('2017')
+      .submit()
+
+    // When I select save and complete later
+    retailTurnoverPage.saveSignOut()
+
+    // Then I am redirected to sign out page and my session is cleared
+    expect(signOut.isOpen(), 'sign out page should be open').to.be.true
+    browser.url(url)
+    expect(browser.getSource()).to.contain('Error 401')
+    })
+
+
+  it('Given whilst completing survey 0102 I have opted to save and complete later, when I return to the questionnaire, then I am returned to the page I was on and can then complete the survey', function() {
+
+    // Given whilst completing survey 0102 I have opted to save and complete later
+    const collectionId = getRandomString(5)
+    startQuestionnaire('1_0102.json', 'test_user', collectionId)
+    reportingPeriod.setFromReportingPeriodDay('01')
+      .setFromReportingPeriodMonth(5)
+      .setFromReportingPeriodYear('2016')
+      .setToReportingPeriodDay('01')
+      .setToReportingPeriodMonth(5)
+      .setToReportingPeriodYear('2017')
+      .submit()
+    retailTurnoverPage.saveSignOut()
+    expect(signOut.isOpen(), 'sign out page should be open').to.be.true
+
+    // When I return to the questionnaire
+    openQuestionnaire('1_0102.json', 'test_user', collectionId)
+
+    // Then I am returned to the page I was on and can then complete the survey
+    expect(retailTurnoverPage.isOpen(), 'retail turnover page should be open').to.be.true
+    expect(retailTurnoverPage.getRetailTurnover()).to.contain('')
+    retailTurnoverPage.setRetailTurnover('3000')
+      .submit()
+    internetSalesPage.setInternetSales('2000')
+      .submit()
+    changeInRetailTurnover.setChangesInRetailTurnover('No reason')
+      .submit()
+    SummaryPage.submit()
+    expect(thankYou.isOpen(), 'Thank you page should be open').to.be.true
+    })
+
+  })

--- a/tests/integration/household_composition/test_household_question.py
+++ b/tests/integration/household_composition/test_household_question.py
@@ -103,6 +103,18 @@ class TestHouseholdQuestion(IntegrationTestCase):
 
         self.assertRegex(resp_url, '/summary')
 
+    def test_save_sign_out_with_household_question(self):
+
+        first_page = self.add_answers()
+
+        form_data = MultiDict()
+        form_data.add("action[save_sign_out]", "")
+
+        resp_url, resp = self.postRedirectGet(first_page, form_data)
+        content = resp.get_data(True)
+        self.assertRegex(content, 'Your survey has been saved')
+        self.assertRegex(resp_url, 'signed-out')
+
     def remove_answer(self, page):
         # Add first person
         form_data = MultiDict()
@@ -181,3 +193,5 @@ class TestHouseholdQuestion(IntegrationTestCase):
         resp = self.client.post(resp_url, data=form_data, follow_redirects=False)
         resp_url = resp.headers['Location']
         return resp, resp_url
+
+

--- a/tests/integration/questionnaire/test_questionnaire_save_sign_out.py
+++ b/tests/integration/questionnaire/test_questionnaire_save_sign_out.py
@@ -1,0 +1,109 @@
+from tests.integration.create_token import create_token
+from tests.integration.integration_test_case import IntegrationTestCase
+
+
+class TestSaveSignOut(IntegrationTestCase):
+
+    def test_save_sign_out_with_mandatory_question_not_answered(self):
+        # We can save and go to the sign-out page without having to fill in mandatory answer
+        base_url = '/questionnaire/1/0205/789/'
+
+        # Given
+        token = create_token('0205', '1')
+        self.client.get('/session?token=' + token.decode(), follow_redirects=False)
+
+        # When
+        post_data = {
+            'action[start_questionnaire]': 'Start Questionnaire'
+        }
+        resp = self.client.post(base_url + 'introduction', data=post_data, follow_redirects=False)
+        self.assertEquals(resp.status_code, 302)
+
+        block_one_url = resp.headers['Location']
+
+        post_data = {
+            "total-retail-turnover": " 1000",
+            "action[save_sign_out]": "Save and sign out"
+        }
+        resp = self.client.post(block_one_url, data=post_data, follow_redirects=False)
+        self.assertEquals(resp.status_code, 302)
+
+        # Then
+        # we are presented with the sign out page
+        self.assertTrue("signed-out" in resp.headers['Location'])
+        self.assertEquals(resp.status_code, 302)
+
+        resp = self.client.get(resp.headers['Location'], follow_redirects=False)
+        self.assertEquals(resp.status_code, 200)
+
+    def test_save_sign_out_with_non_mandatory_validation_error(self):
+        # We can't save if a validation error is caused, this doesn't include missing a mandatory question
+        base_url = '/questionnaire/1/0205/789/'
+
+        # Given
+        token = create_token('0205', '1')
+        self.client.get('/session?token=' + token.decode(), follow_redirects=False)
+
+        # When
+        post_data = {
+            'action[start_questionnaire]': 'Start Questionnaire'
+        }
+        resp = self.client.post(base_url + 'introduction', data=post_data, follow_redirects=False)
+        self.assertEquals(resp.status_code, 302)
+
+        block_one_url = resp.headers['Location']
+
+        post_data = {
+            "total-retail-turnover": "error",
+            "action[save_sign_out]": "Save and sign out"
+        }
+        resp = self.client.post(block_one_url, data=post_data, follow_redirects=False)
+        self.assertEquals(resp.status_code, 200)
+        # Then
+        # we are presented with an error message
+        content = resp.get_data(True)
+        self.assertRegexpMatches(content, 'Please only enter whole numbers into the field.')
+
+    def test_save_sign_out_complete_a_block_then_revist_it(self):
+
+        # If a user completes a block, but then goes back and uses save and come back on that block, that block
+        # should no longer be considered complete and on re-authenticate it should return to it
+
+        base_url = '/questionnaire/1/0102/789/'
+
+        token = create_token('0102', '1')
+        self.client.get('/session?token=' + token.decode(), follow_redirects=False)
+
+        post_data = {
+            'action[start_questionnaire]': 'Start Questionnaire'
+        }
+        resp = self.client.post(base_url + 'introduction', data=post_data, follow_redirects=False)
+        self.assertEquals(resp.status_code, 302)
+
+        block_one_url = resp.headers['Location']
+
+        post_data = {
+            "period-from-day": "01",
+            "period-from-month": "4",
+            "period-from-year": "2016",
+            "period-to-day": "30",
+            "period-to-month": "04",
+            "period-to-year": "2016",
+            "action[save_continue]": "Save &amp; Continue"
+        }
+
+        resp = self.client.post(block_one_url, data=post_data, follow_redirects=False)
+        self.assertEquals(resp.status_code, 302)
+
+        # We go back to the first page and save and complete later
+        self.client.get(block_one_url, follow_redirects=False)
+
+        post_data = {
+            "action[save_sign_out]": "Save and sign out"
+        }
+        self.client.post(block_one_url, data=post_data, follow_redirects=False)
+
+        # We re-authenticate and check we are on the first page
+        resp = self.client.get('/session?token=' + token.decode(), follow_redirects=False)
+        block_one_url = resp.headers['Location']
+        self.assertRegexpMatches(block_one_url, 'reporting-period')


### PR DESCRIPTION
### What is the context of this PR?
Adding the save and come back functionality on all surveys. Mandatory validation should be skipped if save and come back is clicked, however validation errors (i.e. text in a number) should be caught. A block should not be marked as completed if save and come back is clicked, meaning the user gets returned to the same block on authentication.

### How to review 
1. Record your collection ID and user name, complete half of a survey without any potential validation errors and click close and come back (make sure data is on the page), confirm it goes to the correct page(sign-out.html) Now re-authenticate with the same details and make sure it goes to the last place with the data you entered.
2. Repeat the above but leave a mandatory question (1_0102 can be used on the first 2 questions)blank before clicking save and come back , make sure it goes to the sign out page
3. Repeat the above but now generate a validation error, like text in a number field. Make sure a validation error is generated and must be removed/corrected before save and come back later works.
4. Once save and continue has been used make sure you can't get back into the survey without re-authenticating, you should get a 401. You could do this by using back after seeing the sign-out page and trying to refresh.

