### PR TITLE
Implement a flush mechanism to push unfinished surveys downstream

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -180,6 +180,10 @@ def add_blueprints(application):
     application.register_blueprint(session_blueprint)
     session_blueprint.config = application.config.copy()
 
+    from app.views.flush import flush_blueprint
+    application.register_blueprint(flush_blueprint)
+    flush_blueprint.config = application.config.copy()
+
     from app.views.errors import errors_blueprint
     application.register_blueprint(errors_blueprint)
     errors_blueprint.config = application.config.copy()

--- a/app/templates/dev-flush-page.html
+++ b/app/templates/dev-flush-page.html
@@ -1,0 +1,28 @@
+{% set _theme="default" %}
+{% extends 'dev-page.html' %}
+{% block page_title %}EQ Development Flush Data{% endblock %}
+
+{% block devpage %}
+
+<div class="field-container">
+  <label for="schema">Schemas</label>
+    <select id="schema" name="schema" class="qa-select-schema">
+      {% for id in available_schemas %}
+      <option name="{{id}}" value="{{id}}">{{id}}</option>
+      {% endfor %}
+  </select>
+</div>
+
+<div class="field-container">
+  <label for="collection_exercise_sid">Collection Exercise SID</label>
+  <span><input id="collection_exercise_sid" name="collection_exercise_sid" type="text" class="qa-collection-sid">
+  <img class="refresh" data-refresh="collection_exercise_sid"></span>
+</div>
+
+<div class="field-container">
+  <label for="ru_ref">RU Ref</label>
+  <span><input id="ru_ref" name="ru_ref" type="text" class="qa-ru-ref">
+  <img class="refresh" data-refresh="ru_ref"></span>
+</div>
+
+{% endblock devpage %}

--- a/app/templates/dev-page.html
+++ b/app/templates/dev-page.html
@@ -1,5 +1,9 @@
 {% set _theme="default" %}
-{% extends 'layouts/_base.html' %} {% block page_title %}EQ Development{% endblock %} {% block content %}
+{% extends 'layouts/_base.html' %}
+
+{% block page_title %}EQ Development{% endblock %}
+
+{% block content %}
 
 <!-- this page needs a total rethink, but this tidies things up a little for now -->
 
