### PR TITLE
Add an OptionalForm validator

### DIFF
--- a/app/forms/date_form.py
+++ b/app/forms/date_form.py
@@ -2,9 +2,8 @@ import logging
 import calendar
 
 from wtforms import Form, FormField, SelectField, StringField
-from wtforms import validators
 
-from app.validation.validators import DateCheck, DateRangeCheck, DateRequired, MonthYearCheck
+from app.validation.validators import DateCheck, OptionalForm, DateRangeCheck, DateRequired, MonthYearCheck
 
 logger = logging.getLogger(__name__)
 
@@ -21,14 +20,10 @@ def get_date_form(answer=None, to_field_data=None, validate_range=False, error_m
     :return: The generated DateForm metaclass
     """
     class DateForm(Form):
-
-        # Set up all the calendar month choices for select
-        MONTH_CHOICES = [('', 'Select month')] + [(str(x), calendar.month_name[x]) for x in range(1, 13)]
-
-        month = SelectField(choices=MONTH_CHOICES, default='')
+        day = StringField()
         year = StringField()
 
-    validate_with = [validators.Optional()]
+    validate_with = [OptionalForm()]
 
     if not error_messages:
         date_messages = {}
@@ -51,7 +46,10 @@ def get_date_form(answer=None, to_field_data=None, validate_range=False, error_m
     if validate_range and to_field_data:
         validate_with += [DateRangeCheck(to_field_data=to_field_data, messages=date_messages)]
 
-    DateForm.day = StringField(validators=validate_with)
+    # Set up all the calendar month choices for select
+    month_choices = [('', 'Select month')] + [(str(x), calendar.month_name[x]) for x in range(1, 13)]
+
+    DateForm.month = SelectField(choices=month_choices, default='', validators=validate_with)
 
     return DateForm
 
@@ -68,9 +66,7 @@ def get_month_year_form(answer, error_messages):
     class MonthYearDateForm(Form):
         year = StringField()
 
-    month_choices = [('', 'Select month')] + [(str(x), calendar.month_name[x]) for x in range(1, 13)]
-
-    validate_with = [validators.optional()]
+    validate_with = [OptionalForm()]
 
     if answer['mandatory'] is True:
         error_message = error_messages['MANDATORY']
@@ -86,6 +82,9 @@ def get_month_year_form(answer, error_messages):
         validate_with += [MonthYearCheck(error_message)]
     else:
         validate_with += [MonthYearCheck()]
+
+    # Set up all the calendar month choices for select
+    month_choices = [('', 'Select month')] + [(str(x), calendar.month_name[x]) for x in range(1, 13)]
 
     MonthYearDateForm.month = SelectField(choices=month_choices, default='', validators=validate_with)
 

--- a/app/templates/partials/forms/select.html
+++ b/app/templates/partials/forms/select.html
@@ -4,7 +4,7 @@
     <option {{{
       "value": option_value,
       "selected": "selected" if select.data == option_value,
-      "disabled": "disabled" if option_value == ''
+      "disabled": "disabled" if option_value == '' and select.flags.required
     }|xmlattr}}>{{option}}</option>
 
   {%- endfor -%}

--- a/tests/app/helpers/test_form_helper.py
+++ b/tests/app/helpers/test_form_helper.py
@@ -1,14 +1,12 @@
 import unittest
 
-from wtforms import validators
-
 from app import create_app
 from app.helpers.form_helper import get_form_for_location, post_form_for_location
 from app.helpers.schema_helper import SchemaHelper
 from app.questionnaire.location import Location
 from app.schema_loader.schema_loader import load_schema_file
 from app.data_model.answer_store import AnswerStore
-from app.validation.validators import DateRequired
+from app.validation.validators import DateRequired, OptionalForm
 
 from werkzeug.datastructures import MultiDict
 
@@ -36,8 +34,8 @@ class TestFormHelper(unittest.TestCase):
         period_from_field = getattr(form, "period-from")
         period_to_field = getattr(form, "period-to")
 
-        self.assertIsInstance(period_from_field.day.validators[0], DateRequired)
-        self.assertIsInstance(period_to_field.day.validators[0], DateRequired)
+        self.assertIsInstance(period_from_field.month.validators[0], DateRequired)
+        self.assertIsInstance(period_to_field.month.validators[0], DateRequired)
 
     def test_get_form_and_disable_mandatory_answers(self):
 
@@ -56,8 +54,8 @@ class TestFormHelper(unittest.TestCase):
         period_from_field = getattr(form, "period-from")
         period_to_field = getattr(form, "period-to")
 
-        self.assertIsInstance(period_from_field.day.validators[0], validators.Optional)
-        self.assertIsInstance(period_to_field.day.validators[0], validators.Optional)
+        self.assertIsInstance(period_from_field.month.validators[0], OptionalForm)
+        self.assertIsInstance(period_to_field.month.validators[0], OptionalForm)
 
     def test_get_form_deserialises_dates(self):
         survey = load_schema_file("1_0102.json")
@@ -175,8 +173,8 @@ class TestFormHelper(unittest.TestCase):
         period_to_field = getattr(form, "period-to")
         period_from_field = getattr(form, "period-from")
 
-        self.assertIsInstance(period_from_field.day.validators[0], DateRequired)
-        self.assertIsInstance(period_to_field.day.validators[0], DateRequired)
+        self.assertIsInstance(period_from_field.month.validators[0], DateRequired)
+        self.assertIsInstance(period_to_field.month.validators[0], DateRequired)
 
         self.assertEquals(period_from_field.data, {
             'day': '1',
@@ -206,8 +204,8 @@ class TestFormHelper(unittest.TestCase):
         period_from_field = getattr(form, "period-from")
         period_to_field = getattr(form, "period-to")
 
-        self.assertIsInstance(period_from_field.day.validators[0], validators.Optional)
-        self.assertIsInstance(period_to_field.day.validators[0], validators.Optional)
+        self.assertIsInstance(period_from_field.month.validators[0], OptionalForm)
+        self.assertIsInstance(period_to_field.month.validators[0], OptionalForm)
 
     def test_get_form_for_household_composition(self):
 

--- a/tests/app/validation/test_optional_form_validator.py
+++ b/tests/app/validation/test_optional_form_validator.py
@@ -1,0 +1,93 @@
+import unittest
+from unittest.mock import Mock
+
+from app.validation.validators import OptionalForm
+from wtforms.validators import StopValidation
+
+
+class TestOptionalFormValidator(unittest.TestCase):
+    def test_date_optional_empty(self):
+        validator = OptionalForm()
+
+        mock_form = Mock()
+
+        mock_day = Mock()
+        mock_month = Mock()
+        mock_year = Mock()
+
+        mock_day.raw_data = ['']
+        mock_month.raw_data = []
+        mock_year.raw_data = ['']
+
+        mock_form.__iter__ = Mock(return_value=iter([mock_day, mock_month, mock_year]))
+
+        mock_field = Mock()
+
+        with self.assertRaises(StopValidation) as ite:
+            validator(mock_form, mock_field)
+
+        self.assertEqual('', str(ite.exception))
+
+    def test_month_year_optional_month_empty(self):
+        validator = OptionalForm()
+
+        mock_form = Mock()
+
+        mock_month = Mock()
+        mock_year = Mock()
+
+        mock_month.raw_data = []
+        mock_year.raw_data = ['']
+
+        mock_form.__iter__ = Mock(return_value=iter([mock_month, mock_year]))
+
+        mock_field = Mock()
+
+        with self.assertRaises(StopValidation) as ite:
+            validator(mock_form, mock_field)
+
+        self.assertEqual('', str(ite.exception))
+
+    def test_date_optional_missing_day(self):
+
+        validator = OptionalForm()
+
+        mock_form = Mock()
+
+        mock_day = Mock()
+        mock_month = Mock()
+        mock_year = Mock()
+
+        mock_day.raw_data = ['']
+        mock_month.raw_data = ['01']
+        mock_year.raw_data = ['2015']
+
+        mock_form.__iter__ = Mock(return_value=iter([mock_day, mock_month, mock_year]))
+
+        mock_field = Mock()
+
+        try:
+            validator(mock_form, mock_field)
+        except StopValidation:
+            self.fail("Date that needs checking raised StopValidation")
+
+    def test_month_year_optional_missing_year(self):
+
+        validator = OptionalForm()
+
+        mock_form = Mock()
+
+        mock_month = Mock()
+        mock_year = Mock()
+
+        mock_month.raw_data = ['01']
+        mock_year.raw_data = ['']
+
+        mock_form.__iter__ = Mock(return_value=iter([mock_month, mock_year]))
+
+        mock_field = Mock()
+
+        try:
+            validator(mock_form, mock_field)
+        except StopValidation:
+            self.fail("Date that needs checking raised StopValidation")

--- a/tests/functional/pages/surveys/dates/dates-answers.page.js
+++ b/tests/functional/pages/surveys/dates/dates-answers.page.js
@@ -64,6 +64,21 @@ class DatesPage extends QuestionPage {
     browser.setValue('[name="month-year-answer-year"]', year)
     return this
   }
+
+  setNonMandatoryDateAnswerDay(day) {
+    browser.setValue('[name="non-mandatory-date-answer-day"]', day)
+    return this
+  }
+
+  setNonMandatoryDateAnswerMonth(month) {
+    browser.selectByValue('[name="non-mandatory-date-answer-month"]', month)
+    return this
+  }
+
+  setNonMandatoryDateAnswerYear(year) {
+    browser.setValue('[name="non-mandatory-date-answer-year"]', year)
+    return this
+  }
 }
 
 export default new DatesPage()

--- a/tests/functional/pages/surveys/dates/dates-summary.page.js
+++ b/tests/functional/pages/surveys/dates/dates-summary.page.js
@@ -1,6 +1,6 @@
 import SummaryPage from '../../summary.page'
 
-class RSISummaryPage extends SummaryPage {
+class DateSummaryPage extends SummaryPage {
 
   getDateRangeSummary() {
     return browser.element('[data-qa="date-range-from-answer"]').getText()
@@ -17,6 +17,10 @@ class RSISummaryPage extends SummaryPage {
   getNonMandatoryDate() {
     return browser.element('[data-qa="non-mandatory-date-answer-answer"]').getText()
   }
+
+  editNonMandatoryDate() {
+    return browser.element('[data-qa="non-mandatory-date-answer-edit"]').click()
+  }
 }
 
-export default new RSISummaryPage()
+export default new DateSummaryPage()

--- a/tests/functional/spec/dates.spec.js
+++ b/tests/functional/spec/dates.spec.js
@@ -132,7 +132,7 @@ describe('Date checks', function() {
       it('Given the test_dates survey is selected when an error message is shown then when it is corrected, it goes to the summary page and the information is correct', function() {
 
             // Given the test_dates survey is selected
-             startQuestionnaire('test_dates.json')
+            startQuestionnaire('test_dates.json')
 
             // When an error message is shown
             DatesPage.setFromReportingPeriodDay(1)
@@ -168,6 +168,66 @@ describe('Date checks', function() {
             expect(SummaryPage.getDateRangeSummary()).to.contain('01 January 2016 to 03 January 2017')
             expect(SummaryPage.getMonthYearDateSummary()).to.contain('June 2018')
 
+      })
+
+      it('Given the test_dates survey is selected when a partially completed optional date is submitted, an error is shown', function() {
+            // Given the test_dates survey is selected
+            startQuestionnaire('test_dates.json')
+
+            // Setup the mandatory stuff
+            DatesPage.setFromReportingPeriodDay(1)
+              .setFromReportingPeriodMonth(1)
+              .setFromReportingPeriodYear(2016)
+              .setToReportingPeriodDay(3)
+              .setToReportingPeriodMonth(1)
+              .setToReportingPeriodYear(2017)
+              .setMonthYearMonth(6)
+              .setMonthYearYear(2018)
+              .setDateOfBirthDay(4)
+              .setDateOfBirthMonth(1)
+              .setDateOfBirthYear(1999)
+
+            // When
+            DatesPage.setNonMandatoryDateAnswerDay(1)
+                     .setNonMandatoryDateAnswerMonth(10)
+                     .submit()
+            // Then
+            expect(DatesPage.getAlertText()).to.contain('The date entered is not valid. Please correct your answer.')
+      })
+
+      it('Given a optional date is successfully submitted, when the date is edited, it should then be possible to select an empty month', function() {
+            // Given the test_dates survey is selected
+            startQuestionnaire('test_dates.json')
+
+            // Setup the mandatory stuff
+            DatesPage.setFromReportingPeriodDay(1)
+              .setFromReportingPeriodMonth(1)
+              .setFromReportingPeriodYear(2016)
+              .setToReportingPeriodDay(3)
+              .setToReportingPeriodMonth(1)
+              .setToReportingPeriodYear(2017)
+              .setMonthYearMonth(6)
+              .setMonthYearYear(2018)
+              .setDateOfBirthDay(4)
+              .setDateOfBirthMonth(1)
+              .setDateOfBirthYear(1999)
+
+            DatesPage.setNonMandatoryDateAnswerDay(12)
+              .setNonMandatoryDateAnswerMonth(1)
+              .setNonMandatoryDateAnswerYear(2016)
+              .submit()
+
+            expect(SummaryPage.getDateRangeSummary()).to.contain('01 January 2016 to 03 January 2017')
+            expect(SummaryPage.getMonthYearDateSummary()).to.contain('June 2018')
+
+            // When
+            SummaryPage.editNonMandatoryDate()
+
+            DatesPage.setNonMandatoryDateAnswerMonth('')
+              .submit()
+
+            // Then
+            expect(DatesPage.getAlertText()).to.contain('The date entered is not valid. Please correct your answer.')
       })
 
       it('Given the test_dates survey is selected, when a user clicks the day label then the day subfield should gain the focus', function() {

--- a/tests/integration/questionnaire/test_questionnaire_save_sign_out.py
+++ b/tests/integration/questionnaire/test_questionnaire_save_sign_out.py
@@ -26,6 +26,7 @@ class TestSaveSignOut(IntegrationTestCase):
             "action[save_sign_out]": "Save and sign out"
         }
         resp = self.client.post(block_one_url, data=post_data, follow_redirects=False)
+
         self.assertEquals(resp.status_code, 302)
 
         # Then
@@ -63,7 +64,7 @@ class TestSaveSignOut(IntegrationTestCase):
         content = resp.get_data(True)
         self.assertRegexpMatches(content, 'Please only enter whole numbers into the field.')
 
-    def test_save_sign_out_complete_a_block_then_revist_it(self):
+    def test_save_sign_out_complete_a_block_then_revisit_it(self):
 
         # If a user completes a block, but then goes back and uses save and come back on that block, that block
         # should no longer be considered complete and on re-authenticate it should return to it


### PR DESCRIPTION
This adds an OptionalForm validator, which can be applied to any single field on a form to correctly halt validation if all of the fields on the form are empty. 

We use this currently only with DateForms, but could be used on any formfield which has multiple subfields that is only deemed empty when all fields are empty.

Also fixed a regression around optional month fields being able to change their answers back to empty (#930).

Fixes issues #922, #930  

### How to review 
Check it out, using Census/Individual see if you can proceed without entering a day in the date of birth field.