### PR TITLE
Limit number of repeating blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ SAUCE_ACCESS_KEY - Sauce Labs private key
 EQ_DEV_MODE - Enable dev mode
 EQ_ENABLE_FLASK_DEBUG_TOOLBAR - Enable the flask debug toolbar
 EQ_ENABLE_CACHE - Enable caching of the schema
+EQ_MAX_HTTP_POST_CONTENT_LENGTH - The maximum http post content length that the system wil accept
+EQ_MAX_NUM_REPEATS - The maximum number of repeats the system will allow
 ```
 ## Loading schemas from S3
 

--- a/app/questionnaire/rules.py
+++ b/app/questionnaire/rules.py
@@ -1,3 +1,9 @@
+import logging
+from app import settings
+
+logger = logging.getLogger(__name__)
+
+
 def evaluate_rule(when, answer_value):
     """
     Determine whether a rule will be satisfied based on a given answer
@@ -52,7 +58,13 @@ def evaluate_repeat(repeat_rule, answer_store):
         repeat_index = repeat_rule['answer_id']
         filtered = answer_store.filter(answer_id=repeat_index)
         repeat_function = repeat_functions[repeat_rule['type']]
-        return repeat_function(filtered)
+        no_of_repeats = repeat_function(filtered)
+
+        if no_of_repeats > settings.EQ_MAX_NUM_REPEATS:
+            logger.warning('Excessive number of repeats found [%s] capping at [%s]', no_of_repeats, settings.EQ_MAX_NUM_REPEATS)
+            no_of_repeats = settings.EQ_MAX_NUM_REPEATS
+
+        return no_of_repeats
 
 
 def _get_answer_value():

--- a/app/settings.py
+++ b/app/settings.py
@@ -29,7 +29,10 @@ def get_key(_key_name):
 
 EQ_MINIMIZE_ASSETS = parse_mode(os.getenv('EQ_MINIMIZE_ASSETS', 'False'))
 # max request payload size in bytes
-EQ_MAX_HTTP_POST_CONTENT_LENGTH = 65536
+EQ_MAX_HTTP_POST_CONTENT_LENGTH = os.getenv('EQ_MAX_HTTP_POST_CONTENT_LENGTH', 65536)
+
+# max number of repeats from a rule
+EQ_MAX_NUM_REPEATS = os.getenv('EQ_MAX_NUM_REPEATS', 50)
 
 EQ_PROFILING = parse_mode(os.getenv('EQ_PROFILING', 'False'))
 

--- a/tests/app/questionnaire/test_path_finder.py
+++ b/tests/app/questionnaire/test_path_finder.py
@@ -657,6 +657,31 @@ class TestPathFinder(unittest.TestCase):  # pylint: disable=too-many-public-meth
 
         self.assertEqual(expected_path, path_finder.get_location_path())
 
+    def test_excessive_repeating_groups_conditional_location_path(self):
+        survey = load_schema_file("test_repeating_and_conditional_routing.json")
+
+        answers = AnswerStore()
+
+        answers.add(Answer(
+            group_id="repeat-value-group",
+            block_id="no-of-repeats",
+            answer_id="no-of-repeats-answer",
+            value="10000"
+        ))
+
+        for i in range(50):
+            answers.add(Answer(
+                group_id="repeated-group",
+                group_instance=i,
+                block_id="repeated-block",
+                answer_id="conditional-answer",
+                value="Shoe Size Only"
+            ))
+
+        path_finder = PathFinder(survey, answer_store=answers)
+
+        self.assertEqual("thank-you", path_finder.get_location_path().pop().block_id)
+
     def test_next_with_conditional_path_based_on_metadata(self):
         survey = load_schema_file("test_metadata_routing.json")
 


### PR DESCRIPTION
### What is the context of this PR?
This PR fixes https://github.com/ONSdigital/eq-survey-runner/issues/860 by adding a limit to the number of times a block can repeat.
A limit of 50 was chosen after analysis to find the level at which the system started to noticeably degrade in performance

### How to review 
Launch census household survey.
Enter a large number in number of visitors question.
Observe that the system performance is not dramatically effected.