### PR TITLE
Hide/show sections in navigation dependent on skip conditions

### DIFF
--- a/app/data/1_0001.json
+++ b/app/data/1_0001.json
@@ -2538,6 +2538,105 @@
                 },
                 {
                     "id": "constraining-innovation-referendum",
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "id": "not-necessary-possible",
+                                "when": [
+                                    {
+                                        "id": "business-changes-business-practices-answer",
+                                        "condition": "not equals",
+                                        "value":"Yes"
+                                    },
+                                     {
+                                        "id": "business-changes-organising-answer",
+                                        "condition": "not equals",
+                                        "value":"Yes"
+                                    },
+                                     {
+                                        "id": "business-changes-external-relationships-answer",
+                                        "condition": "not equals",
+                                        "value":"Yes"
+                                    },
+                                     {
+                                        "id": "business-changes-answer",
+                                        "condition": "not equals",
+                                        "value":"Yes"
+                                    },
+                                     {
+                                        "id": "internal-investment-r-d-answer",
+                                        "condition": "not equals",
+                                        "value":"Yes"
+                                    },
+                                     {
+                                        "id": "acquisition-internal-investment-r-d-answer",
+                                        "condition": "not equals",
+                                        "value":"Yes"
+                                    },
+                                     {
+                                        "id": "investment-advanced-machinery-answer",
+                                        "condition": "not equals",
+                                        "value":"Yes"
+                                    },
+                                     {
+                                        "id": "investment-existing-knowledge-innovation-answer",
+                                        "condition": "not equals",
+                                        "value":"Yes"
+                                    },
+                                     {
+                                        "id": "investment-training-innovative-answer",
+                                        "condition": "not equals",
+                                        "value":"Yes"
+                                    },
+                                    {
+                                        "id": "investment-design-future-innovation-answer",
+                                        "condition": "not equals",
+                                        "value":"Yes"
+                                    },
+                                     {
+                                        "id": "investment-introduction-innovations-answer",
+                                        "condition": "not equals",
+                                        "value":"Yes"
+                                    },
+                                     {
+                                        "id": "introducing-significantly-improved-goods-answer",
+                                        "condition": "not equals",
+                                        "value":"Yes"
+                                    },
+                                     {
+                                        "id": "introduce-significantly-improvement-answer",
+                                        "condition": "not equals",
+                                        "value":"Yes"
+                                    },
+                                    {
+                                        "id": "process-improved-answer",
+                                        "condition": "not equals",
+                                        "value":"Yes"
+                                    },
+                                     {
+                                        "id": "constraints-innovation-activities-abandoned-answser",
+                                        "condition": "not equals",
+                                        "value":"Yes"
+                                    },
+                                    {
+                                        "id": "constraints-innovation-activities-scaled-back-answser",
+                                        "condition": "not equals",
+                                        "value":"Yes"
+                                    },
+                                     {
+                                        "id": "constraints-innovation-activities-ongoing-2016-answser",
+                                        "condition": "not equals",
+                                        "value":"Yes"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "constraints-on-innovation-completed"
+                            }
+                        }
+                    ],
                     "sections": [
                         {
                             "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
@@ -2577,6 +2676,58 @@
                                     "id": "constraining-innovation-referendum-question",
                                     "number": "6.13",
                                     "title": "How important were the following factors in constraining innovation activities?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Constraints on Innovation"
+                        }
+                    ],
+                    "type": "questionnaire"
+                },
+                 {
+                    "id": "not-necessary-possible",
+                    "sections": [
+                        {
+                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
+                            "id": "not-necessary-possible-section",
+                            "number": "6",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "description": "",
+                                            "id": "not-necessary-possible-answer",
+                                            "label": "Select all that apply",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "No need due to previous innovations",
+                                                    "q_code": "2011",
+                                                    "value": "No need due to previous innovations"
+                                                },
+                                                {
+                                                    "label": "No need due to market conditions",
+                                                    "q_code": "2020",
+                                                    "value": "No need due to market conditions"
+                                                },
+                                                {
+                                                    "label": "The UK does not have a business environment which encourages companies to innovate",
+                                                    "q_code": "2030",
+                                                    "value": "The UK does not have a business environment which encourages companies to innovate"
+                                                },
+                                                {
+                                                    "label": "Other",
+                                                    "q_code": "2040",
+                                                    "value": "Other"
+                                                }
+                                            ],
+                                            "type": "Checkbox"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "id": "not-necessary-possible-question",
+                                    "number": "6.14",
+                                    "title": "If {{respondent.ru_name}} had no innovation activity, please indicate why it has not been necessary or possible to innovate",
                                     "type": "General"
                                 }
                             ],
@@ -3223,6 +3374,97 @@
                 }
             ],
             "id": "factors-affecting-innovation",
+            "skip_condition": [
+                {
+                    "when": [
+                        {
+                            "id": "business-changes-business-practices-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "business-changes-organising-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "business-changes-external-relationships-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "business-changes-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "internal-investment-r-d-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "acquisition-internal-investment-r-d-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "investment-advanced-machinery-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "investment-existing-knowledge-innovation-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "investment-training-innovative-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "investment-design-future-innovation-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "investment-introduction-innovations-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "introducing-significantly-improved-goods-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "introduce-significantly-improvement-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "process-improved-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "constraints-innovation-activities-abandoned-answser",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "constraints-innovation-activities-scaled-back-answser",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "constraints-innovation-activities-ongoing-2016-answser",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        }
+                    ]
+                }
+            ],
             "title": "Factors Affecting Innovation"
         },
         {
@@ -3847,6 +4089,97 @@
                 }
             ],
             "id": "information-needed-for-innovation",
