### PR TITLE
Return to Household Composition - Retain Data

### DIFF
--- a/tests/integration/household_composition/test_repeating_household.py
+++ b/tests/integration/household_composition/test_repeating_household.py
@@ -25,12 +25,7 @@ class TestRepeatingHousehold(IntegrationTestCase):
     def test_change_repeat_answer_removes_all_answers_for_repeated_groups(self):
         # Given I add some people
         household_composition_page = self.first_page
-        form_data = MultiDict()
-        form_data.add("first-name", 'Joe')
-        form_data.add("last-name", 'Bloggs')
-        form_data.add("first-name_1", 'Jane')
-        form_data.add("last-name_1", 'Doe')
-        form_data.add("action[save_continue]", '')
+        form_data = self.get_form_data()
         resp = self.client.post(household_composition_page, data=form_data, follow_redirects=False)
         person1_age_page = resp.location
 
@@ -62,12 +57,14 @@ class TestRepeatingHousehold(IntegrationTestCase):
         form_data.add("action[save_continue]", '')
         self.client.post(person2_shoe_size_page, data=form_data, follow_redirects=False)
 
-        # When I go back to household composition page and submit
+        # When I go back to household composition page and make changes and submit
         self.navigate_to_page(household_composition_page)
         form_data = MultiDict()
         form_data.add("first-name", 'Joe')
+        form_data.add("middle-names", 'S')
         form_data.add("last-name", 'Bloggs')
         form_data.add("first-name_1", 'Jane')
+        form_data.add("middle-names_1", '')
         form_data.add("last-name_1", 'Doe')
         form_data.add("action[save_continue]", '')
         resp = self.client.post(household_composition_page, data=form_data, follow_redirects=True)
@@ -91,6 +88,44 @@ class TestRepeatingHousehold(IntegrationTestCase):
         self.assertRegex(content, 'Jane Doe')
         self.assertRegex(content, 'What is their age')
         self.assertNotRegex(content, '9992')
+
+    def test_no_change_repeat_answer_keeps_repeated_groups(self):
+
+        # Given I add some people
+        household_composition_page = self.first_page
+        form_data = self.get_form_data()
+        resp = self.client.post(household_composition_page, data=form_data, follow_redirects=False)
+        person1_age_page = resp.location
+
+        # And provide details
+        self.navigate_to_page(person1_age_page)
+        form_data = MultiDict()
+        form_data.add("what-is-your-age", '18')
+        form_data.add("action[save_continue]", '')
+        self.client.post(person1_age_page, data=form_data, follow_redirects=False)
+
+        # When I go back to household composition page and submit without any changes
+        self.navigate_to_page(household_composition_page)
+        form_data = self.get_form_data()
+        resp = self.client.post(household_composition_page, data=form_data, follow_redirects=True)
+
+        # Then the details previously entered for the people should have been kept
+        content = resp.get_data(True)
+        self.assertRegex(content, 'Joe Bloggs')
+        self.assertRegex(content, 'What is their age')
+        self.assertRegex(content, '18')
+
+    @staticmethod
+    def get_form_data():
+        form_data = MultiDict()
+        form_data.add("first-name", 'Joe')
+        form_data.add("middle-names", '')
+        form_data.add("last-name", 'Bloggs')
+        form_data.add("first-name_1", 'Jane')
+        form_data.add("middle-names_1", '')
+        form_data.add("last-name_1", 'Doe')
+        form_data.add("action[save_continue]", '')
+        return form_data
 
     def navigate_to_page(self, page):
         resp = self.client.get(page, follow_redirects=False)


### PR DESCRIPTION
### What is the context of this PR?
To retain the repeating answers on Census if there are no changes on the who lives here question. This is done by comparing the answer_store to the request.form dict. If there are no changes then the data for all the repeats should be kept

### How to review 
Using Census_household.json
1. Navigate to the question "2. List the names of everyone who lives here" 
2. Enter 2 people in the boxes below
3. Fill out the rest of the section, including the relationship between the people entered
4. Jump to one of the people on the right and fill out some of their questions
5. Using the link on the right go to "Who lives here"
6. Without changing anything go through that section, making sure anything has been retained
7. Same for the person you filled in 4
8. Go back to "Who lives here" and now change something in regards to the people you have entered
9. Go forward and make sure just the relationship grid is wiped
10. Also check the details you entered in 4 have been wiped.
