### PR TITLE
Enabling piping for list of dicts

### DIFF
--- a/app/questionnaire/questionnaire_manager.py
+++ b/app/questionnaire/questionnaire_manager.py
@@ -3,9 +3,6 @@ import logging
 from app.globals import get_answer_store, get_answers, get_metadata, get_questionnaire_store
 from app.questionnaire.path_finder import PathFinder
 
-from app.templating.schema_context import build_schema_context
-from app.templating.template_renderer import renderer
-
 from flask import g
 
 from flask_login import current_user
@@ -81,7 +78,6 @@ class QuestionnaireManager(object):
         self.state = None
         if self._schema.item_exists(location.block_id):
             metadata = get_metadata(current_user)
-            answer_store = get_answer_store(current_user)
             schema_item = self._schema.get_item_by_id(location.block_id)
             self.state = schema_item.construct_state()
 
@@ -90,9 +86,6 @@ class QuestionnaireManager(object):
                 answer.group_instance = location.group_instance
             self.state.update_state(answers)
             self.state.set_skipped(get_answers(current_user), metadata)
-
-            context = build_schema_context(metadata, self._schema.aliases, answer_store, location.group_instance)
-            renderer.render_state(self.state, context)
 
     def get_state_answers(self, item_id):
         # get the answers from the state

--- a/app/schema/question.py
+++ b/app/schema/question.py
@@ -8,6 +8,7 @@ class Question(Item):
         self.title = None
         self.number = None
         self.description = ""
+        self.guidance = None
         self.answers = []
         self.children = self.answers
         self.container = None

--- a/app/templating/template_renderer.py
+++ b/app/templating/template_renderer.py
@@ -25,23 +25,36 @@ class TemplateRenderer:
         result = rendered if isinstance(renderable, dict) else json.dumps(rendered)
         return json.loads(result)
 
-    def render_state(self, state, context):
+    def render_schema_items(self, schema_item, context):
         """
-        Substitute variables into state items recursively with the variables in context
-        :param state: state with properties to be substituted
+        Substitute variables into schema items recursively with the variables in context
+        :param schema_item: schema with properties to be substituted
         :param context: the variables to substitute
         :return: the rendered version of the state
         """
         # plumb the state and then all its children
-        if state.schema_item:
-            templatable_properties = state.schema_item.templatable_properties
+        if schema_item:
+            templatable_properties = schema_item.templatable_properties
             for templatable_property in templatable_properties:
-                template_string = getattr(state.schema_item, templatable_property)
-                if template_string is not None:
-                    plumbed_value = self.render(template_string, **context)
-                    setattr(state.schema_item, templatable_property, plumbed_value)
-        for child in state.children:
-            self.render_state(child, context)
-        return state
+                self._set_property(context, schema_item, templatable_property)
+        children = schema_item.children or []
+        for child in children:
+            self.render_schema_items(child, context)
+        return schema_item
+
+    def _set_property(self, context, schema_item, templatable_property):
+        template_property = getattr(schema_item, templatable_property)
+        if isinstance(template_property, list):
+            properties = []
+            list_of_dicts = [template_properties for template_properties in template_property if isinstance(template_properties, dict)]
+            for template_property_item in list_of_dicts:
+                plumbed_value = self.render(template_property_item, **context)
+                properties.append(plumbed_value)
+            setattr(schema_item, templatable_property, properties)
+        else:
+            if template_property is not None:
+                plumbed_value = self.render(template_property, **context)
+                setattr(schema_item, templatable_property, plumbed_value)
+
 
 renderer = TemplateRenderer()


### PR DESCRIPTION
### What is the context of this PR?
It is possible to interpolate into top level string objects or dict
templatable properties in schema items but not for list of dicts.

The change make it possible to substitute into next string or dicts.
### How to review 
Run TestTemplateRenderer.test_render_nested_templatable_property
