### PR TITLE
Implement a flush mechanism to push unfinished surveys downstream

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -191,6 +191,10 @@ def add_blueprints(application):
     application.register_blueprint(session_blueprint)
     session_blueprint.config = application.config.copy()
 
+    from app.views.flush import flush_blueprint
+    application.register_blueprint(flush_blueprint)
+    flush_blueprint.config = application.config.copy()
+
     from app.views.errors import errors_blueprint
     application.register_blueprint(errors_blueprint)
     errors_blueprint.config = application.config.copy()

--- a/app/authentication/flush_permission_denied.py
+++ b/app/authentication/flush_permission_denied.py
@@ -1,0 +1,8 @@
+
+class FlushPermissionDenied(Exception):
+    def __init__(self, value):
+        super().__init__()
+        self.value = value
+
+    def __str__(self):
+        return self.value

--- a/app/authentication/map_role_to_permissions.py
+++ b/app/authentication/map_role_to_permissions.py
@@ -1,0 +1,12 @@
+from app import settings
+
+
+def map_role_to_permissions(roles):
+    current_user_permissions = []
+
+    for role in roles:
+        role_permissions = settings.EQ_ROLE_PERMISSIONS.get(role)
+
+        if role_permissions:
+            current_user_permissions.extend(role_permissions)
+    return current_user_permissions

--- a/app/authentication/no_survey_data_to_flush.py
+++ b/app/authentication/no_survey_data_to_flush.py
@@ -1,0 +1,7 @@
+class NoSurveyDataToFlush(Exception):
+    def __init__(self, value):
+        super().__init__()
+        self.value = value
+
+    def __str__(self):
+        return self.value

--- a/app/settings.py
+++ b/app/settings.py
@@ -99,3 +99,5 @@ EUROPE_LONDON = pytz.timezone("Europe/London")
 
 # JWT configurations
 EQ_JWT_LEEWAY_IN_SECONDS = 120
+
+EQ_ROLE_PERMISSIONS = {'admin': ['flush']}

