### PR TITLE
Remove dict unpacking refactor that doesn't work under Python 3.4.3

### DIFF
--- a/app/questionnaire/location.py
+++ b/app/questionnaire/location.py
@@ -67,7 +67,9 @@ class Location(object):
             return url_for('questionnaire.get_confirmation', **path_params)
         else:
             return url_for('questionnaire.get_block',
-                           **path_params,
+                           eq_id=eq_id,
+                           form_type=form_type,
+                           collection_id=collection_id,
                            group_id=self.group_id,
                            group_instance=self.group_instance,
                            block_id=self.block_id)


### PR DESCRIPTION
Additional unpacking functionality was added in Python 3.5 -
https://www.python.org/dev/peps/pep-0448/

The latest Python we can run in Elastic Beanstalk is 3.4.3