### PR TITLE
Eq 888 missing first name error

### DIFF
--- a/app/assets/js/app/modules/household.js
+++ b/app/assets/js/app/modules/household.js
@@ -49,6 +49,8 @@ class HouseholdMember extends EventEmitter {
         errorNode.innerHTML = ''
         errorNode.classList.remove('js-has-errors')
         errorNode.appendChild(clone)
+        // grab the inputs again as the cloning makes the original array out of date
+        this.inputs = this.node.querySelectorAll('input')
       }
     }
 

--- a/app/assets/js/app/modules/household.js
+++ b/app/assets/js/app/modules/household.js
@@ -19,17 +19,6 @@ class HouseholdMember extends EventEmitter {
 
   bindToDOM() {
     this.indexNodes = this.node.querySelectorAll('.js-household-loopindex')
-    const errorNode = this.node.querySelector('.js-has-errors')
-    if (errorNode) {
-      const fieldNodes = this.node.querySelector('.js-fields')
-      if (fieldNodes) {
-        const clone = fieldNodes.cloneNode(true)
-        errorNode.innerHTML = ''
-        errorNode.classList.remove('js-has-errors')
-        errorNode.appendChild(clone)
-      }
-    }
-
     this.inputs = this.node.querySelectorAll('input')
     this.actionNode = this.node.querySelector('.js-household-action')
     if (this.removeBtn) {
@@ -50,6 +39,18 @@ class HouseholdMember extends EventEmitter {
     this.node.classList.add('is-hidden')
     this.actionNode.innerHTML = ''
     this.actionNode.appendChild(this.removeBtn)
+
+    const errorNode = this.node.querySelector('.js-has-errors')
+
+    if (errorNode) {
+      const fieldNodes = this.node.querySelector('.js-fields')
+      if (fieldNodes) {
+        const clone = fieldNodes.cloneNode(true)
+        errorNode.innerHTML = ''
+        errorNode.classList.remove('js-has-errors')
+        errorNode.appendChild(clone)
+      }
+    }
 
     parent.appendChild(this.node)
     this.node.querySelector('input').focus()

--- a/tests/functional/spec/census-household.spec.js
+++ b/tests/functional/spec/census-household.spec.js
@@ -232,18 +232,4 @@ describe('Census Household', function () {
 
       expect(browser.elements('.js-household-person .js-has-errors').value.length).to.equal(1)
     })
-
-    it('Given a census household survey, when a user adds a new person, the "Person x" count should increment in the hidden legend', function() {
-      const numPeople = 4
-      startCensusQuestionnaire('census_household.json', false, 'GB-WLS')
-
-      PermanentOrFamilyHome.clickPermanentOrFamilyHomeAnswerYes().submit()
-      HouseholdComposition.submit()
-
-      for (let i = 1; i < numPeople; i++) {
-        HouseholdComposition.addPerson()
-      }
-
-      expect(browser.getHTML('legend .js-household-loopindex', false)[numPeople - 1]).to.equal(numPeople.toString())
-    })
 })

--- a/tests/functional/spec/household-composition.spec.js
+++ b/tests/functional/spec/household-composition.spec.js
@@ -9,7 +9,7 @@ const assert = chai.assert
 
 describe('Household composition question for census test.', function() {
 
-  var household_composition_schema = 'test_household_question.json';
+  const household_composition_schema = 'test_household_question.json';
 
   it('Given no people added, when enter a name and submit, then name should be displayed on summary.', function() {
     //Given
@@ -210,5 +210,28 @@ describe('Household composition question for census test.', function() {
     HouseholdCompositionSummary.isNameDisplayed('Homer J Simpson')
     HouseholdCompositionSummary.isNameDisplayed('Marge Simpson')
   })
+
+  it('Given a census household survey, when a user adds a new person, the "Person x" count should increment in the hidden legend', function() {
+    const numPeople = 4
+    startQuestionnaire(household_composition_schema)
+
+    for (let i = 1; i < numPeople; i++) {
+      HouseholdCompositionPage.addPerson()
+    }
+
+    expect(browser.getHTML('legend .js-household-loopindex', false)[numPeople - 1]).to.equal(numPeople.toString())
+  })
+
+  it('Given two more people are added, no names are added and submitted, errors should exist for all three individuals', function() {
+    startQuestionnaire(household_composition_schema)
+
+    HouseholdCompositionPage
+      .addPerson()
+      .addPerson()
+      .submit()
+
+      expect(browser.elements('.answer.js-has-errors').value.length).to.equal(3)
+
+  });
 
 })


### PR DESCRIPTION
### What is the context of this PR?

See #888. 

Fixes this bug by moving the logic that strips errors out when the answer (person) is cloned out of the `bindToDOM` method (which is used to bind to existing DOM elements) and into the `add` method which is used to add a new person.

Also, moved an existing test into the correct file.

### How to review 

As per the bug repro steps.
