### PR TITLE
Fix #942: Remove updated empty answers

### DIFF
--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -378,11 +378,11 @@ def update_questionnaire_store_with_form_data(questionnaire_store, location, ans
     for answer_id, answer_value in answer_dict.items():
         if answer_id in survey_answer_ids or location.block_id == 'household-composition':
             answer = None
-            # Dates are comprised of 3 string values
 
+            # Dates are comprised of 3 string values
             if isinstance(answer_value, dict):
-                is_day_month_year = 'day' in answer_value and 'month' in answer_value
-                is_month_year = 'year' in answer_value and 'month' in answer_value
+                is_day_month_year = 'day' in answer_value and 'month' in answer_value and 'year' in answer_value
+                is_month_year = 'day' not in answer_value and 'year' in answer_value and 'month' in answer_value
 
                 if is_day_month_year and answer_value['day'] and answer_value['month']:
                     date_str = "{:02d}/{:02d}/{}".format(
@@ -397,6 +397,13 @@ def update_questionnaire_store_with_form_data(questionnaire_store, location, ans
             elif answer_value != 'None' and answer_value is not None:
                 # Necessary because default select casts to string value 'None'
                 answer = Answer(answer_id=answer_id, value=answer_value, location=location)
+            elif answer_value is None:
+                # Remove previously populated answers that are now empty
+                questionnaire_store.answer_store.remove(
+                    location=location,
+                    answer_id=answer_id,
+                    answer_instance=0,
+                )
 
             if answer:
                 questionnaire_store.answer_store.add_or_update(answer)

--- a/tests/functional/pages/surveys/rsi/0112/employees.page.js
+++ b/tests/functional/pages/surveys/rsi/0112/employees.page.js
@@ -2,7 +2,12 @@ import QuestionPage from '../../question.page'
 
 class EmployeesPage extends QuestionPage {
 
-  setEmployees(employees) {
+  setMaleEmployeesOver30Hours(employees) {
+    browser.setValue('[name="male-employees-over-30-hours"]', employees)
+    return this
+  }
+
+  setTotalEmployees(employees) {
     browser.setValue('[name="total-number-employees"]', employees)
     return this
   }

--- a/tests/functional/pages/surveys/rsi/0112/rsi-summary.page.js
+++ b/tests/functional/pages/surveys/rsi/0112/rsi-summary.page.js
@@ -1,0 +1,39 @@
+import SummaryPage from '../../../summary.page'
+
+class RSISummaryPage extends SummaryPage {
+
+  getReportingPeriodSummary() {
+    return browser.element('[data-qa="period-from-answer"]').getText()
+  }
+
+  getRetailTurnoverSummary() {
+    return browser.element('[data-qa="total-retail-turnover-answer-answer"]').getText()
+  }
+
+  getInternetSalesSummary() {
+    return browser.element('[data-qa="internet-sales-answer-answer"]').getText()
+  }
+
+  getChangeInRetailTurnoverSummary() {
+    return browser.element('[data-qa="changes-in-retail-turnover-answer-answer"]').getText()
+  }
+
+  getChangeMaleEmployeesOver30Hours() {
+    return browser.element('[data-qa="male-employees-over-30-hours-answer"]').getText()
+  }
+
+  editLinkChangeInRetailTurnover() {
+    browser.click('[data-qa="changes-in-retail-turnover-answer-edit"]')
+  }
+
+  editLinkChangeInternetSales() {
+    browser.click('[data-qa="internet-sales-answer-edit"]')
+  }
+
+  editLinkChangeMaleEmployeesOver30Hours() {
+    browser.click('[data-qa="male-employees-over-30-hours-edit"]')
+  }
+
+}
+
+export default new RSISummaryPage()

--- a/tests/functional/spec/rsi-saverestore-0112.spec.js
+++ b/tests/functional/spec/rsi-saverestore-0112.spec.js
@@ -77,7 +77,7 @@ describe('RSI - Save and restore test', function() {
       .submit()
     changeInRetailTurnover.setChangesInRetailTurnover('No reason')
       .submit()
-    employeesPage.setEmployees(10)
+    employeesPage.setTotalEmployees(10)
       .submit()
     changesInEmployeesPage.setChangesInEmployeesPage('No reason')
       .submit()

--- a/tests/functional/spec/summary-screen.spec.js
+++ b/tests/functional/spec/summary-screen.spec.js
@@ -6,7 +6,9 @@ import retailTurnoverPage from '../pages/surveys/rsi/0102/retail-turnover.page'
 import internetSalesPage from '../pages/surveys/rsi/0102/internet-sales.page'
 import changeInRetailTurnover from '../pages/surveys/rsi/0102/changes-in-retail-turnover.page'
 import rsiSummaryPage from '../pages/surveys/rsi/0102/rsi-summary.page'
-import SummaryPage from '../pages/summary.page'
+import employeesPage from '../pages/surveys/rsi/0112/employees.page'
+import changesInEmployeesPage from '../pages/surveys/rsi/0112/changes-in-employees.page'
+import rsiWithEmployeesSummaryPage from '../pages/surveys/rsi/0112/rsi-summary.page'
 
 const expect = chai.expect
 
@@ -39,9 +41,9 @@ describe('RSI - summary screen edit test', function() {
     expect(rsiSummaryPage.getChangeInRetailTurnoverSummary()).to.contain('This is to test edit links on summary screen')
   })
 
-  it('Given the RSI survery 0102 is saved with answers when edit link is clicked then it should allow to edit the answer ', function(done) {
+  it('Given the RSI survey 0102 is saved with answers when edit link is clicked then it should allow to edit the answer ', function(done) {
 
-    //Given the RSI survery 0102 is saved with answers
+    //Given the RSI survey 0102 is saved with answers
     startQuestionnaire('1_0102.json')
     reportingPeriod.setFromReportingPeriodDay(2)
       .setToReportingPeriodDay(2)
@@ -67,6 +69,7 @@ describe('RSI - summary screen edit test', function() {
     expect(rsiSummaryPage.getChangeInRetailTurnoverSummary()).to.contain('This is to test edit links on summary screen - edited')
 
   })
+
   it('Given the RSI survey 0102 when a 0 is entered in a currency field then the summary screen should show £0 and the original page should show 0', function(done) {
 
     //Given the RSI business survey 0102 is started
@@ -92,6 +95,47 @@ describe('RSI - summary screen edit test', function() {
     expect(rsiSummaryPage.getInternetSalesSummary()).to.contain('£' + 0)
     rsiSummaryPage.editLinkChangeInternetSales()
     expect(internetSalesPage.getInternetSales()).to.contain('0')
+
+  })
+
+  it('Given the RSI survey 0112 when a non mandatory field is edited to contain no answer, the summary page should display "No answer provided"', function(done) {
+
+    startQuestionnaire('1_0112.json')
+
+    // when data is entered for the survey
+    reportingPeriod.setFromReportingPeriodDay(2)
+      .setToReportingPeriodDay(2)
+      .setFromReportingPeriodMonth(5)
+      .setToReportingPeriodMonth(5)
+      .setFromReportingPeriodYear(2016)
+      .setToReportingPeriodYear(2017)
+      .submit()
+    retailTurnoverPage.setRetailTurnover(1000)
+      .submit()
+    internetSalesPage.setInternetSales(0)
+      .submit()
+    changeInRetailTurnover.setChangesInRetailTurnover('')
+      .submit()
+    employeesPage.setMaleEmployeesOver30Hours(2)
+        .setTotalEmployees(2)
+        .submit()
+    changesInEmployeesPage.setChangesInEmployeesPage('')
+        .submit()
+
+    // Then summary screen and the original page shows the data entered
+    expect(rsiWithEmployeesSummaryPage.getRetailTurnoverSummary()).to.contain('£1,000')
+    expect(rsiWithEmployeesSummaryPage.getInternetSalesSummary()).to.contain('£' + 0)
+    expect(rsiWithEmployeesSummaryPage.getChangeMaleEmployeesOver30Hours()).to.contain('2')
+
+    // and when we edit the total male employees
+    rsiWithEmployeesSummaryPage.editLinkChangeMaleEmployeesOver30Hours()
+    employeesPage.setMaleEmployeesOver30Hours('')
+        .submit()
+    changesInEmployeesPage.setChangesInEmployeesPage('')
+        .submit()
+
+    // Then the summary screen should show the updated answer with no response
+    expect(rsiWithEmployeesSummaryPage.getChangeMaleEmployeesOver30Hours()).to.contain('No answer provided')
 
   })
 })


### PR DESCRIPTION
### What is the context of this PR?
Clears answers that have been updated and are now empty during update of the answer store.

Fixes #942 

### How to review 
Confirm if tests pass.
