### PR TITLE
Fix #931: Override validate and add date range validation at form level

### DIFF
--- a/app/forms/date_form.py
+++ b/app/forms/date_form.py
@@ -1,22 +1,20 @@
 import logging
 import calendar
 
-from wtforms import Form, FormField, SelectField, StringField
+from wtforms import Form, SelectField, StringField
 
-from app.validation.validators import DateCheck, OptionalForm, DateRangeCheck, DateRequired, MonthYearCheck
+from app.validation.validators import DateCheck, OptionalForm, DateRequired, MonthYearCheck
 
 logger = logging.getLogger(__name__)
 
 
-def get_date_form(answer=None, to_field_data=None, validate_range=False, error_messages=None):
+def get_date_form(answer=None, error_messages=None):
     """
     Returns a date form metaclass with appropriate validators. Used in both date and
     date range form creation.
 
     :param error_messages: The messages during validation
     :param answer: The answer on which to base this form
-    :param to_field_data: The data coming from the
-    :param validate_range: Whether the dateform should add a daterange validator
     :return: The generated DateForm metaclass
     """
     class DateForm(Form):
@@ -42,9 +40,6 @@ def get_date_form(answer=None, to_field_data=None, validate_range=False, error_m
         date_messages['INVALID_DATE'] = answer['validation']['messages']['INVALID_DATE']
 
     validate_with += [DateCheck(date_messages['INVALID_DATE'])]
-
-    if validate_range and to_field_data:
-        validate_with += [DateRangeCheck(to_field_data=to_field_data, messages=date_messages)]
 
     # Set up all the calendar month choices for select
     month_choices = [('', 'Select month')] + [(str(x), calendar.month_name[x]) for x in range(1, 13)]
@@ -89,50 +84,3 @@ def get_month_year_form(answer, error_messages):
     MonthYearDateForm.month = SelectField(choices=month_choices, default='', validators=validate_with)
 
     return MonthYearDateForm
-
-
-def get_date_range_fields(question_json, to_field_data, error_messages):
-    """
-    Create a date form for each answer id within a date range question
-
-    :param question_json: The question json on which to base the date ranges
-    :param to_field_data: The to_field_data to use during validation of the from field
-    :param error_messages: The messages to use upon this form during validation
-    :return: The generated form fields to use upon a metaclass
-    """
-    answer_from = question_json['answers'][0]
-    answer_to = question_json['answers'][1]
-
-    field_from = FormField(
-        get_date_form(answer=answer_from, to_field_data=to_field_data, validate_range=True, error_messages=error_messages),
-        label=answer_from['label'] if 'label' in answer_from else '',
-        description=answer_from['guidance'] if 'guidance' in answer_from else '',
-    )
-    field_to = FormField(
-        get_date_form(answer=answer_to, error_messages=error_messages),
-        label=answer_to['label'] if 'label' in answer_to else '',
-        description=answer_to['guidance'] if 'guidance' in answer_to else '',
-    )
-
-    return field_from, field_to
-
-
-def get_date_data(form_data, answer_id):
-    """
-    Extract date from a form or serialised answer and return as a dict that wtforms would use
-
-    :param form_data: The form data to search through
-    :param answer_id: The answer_id to search for
-    :return:
-    """
-    day_id = answer_id + '-day'
-    month_id = answer_id + '-month'
-    year_id = answer_id + '-year'
-
-    if all(x in form_data for x in [day_id, month_id, year_id]):
-        return {
-            'day': form_data[day_id],
-            'month': form_data[month_id],
-            'year': form_data[year_id],
-        }
-    return None

--- a/app/forms/household_composition_form.py
+++ b/app/forms/household_composition_form.py
@@ -72,6 +72,7 @@ def map_field_errors(errors, index):
 
 def generate_household_composition_form(block_json, data, error_messages):
     class HouseHoldCompositionForm(FlaskForm):
+        question_errors = {}
         household = FieldList(FormField(get_name_form(block_json, error_messages)), min_entries=1)
 
         def map_errors(self):

--- a/app/forms/household_relationship_form.py
+++ b/app/forms/household_relationship_form.py
@@ -85,6 +85,8 @@ def generate_relationship_form(block_json, number_of_entries, data, error_messag
     answer = SchemaHelper.get_first_answer_for_block(block_json)
 
     class HouseHoldRelationshipForm(FlaskForm):
+        question_errors = {}
+
         def map_errors(self):
             ordered_errors = []
 

--- a/app/forms/questionnaire_form.py
+++ b/app/forms/questionnaire_form.py
@@ -1,26 +1,74 @@
 import logging
 
+from wtforms import validators
+
 from flask_wtf import FlaskForm
 
-from app.forms.date_form import get_date_data, get_date_range_fields
 from app.forms.fields import get_field
 from app.helpers.schema_helper import SchemaHelper
+from app.validation.validators import DateRangeCheck
 
 from werkzeug.datastructures import MultiDict
 
 logger = logging.getLogger(__name__)
 
 
-def get_date_range_field(question, data, error_messages):
-    to_field_id = question['answers'][1]['id']
-    to_field_data = get_date_data(data, to_field_id)
+class QuestionnaireForm(FlaskForm):
 
-    from_field, to_field = get_date_range_fields(question, to_field_data, error_messages)
+    def __init__(self, block_json, formdata=None, **kwargs):
+        self.block_json = block_json
+        self.question_errors = {}
 
-    return {
-        question['answers'][0]['id']: from_field,
-        question['answers'][1]['id']: to_field,
-    }
+        if formdata:
+            super(QuestionnaireForm, self).__init__(formdata=formdata, **kwargs)
+        else:
+            super(QuestionnaireForm, self).__init__(**kwargs)
+
+    def validate(self):
+        """
+        Validate this form as usual and check for any form-level date-range validation errors
+        :return:
+        """
+        valid_form = True
+        valid_fields = FlaskForm.validate(self)
+
+        for question_id, period_from_id, period_to_id in self.date_ranges:
+            if period_from_id not in self.errors and period_to_id not in self.errors:
+                period_from = getattr(self, period_from_id)
+                period_to = getattr(self, period_to_id)
+                validator = DateRangeCheck()
+
+                # Check every field on each form has populated data
+                populated = all([f.data for f in period_from] + [f.data for f in period_to])
+
+                if populated:
+                    try:
+                        validator(self, period_from, period_to)
+                    except validators.ValidationError as e:
+                        self.question_errors[question_id] = str(e)
+                        valid_form = False
+
+        return valid_fields and valid_form
+
+    def map_errors(self):
+        ordered_errors = []
+
+        question_json_list = SchemaHelper.get_questions_for_block(self.block_json)
+
+        for question_json in question_json_list:
+            if question_json['id'] in self.question_errors:
+                ordered_errors += [(question_json['id'], self.question_errors[question_json['id']])]
+
+            for answer_json in question_json['answers']:
+                if answer_json['id'] in self.errors and 'parent_answer_id' not in answer_json:
+                    ordered_errors += map_subfield_errors(self.errors, answer_json['id'])
+                if 'options' in answer_json and 'parent_answer_id' not in answer_json:
+                    ordered_errors += map_child_option_errors(self.errors, answer_json)
+
+        return ordered_errors
+
+    def answer_errors(self, input_id):
+        return [error[1] for error in self.map_errors() if input_id == error[0]]
 
 
 def get_answer_fields(question, data, error_messages):
@@ -63,38 +111,22 @@ def map_child_option_errors(errors, answer_json):
 
 
 def generate_form(block_json, data, error_messages):
-
-    class QuestionnaireForm(FlaskForm):
-        def map_errors(self):
-            ordered_errors = []
-
-            answer_json_list = SchemaHelper.get_answers_for_block(block_json)
-
-            for answer_json in answer_json_list:
-                if answer_json['id'] in self.errors and 'parent_answer_id' not in answer_json:
-                    ordered_errors += map_subfield_errors(self.errors, answer_json['id'])
-                if 'options' in answer_json and 'parent_answer_id' not in answer_json:
-                    ordered_errors += map_child_option_errors(self.errors, answer_json)
-
-            return ordered_errors
-
-        def answer_errors(self, input_id):
-            return [error[1] for error in self.map_errors() if input_id == error[0]]
-
     answer_fields = {}
+
+    class DynamicForm(QuestionnaireForm):
+        date_ranges = []
 
     for question in SchemaHelper.get_questions_for_block(block_json):
         if question['type'] == 'DateRange':
-            answer_fields.update(get_date_range_field(question, data, error_messages))
-        else:
-            answer_fields.update(get_answer_fields(question, data, error_messages))
+            DynamicForm.date_ranges += [(question['id'], question['answers'][0]['id'], question['answers'][1]['id'])]
+        answer_fields.update(get_answer_fields(question, data, error_messages))
 
     for answer_id, field in answer_fields.items():
-        setattr(QuestionnaireForm, answer_id, field)
+        setattr(DynamicForm, answer_id, field)
 
     if data:
-        form = QuestionnaireForm(MultiDict(data), meta={'csrf': False})
+        form = DynamicForm(block_json, MultiDict(data), meta={'csrf': False})
     else:
-        form = QuestionnaireForm(meta={'csrf': False})
+        form = DynamicForm(block_json, meta={'csrf': False})
 
     return form

--- a/app/templates/partials/answer.html
+++ b/app/templates/partials/answer.html
@@ -31,7 +31,18 @@
 
   {% if invalid %}
     {% set answer_id = answer.id %}
-    {% include 'partials/errors.html' %}
+    <div class="panel panel--simple panel--error" data-qa="error">
+      <div class="panel__header">
+        <ul class="list list--bare list--errors">
+            {% for field_error in form.answer_errors(answer_id) %}
+                <li class="list__item mars" {{helpers.errorTracking(question.id, field_error)}}>{{ field_error }}</li>
+            {% endfor %}
+        </ul>
+      </div>
+      <div class="panel__body" data-qa="error-body">
+        {{answer_fields|safe}}
+      </div>
+    </div>
 
     {{answer_guidance|safe}}
 

--- a/app/templates/partials/question.html
+++ b/app/templates/partials/question.html
@@ -1,6 +1,6 @@
 {% import 'macros/helpers.html' as helpers %}
 
-{% set invalid = question.is_valid == False %}
+{% set invalid = form.question_errors[question.id] | length > 0 if form else False %}
 
 {% set question_number = question.number %}
 {% set question_title = question.title %}

--- a/app/templates/partials/questions/errors.html
+++ b/app/templates/partials/questions/errors.html
@@ -1,10 +1,8 @@
 <div class="panel panel--simple panel--error" data-qa="error">
   <div class="panel__header">
-    {% if question.errors %}
+    {% if form.question_errors[question.id] is not none %}
     <ul class="list list--bare list--errors">
-      {% for error in question.errors %}
-        <li class="list__item venus" {{helpers.errorTracking(question.id, error)}}>{{ error }}</li>
-      {% endfor %}
+      <li class="list__item venus" {{helpers.errorTracking(question.id, error)}}>{{ form.question_errors[question.id] }}</li>
     </ul>
     {% endif %}
   </div>

--- a/app/templates/questionnaire.html
+++ b/app/templates/questionnaire.html
@@ -13,7 +13,7 @@
 
 {% block main %}
 
-    {% if form and form.errors %}
+    {% if form and (form.errors or form.question_errors) %}
 
     {% set mapped_errors = form.map_errors() %}
 

--- a/app/validation/validators.py
+++ b/app/validation/validators.py
@@ -122,26 +122,22 @@ class MonthYearCheck(object):
 
 
 class DateRangeCheck(object):
-    def __init__(self, to_field_data=None, messages=None):
-        self.to_field_data = to_field_data
+    def __init__(self, messages=None):
         if not messages:
             messages = error_messages
         self.messages = messages
 
-    def __call__(self, form, from_field):
+    def __call__(self, form, from_field, to_field):
 
-        if form.day and form.month and form.year and self.to_field_data:
-            to_date_str = "{:02d}/{:02d}/{}".format(int(self.to_field_data['day'] or 0), int(self.to_field_data['month'] or 0),
-                                                    self.to_field_data['year'] or '')
-            from_date_str = "{:02d}/{:02d}/{}".format(int(form.day.data or 0), int(form.month.data or 0),
-                                                      form.year.data or '')
+        from_date_str = "{:02d}/{:02d}/{}".format(int(from_field.day.data or 0), int(from_field.month.data or 0),
+                                                  from_field.year.data or '')
+        to_date_str = "{:02d}/{:02d}/{}".format(int(to_field.day.data or 0), int(to_field.month.data or 0),
+                                                to_field.year.data or '')
 
-            from_date = datetime.strptime(from_date_str, "%d/%m/%Y")
-            to_date = datetime.strptime(to_date_str, "%d/%m/%Y")
+        from_date = datetime.strptime(from_date_str, "%d/%m/%Y")
+        to_date = datetime.strptime(to_date_str, "%d/%m/%Y")
 
-            date_diff = to_date - from_date
-
-            if date_diff.total_seconds() == 0:
-                raise validators.ValidationError(self.messages['INVALID_DATE_RANGE_TO_FROM_SAME'])
-            elif date_diff.total_seconds() < 0:
-                raise validators.ValidationError(self.messages['INVALID_DATE_RANGE_TO_BEFORE_FROM'])
+        if from_date == to_date:
+            raise validators.ValidationError(self.messages['INVALID_DATE_RANGE_TO_FROM_SAME'])
+        elif from_date > to_date:
+            raise validators.ValidationError(self.messages['INVALID_DATE_RANGE_TO_BEFORE_FROM'])

--- a/tests/app/forms/test_date_form.py
+++ b/tests/app/forms/test_date_form.py
@@ -1,7 +1,7 @@
 import unittest
 
 from app import create_app
-from app.forms.date_form import get_date_form, get_month_year_form, get_date_data, get_date_range_fields
+from app.forms.date_form import get_date_form, get_month_year_form
 from app.schema_loader.schema_loader import load_schema_file
 from app.helpers.schema_helper import SchemaHelper
 
@@ -38,47 +38,3 @@ class TestDateForm(unittest.TestCase):
         self.assertFalse(hasattr(form, 'day'))
         self.assertTrue(hasattr(form, 'month'))
         self.assertTrue(hasattr(form, 'year'))
-
-    def test_get_date_data(self):
-        form_data = {
-            'some-answer-id-day': '1',
-            'some-answer-id-month': '01',
-            'some-answer-id-year': '2016'
-        }
-        expected = {
-            'day': '1',
-            'month': '01',
-            'year': '2016'
-        }
-        actual = get_date_data(form_data, "some-answer-id")
-
-        self.assertEqual(actual, expected)
-
-    def test_get_date_data_rejects_invalid(self):
-        form_data = {
-            'some-answer-id-day': '1',
-            'some-answer-id-month': '01'
-        }
-        actual = get_date_data(form_data, "some-answer-id")
-
-        self.assertEqual(actual, None)
-
-    def test_get_date_range_fields(self):
-        survey = load_schema_file("test_dates.json")
-        error_messages = SchemaHelper.get_messages(survey)
-
-        questions = SchemaHelper.get_questions_by_id(survey)
-
-        from_field, to_field = get_date_range_fields(questions["date-range-question"], {
-            'day': '1',
-            'month': '01',
-            'year': '2016'
-        }, error_messages)
-
-        self.assertTrue(hasattr(from_field.args[0], 'day'))
-        self.assertTrue(hasattr(from_field.args[0], 'month'))
-        self.assertTrue(hasattr(from_field.args[0], 'year'))
-
-        self.assertTrue(hasattr(to_field.args[0], 'day'))
-        self.assertTrue(hasattr(to_field.args[0], 'month'))
-        self.assertTrue(hasattr(to_field.args[0], 'year'))

--- a/tests/app/forms/test_questionnaire_form.py
+++ b/tests/app/forms/test_questionnaire_form.py
@@ -49,10 +49,63 @@ class TestQuestionnaireForm(unittest.TestCase):
             'period-from': {'day': '01', 'month': '3', 'year': '2016'},
             'period-to': {'day': '31', 'month': '3', 'year': '2016'}
         }
-
         form = generate_form(block_json, data, error_messages)
 
         self.assertEqual(form.data, expected_form_data)
+
+    def test_date_range_matching_dates_raises_question_error(self):
+        survey = load_schema_file("1_0102.json")
+
+        block_json = SchemaHelper.get_block(survey, "reporting-period")
+        error_messages = SchemaHelper.get_messages(survey)
+
+        data = {
+            'period-from-day': '25',
+            'period-from-month': '12',
+            'period-from-year': '2016',
+            'period-to-day': '25',
+            'period-to-month': '12',
+            'period-to-year': '2016'
+        }
+
+        expected_form_data = {
+            'period-from': {'day': '25', 'month': '12', 'year': '2016'},
+            'period-to': {'day': '25', 'month': '12', 'year': '2016'}
+        }
+        form = generate_form(block_json, data, error_messages)
+
+        expected_message = "The 'period to' date must be different to the 'period from' date."
+
+        form.validate()
+        self.assertEqual(form.data, expected_form_data)
+        self.assertEqual(form.question_errors['reporting-period-question'], expected_message)
+
+    def test_date_range_to_precedes_from_raises_question_error(self):
+        survey = load_schema_file("1_0102.json")
+
+        block_json = SchemaHelper.get_block(survey, "reporting-period")
+        error_messages = SchemaHelper.get_messages(survey)
+
+        data = {
+            'period-from-day': '25',
+            'period-from-month': '12',
+            'period-from-year': '2016',
+            'period-to-day': '24',
+            'period-to-month': '12',
+            'period-to-year': '2016'
+        }
+
+        expected_form_data = {
+            'period-from': {'day': '25', 'month': '12', 'year': '2016'},
+            'period-to': {'day': '24', 'month': '12', 'year': '2016'}
+        }
+        form = generate_form(block_json, data, error_messages)
+
+        expected_message = "The 'period to' date cannot be before the 'period from' date."
+
+        form.validate()
+        self.assertEqual(form.data, expected_form_data)
+        self.assertEqual(form.question_errors['reporting-period-question'], expected_message)
 
     def test_form_errors_are_correctly_mapped(self):
         survey = load_schema_file("1_0112.json")

--- a/tests/app/validation/test_date_range_validator.py
+++ b/tests/app/validation/test_date_range_validator.py
@@ -14,60 +14,63 @@ class TestDateRangeValidator(unittest.TestCase):
     """
     def test_date_range_matching_dates(self):
 
-        validator = DateRangeCheck(to_field_data={
-            'day': '01',
-            'month': '01',
-            'year': '2016',
-        })
+        validator = DateRangeCheck()
 
         period_from = Mock()
         period_from.day.data = '01'
         period_from.month.data = '01'
         period_from.year.data = '2016'
 
-        mock_field = Mock()
+        period_to = Mock()
+        period_to.day.data = '01'
+        period_to.month.data = '01'
+        period_to.year.data = '2016'
+
+        mock_form = Mock()
 
         with self.assertRaises(ValidationError) as ite:
-            validator(period_from, mock_field)
+            validator(mock_form, period_from, period_to)
 
         self.assertEqual(error_messages['INVALID_DATE_RANGE_TO_FROM_SAME'], str(ite.exception))
 
     def test_date_range_to_before_from(self):
 
-        validator = DateRangeCheck(to_field_data={
-            'day': '20',
-            'month': '01',
-            'year': '2016',
-        })
+        validator = DateRangeCheck()
 
         period_from = Mock()
         period_from.day.data = '20'
         period_from.month.data = '01'
         period_from.year.data = '2018'
 
-        mock_field = Mock()
+        period_to = Mock()
+        period_to.day.data = '20'
+        period_to.month.data = '01'
+        period_to.year.data = '2016'
+
+        mock_form = Mock()
 
         with self.assertRaises(ValidationError) as ite:
-            validator(period_from, mock_field)
+            validator(mock_form, period_from, period_to)
 
         self.assertEqual(error_messages['INVALID_DATE_RANGE_TO_BEFORE_FROM'], str(ite.exception))
 
     def test_date_range_valid(self):
 
-        validator = DateRangeCheck(to_field_data={
-            'day': '01',
-            'month': '01',
-            'year': '2017',
-        })
+        validator = DateRangeCheck()
 
         period_from = Mock()
         period_from.day.data = '01'
         period_from.month.data = '01'
         period_from.year.data = '2016'
 
-        mock_field = Mock()
+        period_to = Mock()
+        period_to.day.data = '01'
+        period_to.month.data = '01'
+        period_to.year.data = '2017'
+
+        mock_form = Mock()
 
         try:
-            validator(period_from, mock_field)
+            validator(mock_form, period_from, period_to)
         except ValidationError:
             self.fail("Valid date raised ValidationError")


### PR DESCRIPTION
### What is the context of this PR?
Add form level validation to the QuestionnaireForm by overriding it's validate method in order to validate DateRanges at a question level and display errors appropriately. Additionally, this moves the metaclass definition for QuestionnaireForm out of the generate_form method and reduces the methods complexity.

Removes the need for current DateRange validation as part of the date_form.

Fixes #931.

### How to review 

Confirm if unit tests pass, whether you agree with approach.
