### PR TITLE
Fixes #923 other text value retained even when other not selected.

### DIFF
--- a/tests/app/helpers/test_form_helper.py
+++ b/tests/app/helpers/test_form_helper.py
@@ -348,3 +348,71 @@ class TestFormHelper(unittest.TestCase):
 
         # Check the data matches what was passed from request
         self.assertEqual(field_list.entries[0].data, "3")
+
+    def test_post_form_for_radio_other_not_selected(self):
+        survey = load_schema_file("test_radio.json")
+
+        block_json = SchemaHelper.get_block(survey, 'block-1')
+        location = Location('14ba4707-321d-441d-8d21-b8367366e766', 0, 'block-1')
+        error_messages = SchemaHelper.get_messages(survey)
+
+        answer_store = AnswerStore([
+            {
+                'answer_id': 'ca3ce3a3-ae44-4e30-8f85-5b6a7a2fb23c',
+                'block_id': 'block-1',
+                'value': 'Other',
+                'answer_instance': 0,
+            },
+            {
+                'answer_id': 'other-answer-mandatory',
+                'block_id': 'block-1',
+                'value': 'Other text field value',
+                'answer_instance': 0,
+            }
+        ])
+
+        answer = SchemaHelper.get_first_answer_for_block(block_json)
+
+        form, _ = post_form_for_location(block_json, location, answer_store, MultiDict({
+            '{answer_id}'.format(answer_id=answer['id']): 'Bacon',
+            'other-answer-mandatory': 'Old other text'
+        }), error_messages)
+
+        self.assertTrue(hasattr(form, answer['id']))
+
+        other_text_field = getattr(form, 'other-answer-mandatory')
+        self.assertEqual(other_text_field.data, '')
+
+    def test_post_form_for_radio_other_selected(self):
+        survey = load_schema_file("test_radio.json")
+
+        block_json = SchemaHelper.get_block(survey, 'block-1')
+        location = Location('14ba4707-321d-441d-8d21-b8367366e766', 0, 'block-1')
+        error_messages = SchemaHelper.get_messages(survey)
+
+        answer_store = AnswerStore([
+            {
+                'answer_id': 'ca3ce3a3-ae44-4e30-8f85-5b6a7a2fb23c',
+                'block_id': 'block-1',
+                'value': 'Other',
+                'answer_instance': 0,
+            },
+            {
+                'answer_id': 'other-answer-mandatory',
+                'block_id': 'block-1',
+                'value': 'Other text field value',
+                'answer_instance': 0,
+            }
+        ])
+
+        radio_answer = SchemaHelper.get_first_answer_for_block(block_json)
+        text_answer = 'other-answer-mandatory'
+
+        form, _ = post_form_for_location(block_json, location, answer_store, MultiDict({
+            '{answer_id}'.format(answer_id=radio_answer['id']): 'Other',
+            '{answer_id}'.format(answer_id=text_answer): 'Other text field value',
+        }), error_messages)
+
+        other_text_field = getattr(form, 'other-answer-mandatory')
+        self.assertEqual(other_text_field.data, 'Other text field value')
+

--- a/tests/functional/pages/surveys/multiple-choice.page.js
+++ b/tests/functional/pages/surveys/multiple-choice.page.js
@@ -2,8 +2,18 @@ import QuestionPage from './question.page'
 
 class MultipleChoiceWithOtherPage extends QuestionPage {
 
-  clickOther(){
+  clickOther() {
     browser.element('[data-qa="has-other-option"]').click()
+    return this
+  }
+
+  clickBacon() {
+    browser.element('[name="ca3ce3a3-ae44-4e30-8f85-5b6a7a2fb23c"]').click()
+    return this
+  }
+
+  clickCheese() {
+    browser.element('[name="ca3ce3a3-ae44-4e30-8f85-5b6a7a2fb23c"]').click()
     return this
   }
 
@@ -20,6 +30,14 @@ class MultipleChoiceWithOtherPage extends QuestionPage {
     return this
   }
 
+  getOtherInputField() {
+    return browser.element('[data-qa="other-option"]').getValue()
+  }
+
+  clickTopprevious() {
+    browser.element('a[id="top-previous"]').click()
+    return this
+  }
 }
 
 export default MultipleChoiceWithOtherPage

--- a/tests/functional/spec/checkbox.spec.js
+++ b/tests/functional/spec/checkbox.spec.js
@@ -82,4 +82,20 @@ describe('Checkbox with "other" option', function() {
      expect(SummaryPage.getPage2OtherAnswer()).to.have.string('The other value');
   })
 
+  it('Given I have previously added text in other texfiled and saved, when I uncheck other options and select a different checkbox as answer, then the text entered in other field must be wiped.', function() {
+     // Given
+     startQuestionnaire(checkbox_schema)
+
+     // When
+     MandatoryCheckboxPage.clickOther().setOtherInputField('Other value').submit();
+     OptionalCheckboxPage.clickTopprevious()
+     MandatoryCheckboxPage.clickOther()
+     .clickCheese()
+     .submit()
+     OptionalCheckboxPage.clickTopprevious()
+     // Then
+     MandatoryCheckboxPage.clickOther()
+     expect(MandatoryCheckboxPage.getOtherInputField()).to.equal('')
+  })
+
 })

--- a/tests/functional/spec/radio.spec.js
+++ b/tests/functional/spec/radio.spec.js
@@ -29,6 +29,7 @@ describe('Radio button with "other" option', function() {
     MandatoryRadioPage.clickOther().setOtherInputField('Hello').submit()
     OptionalRadioPage.submit(); // Skip second page.
 
+
     //Then
     expect(SummaryPage.getPage1Answer()).to.contain('Hello')
   })
@@ -56,4 +57,20 @@ describe('Radio button with "other" option', function() {
     //Then
     expect(OptionalRadioPage.errorExists()).to.be.false
   })
+
+  it('Given I have previously added text in other texfiled and saved, when I change the awnser to a diffrent answer, then the text entered in other field must be wiped.', function() {
+    //Given
+    startQuestionnaire(radio_schema);
+
+    //When
+    MandatoryRadioPage.clickOther().setOtherInputField('Other Text').submit()
+    OptionalRadioPage.clickTopprevious()
+    MandatoryRadioPage.clickBacon().submit()
+    OptionalRadioPage.clickTopprevious()
+
+    //Then
+    MandatoryRadioPage.clickOther()
+    expect(MandatoryRadioPage.getOtherInputField()).to.equal('')
+  })
+
 })


### PR DESCRIPTION
### What is the context of this PR?
Fixes #923.

### How to review 
All automated tests should pass.
Open either `test_checkbox.json` and `test_radio.json` schemas.
Select the `Other` option and enter a value into the text field.
Save and continue.
Go back.
Select a different option.
Save and continue.
Go back.
Select the `Other` option again.
Confirm that the previous value is not in the Other text field.

Should also work when selecting multiple options (checkbox).