### PR TITLE
Enables CSS sourcemaps for local build

### DIFF
--- a/gulp/styles.js
+++ b/gulp/styles.js
@@ -45,7 +45,6 @@ export function styles() {
         removeAll: true
       }
     })
-    .pipe(sourcemaps.write, '.')
     .pipe(gulp.dest, paths.styles.output)
 
   return gulp.src(paths.styles.input)
@@ -83,6 +82,7 @@ export function styles() {
       path.dirname = path.dirname.replace('themes/', '')
       return path
     }))
+    .pipe(sourcemaps.write('.'))
     .pipe(gulp.dest(paths.styles.output))
     .pipe(browserSync.reload({ stream: true }))
     .pipe(gulpif(process.env.EQ_MINIMIZE_ASSETS === 'True', minifyStyles()))

--- a/gulp/styles.js
+++ b/gulp/styles.js
@@ -35,6 +35,8 @@ export function lint() {
 }
 
 export function styles() {
+  const minifyAssets = process.env.EQ_MINIMIZE_ASSETS === 'True'
+
   const minifyStyles = lazypipe()
     .pipe(rename, {
       suffix: '.min'
@@ -82,8 +84,8 @@ export function styles() {
       path.dirname = path.dirname.replace('themes/', '')
       return path
     }))
-    .pipe(sourcemaps.write('.'))
+    .pipe(gulpif(!minifyAssets, sourcemaps.write('.')))
     .pipe(gulp.dest(paths.styles.output))
     .pipe(browserSync.reload({ stream: true }))
-    .pipe(gulpif(process.env.EQ_MINIMIZE_ASSETS === 'True', minifyStyles()))
+    .pipe(gulpif(minifyAssets, minifyStyles()))
 }


### PR DESCRIPTION
### What is the context of this PR?

Enables sourcemap support for CSS on local environment.

### How to review 

Check sourcemaps are working as expected:

![screenshot 2017-01-09 15 18 28](https://cloud.githubusercontent.com/assets/930398/21771395/18cf532c-d67f-11e6-92e8-128f7c3a1a66.png)

