### PR TITLE
ID is displayed as N/A for all Surveys

### DIFF
--- a/app/templates/partials/header.html
+++ b/app/templates/partials/header.html
@@ -13,7 +13,7 @@
       {% if meta %}
       <dl class="info__list">
         <dt class="info__dt first"><abbr title="Survey identification code">ID:</abbr></dt>
-        <dd class="info__dd">{{ meta.survey.survey_code or 'N/A'}}</dd>
+        <dd class="info__dd">{{ survey_id or 'N/A'}}</dd>
         <dt class="info__dt">Period:</dt>
         <dd class="info__dd">{{ meta.survey.period_str or 'N/A'}}</dd>
         <dt class="info__dt"><abbr title="Reference number">Ref:</abbr></dt>

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -345,4 +345,5 @@ def _render_template(context, block_id, front_end_navigation=None, metadata_cont
                                  previous_location=previous_url,
                                  navigation=front_end_navigation,
                                  schema_title=g.schema_json['title'],
-                                 legal_basis=g.schema_json['legal_basis'])
+                                 legal_basis=g.schema_json['legal_basis'],
+                                 survey_id=g.schema_json['survey_id'],)


### PR DESCRIPTION
### What is the context of this PR?
Fixes #891 Missing Survey ID in header

### How to review 
Using any default theme survey, make sure the survey_id is in the header and not N/A
