### PR TITLE
Spike flush data

### DIFF
--- a/app/parser/metadata_parser.py
+++ b/app/parser/metadata_parser.py
@@ -59,6 +59,7 @@ metadata_fields = {
     "language_code": MetadataField(mandatory=False),
     "tx_id": MetadataField(mandatory=False, validator=uuid_4_parser, generator=id_generator),
     "variant_flags": MetadataField(mandatory=False),
+    "flush_data": MetadataField(mandatory=False),
 }
 
 

--- a/app/submitter/submitter.py
+++ b/app/submitter/submitter.py
@@ -31,6 +31,7 @@ class Submitter(object):
         :raise: a submission failed exception
         """
         encrypted_message = self.encrypt_message(message)
+        logger.error(message)
         sent = self.send_message(encrypted_message, settings.EQ_RABBITMQ_QUEUE_NAME)
         if not sent:
             raise SubmissionFailedException()

--- a/app/templates/dev-page.html
+++ b/app/templates/dev-page.html
@@ -181,6 +181,11 @@ select {
             </div>
 
             <div class="field-container">
+                <label for="flush_data">Flush Data</label>
+                <input id="flush_data" type="checkbox" name="flush_data" class="qa-flush-data" value="true">
+            </div>
+
+            <div class="field-container">
               <input type="submit" value="Open Survey" class="qa-btn-submit-dev btn"/>
             </div>
 

--- a/app/views/dev_mode.py
+++ b/app/views/dev_mode.py
@@ -38,6 +38,7 @@ def dev_mode():
         language_code = form.get("language_code")
         sexual_identity = form.get("sexual_identity") == "true"
         variant_flags = {"sexual_identity": sexual_identity}
+        flush_data = form.get("flush_data") == "true"
         payload = create_payload(user=user,
                                  exp_time=exp_time,
                                  eq_id=eq_id,
@@ -54,7 +55,9 @@ def dev_mode():
                                  employment_date=employment_date,
                                  region_code=region_code,
                                  language_code=language_code,
-                                 variant_flags=variant_flags)
+                                 variant_flags=variant_flags,
+                                 flush_data=flush_data,
+                                 )
         return redirect("/session?token=" + generate_token(payload).decode())
 
     return render_template("dev-page.html", user=os.getenv('USER', 'UNKNOWN'), available_schemas=available_schemas())
@@ -106,6 +109,7 @@ def create_payload(**metadata):
         "employment_date": metadata['employment_date'],
         "region_code": metadata['region_code'],
         "language_code": metadata['language_code'],
+        "flush_data": metadata['flush_data'],
         "variant_flags": metadata['variant_flags'],
     }
 

--- a/tests/integration/create_token.py
+++ b/tests/integration/create_token.py
@@ -13,6 +13,7 @@ PAYLOAD = {
     "trad_as": "Integration Tests",
     "employment_date": "1983-06-02",
     "variant_flags": None,
+    "flush_data": False,
     "exp_time": 3600  # one hour from now
 }
 


### PR DESCRIPTION
### What is the context of this PR?
To get a first look at flushing data from a survey. The spike was initially undertaken to investigate whether it was possible, which it is. However, how it should work is still up for discussion.

As long as we have the eq_id, form_type, collection_exercise_sid and ru_ref we can recreate the user_id and ik meaning we can get the data out of the database for any user, without needing any session stored keys. 

At the moment I have put a flag on the JWT and dealt with it in session.py, however I also experimented with making an end point and that was just as effective. A middle ground is probably the best solution, with a flag in the JWT passing to an endpoint to do the flushing.
The JWT seems to be the way to go as it offers authentication but the rest is up for debate

N.B You can see it working by using /dev and ticking the flush data checkbox. I have left a logger statement in the code on purpose so the flushed data can be seen for this spike

### How to review 
No review required, just general comments and idea's how it should work