### PR TITLE
Change converter to use routing path.

### DIFF
--- a/tests/app/submitter/test_converter.py
+++ b/tests/app/submitter/test_converter.py
@@ -33,7 +33,8 @@ metadata = parse_metadata({
 class TestConverter(SurveyRunnerTestCase):
     def test_convert_answers(self):
         with self.application.test_request_context():
-            user_answer = [create_answer('ABC', '2016-01-01'), create_answer('DEF', '2016-03-30')]
+            user_answer = [create_answer('ABC', '2016-01-01', group_id='group-1', block_id='block-1'),
+                           create_answer('DEF', '2016-03-30', group_id='group-1', block_id='block-1')]
 
             answer_1 = Answer()
             answer_1.id = "ABC"
@@ -71,7 +72,8 @@ class TestConverter(SurveyRunnerTestCase):
             questionnaire.register(answer_1)
             questionnaire.register(answer_2)
 
-            answer_object = convert_answers(metadata, questionnaire, AnswerStore(user_answer), {})
+            routing_path = [Location(group_id='group-1', group_instance=0, block_id='block-1')]
+            answer_object = convert_answers(metadata, questionnaire, AnswerStore(user_answer), routing_path)
 
             self.assertEqual(answer_object['type'], 'uk.gov.ons.edc.eq:surveyresponse')
             self.assertEqual(answer_object['version'], '0.0.1')
@@ -98,7 +100,7 @@ class TestConverter(SurveyRunnerTestCase):
 
     def test_answer_with_zero(self):
         with self.application.test_request_context():
-            user_answer = [create_answer('GHI', 0)]
+            user_answer = [create_answer('GHI', 0, group_id='group-1', block_id='block-1')]
 
             answer = Answer()
             answer.id = "GHI"
@@ -126,16 +128,18 @@ class TestConverter(SurveyRunnerTestCase):
             questionnaire.register(question)
             questionnaire.register(answer)
 
-            answer_object = convert_answers(metadata, questionnaire, AnswerStore(user_answer), {})
+            routing_path = [Location(group_id='group-1', group_instance=0, block_id='block-1')]
+
+            answer_object = convert_answers(metadata, questionnaire, AnswerStore(user_answer), routing_path)
 
             # Check the converter correctly
             self.assertEqual("0", answer_object["data"]["003"])
 
     def test_answer_with_multiple_instances(self):
         with self.application.test_request_context():
-            user_answer = [create_answer('GHI', 0),
-                           create_answer('GHI', value=1, answer_instance=1),
-                           create_answer('GHI', value=2, answer_instance=2)]
+            user_answer = [create_answer('GHI', 0, group_id='group-1', block_id='block-1'),
+                           create_answer('GHI', value=1, answer_instance=1, group_id='group-1', block_id='block-1'),
+                           create_answer('GHI', value=2, answer_instance=2, group_id='group-1', block_id='block-1')]
 
             answer = Answer()
             answer.id = "GHI"
@@ -163,7 +167,10 @@ class TestConverter(SurveyRunnerTestCase):
             questionnaire.register(question)
             questionnaire.register(answer)
 
-            answer_object = convert_answers(metadata, questionnaire, AnswerStore(user_answer), {})
+            routing_path = [Location(group_id='group-1', group_instance=0, block_id='block-1')]
+
+            answer_object = convert_answers(metadata, questionnaire, AnswerStore(user_answer), routing_path)
+
             # Check the converter correctly
             self.assertEqual(answer_object["data"]["003"], ['0', '1', '2'])
 

--- a/tests/integration/create_token.py
+++ b/tests/integration/create_token.py
@@ -23,11 +23,11 @@ def create_token(form_type_id, eq_id, start_date=None, end_date=None, employment
     payload_vars['ref_p_start_date'] = start_date or payload_vars['ref_p_start_date']
     payload_vars['ref_p_end_date'] = end_date or payload_vars['ref_p_end_date']
     payload_vars['employment_date'] = employment_date or payload_vars['employment_date']
+    payload_vars['eq_id'] = eq_id
+    payload_vars['form_type'] = form_type_id
+    payload_vars['region_code'] = region_code
+    payload_vars['language_code'] = language_code
 
-    payload = create_payload(**payload_vars,
-                             eq_id=eq_id,
-                             form_type=form_type_id,
-                             region_code=region_code,
-                             language_code=language_code)
+    payload = create_payload(**payload_vars)
 
     return generate_token(payload)


### PR DESCRIPTION
### What is the context of this PR?
Fixes #858.

### How to review 
Please test the defect as described and observe only the answers from the route the user takes are output.
All existing tests should pass and the structure of the output should still be qcode -> answer value as before for any surveys with data version 0.0.1.