### PR TITLE
Re-add Apache WSGI config to fix

### DIFF
--- a/.ebextensions/custom-apache.config
+++ b/.ebextensions/custom-apache.config
@@ -1,5 +1,6 @@
 container_commands:
   add_apache_conf:
     command: "cp app-httpd.conf /etc/httpd/conf.d"
+    command: "cp app-wsgi.conf /etc/httpd/conf.d/app-wsgi.conf"        
   add_apache_mod_deflate:
     command: "cp .ebextensions/enable_mod_deflate.conf /etc/httpd/conf.d/enable_mod_deflate.conf"

--- a/app-wsgi.conf
+++ b/app-wsgi.conf
@@ -1,0 +1,1 @@
+WSGIApplicationGroup %{GLOBAL}


### PR DESCRIPTION
The error `extern "Python": function Cryptography_pem_password_cb() called, but @ffi.def_extern() was not called in the current subinterpreter.  Returning 0.` started occurring on one of the Elastic Beanstalk ec2 instances after the Apache fix was removed in #870. This pull request re-adds the Apache WSGI config fix.

Fixes #895 