@@ -85,6 +89,8 @@ select {
       <form action="" method="POST" xmlns="http://www.w3.org/1999/html">
 
         <div class="field-wrap">
+
+          {% block devpage %}
 
             <div class="field-container">
               <label for="user_id">User ID</label>
@@ -180,6 +186,8 @@ select {
               <input id="sexual_identity" type="checkbox" name="sexual_identity" class="qa-sexual-identity" value="true">
             </div>
 
+            {% endblock devpage %}
+
             <div class="field-container">
               <input type="submit" value="Open Survey" class="qa-btn-submit-dev btn"/>
             </div>
@@ -213,4 +221,4 @@ select {
 
 </script>
 
-{% endblock %}
+{% endblock content %}

--- a/app/views/dev_mode.py
+++ b/app/views/dev_mode.py
@@ -54,9 +54,36 @@ def dev_mode():
                                  region_code=region_code,
                                  language_code=language_code,
                                  variant_flags=variant_flags)
+
         return redirect("/session?token=" + generate_token(payload).decode())
 
     return render_template("dev-page.html", user=os.getenv('USER', 'UNKNOWN'), available_schemas=available_schemas())
+
+
+@dev_mode_blueprint.route('/dev/flush', methods=['POST'])
+def dev_flush_mode_post():
+    form = request.form
+    schema = form.get("schema")
+    eq_id, form_type = extract_eq_id_and_form_type(schema)
+    collection_exercise_sid = form.get("collection_exercise_sid")
+    ru_ref = form.get("ru_ref")
+
+    payload = {
+        'iat': time.time(),
+        'exp': time.time() + 1000,
+        "eq_id": eq_id,
+        "form_type": form_type,
+        "collection_exercise_sid": collection_exercise_sid,
+        "ru_ref": ru_ref,
+        "roles": ["flusher"],
+    }
+
+    return redirect("/flush?token=" + generate_token(payload).decode())
+
+
+@dev_mode_blueprint.route('/dev/flush', methods=['GET'])
+def dev_flush_mode_get():
+    return render_template("dev-flush-page.html", available_schemas=available_schemas())
 
 
 def extract_eq_id_and_form_type(schema_name):

--- a/app/views/flush.py
+++ b/app/views/flush.py
@@ -1,0 +1,62 @@
+from app.globals import get_answer_store, get_metadata, get_questionnaire_store
+from app.submitter.submitter import SubmitterFactory
+from app.submitter.converter import convert_answers
+from app.utilities.schema import get_schema
+
+from app.authentication.user import User
+from app.authentication.user_id_generator import UserIDGenerator
+from app.authentication.authenticator import jwt_decrypt
+
+from app.questionnaire.path_finder import PathFinder
+
+from flask import Blueprint, Response, request, session
+
+flush_blueprint = Blueprint('flush', __name__)
+
+
+@flush_blueprint.route('/flush', methods=['GET'])
+def flush_data():
+
+    if session:
+        session.clear()
+
+    encrypted_token = request.args.get('token')
+
+    if encrypted_token is None:
+        return Response(status=403)
+
+    decrypted_token = jwt_decrypt(encrypted_token)
+
+    roles = decrypted_token.get('roles')
+
+    if roles and 'flusher' in roles:
+        user = _get_user(decrypted_token)
+        if _submit_data(user):
+            return Response(status=200)
+        else:
+            return Response(status=404)
+    else:
+        return Response(status=403)
+
+
+def _submit_data(user):
+
+    answer_store = get_answer_store(user)
+
+    if answer_store.answers:
+        metadata = get_metadata(user)
+        schema = get_schema(metadata)
+        routing_path = PathFinder(schema, answer_store, metadata).get_routing_path()
+        submitter = SubmitterFactory.get_submitter()
+        message = convert_answers(metadata, schema, answer_store, routing_path)
+        submitter.send_answers(message)
+        get_questionnaire_store(user.user_id, user.user_ik).delete()
+        return True
+    else:
+        return False
+
+
+def _get_user(decrypted_token):
+    user_id = UserIDGenerator.generate_id(decrypted_token)
+    user_ik = UserIDGenerator.generate_ik(decrypted_token)
+    return User(user_id, user_ik)

--- a/tests/app/views/test_dev_mode.py
+++ b/tests/app/views/test_dev_mode.py
@@ -1,24 +1,41 @@
-def test_dev_mode(survey_runner):
-    response = survey_runner.test_client().get('/dev')
-    assert response.status_code == 200
+from tests.integration.integration_test_case import IntegrationTestCase
 
 
-def test_dev_mode_submission(survey_runner):
-    # Use the parameters from the dev page
-    response = survey_runner.test_client().post('/dev', data=dict(
-        exp="1800",
-        schema="0_star_wars.json",
-        period_str="May 2016",
-        period_id="201605",
-        collection_exercise_sid="789",
-        ru_ref="12346789012A",
-        ru_name="Apple",
-        trad_as="Apple",
-        ref_p_start_date="2016-05-01",
-        ref_p_end_date="2016-05-31",
-        return_by="2016-06-12",
-        employment_date="2016-06-10",
-        region_code="GB-GBN",
-        user_id="test"
-    ), follow_redirects=True)
-    assert response.status_code == 200
+class TestDevMode(IntegrationTestCase):
+
+    def test_dev_mode(self):
+        response = self.client.get('/dev')
+        self.assertEqual(response.status_code, 200)
+
+    def test_dev_flush_mode(self):
+        response = self.client.get('/dev/flush')
+        self.assertEqual(response.status_code, 200)
+
+
+    def test_dev_mode_submission(self):
+        # Use the parameters from the dev page
+        response = self.client.post('/dev', data=dict(
+            exp="1800",
+            schema="0_star_wars.json",
+            period_str="May 2016",
+            period_id="201605",
+            collection_exercise_sid="789",
+            ru_ref="12346789012A",
+            ru_name="Apple",
+            trad_as="Apple",
+            ref_p_start_date="2016-05-01",
+            ref_p_end_date="2016-05-31",
+            return_by="2016-06-12",
+            employment_date="2016-06-10",
+            region_code="GB-GBN",
+            user_id="test"
+        ), follow_redirects=True)
+        self.assertEqual(response.status_code, 200)
+
+    def test_dev_flush_mode_submission(self):
+        response = self.client.post('/dev/flush', data=dict(
+            schema="1_0205.json",
+            collection_exercise_sid="789",
+            ru_ref="12346789012A",
+        ), follow_redirects=True)
+        self.assertEqual(response.status_code, 404)

--- a/tests/integration/test_flush_data.py
+++ b/tests/integration/test_flush_data.py
@@ -1,0 +1,95 @@
+import time
+
+from tests.integration.create_token import create_token
+from tests.integration.integration_test_case import IntegrationTestCase
+from tests.integration.mci import mci_test_urls
+from app.views.dev_mode import generate_token
+
+
+class TestFlushData(IntegrationTestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        token = create_token('0205', '1')
+        self.client.get('/session?token=' + token.decode(), follow_redirects=True)
+
+        post_data = {
+            'action[start_questionnaire]': 'Start Questionnaire'
+        }
+        resp = self.client.post(mci_test_urls.MCI_0205_INTRODUCTION, data=post_data, follow_redirects=False)
+        block_one_url = resp.location
+        self.client.get(block_one_url, follow_redirects=False)
+
+        form_data = {
+            "period-from-day": "01",
+            "period-from-month": "4",
+            "period-from-year": "2016",
+            "period-to-day": "30",
+            "period-to-month": "4",
+            "period-to-year": "2016",
+            "total-retail-turnover": "100000",
+            "action[save_continue]": "Save &amp; Continue"
+        }
+
+        self.client.post(block_one_url, data=form_data, follow_redirects=False)
+
+    def test_flush_data_successful(self):
+
+        resp = self.client.get('/flush?token=' + generate_token(self.get_payload()).decode(), follow_redirects=True)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_no_data_to_flush(self):
+
+        payload = self.get_payload()
+        # Made up ru_ref
+        payload['ru_ref'] = "no data"
+
+        resp = self.client.get('/flush?token=' + generate_token(payload).decode(), follow_redirects=False)
+        self.assertEqual(resp.status_code, 404)
+
+    def test_no_permission_to_flush(self):
+
+        payload = self.get_payload()
+        # A role with no flush permissions
+        payload['roles'] = ["test"]
+
+        resp = self.client.get('/flush?token=' + generate_token(payload).decode(), follow_redirects=False)
+        self.assertEqual(resp.status_code, 403)
+
+    def test_no_role_on_token(self):
+
+        payload = self.get_payload()
+        # Payload with no roles
+        del payload['roles']
+
+        resp = self.client.get('/flush?token=' + generate_token(payload).decode(), follow_redirects=False)
+        self.assertEqual(resp.status_code, 403)
+
+    def test_double_flush(self):
+
+        self.client.get('/flush?token=' + generate_token(self.get_payload()).decode(), follow_redirects=True)
+
+        # Once the data has been flushed it is wiped. It can't be flushed again and should return 404 no data on second flush
+        resp = self.client.get('/flush?token=' + generate_token(self.get_payload()).decode(), follow_redirects=True)
+        self.assertEqual(resp.status_code, 404)
+
+    def test_no_token_passed_to_flush(self):
+        resp = self.client.get('/flush', follow_redirects=False)
+        self.assertEqual(resp.status_code, 403)
+
+    def test_invalid_token_passed_to_flush(self):
+        resp = self.client.get('/flush?token=test', follow_redirects=False)
+        self.assertEqual(resp.status_code, 403)
+
+    @staticmethod
+    def get_payload():
+        return {
+            'iat': time.time(),
+            'exp': time.time() + 1000,
+            "eq_id": "1",
+            "form_type": "0205",
+            "collection_exercise_sid": "789",
+            "ru_ref": "123456789012A",
+            "roles": ["flusher"],
+        }


### PR DESCRIPTION
### What is the context of this PR?
Add a /flush endpoint to survey runner that authenticates via the JWT, identifies which survey response the flush is required for (collection_exercise_sid, eq_id, form_type, ru_ref), and attempts to flush the requested survey response.

N.B at the moment its purely returning a status 200 if successful

### How to review 
1. Put a logger message in flush.py to expose the message being sent to RabbitMQ, just before submitter.send_answers(message) line 60
1. Open a survey as normal, taking note of the collection_exercise_sid, eq_id, form_type, ru_ref. Close the survey without submitting
2. Go to /dev_flush and put in the details above and hit flush, it should return a status 200
3. Test for incorrect and missing details and double flushing, recording the results