+            "skip_condition": [
+                {
+                    "when": [
+                        {
+                            "id": "business-changes-business-practices-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "business-changes-organising-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "business-changes-external-relationships-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "business-changes-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "internal-investment-r-d-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "acquisition-internal-investment-r-d-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "investment-advanced-machinery-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "investment-existing-knowledge-innovation-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "investment-training-innovative-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "investment-design-future-innovation-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "investment-introduction-innovations-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "introducing-significantly-improved-goods-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "introduce-significantly-improvement-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "process-improved-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "constraints-innovation-activities-abandoned-answser",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "constraints-innovation-activities-scaled-back-answser",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "constraints-innovation-activities-ongoing-2016-answser",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        }
+                    ]
+                }
+            ],
             "title": "Information Needed for Innovation"
         },
         {
@@ -4275,58 +4608,6 @@
                     "type": "questionnaire"
                 },
                 {
-                    "id": "not-necessary-possible",
-                    "sections": [
-                        {
-                            "description": "<p>3 year period 1 January 2014 to 31 December 2016.</p>",
-                            "id": "not-necessary-possible-section",
-                            "number": "9",
-                            "questions": [
-                                {
-                                    "answers": [
-                                        {
-                                            "description": "",
-                                            "id": "not-necessary-possible-answer",
-                                            "label": "Select all that apply",
-                                            "mandatory": false,
-                                            "options": [
-                                                {
-                                                    "label": "No need due to previous innovations",
-                                                    "q_code": "2011",
-                                                    "value": "No need due to previous innovations"
-                                                },
-                                                {
-                                                    "label": "No need due to market conditions",
-                                                    "q_code": "2020",
-                                                    "value": "No need due to market conditions"
-                                                },
-                                                {
-                                                    "label": "The UK does not have a business environment which encourages companies to innovate",
-                                                    "q_code": "2030",
-                                                    "value": "The UK does not have a business environment which encourages companies to innovate"
-                                                },
-                                                {
-                                                    "label": "Other",
-                                                    "q_code": "2040",
-                                                    "value": "Other"
-                                                }
-                                            ],
-                                            "type": "Checkbox"
-                                        }
-                                    ],
-                                    "description": "",
-                                    "id": "not-necessary-possible-question",
-                                    "number": "9.9",
-                                    "title": "If {{respondent.ru_name}} had no innovation activity, please indicate why it has not been necessary or possible to innovate",
-                                    "type": "General"
-                                }
-                            ],
-                            "title": "Co-operation on Innovation"
-                        }
-                    ],
-                    "type": "questionnaire"
-                },
-                {
                     "id": "innovations-protected-patents",
                     "sections": [
                         {
@@ -4365,7 +4646,7 @@
                                     ],
                                     "description": "<p>patents?</p>",
                                     "id": "innovations-protected-patents-question",
-                                    "number": "9.10",
+                                    "number": "9.9",
                                     "title": "What proportions of your innovations were protected by:",
                                     "type": "General"
                                 }
@@ -4414,7 +4695,7 @@
                                     ],
                                     "description": "<p>design registration?</p>",
                                     "id": "innovations-protected-design-question",
-                                    "number": "9.11",
+                                    "number": "9.10",
                                     "title": "What proportions of your innovations were protected by:",
                                     "type": "General"
                                 }
@@ -4463,7 +4744,7 @@
                                     ],
                                     "description": "<p>copyright?</p>",
                                     "id": "innovations-protected-copyright-question",
-                                    "number": "9.12",
+                                    "number": "9.11",
                                     "title": "What proportions of your innovations were protected by:",
                                     "type": "General"
                                 }
@@ -4512,7 +4793,7 @@
                                     ],
                                     "description": "<p>trademarks?</p>",
                                     "id": "innovations-protected-trademark-question",
-                                    "number": "9.13",
+                                    "number": "9.12",
                                     "title": "What proportions of your innovations  were protected by:",
                                     "type": "General"
                                 }
@@ -4561,7 +4842,7 @@
                                     ],
                                     "description": "<p>lead time advantages?</p>",
                                     "id": "innovations-protected-lead-time-question",
-                                    "number": "9.14",
+                                    "number": "9.13",
                                     "title": "What proportions of your innovations were protected by:",
                                     "type": "General"
                                 }
@@ -4610,7 +4891,7 @@
                                     ],
                                     "description": "<p>complexity of goods or services?</p>",
                                     "id": "innovations-protected-services-question",
-                                    "number": "9.15",
+                                    "number": "9.14",
                                     "title": "What proportions of your innovations were protected by:",
                                     "type": "General"
                                 }
@@ -4668,7 +4949,7 @@
                                         }
                                     ],
                                     "id": "innovations-protected-secrecy-question",
-                                    "number": "9.16",
+                                    "number": "9.15",
                                     "title": "What proportions of your innovations were protected by:",
                                     "type": "General"
                                 }
@@ -4701,6 +4982,97 @@
                 }
             ],
             "id": "co-operation-on-innovation",
