### PR TITLE
eq-758 Household errors pre-exist bug

### DIFF
--- a/app/assets/js/app/modules/household.js
+++ b/app/assets/js/app/modules/household.js
@@ -25,6 +25,7 @@ class HouseholdMember extends EventEmitter {
       const fieldNodes = this.node.querySelector('.js-fields')
       if (fieldNodes) {
         errorNode.innerHTML = ''
+        errorNode.classList.remove('js-has-errors')
         errorNode.appendChild(fieldNodes)
       }
     }

--- a/app/templates/partials/answer.html
+++ b/app/templates/partials/answer.html
@@ -5,7 +5,7 @@
 <div class="answer answer--{{answer.schema_item.type|lower}} {{'js-has-errors' if invalid}}" id="{{answer.schema_item.widget.id}}">
 
   {% if render_guidance != False %}
-    
+
   {%- set answer_guidance %}
     {% if answer.schema_item.guidance %}
       {% with answer_guidance = {
@@ -21,7 +21,7 @@
   {% endif %}
 
   {%- set answer_fields %}
-    <div class="answer__fields">
+    <div class="answer__fields js-fields">
       {% if answer.schema_item.display and answer.schema_item.display.properties %}
         {% set use_grid = answer.schema_item.display.properties.columns %}
       {% endif %}

--- a/tests/functional/spec/census-household.spec.js
+++ b/tests/functional/spec/census-household.spec.js
@@ -223,4 +223,14 @@ describe('Census Household', function () {
         expect(ThankYou.isOpen()).to.be.true
     })
 
+    it('Given a census household survey, when a user submits the household composition page with errors, adding a new person should not duplicate those errors', function() {
+      startCensusQuestionnaire('census_household.json', false, 'GB-WLS')
+
+      PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
+      HouseholdComposition.submit()
+      HouseholdComposition.addPerson()
+
+      expect(browser.elements('.js-household-person .js-has-errors').value.length).to.equal(1)
+    })
+
 })


### PR DESCRIPTION
### What is the context of this PR?

Fixes #758.

- Added missing js hook used in filtering out pre-existing error messages when the new DOM elements are created for adding a person.

### How to review 

- As per bug repro steps.
