### PR TITLE
Re-add Apache WSGI config to fix time-outs on Elastic Beanstalk

### DIFF
--- a/.ebextensions/custom-apache.config
+++ b/.ebextensions/custom-apache.config
@@ -1,5 +1,6 @@
 container_commands:
   add_apache_conf:
     command: "cp app-httpd.conf /etc/httpd/conf.d"
+    command: "cp app-wsgi.conf /etc/httpd/conf.d/app-wsgi.conf"
   add_apache_mod_deflate:
     command: "cp .ebextensions/enable_mod_deflate.conf /etc/httpd/conf.d/enable_mod_deflate.conf"

--- a/app-wsgi.conf
+++ b/app-wsgi.conf
@@ -1,0 +1,1 @@
+WSGIApplicationGroup %{GLOBAL}


### PR DESCRIPTION
We got "Script timed out before returning headers: application.py" in our Apache error logs when the application started up on Elastic Beanstalk.

Apache mod_wsgi launches multiple Python sub-interpreters, which fail with the OpenSSL 'C' module due to corrupt locks and shared memory. It is a known issue, adding `WSGIApplicationGroup %{GLOBAL}` to Apache conf to force mod_wsgi to use a single Python sub-interpreter fixes this.

See https://code.google.com/archive/p/modwsgi/wikis/ApplicationIssues.wiki#Python_Simplified_GIL_State_API
and
https://digitaleq.atlassian.net/wiki/display/EQ/Debugging+ElasticBeanstalk+EC2+Instances+Timing+out