--- a/app/templates/dev-flush-page.html
+++ b/app/templates/dev-flush-page.html
@@ -1,0 +1,118 @@
+{% set _theme="default" %}
+{% extends 'layouts/_base.html' %} {% block page_title %}EQ Development Flush Data{% endblock %} {% block content %}
+
+<!-- this page needs a total rethink, but this tidies things up a little for now -->
+
+{% block header %}{% endblock header %}
+{% block subheader %}{% endblock subheader %}
+{% block prefooter %}{% endblock prefooter %}
+{% block footer %}{% endblock footer %}
+
+<style media="screen">
+
+* { font-family: "lato" }
+
+label { display:inline-block; font-weight: 600; margin-bottom: 0.25rem; width:200px; font-size:0.9rem; }
+
+.field-wrap {
+  margin:0 auto;
+}
+
+.field-container {
+  display:block;
+  margin: 0 0 0.2rem 0;
+  position: relative;
+}
+
+.field-container span {
+  position: relative;
+}
+
+input[type=text] {
+  padding:0.3rem;
+  width:300px;
+  font-size:0.9rem;
+}
+
+select {
+  width:300px;
+  font-size:0.9rem;
+  padding:0.35rem;
+  -webkit-appearance:none;
+  appearance:none;
+  border-radius:0;
+  border:1px solid #dfdfdf;
+  background:url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGVuYWJsZS1iYWNrZ3JvdW5kPSJuZXcgMCAwIDMyIDMyIiBoZWlnaHQ9IjMycHgiIGlkPSLQodC70L7QuV8xIiB2ZXJzaW9uPSIxLjEiIHZpZXdCb3g9IjAgMCAzMiAzMiIgd2lkdGg9IjMycHgiIHhtbDpzcGFjZT0icHJlc2VydmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPjxwYXRoIGQ9Ik0yNC4yODUsMTEuMjg0TDE2LDE5LjU3MWwtOC4yODUtOC4yODhjLTAuMzk1LTAuMzk1LTEuMDM0LTAuMzk1LTEuNDI5LDAgIGMtMC4zOTQsMC4zOTUtMC4zOTQsMS4wMzUsMCwxLjQzbDguOTk5LDkuMDAybDAsMGwwLDBjMC4zOTQsMC4zOTUsMS4wMzQsMC4zOTUsMS40MjgsMGw4Ljk5OS05LjAwMiAgYzAuMzk0LTAuMzk1LDAuMzk0LTEuMDM2LDAtMS40MzFDMjUuMzE5LDEwLjg4OSwyNC42NzksMTAuODg5LDI0LjI4NSwxMS4yODR6IiBmaWxsPSIjMTIxMzEzIiBpZD0iRXhwYW5kX01vcmUiLz48Zy8+PGcvPjxnLz48Zy8+PGcvPjxnLz48L3N2Zz4=);
+  background-position: center right 5px;
+  background-repeat:no-repeat;
+  background-size:22px;
+}
+
+.field-container img {
+  width:26px;
+  height:auto;
+  display:block;
+  position:absolute;
+  top: -1px;
+  right: 2px;
+  cursor:pointer;
+}
+
+.btn {
+  background:#6099c6;
+  color:white;
+  border:0;
+  border-radius:3px;
+  display:block;
+  padding:0.75rem 2rem;
+  text-align: center;
+  font-size: 1rem;
+  margin: 0.5rem 0;
+}
+
+
+</style>
+
+<div class="container">
+
+  <div class="u-mt-l">
+
+    <div role="main" id="main">
+
+      <form action="" method="POST" xmlns="http://www.w3.org/1999/html">
+
+        <div class="field-wrap">
+
+            <div class="field-container">
+              <label for="schema">Schemas</label>
+                <select id="schema" name="schema" class="qa-select-schema">
+                  {% for id in available_schemas %}
+                  <option name="{{id}}" value="{{id}}">{{id}}</option>
+                  {% endfor %}
+              </select>
+            </div>
+
+            <div class="field-container">
+              <label for="collection_exercise_sid">Collection Exercise SID</label>
+              <span><input id="collection_exercise_sid" name="collection_exercise_sid" type="text" class="qa-collection-sid">
+              <img class="refresh" data-refresh="collection_exercise_sid"></span>
+            </div>
+
+            <div class="field-container">
+              <label for="ru_ref">RU Ref</label>
+              <span><input id="ru_ref" name="ru_ref" type="text" class="qa-ru-ref">
+              <img class="refresh" data-refresh="ru_ref"></span>
+            </div>
+
+             <div class="field-container">
+              <input type="submit" value="Flush Data" class="qa-btn-submit-dev btn"/>
+            </div>
+
+        </div>
+
+      </form>
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/dev_mode.py
+++ b/app/views/dev_mode.py
@@ -54,9 +54,34 @@ def dev_mode():
                                  region_code=region_code,
                                  language_code=language_code,
                                  variant_flags=variant_flags)
+
         return redirect("/session?token=" + generate_token(payload).decode())
 
     return render_template("dev-page.html", user=os.getenv('USER', 'UNKNOWN'), available_schemas=available_schemas())
+
+
+@dev_mode_blueprint.route('/dev_flush', methods=['GET', 'POST'])
+def dev_flush_mode():
+    if request.method == "POST":
+        form = request.form
+        schema = form.get("schema")
+        eq_id, form_type = extract_eq_id_and_form_type(schema)
+        collection_exercise_sid = form.get("collection_exercise_sid")
+        ru_ref = form.get("ru_ref")
+
+        payload = {
+            'iat': time.time(),
+            'exp': time.time() + 1000,
+            "eq_id": eq_id,
+            "form_type": form_type,
+            "collection_exercise_sid": collection_exercise_sid,
+            "ru_ref": ru_ref,
+            "roles": ["admin"],
+        }
+
+        return redirect("/flush?token=" + generate_token(payload).decode())
+
+    return render_template("dev-flush-page.html", user=os.getenv('USER', 'UNKNOWN'), available_schemas=available_schemas())
 
 
 def extract_eq_id_and_form_type(schema_name):

--- a/app/views/errors.py
+++ b/app/views/errors.py
@@ -5,7 +5,9 @@ from flask_login import current_user
 from structlog import get_logger
 from ua_parser import user_agent_parser
 
+from app.authentication.flush_permission_denied import FlushPermissionDenied
 from app.authentication.invalid_token_exception import InvalidTokenException
+from app.authentication.no_survey_data_to_flush import NoSurveyDataToFlush
 from app.authentication.no_token_exception import NoTokenException
 from app.globals import get_metadata
 from app.libs.utils import convert_tx_id
@@ -35,6 +37,7 @@ def unauthorized(error=None):
 
 
 @errors_blueprint.app_errorhandler(InvalidTokenException)
+@errors_blueprint.app_errorhandler(FlushPermissionDenied)
 def forbidden(error=None):
     log_exception(error)
     return _render_error_page(403)