+            "skip_condition": [
+                {
+                    "when": [
+                        {
+                            "id": "business-changes-business-practices-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "business-changes-organising-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "business-changes-external-relationships-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "business-changes-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "internal-investment-r-d-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "acquisition-internal-investment-r-d-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "investment-advanced-machinery-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "investment-existing-knowledge-innovation-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "investment-training-innovative-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "investment-design-future-innovation-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "investment-introduction-innovations-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "introducing-significantly-improved-goods-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "introduce-significantly-improvement-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "process-improved-answer",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "constraints-innovation-activities-abandoned-answser",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "constraints-innovation-activities-scaled-back-answser",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        },
+                        {
+                            "id": "constraints-innovation-activities-ongoing-2016-answser",
+                            "condition": "not equals",
+                            "value": "Yes"
+                        }
+                    ]
+                }
+            ],
             "title": "Co-operation on Innovation"
         },
         {

--- a/app/data/test_navigation.json
+++ b/app/data/test_navigation.json
@@ -124,6 +124,75 @@
             "blocks": [
                 {
                     "type": "questionnaire",
+                    "id": "house-type",
+                    "sections": [
+                        {
+                            "description": "",
+                            "id": "house-type-section",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "guidance": "",
+                                            "id": "house-type-answer",
+                                            "label": "",
+                                            "mandatory": false,
+                                            "options": [
+                                                {
+                                                    "label": "Detached",
+                                                    "value": "Detached"
+                                                },
+                                                {
+                                                    "label": "Semi-detached",
+                                                    "value": "Semi-detached"
+                                                },
+                                                {
+                                                    "label": "Terrace",
+                                                    "value": "Terrace"
+                                                }
+                                            ],
+                                            "q_code": "12",
+                                            "type": "Radio"
+                                        }
+                                    ],
+                                    "description": "",
+                                    "id": "house-type-question",
+                                    "title": "What kind of house is it?",
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "House Details"
+                        }
+                    ],
+                    "title": "House Details"
+                }
+            ],
+            "id": "house-details",
+            "skip_condition": [
+                {
+                    "when": [
+                        {
+                            "id": "insurance-type-answer",
+                            "condition": "equals",
+                            "value": "Contents"
+                        }
+                    ]
+                },
+                 {
+                    "when": [
+                        {
+                            "id": "insurance-type-answer",
+                            "condition": "not set"
+                        }
+                    ]
+                }
+            ],
+            "title": "House Details"
+        },
+        {
+            "blocks": [
+                {
+                    "type": "questionnaire",
                     "id": "household-composition",
                     "sections": [
                         {

--- a/app/helpers/schema_helper.py
+++ b/app/helpers/schema_helper.py
@@ -52,6 +52,10 @@ class SchemaHelper(object):
                 if 'repeat' in rule.keys():
                     return rule['repeat']
 
+    @staticmethod
+    def get_skip_condition(group):
+        return group.get('skip_condition')
+
     @classmethod
     def get_group(cls, survey_json, group_id):
         return next(g for g in cls.get_groups(survey_json) if g["id"] == group_id)

--- a/tests/app/questionnaire/test_navigation.py
+++ b/tests/app/questionnaire/test_navigation.py
@@ -518,3 +518,106 @@ class TestNavigation(unittest.TestCase):
         ]
 
         self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
+
+    def test_navigation_skip_condition_hide_group(self):
+        survey = load_schema_file("test_navigation.json")
+
+        metadata = {
+            "eq_id": '1',
+            "collection_exercise_sid": '999',
+            "form_type": "some_form"
+        }
+
+        completed_blocks = []
+
+        answer_store = AnswerStore()
+
+        answer_1 = Answer(
+            value="Contents",
+            group_instance=0,
+            block_id='insurance-type',
+            group_id='property-details',
+            answer_instance=0,
+            answer_id='insurance-type-answer'
+        )
+
+        answer_store.add(answer_1)
+
+        navigation = Navigation(survey, answer_store, metadata, completed_blocks=completed_blocks)
+        user_navigation = navigation.build_navigation('property-details', 0)
+        link_names = [d['link_name'] for d in user_navigation]
+        self.assertNotIn('House Details', link_names)
+
+    def test_navigation_skip_condition_show_group(self):
+        survey = load_schema_file("test_navigation.json")
+
+        metadata = {
+            "eq_id": '1',
+            "collection_exercise_sid": '999',
+            "form_type": "some_form"
+        }
+
+        completed_blocks = []
+
+        answer_store = AnswerStore()
+
+        answer_1 = Answer(
+            value="Buildings",
+            group_instance=0,
+            block_id='insurance-type',
+            group_id='property-details',
+            answer_instance=0,
+            answer_id='insurance-type-answer'
+        )
+
+        answer_store.add(answer_1)
+
+        navigation = Navigation(survey, answer_store, metadata, completed_blocks=completed_blocks)
+
+        user_navigation = navigation.build_navigation('property-details', 0)
+        link_names = [d['link_name'] for d in user_navigation]
+        self.assertIn('House Details', link_names)
+
+    def test_navigation_skip_condition_change_answer(self):
+        survey = load_schema_file("test_navigation.json")
+
+        metadata = {
+            "eq_id": '1',
+            "collection_exercise_sid": '999',
+            "form_type": "some_form"
+        }
+
+        completed_blocks = []
+
+        answer_store = AnswerStore()
+
+        answer_1 = Answer(
+            value="Buildings",
+            group_instance=0,
+            block_id='insurance-type',
+            group_id='property-details',
+            answer_instance=0,
+            answer_id='insurance-type-answer'
+        )
+
+        answer_store.add(answer_1)
+        navigation = Navigation(survey, answer_store, metadata, completed_blocks=completed_blocks)
+
+        user_navigation = navigation.build_navigation('property-details', 0)
+        link_names = [d['link_name'] for d in user_navigation]
+        self.assertIn('House Details', link_names)
+
+        change_answer = Answer(
+            value="Contents",
+            group_instance=0,
+            block_id='insurance-type',
+            group_id='property-details',
+            answer_instance=0,
+            answer_id='insurance-type-answer'
+        )
+
+        answer_store.update(change_answer)
+
+        user_navigation = navigation.build_navigation('property-details', 0)
+        link_names = [d['link_name'] for d in user_navigation]
+        self.assertNotIn('House Details', link_names)

--- a/tests/functional/pages/surveys/ukis/constraining-innovation-notnecessary.page.js
+++ b/tests/functional/pages/surveys/ukis/constraining-innovation-notnecessary.page.js
@@ -1,0 +1,13 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class ConstrainingInnovationNotnecessaryPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('not-necessary-possible')
+  }
+
+}
+
+export default new ConstrainingInnovationNotnecessaryPage()

--- a/tests/functional/pages/surveys/ukis/navigation.page.js
+++ b/tests/functional/pages/surveys/ukis/navigation.page.js
@@ -1,7 +1,7 @@
       class Navigation {
 
         navigateToInnovationActivitiesBusinessStrategyandPractices() {
-          browser.element('//a[contains(@href, \'innovation-activities-section-8-group-8/0/business-strategy-and-practices-block-7\')]').click()
+          browser.element('//a[contains(@href, \'business-strategy-practices/0/business-changes\')]').click()
           return this
         }
 
@@ -26,7 +26,7 @@
         }
 
         navigateToConstraintsonInnovation() {
-          browser.element('//a[contains(@href, \'innovation-activities-section-61-group-51/0/innovation-activities-block-35\')]').click()
+          browser.element('//a[contains(@href, \'constraints-on-innovation/0/constraints-innovation-activities\')]').click()
           return this
         }
 

--- a/tests/functional/spec/ukis/routing/why-no-innovation.spec.js
+++ b/tests/functional/spec/ukis/routing/why-no-innovation.spec.js
@@ -1,0 +1,459 @@
+  import chai from 'chai'
+  import {openQuestionnaire} from '../../../helpers'
+
+  import GeographicMarkets from '../../../pages/surveys/ukis/geographic-markets.page.js'
+  import SignificantEvents from '../../../pages/surveys/ukis/significant-events.page.js'
+  import GeneralBusinessInformationCompleted from '../../../pages/surveys/ukis/general-business-information-completed.page.js'
+  import BusinessChanges from '../../../pages/surveys/ukis/business-changes.page.js'
+  import BusinessStrategyPracticesCompleted from '../../../pages/surveys/ukis/business-strategy-practices-completed.page.js'
+  import InternalInvestmentRD from '../../../pages/surveys/ukis/internal-investment-r-d.page.js'
+  import YearsInternalInvestmentRD from '../../../pages/surveys/ukis/years-internal-investment-r-d.page.js'
+  import ExpenditureInternalInvestmentRD from '../../../pages/surveys/ukis/expenditure-internal-investment-r-d.page.js'
+  import AcquisitionInternalInvestmentRD from '../../../pages/surveys/ukis/acquisition-internal-investment-r-d.page.js'
+  import AmountAcquisitionInternalInvestmentRD from '../../../pages/surveys/ukis/amount-acquisition-internal-investment-r-d.page.js'
+  import InvestmentAdvancedMachinery from '../../../pages/surveys/ukis/investment-advanced-machinery.page.js'
+  import InvestmentPurposesInnovation from '../../../pages/surveys/ukis/investment-purposes-innovation.page.js'
+  import AmountAcquisitionAdvancedMachinery from '../../../pages/surveys/ukis/amount-acquisition-advanced-machinery.page.js'
+  import InvestmentExistingKnowledgeInnovation from '../../../pages/surveys/ukis/investment-existing-knowledge-innovation.page.js'
+  import ExpenditureExisting2016 from '../../../pages/surveys/ukis/expenditure-existing-2016.page.js'
+  import InvestmentTrainingInnovative from '../../../pages/surveys/ukis/investment-training-innovative.page.js'
+  import ExpenditureTrainingInnovative2016 from '../../../pages/surveys/ukis/expenditure-training-innovative-2016.page.js'
+  import InvestmentDesignFutureInnovation from '../../../pages/surveys/ukis/investment-design-future-innovation.page.js'
+  import ExpenditureDesign2016 from '../../../pages/surveys/ukis/expenditure-design-2016.page.js'
+  import InvestmentIntroductionInnovations from '../../../pages/surveys/ukis/investment-introduction-innovations.page.js'
+  import InvestmentPurposesInnovation2 from '../../../pages/surveys/ukis/investment-purposes-innovation-2.page.js'
+  import ExpenditureIntroductionInnovations2016 from '../../../pages/surveys/ukis/expenditure-introduction-innovations-2016.page.js'
+  import InnovationInvestmentCompleted from '../../../pages/surveys/ukis/innovation-investment-completed.page.js'
+  import IntroducingSignificantlyImprovedGoods from '../../../pages/surveys/ukis/introducing-significantly-improved-goods.page.js'
+  import EntityDevelopedTheseGoods from '../../../pages/surveys/ukis/entity-developed-these-goods.page.js'
+  import IntroduceSignificantlyImprovement from '../../../pages/surveys/ukis/introduce-significantly-improvement.page.js'
+  import EntityMainlyDevelopedThese from '../../../pages/surveys/ukis/entity-mainly-developed-these.page.js'
+  import NewGoodsServicesInnovations from '../../../pages/surveys/ukis/new-goods-services-innovations.page.js'
+  import GoodsServicesInnovationsNew from '../../../pages/surveys/ukis/goods-services-innovations-new.page.js'
+  import PercentageTurnover2016 from '../../../pages/surveys/ukis/percentage-turnover-2016.page.js'
+  import GoodsAndServicesInnovationCompleted from '../../../pages/surveys/ukis/goods-and-services-innovation-completed.page.js'
+  import ProcessImproved from '../../../pages/surveys/ukis/process-improved.page.js'
+  import DevelopedProcesses from '../../../pages/surveys/ukis/developed-processes.page.js'
+  import ImprovedProcesses from '../../../pages/surveys/ukis/improved-processes.page.js'
+  import ProcessInnovationCompleted from '../../../pages/surveys/ukis/process-innovation-completed.page.js'
+  import ConstraintsInnovationActivities from '../../../pages/surveys/ukis/constraints-innovation-activities.page.js'
+  import ConstrainingInnovationEconomic from '../../../pages/surveys/ukis/constraining-innovation-economic.page.js'
+  import ConstrainingInnovationCosts from '../../../pages/surveys/ukis/constraining-innovation-costs.page.js'
+  import ConstrainingInnovationFinance from '../../../pages/surveys/ukis/constraining-innovation-finance.page.js'
+  import ConstrainingInnovationAvailableFinance from '../../../pages/surveys/ukis/constraining-innovation-available-finance.page.js'
+  import ConstrainingInnovationLackQualified from '../../../pages/surveys/ukis/constraining-innovation-lack-qualified.page.js'
+  import ConstrainingInnovationLackTechnology from '../../../pages/surveys/ukis/constraining-innovation-lack-technology.page.js'
+  import ConstrainingInnovationLackInformation from '../../../pages/surveys/ukis/constraining-innovation-lack-information.page.js'
+  import ConstrainingInnovationDominated from '../../../pages/surveys/ukis/constraining-innovation-dominated.page.js'
+  import ConstrainingInnovationUncertain from '../../../pages/surveys/ukis/constraining-innovation-uncertain.page.js'
+  import ConstrainingInnovationGovernment from '../../../pages/surveys/ukis/constraining-innovation-government.page.js'
+  import ConstrainingInnovationEu from '../../../pages/surveys/ukis/constraining-innovation-eu.page.js'
+  import ConstrainingInnovationReferendum from '../../../pages/surveys/ukis/constraining-innovation-referendum.page.js'
+  import ConstrainingInnovationNotNecessary from '../../../pages/surveys/ukis/constraining-innovation-notnecessary.page.js'
+  import ConstraintsOnInnovationCompleted from '../../../pages/surveys/ukis/constraints-on-innovation-completed.page.js'
+  import FactorsAffectingIncreasingRange from '../../../pages/surveys/ukis/factors-affecting-increasing-range.page.js'
+  import FactorsAffectingNewMarkets from '../../../pages/surveys/ukis/factors-affecting-new-markets.page.js'
+  import FactorsAffectingMarketShare from '../../../pages/surveys/ukis/factors-affecting-market-share.page.js'
+  import FactorsAffectingQuality from '../../../pages/surveys/ukis/factors-affecting-quality.page.js'
+  import FactorsAffectingFlexibility from '../../../pages/surveys/ukis/factors-affecting-flexibility.page.js'
+  import FactorsAffectingCapacity from '../../../pages/surveys/ukis/factors-affecting-capacity.page.js'
+  import FactorsAffectingValue from '../../../pages/surveys/ukis/factors-affecting-value.page.js'
+  import FactorsAffectingReducingCost from '../../../pages/surveys/ukis/factors-affecting-reducing-cost.page.js'
+  import FactorsAffectingHealthSafety from '../../../pages/surveys/ukis/factors-affecting-health-safety.page.js'
+  import FactorsAffectingEnvironmental from '../../../pages/surveys/ukis/factors-affecting-environmental.page.js'
+  import FactorsAffectingReplacing from '../../../pages/surveys/ukis/factors-affecting-replacing.page.js'
+  import FactorsAffectingRegulatory from '../../../pages/surveys/ukis/factors-affecting-regulatory.page.js'
+  import FactorsAffectingCompleted from '../../../pages/surveys/ukis/factors-affecting-completed.page.js'
+  import ImportancesInformationInnovation from '../../../pages/surveys/ukis/importances-information-innovation.page.js'
+  import ImportancesInformationSuppliers from '../../../pages/surveys/ukis/importances-information-suppliers.page.js'
+  import ImportancesInformationClient from '../../../pages/surveys/ukis/importances-information-client.page.js'
+  import ImportancesInformationPublicSector from '../../../pages/surveys/ukis/importances-information-public-sector.page.js'
+  import ImportancesInformationCompetitors from '../../../pages/surveys/ukis/importances-information-competitors.page.js'
+  import ImportancesInformationConsultants from '../../../pages/surveys/ukis/importances-information-consultants.page.js'
+  import ImportancesInformationUniversities from '../../../pages/surveys/ukis/importances-information-universities.page.js'
+  import ImportancesInformationGovernment from '../../../pages/surveys/ukis/importances-information-government.page.js'
+  import ImportancesInformationConferences from '../../../pages/surveys/ukis/importances-information-conferences.page.js'
+  import ImportancesInformationAssociations from '../../../pages/surveys/ukis/importances-information-associations.page.js'
+  import ImportancesInformationStandards from '../../../pages/surveys/ukis/importances-information-standards.page.js'
+  import ImportancesInformationPublications from '../../../pages/surveys/ukis/importances-information-publications.page.js'
+  import InformationNeededForInnovationCompleted from '../../../pages/surveys/ukis/information-needed-for-innovation-completed.page.js'
+  import CoOperationOtherBusinesses from '../../../pages/surveys/ukis/co-operation-other-businesses.page.js'
+  import CoOperationSuppliers from '../../../pages/surveys/ukis/co-operation-suppliers.page.js'
+  import CoOperationPrivateSector from '../../../pages/surveys/ukis/co-operation-private-sector.page.js'
+  import CoOperationPublicSector from '../../../pages/surveys/ukis/co-operation-public-sector.page.js'
+  import CoOperationCompetitors from '../../../pages/surveys/ukis/co-operation-competitors.page.js'
+  import CoOperationConsultants from '../../../pages/surveys/ukis/co-operation-consultants.page.js'
+  import CoOperationInstitutions from '../../../pages/surveys/ukis/co-operation-institutions.page.js'
+  import CoOperationGovernment from '../../../pages/surveys/ukis/co-operation-government.page.js'
+  import NotNecessaryPossible from '../../../pages/surveys/ukis/not-necessary-possible.page.js'
+  import InnovationsProtectedPatents from '../../../pages/surveys/ukis/innovations-protected-patents.page.js'
+  import InnovationsProtectedDesign from '../../../pages/surveys/ukis/innovations-protected-design.page.js'
+  import InnovationsProtectedCopyright from '../../../pages/surveys/ukis/innovations-protected-copyright.page.js'
+  import InnovationsProtectedTrademark from '../../../pages/surveys/ukis/innovations-protected-trademark.page.js'
+  import InnovationsProtectedLeadTime from '../../../pages/surveys/ukis/innovations-protected-lead-time.page.js'
+  import InnovationsProtectedServices from '../../../pages/surveys/ukis/innovations-protected-services.page.js'
+  import InnovationsProtectedSecrecy from '../../../pages/surveys/ukis/innovations-protected-secrecy.page.js'
+  import CoOperationOnInnovationCompleted from '../../../pages/surveys/ukis/co-operation-on-innovation-completed.page.js'
+  import PublicFinancialSupport from '../../../pages/surveys/ukis/public-financial-support.page.js'
+  import KindFinancialCentralGovernmentSupport from '../../../pages/surveys/ukis/kind-financial-central-government-support.page.js'
+  import PublicFinancialSupportForInnovationCompleted from '../../../pages/surveys/ukis/public-financial-support-for-innovation-completed.page.js'
+  import Turnover2014 from '../../../pages/surveys/ukis/turnover-2014.page.js'
+  import Turnover2016 from '../../../pages/surveys/ukis/turnover-2016.page.js'
+  import Exports2016 from '../../../pages/surveys/ukis/exports-2016.page.js'
+  import TurnoverAndExportsCompleted from '../../../pages/surveys/ukis/turnover-and-exports-completed.page.js'
+  import Employees2014 from '../../../pages/surveys/ukis/employees-2014.page.js'
+  import Employees2016 from '../../../pages/surveys/ukis/employees-2016.page.js'
+  import EmployeesQualifications2016 from '../../../pages/surveys/ukis/employees-qualifications-2016.page.js'
+  import EmployeesInHouseSkills from '../../../pages/surveys/ukis/employees-in-house-skills.page.js'
+  import EmployeesAndSkillsCompleted from '../../../pages/surveys/ukis/employees-and-skills-completed.page.js'
+  import AdditionalComments from '../../../pages/surveys/ukis/additional-comments.page.js'
+  import HowLong from '../../../pages/surveys/ukis/how-long.page.js'
+  import ApproachedTelephone from '../../../pages/surveys/ukis/approached-telephone.page.js'
+  import ReadyToSubmitCompleted from '../../../pages/surveys/ukis/ready-to-submit-completed.page.js'
+  import Navigation from '../../../pages/surveys/ukis/navigation.page.js'
+
+  const expect = chai.expect
+
+  describe('UKIS - Should the description be UKIS - Yes to 2.1, 3.1, 3.4, 3.6, 3.9, 3.11, 3.13, 3.15, 4.1, 4.3, 5.1 6.1 skips to interstitial section 6', function() {
+
+    it('Given I have selected Yes to 2.1, When I do not answer 6.13, Then I will be routed to Section 7', function() {
+      openQuestionnaire('1_0001.json')
+      Navigation.navigateToInnovationActivitiesBusinessStrategyandPractices()
+      BusinessChanges.clickBusinessChangesBusinessPracticesAnswerYes()
+        .clickBusinessChangesOrganisingAnswerYes()
+        .clickBusinessChangesExternalRelationshipsAnswerYes()
+        .clickBusinessChangesAnswerYes()
+        .submit()
+      Navigation.navigateToConstraintsonInnovation()
+      ConstraintsInnovationActivities.submit()
+      ConstrainingInnovationEconomic.submit()
+      ConstrainingInnovationCosts.submit()
+      ConstrainingInnovationFinance.submit()
+      ConstrainingInnovationAvailableFinance.submit()
+      ConstrainingInnovationLackQualified.submit()
+      ConstrainingInnovationLackTechnology.submit()
+      ConstrainingInnovationLackInformation.submit()
+      ConstrainingInnovationDominated.submit()
+      ConstrainingInnovationUncertain.submit()
+      ConstrainingInnovationGovernment.submit()
+      ConstrainingInnovationEu.submit()
+      ConstrainingInnovationReferendum.submit()
+      ConstraintsOnInnovationCompleted.submit()
+      expect(FactorsAffectingIncreasingRange.isOpen()).to.equal(true, 'Expected to navigate to Section 7')
+    })
+
+    it('Given I have selected Yes to 3.1, When I am answering question 6.13 , Then I will NOT see question 6.14 and will be routed to section 7', function() {
+      openQuestionnaire('1_0001.json')
+      Navigation.navigateToInnovationInvestment()
+      InternalInvestmentRD.clickInternalInvestmentRDAnswerYes().submit()
+      Navigation.navigateToConstraintsonInnovation()
+      ConstraintsInnovationActivities.submit()
+      ConstrainingInnovationEconomic.submit()
+      ConstrainingInnovationCosts.submit()
+      ConstrainingInnovationFinance.submit()
+      ConstrainingInnovationAvailableFinance.submit()
+      ConstrainingInnovationLackQualified.submit()
+      ConstrainingInnovationLackTechnology.submit()
+      ConstrainingInnovationLackInformation.submit()
+      ConstrainingInnovationDominated.submit()
+      ConstrainingInnovationUncertain.submit()
+      ConstrainingInnovationGovernment.submit()
+      ConstrainingInnovationEu.submit()
+      ConstrainingInnovationReferendum.submit()
+      ConstraintsOnInnovationCompleted.submit()
+      expect(FactorsAffectingIncreasingRange.isOpen()).to.equal(true, 'Expected to navigate to Section 7')
+    })
+
+    it('Given I have selected Yes to 3.4, When I am answering question 6.13, Then I will NOT see question 6.14 and will be routed to section 7', function() {
+      openQuestionnaire('1_0001.json')
+      Navigation.navigateToInnovationInvestment()
+      InternalInvestmentRD.submit()
+      AcquisitionInternalInvestmentRD.clickAcquisitionInternalInvestmentRDAnswerYes().submit()
+      Navigation.navigateToConstraintsonInnovation()
+      ConstraintsInnovationActivities.submit()
+      ConstrainingInnovationEconomic.submit()
+      ConstrainingInnovationCosts.submit()
+      ConstrainingInnovationFinance.submit()
+      ConstrainingInnovationAvailableFinance.submit()
+      ConstrainingInnovationLackQualified.submit()
+      ConstrainingInnovationLackTechnology.submit()
+      ConstrainingInnovationLackInformation.submit()
+      ConstrainingInnovationDominated.submit()
+      ConstrainingInnovationUncertain.submit()
+      ConstrainingInnovationGovernment.submit()
+      ConstrainingInnovationEu.submit()
+      ConstrainingInnovationReferendum.submit()
+      ConstraintsOnInnovationCompleted.submit()
+      expect(FactorsAffectingIncreasingRange.isOpen()).to.equal(true, 'Expected to navigate to Section 7')
+    })
+
+    it('Given I have selected Yes to 3.6, When I am answering question 6.13, Then I will NOT see question 6.14 and will be routed toto section 7', function() {
+      openQuestionnaire('1_0001.json')
+      Navigation.navigateToInnovationInvestment()
+      InternalInvestmentRD.submit()
+      AcquisitionInternalInvestmentRD.submit()
+      InvestmentAdvancedMachinery.clickInvestmentAdvancedMachineryAnswerYes().submit()
+      Navigation.navigateToConstraintsonInnovation()
+      ConstraintsInnovationActivities.submit()
+      ConstrainingInnovationEconomic.submit()
+      ConstrainingInnovationCosts.submit()
+      ConstrainingInnovationFinance.submit()
+      ConstrainingInnovationAvailableFinance.submit()
+      ConstrainingInnovationLackQualified.submit()
+      ConstrainingInnovationLackTechnology.submit()
+      ConstrainingInnovationLackInformation.submit()
+      ConstrainingInnovationDominated.submit()
+      ConstrainingInnovationUncertain.submit()
+      ConstrainingInnovationGovernment.submit()
+      ConstrainingInnovationEu.submit()
+      ConstrainingInnovationReferendum.submit()
+      ConstraintsOnInnovationCompleted.submit()
+      expect(FactorsAffectingIncreasingRange.isOpen()).to.equal(true, 'Expected to navigate to Section 7')
+    })
+
+    it('Given I have selected Yes to 3.9, When I am answering question 6.13, Then I will NOT see question 6.14 and will be routed to section 7', function() {
+      openQuestionnaire('1_0001.json')
+      Navigation.navigateToInnovationInvestment()
+      InternalInvestmentRD.submit()
+      AcquisitionInternalInvestmentRD.submit()
+      InvestmentAdvancedMachinery.submit()
+      InvestmentExistingKnowledgeInnovation.clickInvestmentExistingKnowledgeInnovationAnswerYes().submit()
+      Navigation.navigateToConstraintsonInnovation()
+      ConstraintsInnovationActivities.submit()
+      ConstrainingInnovationEconomic.submit()
+      ConstrainingInnovationCosts.submit()
+      ConstrainingInnovationFinance.submit()
+      ConstrainingInnovationAvailableFinance.submit()
+      ConstrainingInnovationLackQualified.submit()
+      ConstrainingInnovationLackTechnology.submit()
+      ConstrainingInnovationLackInformation.submit()
+      ConstrainingInnovationDominated.submit()
+      ConstrainingInnovationUncertain.submit()
+      ConstrainingInnovationGovernment.submit()
+      ConstrainingInnovationEu.submit()
+      ConstrainingInnovationReferendum.submit()
+      ConstraintsOnInnovationCompleted.submit()
+      expect(FactorsAffectingIncreasingRange.isOpen()).to.equal(true, 'Expected to navigate to Section 7')
+    })
+
+    it('Given I have selected Yes to 3.11, When I am answering question 6.13 , Then I will NOT see question 6.14 and will be routed to section 7', function() {
+      openQuestionnaire('1_0001.json')
+      Navigation.navigateToInnovationInvestment()
+      InternalInvestmentRD.submit()
+      AcquisitionInternalInvestmentRD.submit()
+      InvestmentAdvancedMachinery.submit()
+      InvestmentExistingKnowledgeInnovation.submit()
+      InvestmentTrainingInnovative.clickInvestmentTrainingInnovativeAnswerYes().submit()
+      Navigation.navigateToConstraintsonInnovation()
+      ConstraintsInnovationActivities.submit()
+      ConstrainingInnovationEconomic.submit()
+      ConstrainingInnovationCosts.submit()
+      ConstrainingInnovationFinance.submit()
+      ConstrainingInnovationAvailableFinance.submit()
+      ConstrainingInnovationLackQualified.submit()
+      ConstrainingInnovationLackTechnology.submit()
+      ConstrainingInnovationLackInformation.submit()
+      ConstrainingInnovationDominated.submit()
+      ConstrainingInnovationUncertain.submit()
+      ConstrainingInnovationGovernment.submit()
+      ConstrainingInnovationEu.submit()
+      ConstrainingInnovationReferendum.submit()
+      ConstraintsOnInnovationCompleted.submit()
+      expect(FactorsAffectingIncreasingRange.isOpen()).to.equal(true, 'Expected to navigate to Section 7')
+    })
+
+    it('Given I have selected Yes to 3.13, When I am answering question 6.13, Then I will NOT see question 6.14 and will be routed to section 7', function() {
+      openQuestionnaire('1_0001.json')
+      Navigation.navigateToInnovationInvestment()
+      InternalInvestmentRD.submit()
+      AcquisitionInternalInvestmentRD.submit()
+      InvestmentAdvancedMachinery.submit()
+      InvestmentExistingKnowledgeInnovation.submit()
+      InvestmentTrainingInnovative.submit()
+      InvestmentDesignFutureInnovation.clickInvestmentDesignFutureInnovationAnswerYes().submit()
+      Navigation.navigateToConstraintsonInnovation()
+      ConstraintsInnovationActivities.submit()
+      ConstrainingInnovationEconomic.submit()
+      ConstrainingInnovationCosts.submit()
+      ConstrainingInnovationFinance.submit()
+      ConstrainingInnovationAvailableFinance.submit()
+      ConstrainingInnovationLackQualified.submit()
+      ConstrainingInnovationLackTechnology.submit()
+      ConstrainingInnovationLackInformation.submit()
+      ConstrainingInnovationDominated.submit()
+      ConstrainingInnovationUncertain.submit()
+      ConstrainingInnovationGovernment.submit()
+      ConstrainingInnovationEu.submit()
+      ConstrainingInnovationReferendum.submit()
+      ConstraintsOnInnovationCompleted.submit()
+      expect(FactorsAffectingIncreasingRange.isOpen()).to.equal(true, 'Expected to navigate to Section 7')
+    })
+
+    it('Given I have selected Yes to 3.15, When I am answering question 6.13, Then I will NOT see question 6.14 and will be routed to section 7', function() {
+      openQuestionnaire('1_0001.json')
+      Navigation.navigateToInnovationInvestment()
+      InternalInvestmentRD.submit()
+      AcquisitionInternalInvestmentRD.submit()
+      InvestmentAdvancedMachinery.submit()
+      InvestmentExistingKnowledgeInnovation.submit()
+      InvestmentTrainingInnovative.submit()
+      InvestmentDesignFutureInnovation.submit()
+      InvestmentIntroductionInnovations.clickInvestmentIntroductionInnovationsAnswerYes().submit()
+      Navigation.navigateToConstraintsonInnovation()
+      ConstraintsInnovationActivities.submit()
+      ConstrainingInnovationEconomic.submit()
+      ConstrainingInnovationCosts.submit()
+      ConstrainingInnovationFinance.submit()
+      ConstrainingInnovationAvailableFinance.submit()
+      ConstrainingInnovationLackQualified.submit()
+      ConstrainingInnovationLackTechnology.submit()
+      ConstrainingInnovationLackInformation.submit()
+      ConstrainingInnovationDominated.submit()
+      ConstrainingInnovationUncertain.submit()
+      ConstrainingInnovationGovernment.submit()
+      ConstrainingInnovationEu.submit()
+      ConstrainingInnovationReferendum.submit()
+      ConstraintsOnInnovationCompleted.submit()
+      expect(FactorsAffectingIncreasingRange.isOpen()).to.equal(true, 'Expected to navigate to Section 7')
+    })
+
+    it('Given I have selected Yes to 4.1, When I am answering question 6.13, Then I will NOT see question 6.14 and will be routed to section 7', function() {
+      openQuestionnaire('1_0001.json')
+      Navigation.navigateToGoodsandServicesInnovation()
+      IntroducingSignificantlyImprovedGoods.clickIntroducingSignificantlyImprovedGoodsAnswerYes().submit()
+      Navigation.navigateToConstraintsonInnovation()
+      ConstraintsInnovationActivities.submit()
+      ConstrainingInnovationEconomic.submit()
+      ConstrainingInnovationCosts.submit()
+      ConstrainingInnovationFinance.submit()
+      ConstrainingInnovationAvailableFinance.submit()
+      ConstrainingInnovationLackQualified.submit()
+      ConstrainingInnovationLackTechnology.submit()
+      ConstrainingInnovationLackInformation.submit()
+      ConstrainingInnovationDominated.submit()
+      ConstrainingInnovationUncertain.submit()
+      ConstrainingInnovationGovernment.submit()
+      ConstrainingInnovationEu.submit()
+      ConstrainingInnovationReferendum.submit()
+      ConstraintsOnInnovationCompleted.submit()
+      expect(FactorsAffectingIncreasingRange.isOpen()).to.equal(true, 'Expected to navigate to Section 7')
+    })
+
+    it('Given I have selected Yes to 4.3, When I am answering question 6.13, Then I will NOT see question 6.14 and will be routed to section 7', function() {
+      openQuestionnaire('1_0001.json')
+      Navigation.navigateToGoodsandServicesInnovation()
+      IntroducingSignificantlyImprovedGoods.submit()
+      IntroduceSignificantlyImprovement.clickIntroduceSignificantlyImprovementAnswerYes().submit()
+      Navigation.navigateToConstraintsonInnovation()
+      ConstraintsInnovationActivities.submit()
+      ConstrainingInnovationEconomic.submit()
+      ConstrainingInnovationCosts.submit()
+      ConstrainingInnovationFinance.submit()
+      ConstrainingInnovationAvailableFinance.submit()
+      ConstrainingInnovationLackQualified.submit()
+      ConstrainingInnovationLackTechnology.submit()
+      ConstrainingInnovationLackInformation.submit()
+      ConstrainingInnovationDominated.submit()
+      ConstrainingInnovationUncertain.submit()
+      ConstrainingInnovationGovernment.submit()
+      ConstrainingInnovationEu.submit()
+      ConstrainingInnovationReferendum.submit()
+      ConstraintsOnInnovationCompleted.submit()
+      expect(FactorsAffectingIncreasingRange.isOpen()).to.equal(true, 'Expected to navigate to Section 7')
+    })
+
+    it('Given I have selected Yes to 5.1, When I am answering question 6.13, Then I will NOT see question 6.14 and will be routed to section 7', function() {
+      openQuestionnaire('1_0001.json')
+      Navigation.navigateToProcessInnovation()
+      ProcessImproved.clickProcessImprovedAnswerYes().submit()
+      Navigation.navigateToConstraintsonInnovation()
+      ConstraintsInnovationActivities.submit()
+      ConstrainingInnovationEconomic.submit()
+      ConstrainingInnovationCosts.submit()
+      ConstrainingInnovationFinance.submit()
+      ConstrainingInnovationAvailableFinance.submit()
+      ConstrainingInnovationLackQualified.submit()
+      ConstrainingInnovationLackTechnology.submit()
+      ConstrainingInnovationLackInformation.submit()
+      ConstrainingInnovationDominated.submit()
+      ConstrainingInnovationUncertain.submit()
+      ConstrainingInnovationGovernment.submit()
+      ConstrainingInnovationEu.submit()
+      ConstrainingInnovationReferendum.submit()
+      ConstraintsOnInnovationCompleted.submit()
+      expect(FactorsAffectingIncreasingRange.isOpen()).to.equal(true, 'Expected to navigate to Section 7')
+    })
+
+    it('Given I have selected Yes to 6.1, When I am answering question 6.13, Then I will NOT see question 6.14 and will be routed to section 7', function() {
+      openQuestionnaire('1_0001.json')
+      Navigation.navigateToConstraintsonInnovation()
+      ConstraintsInnovationActivities.clickConstraintsInnovationActivitiesAbandonedAnswserYes()
+        .clickConstraintsInnovationActivitiesScaledBackAnswserYes()
+        .clickConstraintsInnovationActivitiesOngoing2016AnswserYes()
+        .submit()
+      ConstrainingInnovationEconomic.submit()
+      ConstrainingInnovationCosts.submit()
+      ConstrainingInnovationFinance.submit()
+      ConstrainingInnovationAvailableFinance.submit()
+      ConstrainingInnovationLackQualified.submit()
+      ConstrainingInnovationLackTechnology.submit()
+      ConstrainingInnovationLackInformation.submit()
+      ConstrainingInnovationDominated.submit()
+      ConstrainingInnovationUncertain.submit()
+      ConstrainingInnovationGovernment.submit()
+      ConstrainingInnovationEu.submit()
+      ConstrainingInnovationReferendum.submit()
+      ConstraintsOnInnovationCompleted.submit()
+      expect(FactorsAffectingIncreasingRange.isOpen()).to.equal(true, 'Expected to navigate to Section 7')
+    })
+
+    it('Given I have a combination of NO and not selected answers to questions 2.1, 3.1, 3.4, 3.6, 3.9, 3.11, 3.13, 3.15, 4.1, 4.3, 5.1 6.1, When I am answering question 6.13, Then I WILL see question 6.14 and then be routed to section 10', function() {
+      openQuestionnaire('1_0001.json')
+      Navigation.navigateToInnovationActivitiesBusinessStrategyandPractices()
+      BusinessChanges.clickBusinessChangesBusinessPracticesAnswerNo()
+        .clickBusinessChangesOrganisingAnswerNo()
+        .clickBusinessChangesExternalRelationshipsAnswerNo()
+        .clickBusinessChangesAnswerNo()
+        .submit()
+      Navigation.navigateToConstraintsonInnovation()
+      ConstraintsInnovationActivities.submit()
+      ConstrainingInnovationEconomic.submit()
+      ConstrainingInnovationCosts.submit()
+      ConstrainingInnovationFinance.submit()
+      ConstrainingInnovationAvailableFinance.submit()
+      ConstrainingInnovationLackQualified.submit()
+      ConstrainingInnovationLackTechnology.submit()
+      ConstrainingInnovationLackInformation.submit()
+      ConstrainingInnovationDominated.submit()
+      ConstrainingInnovationUncertain.submit()
+      ConstrainingInnovationGovernment.submit()
+      ConstrainingInnovationEu.submit()
+      ConstrainingInnovationReferendum.submit()
+      ConstrainingInnovationNotNecessary.submit()
+      ConstraintsOnInnovationCompleted.submit()
+      expect(PublicFinancialSupport.isOpen()).to.equal(true, 'Expected to Navigate to question 10.1')
+    })
+
+    it('Given I have not selected answers to questions 2.1, 3.1, 3.4, 3.6, 3.9, 3.11, 3.13, 3.15, 4.1, 4.3, 5.1 6.1, When I am answering question 6.13, Then I WILL see question 6.14 and then be routed to section 10', function() {
+      openQuestionnaire('1_0001.json')
+      Navigation.navigateToInnovationActivitiesBusinessStrategyandPractices()
+      BusinessChanges.submit()
+      Navigation.navigateToConstraintsonInnovation()
+      ConstraintsInnovationActivities.submit()
+      ConstrainingInnovationEconomic.submit()
+      ConstrainingInnovationCosts.submit()
+      ConstrainingInnovationFinance.submit()
+      ConstrainingInnovationAvailableFinance.submit()
+      ConstrainingInnovationLackQualified.submit()
+      ConstrainingInnovationLackTechnology.submit()
+      ConstrainingInnovationLackInformation.submit()
+      ConstrainingInnovationDominated.submit()
+      ConstrainingInnovationUncertain.submit()
+      ConstrainingInnovationGovernment.submit()
+      ConstrainingInnovationEu.submit()
+      ConstrainingInnovationReferendum.submit()
+      ConstrainingInnovationNotNecessary.submit()
+      ConstraintsOnInnovationCompleted.submit()
+      expect(PublicFinancialSupport.isOpen()).to.equal(true, 'Expected to Navigate to question 10.1')
+    })
+  })


### PR DESCRIPTION
### What is the context of this PR?
When a group has a skip condition on it, it should be hidden in the navigation until it is answered. It should also be hidden if it matches that skip condition and appear if it doesn't

N.B this also includes the moving of 9.9 to 16.14 as written on the Story
### How to review 
Using test_navigation.json, 
1. Confirm that the navigation on the right has only 4 sections (Property Details, Household Details, Extra Cover, Payment Details) 
2. Leaving the first question empty, complete the first group and make sure it goes next to Household Details
3. Go back to Property Details group and repeat but answer the first questions with 'Buildings', confirm a new section appears in the navigation and on completion of the first group it goes to the House Details group.
4. Go back to Property Details and repeat but answer the first question 'Contents', notice the section in navigation disappears and after completing the group it goes to Household Details
