### PR TITLE
Update cryptography to use ONS fork, prior to Cryptography release

### DIFF
--- a/.ebextensions/deploy.config
+++ b/.ebextensions/deploy.config
@@ -9,4 +9,4 @@ commands:
     01-upgrade-pip:
         command: "/opt/python/run/venv/bin/pip  install --upgrade pip"
     02-install-cryptography:
-        command: "source /opt/python/run/venv/bin/activate; pip install -e git+https://github.com/reaperhulk/cryptography.git@password-cb#egg=cryptography"
+        command: "source /opt/python/run/venv/bin/activate; pip install -e git+https://github.com/ONSdigital/cryptography.git@4a90c254278231d7defeac304a3cfd752e96e786#egg=cryptography"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
     - nvm install v6.9.1
     - pip install -U pip wheel
     - pip install --require-hashes -r requirements.txt
-    - pip install -e git+https://github.com/reaperhulk/cryptography.git@password-cb#egg=cryptography
+    - pip install -e git+https://github.com/ONSdigital/cryptography.git@4a90c254278231d7defeac304a3cfd752e96e786#egg=cryptography
     - pip install -r requirements_for_test.txt
 
 before_script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM onsdigital/docker-aws-apache-wsgi:python-3.4.2-onbuild
 # Install branched Python Cryptography to fix Apache issue
 # TO BE REMOVED ONCE OFFICIAL PACKAGE (1.8?) RELEASED
 RUN yum install -y git && \
-    pip install -e git+https://github.com/reaperhulk/cryptography.git@password-cb#egg=cryptography
+    pip install -e git+https://github.com/ONSdigital/cryptography.git@4a90c254278231d7defeac304a3cfd752e96e786#egg=cryptography
 
 # Compile frontend
 RUN yarn compile

--- a/README.md
+++ b/README.md
@@ -65,7 +65,15 @@ Upgrade pip and install dependencies:
 ```
 pip install --upgrade pip setuptools
 pip install -r requirements.txt
-pip install -e git+https://github.com/reaperhulk/cryptography.git@password-cb#egg=cryptography
+pip install -e git+https://github.com/ONSdigital/cryptography.git@4a90c254278231d7defeac304a3cfd752e96e786#egg=cryptography
+```
+
+You may need to point the build on a mac if you have problems building OpenSSL. See [here](https://github.com/pyca/cryptography/issues/2692) for more details.
+
+```
+export LDFLAGS="-L/usr/local/opt/openssl/lib"
+export CPPFLAGS="-I/usr/local/opt/openssl/include"
+export PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig"
 ```
 
 If you need to run the tests:


### PR DESCRIPTION
### What is the context of this PR?
Updated the cryptography library to point to our own ons fork, to be in control of availability until the cryptography library is officially released with a fix for errors running under multithreaded apache - https://github.com/ONSdigital/eq-survey-runner/pull/934.

### How to review 
See if it builds!