@@ -42,6 +45,7 @@ def forbidden(error=None):
 
 @errors_blueprint.app_errorhandler(404)
 @errors_blueprint.app_errorhandler(QuestionnaireException)
+@errors_blueprint.app_errorhandler(NoSurveyDataToFlush)
 def page_not_found(error=None):
     log_exception(error)
     return _render_error_page(404)

--- a/app/views/flush.py
+++ b/app/views/flush.py
@@ -1,0 +1,74 @@
+from app.globals import get_answer_store, get_metadata, get_questionnaire_store
+from app.submitter.submitter import SubmitterFactory
+from app.submitter.converter import convert_answers
+from app.utilities.schema import get_schema
+
+from app.authentication.flush_permission_denied import FlushPermissionDenied
+from app.authentication.jwt_decoder import JWTDecryptor
+from app.authentication.map_role_to_permissions import map_role_to_permissions
+from app.authentication.no_survey_data_to_flush import NoSurveyDataToFlush
+from app.authentication.no_token_exception import NoTokenException
+from app.authentication.user import User
+from app.authentication.user_id_generator import UserIDGenerator
+
+from app.questionnaire.path_finder import PathFinder
+
+from flask import Blueprint, Response, request, session
+
+flush_blueprint = Blueprint('flush', __name__)
+
+
+@flush_blueprint.route('/flush', methods=['GET'])
+def flush_data():
+
+    if session:
+        session.clear()
+
+    encrypted_token = request.args.get('token')
+
+    if encrypted_token is None:
+        raise NoTokenException("Please provide a token")
+
+    decrypted_token = _jwt_decrypt(encrypted_token)
+
+    if decrypted_token.get('roles'):
+        current_user_permissions = map_role_to_permissions(decrypted_token["roles"])
+
+        if 'flush' in current_user_permissions:
+            user = _get_user(decrypted_token)
+            _submit_data(user)
+            get_questionnaire_store(user.user_id, user.user_ik).delete()
+        else:
+            raise FlushPermissionDenied("Your role doesn't have permission to flush data")
+    else:
+        raise FlushPermissionDenied("No role defined, you can't flush data")
+
+    return Response(status=200)
+
+
+def _submit_data(user):
+
+    answer_store = get_answer_store(user)
+
+    if answer_store.answers:
+        metadata = get_metadata(user)
+        json, schema = get_schema(metadata)
+        routing_path = PathFinder(json, answer_store, metadata).get_routing_path()
+        submitter = SubmitterFactory.get_submitter()
+        message = convert_answers(metadata, schema, answer_store, routing_path)
+        message['completed'] = False
+        submitter.send_answers(message)
+    else:
+        raise NoSurveyDataToFlush("There are no answers to flush")
+
+
+def _get_user(decrypted_token):
+    user_id = UserIDGenerator.generate_id(decrypted_token)
+    user_ik = UserIDGenerator.generate_ik(decrypted_token)
+    return User(user_id, user_ik)
+
+
+def _jwt_decrypt(encrypted_token):
+    decoder = JWTDecryptor()
+    decrypted_token = decoder.decrypt_jwt_token(encrypted_token)
+    return decrypted_token

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -294,6 +294,7 @@ def submit_answers(eq_id, form_type, collection_id):
         path_finder = PathFinder(g.schema_json, answer_store, metadata)
         submitter = SubmitterFactory.get_submitter()
         message = convert_answers(metadata, g.schema_json, answer_store, path_finder.get_routing_path())
+        message['completed'] = True
         submitter.send_answers(message)
 
         return redirect(url_for('.get_thank_you', eq_id=eq_id, form_type=form_type, collection_id=collection_id))

--- a/tests/app/views/test_dev_mode.py
+++ b/tests/app/views/test_dev_mode.py
@@ -3,6 +3,11 @@ def test_dev_mode(survey_runner):
     assert response.status_code == 200
 
 
+def test_dev_flush_mode(survey_runner):
+    response = survey_runner.test_client().get('/dev_flush')
+    assert response.status_code == 200
+
+
 def test_dev_mode_submission(survey_runner):
     # Use the parameters from the dev page
     response = survey_runner.test_client().post('/dev', data=dict(
@@ -22,3 +27,14 @@ def test_dev_mode_submission(survey_runner):
         user_id="test"
     ), follow_redirects=True)
     assert response.status_code == 200
