### PR TITLE
Add RU ref into email subject on introduction page.

### DIFF
--- a/app/templates/introduction.html
+++ b/app/templates/introduction.html
@@ -25,7 +25,7 @@
               <dd class="dl__data mars">{{ meta.respondent.address.trading_as }}</dd>
             {% endif %}
             <dt id="details-changed-title" class="dl__title mercury">Change in details</dt>
-            <dd class="dl__data mars">Call <a href="tel:0300 1234 931" aria-describedby="details-changed-title">0300 1234 931</a> or email <a href="mailto:surveys@ons.gov.uk" aria-describedby="details-changed-title">surveys@ons.gov.uk</a> if there have been any changes to your business name, address or structure</dd>
+            <dd class="dl__data mars">Call <a href="tel:0300 1234 931" aria-describedby="details-changed-title">0300 1234 931</a> or email <a href="mailto:surveys@ons.gov.uk?subject=Change%20of%20details%20reference%20{{ meta.respondent.respondent_id }}" aria-describedby="details-changed-title">surveys@ons.gov.uk</a> if there have been any changes to your business name, address or structure</dd>
           </dl>
         </div>
         <div class="grid__col col-6@s">

--- a/tests/integration/introduction/test_introduction.py
+++ b/tests/integration/introduction/test_introduction.py
@@ -1,0 +1,23 @@
+from tests.integration.integration_test_case import IntegrationTestCase
+from tests.integration.create_token import create_token
+
+
+class TestIntroduction(IntegrationTestCase):
+
+    def test_mail_link_contains_ru_ref_in_subject(self):
+        # Given
+        response = self.start_new_survey()
+
+        # When
+        content = response.get_data(True)
+
+        # Then
+        self.assertRegex(content, '\"mailto\:.+\?subject\=.+123456789012A\"')
+
+    def start_new_survey(self):
+        token = create_token('0203', '1')
+        resp = self.client.get('/session?token=' + token.decode(), follow_redirects=True)
+        self.assertEquals(resp.status_code, 200)
+        return resp
+
+


### PR DESCRIPTION
### What is the context of this PR?
This PR adds the reporting unit reference into the subject of the email when the email link is clicked on the survey introduction page.

### How to review 
Open up any survey that has an introduction page.
When the email link is clicked, observe that the subject line has the RU reference number inline.
All existing tests should pass.
