### PR TITLE
eq-890 Move previous link out of footer

### DIFF
--- a/app/assets/styles/partials/objects/_page.scss
+++ b/app/assets/styles/partials/objects/_page.scss
@@ -32,10 +32,6 @@
 
 .page__previous {
   float: left;
-  font-size: 0.8rem;
-  @include mq(m) {
-    font-size: 1rem;
-  }
   .has-nav-open & {
     display: none;
   }
@@ -55,7 +51,7 @@
 }
 
 .page__nav.nav {
-  margin: 0.5rem 0 1rem;
+  margin: 0 0 1rem;
   position: absolute;
   right: -13rem;
   width: 12rem;

--- a/app/templates/layouts/_base.html
+++ b/app/templates/layouts/_base.html
@@ -55,25 +55,24 @@
           {% include theme('partials/topbar.html') %}
         {% endblock %}</div>
         <div class="page__subheader">
+          <div class="container">
           {%- block subheader -%}
-          {% if previous_location %}
-            <div class="container">
-              <a class="page__previous" id="top-previous" href="{{previous_location}}">Previous</a>
-            </div>
-          {% endif %}
+            {% if previous_location %}
+                <a class="page__previous" id="top-previous" href="{{previous_location}}">Previous</a>
+            {% endif %}
+
+            {% if navigation %}
+              <div class="page__menubtn">
+                <button class="btn btn--link pluto btn--menu js-menu-btn" data-close-label="{{_('Hide sections')}}" type="button" id="menu-btn">{{_('View sections')}}</button>
+              </div>
+            {% endif %}
           {%- endblock subheader -%}
+          </div>
         </div>
         <div class="page__container container">
-          {% block content %}{% endblock %}
-        </div>
-
-      </div>
-
-      <div class="page__prefooter">
-        <div class="container">
-          {% block prefooter %}
+          {% block content %}
             {% if previous_location %}
-                <a class="page__previous" id="bottom-previous" href="{{previous_location}}">Previous</a>
+              <a class="page__previous page__previous--bottom" href="{{previous_location}}" id="bottom-previous">Previous</a>
             {% endif %}
           {% endblock %}
         </div>
@@ -84,6 +83,7 @@
           {% include theme('partials/footer.html') %}
         {% endblock %}
       </div>
+
 
     </div>
 

--- a/app/templates/layouts/_onecol.html
+++ b/app/templates/layouts/_onecol.html
@@ -6,6 +6,7 @@
   <div class="grid__col col-12@xs">
     <div role="main" id="main" class="page__main">
       {% block main %}{% endblock %}
+      {{super()}}
     </div>
   </div>
 </div>

--- a/app/templates/layouts/_twocol.html
+++ b/app/templates/layouts/_twocol.html
@@ -10,6 +10,7 @@
   <div class="grid__col col-7@m pull-1@m">
     <div role="main" id="main" class="page__main">
       {% block main %}{% endblock %}
+      {{super()}}
     </div>
   </div>
 </div>

--- a/app/templates/questionnaire.html
+++ b/app/templates/questionnaire.html
@@ -8,26 +8,6 @@
 {% set block = state.schema_item %}
 {% set all_errors = state.get_errors().items() %}
 
-{%- block subheader -%}
-
-  {% if previous_location or navigation %}
-
-  <div class="container">
-    {% if previous_location %}
-      <a class="page__previous" id="top-previous" href="{{previous_location}}">Previous</a>
-    {% endif %}
-
-    {% if navigation %}
-      <div class="page__menubtn">
-        <button class="btn btn--link pluto btn--menu js-menu-btn" data-close-label="{{_('Hide sections')}}" type="button" id="menu-btn">{{_('View sections')}}</button>
-      </div>
-    {% endif %}
-  </div>
-
-  {% endif %}
-
-{%- endblock subheader -%}
-
 {% block sidebar %}
   {% if navigation %}
     {% include theme('partials/navigation.html') %}
@@ -79,16 +59,9 @@
       </div>
 
       <button class="btn btn--primary btn--lg qa-btn-submit venus" type="submit" name="action[save_continue]">{% block submit_button_text %}Save and continue{% endblock %}</button>
-      <div>
+      <div class="u-mb-m">
         <button class="btn btn--link mars" type="submit" name="action[save_sign_out]">{% block save_sign_out_button_text %}Save and complete later{% endblock %}</button>
       </div>
     </form>
 
 {% endblock main %}
-
-{% block prefooter %}
-
-  {% if previous_location %}
-    <a class="page__previous page__previous--bottom" href="{{previous_location}}" id="bottom-previous">Previous</a>
-  {% endif %}
-{% endblock prefooter %}

--- a/app/templates/summary.html
+++ b/app/templates/summary.html
@@ -60,4 +60,6 @@
   </form>
 </div>
 
+{{super()}}
+
 {% endblock -%}

--- a/app/themes/census/templates/layouts/_twocol.html
+++ b/app/themes/census/templates/layouts/_twocol.html
@@ -10,6 +10,7 @@
   <div class="grid__col col-7@m pull-1@m">
     <div role="main" id="main" class="page__main">
       {% block main %}{% endblock %}
+      {{super()}}
     </div>
   </div>
 </div>


### PR DESCRIPTION
### What is the context of this PR?

Fixes #890 

- Moved the bottom previous link out of "pre footer" (removing this) and into the "content" block
- Consolidated the nav and (top) previous link into one place in the base layout template.
- Fixed issue with previous link size on mobile

### How to review 

- start any survey
- check previous link is no longer visually anchored to footer.
