### PR TITLE
Removes the ukis landing page introduction description

### DIFF
--- a/app/data/1_0001.json
+++ b/app/data/1_0001.json
@@ -5774,7 +5774,7 @@
     "theme": "ukis",
     "legal_basis": "Voluntary",
     "introduction": {
-        "description": "<p>The information supplied is used to produce monthly estimates of the total retail sales in Great Britain where retailing is defined as the sale of goods to the general public for household consumption. The Retail Sales Index is a key indicator of the progress of the economy. It is also used to help estimate consumer spending on retail goods and the output of the retail sector, both of which feed into the compilation of the National Accounts. The results are also used by the Bank of England and HM Treasury to inform decision making by government and in formulating financial policies. The results <a href=\"http://www.ons.gov.uk/businessindustryandtrade/retailindustry\">are published on our website</a>.</p>",
+        "description": "",
         "information_to_provide": [
           "business strategy and practices",
           "innovation investment",


### PR DESCRIPTION
### What is the context of this PR?
Removes the introduction description from the UKIS landing page.

### How to review 
Retest Defect #946 

Launch UKIS survey and make sure that introduction description is not present on UKIS landing page.
