### PR TITLE
Eq 857 update Travis configuration to use Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 sudo: required
 dist: trusty
-python: '3.5'
+python: '3.4'
 env:
   global:
     - EQ_SCHEMA_BUCKET=""

--- a/tests/app/data/test_schema_id_regex.py
+++ b/tests/app/data/test_schema_id_regex.py
@@ -1,7 +1,8 @@
 import logging
 import os
 import unittest
-from json import JSONDecodeError, load
+
+from json import load
 
 from jsonschema import ValidationError, validate
 
@@ -29,8 +30,6 @@ def validate_json_against_schema(json_to_validate, schema):
     except ValidationError as e:
         return ["Schema Validation Error! JSON [{}] does not validate against schema. Error [{}]"
                 .format(json_to_validate, e)]
-    except JSONDecodeError as e:
-        return ["JSON Parse Error! Could not parse [{}]. Error [{}]".format(json_to_validate, e)]
 
 
 class TestSchemaIdRegEx(unittest.TestCase):

--- a/tests/app/data/test_schema_validation.py
+++ b/tests/app/data/test_schema_validation.py
@@ -1,7 +1,10 @@
+
+from json import load
+
+import json
 import logging
 import os
 import unittest
-from json import load, JSONDecodeError
 
 import jsonschema
 from jsonschema import validate
@@ -25,18 +28,12 @@ class TestSchemaValidation(unittest.TestCase):
         schema = load(schema_file)
 
         for file in files:
+            json_file = open(os.path.join(settings.EQ_SCHEMA_DIRECTORY, file), encoding="utf8")
+            json_to_validate = json.load(json_file)
 
-            try:
-                json_file = open(os.path.join(settings.EQ_SCHEMA_DIRECTORY, file), encoding="utf8")
-                json_to_validate = load(json_file)
-
-                errors.extend(self.validate_json_against_schema(file, json_to_validate, schema))
-
-                errors.extend(self.validate_schema_contains_valid_routing_rules(file, json_to_validate))
-
-                errors.extend(self.validate_routing_rules_has_default_if_not_all_answers_routed(file, json_to_validate))
-            except JSONDecodeError as e:
-                errors.append("JSON Decode Error! Could not decode [{}]. Error [{}]".format(file, e))
+            errors.extend(self.validate_json_against_schema(file, json_to_validate, schema))
+            errors.extend(self.validate_schema_contains_valid_routing_rules(file, json_to_validate))
+            errors.extend(self.validate_routing_rules_has_default_if_not_all_answers_routed(file, json_to_validate))
 
         if errors:
             for error in errors:
@@ -81,7 +78,7 @@ class TestSchemaValidation(unittest.TestCase):
             return []
         except jsonschema.exceptions.ValidationError as e:
             return ["Schema Validation Error! File [{}] does not validate against schema. Error [{}]".format(file, e)]
-        except JSONDecodeError as e:
+        except Exception as e:
             return ["JSON Parse Error! Could not parse [{}]. Error [{}]".format(file, e)]
 
     @classmethod

--- a/tests/integration/questionnaire/test_questionnaire_previous_link.py
+++ b/tests/integration/questionnaire/test_questionnaire_previous_link.py
@@ -31,7 +31,7 @@ class TestQuestionnairePreviousLink(IntegrationTestCase):
         block_one_url, resp = self.postRedirectGet(base_url + 'introduction', post_data)
 
         content = resp.get_data(True)
-        self.assertNotRegexpMatches(content, 'Previous')
+        self.assertNotRegex(content, 'Previous')
 
         post_data = {
             "ca3ce3a3-ae44-4e30-8f85-5b6a7a2fb23c": " Bacon",


### PR DESCRIPTION
### What is the context of this PR?
Changed Travis configuration to use the Python 3.4 interpreter so that it more closely resembles what's available in Elastic Beanstalk (3.4.3).
Updated some tests that used features not available in the 3.4 standard libraries.

### How to review 
All tests should pass and Travis build should succeed.
