### PR TITLE
add repeat limit to household relationships

### DIFF
--- a/app/data_model/answer_store.py
+++ b/app/data_model/answer_store.py
@@ -151,7 +151,7 @@ class AnswerStore(object):
 
         return len(self.filter(answer.group_id, answer.block_id, answer.answer_id, answer.group_instance, answer.answer_instance))
 
-    def filter(self, group_id=None, block_id=None, answer_id=None, group_instance=None, answer_instance=None, location=None):
+    def filter(self, group_id=None, block_id=None, answer_id=None, group_instance=None, answer_instance=None, location=None, limit=None):
         """
         Find all answers in the answer store for a given set of filter parameter matches.
         If no filter parameters are passed it returns a copy of the list of all answers.
@@ -162,6 +162,7 @@ class AnswerStore(object):
         :param answer_instance: The answer instance to filter results by
         :param group_instance: The group instance to filter results by
         :param location: The location to filter results by (takes precedence over group_id, group_instance and block_id)
+        :param limit: Limit the number of answers returned
         :return: Return a list of answers which satisfy the filter criteria
         """
         filtered = []
@@ -187,6 +188,8 @@ class AnswerStore(object):
                     matches = matches and answer[k] == v
             if matches:
                 filtered.append(answer)
+                if limit and len(filtered) == limit:
+                    break
         return filtered
 
     def clear(self):

--- a/app/questionnaire_state/relationship_state_question.py
+++ b/app/questionnaire_state/relationship_state_question.py
@@ -1,5 +1,6 @@
 from flask_login import current_user
 
+from app import settings
 from app.globals import get_answer_store
 from app.jinja_filters import format_household_member_name
 from app.questionnaire_state.state_repeating_answer_question import RepeatingAnswerStateQuestion
@@ -14,9 +15,10 @@ class RelationshipStateQuestion(RepeatingAnswerStateQuestion):
     def build_repeating_state(self, user_input):
         template_answer = self.answers.pop()
         group_instance = template_answer.group_instance
+        answer_store = get_answer_store(current_user)
 
-        first_name_answers = get_answer_store(current_user).filter(answer_id='first-name')
-        last_name_answers = get_answer_store(current_user).filter(answer_id='last-name')
+        first_name_answers = answer_store.filter(answer_id='first-name', limit=settings.EQ_MAX_NUM_REPEATS)
+        last_name_answers = answer_store.filter(answer_id='last-name', limit=settings.EQ_MAX_NUM_REPEATS)
 
         first_names = [answer['value'] for answer in first_name_answers]
         last_names = [answer['value'] for answer in last_name_answers]

--- a/app/settings.py
+++ b/app/settings.py
@@ -32,7 +32,7 @@ EQ_MINIMIZE_ASSETS = parse_mode(os.getenv('EQ_MINIMIZE_ASSETS', 'False'))
 EQ_MAX_HTTP_POST_CONTENT_LENGTH = os.getenv('EQ_MAX_HTTP_POST_CONTENT_LENGTH', 65536)
 
 # max number of repeats from a rule
-EQ_MAX_NUM_REPEATS = os.getenv('EQ_MAX_NUM_REPEATS', 50)
+EQ_MAX_NUM_REPEATS = os.getenv('EQ_MAX_NUM_REPEATS', 25)
 
 EQ_PROFILING = parse_mode(os.getenv('EQ_PROFILING', 'False'))
 

--- a/tests/app/data_model/test_answer_store.py
+++ b/tests/app/data_model/test_answer_store.py
@@ -288,6 +288,22 @@ class TestAnswerStore(unittest.TestCase):  # pylint: disable=too-many-public-met
 
         self.assertEqual(len(filtered), 1)
 
+    def test_filters_answers_with_limit(self):
+
+        for i in range(1, 50):
+            self.store.add(Answer(
+                block_id="1",
+                answer_id="2",
+                answer_instance=i,
+                group_id="5",
+                group_instance=1,
+                value=25,
+            ))
+
+        filtered = self.store.filter(limit=25)
+
+        self.assertEqual(len(filtered), 25)
+
     def test_maps_answers(self):
 
         answer_1 = Answer(


### PR DESCRIPTION
Fixes https://github.com/ONSdigital/eq-survey-runner/issues/883
Fixes https://github.com/ONSdigital/eq-survey-runner/issues/884

### How to review 
Test adding over 25 household members and observe that household relationship questions are only asked for first 25.