+
+
+def test_dev_flush_mode_submission(survey_runner):
+    response = survey_runner.test_client().post('/dev_flush', data=dict(
+        schema="1_0205.json",
+        collection_exercise_sid="789",
+        ru_ref="12346789012A",
+    ), follow_redirects=True)
+
+    # As there is no data in the system there is nothing to flush and a 404 is returned
+    assert response.status_code == 404

--- a/tests/integration/test_flush_data.py
+++ b/tests/integration/test_flush_data.py
@@ -1,0 +1,94 @@
+import time
+
+from tests.integration.create_token import create_token
+from tests.integration.integration_test_case import IntegrationTestCase
+from tests.integration.mci import mci_test_urls
+from app.views.dev_mode import generate_token
+
+
+class TestFlushData(IntegrationTestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        token = create_token('0205', '1')
+        self.client.get('/session?token=' + token.decode(), follow_redirects=True)
+
+        post_data = {
+            'action[start_questionnaire]': 'Start Questionnaire'
+        }
+        resp = self.client.post(mci_test_urls.MCI_0205_INTRODUCTION, data=post_data, follow_redirects=False)
+        block_one_url = resp.location
+        self.client.get(block_one_url, follow_redirects=False)
+
+        form_data = {
+            "period-from-day": "01",
+            "period-from-month": "1",
+            "period-from-year": "2017",
+            "period-to-day": "01",
+            "period-to-month": "02",
+            "period-to-year": "2017",
+            "total-retail-turnover": "100000",
+            "action[save_continue]": "Save &amp; Continue"
+        }
+
+        self.client.post(block_one_url, data=form_data, follow_redirects=False)
+
+
+    def test_flush_data_successful(self):
+        resp = self.client.get('/flush?token=' + generate_token(self.get_payload()).decode(), follow_redirects=True)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_no_data_to_flush(self):
+
+        payload = self.get_payload()
+        # Made up ru_ref
+        payload['ru_ref'] = "no data"
+
+        resp = self.client.get('/flush?token=' + generate_token(payload).decode(), follow_redirects=False)
+        self.assertEqual(resp.status_code, 404)
+
+    def test_no_permission_to_flush(self):
+
+        payload = self.get_payload()
+        # A role with no flush permissions
+        payload['roles'] = ["test"]
+
+        resp = self.client.get('/flush?token=' + generate_token(payload).decode(), follow_redirects=False)
+        self.assertEqual(resp.status_code, 403)
+
+    def test_no_role_on_token(self):
+
+        payload = self.get_payload()
+        # Payload with no roles
+        del payload['roles']
+
+        resp = self.client.get('/flush?token=' + generate_token(payload).decode(), follow_redirects=False)
+        self.assertEqual(resp.status_code, 403)
+
+    def test_double_flush(self):
+
+        self.client.get('/flush?token=' + generate_token(self.get_payload()).decode(), follow_redirects=True)
+
+        # Once the data has been flushed it is wiped. It can't be flushed again and should return 404 no data on second flush
+        resp = self.client.get('/flush?token=' + generate_token(self.get_payload()).decode(), follow_redirects=True)
+        self.assertEqual(resp.status_code, 404)
+
+    def test_no_token_passed_to_flush(self):
+        resp = self.client.get('/flush', follow_redirects=False)
+        self.assertEqual(resp.status_code, 401)
+
+    def test_in_valid_token_passed_to_flush(self):
+        resp = self.client.get('/flush?token=test', follow_redirects=False)
+        self.assertEqual(resp.status_code, 403)
+
+    def get_payload(self):
+        return {
+            'iat': time.time(),
+            'exp': time.time() + 1000,
+            "eq_id": "1",
+            "form_type": "0205",
+            "collection_exercise_sid": "789",
+            "ru_ref": "123456789012A",
+            "roles": ["admin"],
+        }


### PR DESCRIPTION
### What is the context of this PR?
Add a /flush endpoint to survey runner that authenticates via the JWT, identifies which survey response the flush is required for (collection_exercise_sid, eq_id, form_type, ru_ref), and attempts to flush the requested survey response.

N.B at the moment its purely returning a status 200 if successful

### How to review 
1. Put a logger message in flush.py to expose the message being sent to RabbitMQ, just before submitter.send_answers(message) line 60
1. Open a survey as normal, taking note of the collection_exercise_sid, eq_id, form_type, ru_ref. Close the survey without submitting
2. Go to /dev_flush and put in the details above and hit flush, it should return a status 200
3. Test for incorrect and missing details and double flushing, recording the results