### PR TITLE
eq-881 missing first name field (in IE) | eq-882 hidden legend does not increment

### DIFF
--- a/app/assets/js/app/modules/household.js
+++ b/app/assets/js/app/modules/household.js
@@ -18,7 +18,7 @@ class HouseholdMember extends EventEmitter {
   }
 
   bindToDOM() {
-    this.indexNode = this.node.querySelector('.js-household-loopindex')
+    this.indexNodes = this.node.querySelectorAll('.js-household-loopindex')
     const errorNode = this.node.querySelector('.js-has-errors')
     if (errorNode) {
       const fieldNodes = this.node.querySelector('.js-fields')
@@ -60,7 +60,7 @@ class HouseholdMember extends EventEmitter {
 
   setIndex(index) {
     this.index = index
-    this.indexNode.innerHTML = index
+    forEach(this.indexNodes, node => { node.innerHTML = index })
     forEach(this.inputs, input => {
       const id = input.id
       const label = this.node.querySelector(`label[for=${id}]`)

--- a/app/assets/js/app/modules/household.js
+++ b/app/assets/js/app/modules/household.js
@@ -20,13 +20,13 @@ class HouseholdMember extends EventEmitter {
   bindToDOM() {
     this.indexNode = this.node.querySelector('.js-household-loopindex')
     const errorNode = this.node.querySelector('.js-has-errors')
-
     if (errorNode) {
       const fieldNodes = this.node.querySelector('.js-fields')
       if (fieldNodes) {
+        const clone = fieldNodes.cloneNode(true)
         errorNode.innerHTML = ''
         errorNode.classList.remove('js-has-errors')
-        errorNode.appendChild(fieldNodes)
+        errorNode.appendChild(clone)
       }
     }
 

--- a/app/templates/partials/questions/repeatinganswer.html
+++ b/app/templates/partials/questions/repeatinganswer.html
@@ -27,7 +27,7 @@
           )</small>
         </h3>
         <fieldset class="question__fieldset">
-          <legend class="question__legend u-vh">{{ _('Person ') }} {{ loop.index }}</legend>
+          <legend class="question__legend u-vh">{{ _('Person ') }} <span class="js-household-loopindex">{{ loop.index }}</span></legend>
           {% for answer in composite_answer %}
             {% with render_guidance = False %}
               {% include theme('partials/answer.html') %}

--- a/tests/functional/spec/census-household.spec.js
+++ b/tests/functional/spec/census-household.spec.js
@@ -233,4 +233,17 @@ describe('Census Household', function () {
       expect(browser.elements('.js-household-person .js-has-errors').value.length).to.equal(1)
     })
 
+    it('Given a census household survey, when a user adds a new person, the "Person x" count should increment in the hidden legend', function() {
+      const numPeople = 4
+      startCensusQuestionnaire('census_household.json', false, 'GB-WLS')
+
+      PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
+      HouseholdComposition.submit()
+
+      for (let i = 1; i < numPeople; i++) {
+        HouseholdComposition.addPerson()
+      }
+
+      expect(browser.getHTML('legend .js-household-loopindex', false)[numPeople - 1]).to.equal(numPeople.toString())
+    })
 })


### PR DESCRIPTION
### What is the context of this PR?

Fixes #881 

- The way IE handles some of the DOM operations slightly differently was causing a bug in the logic that removes pre-existing errors from adding a new person.

Fixes #882

- There is a visually hidden legend which mirrors the content of the 'Person x' title — this wasn't being incremented when a new person is added.

### How to review 

As per repro steps on bugs.
