### PR TITLE
Fixes Census Household Name piping on 'Your household includes' page

### DIFF
--- a/app/templating/schema_context.py
+++ b/app/templating/schema_context.py
@@ -1,3 +1,4 @@
+from app import settings
 from app.utilities.date_utils import to_date
 
 
@@ -23,7 +24,7 @@ def _map_alias_to_answers(aliases, answer_store):
     for alias, answer_info in aliases.items():
         matching_answers = []
 
-        answers = answer_store.filter(answer_id=answer_info['answer_id'])
+        answers = answer_store.filter(answer_id=answer_info['answer_id'], limit=settings.EQ_MAX_NUM_REPEATS)
         matching_answers.extend([answer['value'] for answer in answers])
 
         number_of_matches = len(matching_answers)

--- a/tests/app/templating/test_schema_context.py
+++ b/tests/app/templating/test_schema_context.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock
 
+from app.data_model.answer_store import AnswerStore
 from app.templating.schema_context import build_schema_context
 from tests.app.framework.survey_runner_test_case import SurveyRunnerTestCase
 
@@ -192,3 +193,21 @@ class TestMetadataContext(SurveyRunnerTestCase):
         context_answers = schema_context['answers']
         self.assertIsInstance(context_answers['non_repeating_answer_alias'], str)
         self.assertEqual(context_answers['non_repeating_answer_alias'], 'Some Value')
+
+    def test_maximum_answers_must_be_limited_to_system_max(self):
+        aliases = {
+            'repeating_answer_alias': {
+                'answer_id': 'answer_id',
+                'repeats': True,
+            },
+        }
+        answers = [{
+            'answer_id': 'answer_id',
+            'answer_instance': instance,
+            'value': 'Some Value',
+        } for instance in range(26)]
+
+        schema_context = build_schema_context(self.metadata, aliases, AnswerStore(answers))
+
+        context_answers = schema_context['answers']
+        self.assertEqual(len(context_answers['repeating_answer_alias']), 25)


### PR DESCRIPTION
### What is the context of this PR?
Fixes #906 

### How to review 
Retest defect #906

Launch Census Household schema
Add more than 25 people to the household and
Navigate to 'Your household includes:' screen
Must only display 25 people on 'Your household includes:' and on the Navigation panel