### PR TITLE
Fix #941: Add a response required validator

### DIFF
--- a/app/forms/fields.py
+++ b/app/forms/fields.py
@@ -2,7 +2,7 @@ from wtforms import FormField, IntegerField, SelectField, SelectMultipleField, S
 from wtforms import validators
 
 from app.forms.date_form import get_date_form, get_month_year_form
-from app.validation.validators import IntegerCheck, NumberRange
+from app.validation.validators import IntegerCheck, NumberRange, ResponseRequired
 from structlog import get_logger
 
 
@@ -49,7 +49,7 @@ def get_mandatory_validator(answer, error_messages):
             mandatory_message = answer['validation']['messages']['MANDATORY']
 
         validate_with = [
-            validators.InputRequired(
+            ResponseRequired(
                 message=mandatory_message,
             ),
         ]
@@ -73,7 +73,6 @@ def get_text_area_field(answer, label, guidance, error_messages):
         label=label,
         description=guidance,
         validators=validate_with,
-        filters=[lambda x: x if x else None],
     )
 
 

--- a/app/forms/household_composition_form.py
+++ b/app/forms/household_composition_form.py
@@ -1,8 +1,8 @@
 from flask_wtf import FlaskForm
-from wtforms import FieldList, Form, FormField, StringField
-from wtforms import validators
+from wtforms import FieldList, Form, FormField
 
 from app.data_model.answer_store import Answer
+from app.forms.fields import get_string_field
 from app.helpers.schema_helper import SchemaHelper
 
 from werkzeug.datastructures import MultiDict
@@ -12,24 +12,14 @@ def get_name_form(block_json, error_messages):
     class NameForm(Form):
         pass
 
-    for answer in SchemaHelper.get_answers_for_block(block_json):
-        validate_with = [validators.optional()]
+    for question in SchemaHelper.get_questions_for_block(block_json):
+        for answer in question['answers']:
+            guidance = answer.get('guidance', '')
+            label = answer.get('label') or question.get('title')
 
-        if answer['mandatory'] is True:
-            error_message = error_messages['MANDATORY']
-            if 'validation' in answer and 'messages' in answer['validation'] \
-                    and 'MANDATORY' in answer['validation']['messages']:
-                error_message = answer['validation']['messages']['MANDATORY']
+            field = get_string_field(answer, label, guidance, error_messages)
 
-            validate_with = [validators.InputRequired(
-                message=error_message,
-            )]
-
-        # Have to be set this way given hyphenated names
-        # are considered invalid in python
-        field = StringField(validators=validate_with)
-
-        setattr(NameForm, answer['id'], field)
+            setattr(NameForm, answer['id'], field)
 
     return NameForm
 

--- a/app/validation/validators.py
+++ b/app/validation/validators.py
@@ -19,6 +19,32 @@ class IntegerCheck(object):
             raise validators.StopValidation(self.message)
 
 
+class ResponseRequired(object):
+    """
+    Validates that input was provided for this field. This is a copy of the
+    InputRequired validator provided by wtforms, which checks that form-input data
+    was provided, but additionally adds a kwarg to strip whitespace, as is available
+    on the Optional() validator wtforms provides. Oddly, stripping whitespace is not
+    an option for DataRequired or InputRequired validators in wtforms.
+    """
+    field_flags = ('required', )
+
+    def __init__(self, message=None, strip_whitespace=True):
+        if not message:
+            message = error_messages['MANDATORY']
+        self.message = message
+
+        if strip_whitespace:
+            self.string_check = lambda s: s.strip()
+        else:
+            self.string_check = lambda s: s
+
+    def __call__(self, form, field):
+        if not field.raw_data or not field.raw_data[0] or not self.string_check(field.raw_data[0]):
+            field.errors[:] = []
+            raise validators.StopValidation(self.message)
+
+
 class NumberRange(object):
     """
     Validates that a number is of a minimum and/or maximum value, inclusive.

--- a/tests/app/forms/test_fields.py
+++ b/tests/app/forms/test_fields.py
@@ -4,6 +4,7 @@ from wtforms import validators, StringField, TextAreaField, FormField, SelectFie
 
 from app.forms.fields import CustomIntegerField, get_field, get_mandatory_validator
 from app.validation.error_messages import error_messages
+from app.validation.validators import ResponseRequired
 
 
 class TestFields(unittest.TestCase):
@@ -24,7 +25,7 @@ class TestFields(unittest.TestCase):
             'MANDATORY': 'This is the default mandatory message'
         })
 
-        self.assertIsInstance(validate_with[0], validators.InputRequired)
+        self.assertIsInstance(validate_with[0], ResponseRequired)
         self.assertEqual(validate_with[0].message, 'This is the default mandatory message')
 
     def test_get_mandatory_validator_mandatory_with_error(self):
@@ -40,7 +41,7 @@ class TestFields(unittest.TestCase):
             'MANDATORY': 'This is the default mandatory message'
         })
 
-        self.assertIsInstance(validate_with[0], validators.InputRequired)
+        self.assertIsInstance(validate_with[0], ResponseRequired)
         self.assertEqual(validate_with[0].message, 'This is the mandatory message for an answer')
 
     def test_string_field(self):

--- a/tests/app/forms/test_household_composition.py
+++ b/tests/app/forms/test_household_composition.py
@@ -5,6 +5,7 @@ from wtforms import validators
 from app import create_app
 
 from app.forms.household_composition_form import generate_household_composition_form, deserialise_composition_answers
+from app.validation.validators import ResponseRequired
 from app.schema_loader.schema_loader import load_schema_file
 from app.helpers.schema_helper import SchemaHelper
 from app.questionnaire.location import Location
@@ -35,7 +36,7 @@ class TestHouseholdCompositionForm(unittest.TestCase):
         middle_names_field = getattr(form.household.entries[0], 'middle-names')
         last_name_field = getattr(form.household.entries[0], 'last-name')
 
-        self.assertIsInstance(first_name_field.validators[0], validators.InputRequired)
+        self.assertIsInstance(first_name_field.validators[0], ResponseRequired)
         self.assertIsInstance(middle_names_field.validators[0], validators.Optional)
         self.assertIsInstance(last_name_field.validators[0], validators.Optional)
 
@@ -79,6 +80,19 @@ class TestHouseholdCompositionForm(unittest.TestCase):
             'middle-names': '',
             'last-name': 'Seymour'
         })
+
+    def test_whitespace_in_first_name_invalid(self):
+
+        form = generate_household_composition_form(self.block_json, {
+            'household-0-first-name': '     ',
+            'household-0-last-name': 'Bloggs',
+        }, error_messages=self.error_messages)
+
+        form.validate()
+
+        message = "Please enter a name or remove the person to continue"
+
+        self.assertIn(message, form.answer_errors('household-0-first-name'))
 
     def test_remove_first_person(self):
 

--- a/tests/app/forms/test_questionnaire_form.py
+++ b/tests/app/forms/test_questionnaire_form.py
@@ -1,11 +1,10 @@
 import unittest
 
-from wtforms import validators
-
 from app import create_app
 from app.forms.questionnaire_form import generate_form
 from app.helpers.schema_helper import SchemaHelper
 from app.schema_loader.schema_loader import load_schema_file
+from app.validation.validators import ResponseRequired
 
 
 class TestQuestionnaireForm(unittest.TestCase):
@@ -150,7 +149,7 @@ class TestQuestionnaireForm(unittest.TestCase):
 
         child_field = getattr(form, 'other-answer-mandatory')
 
-        self.assertIsInstance(child_field.validators[0], validators.InputRequired)
+        self.assertIsInstance(child_field.validators[0], ResponseRequired)
 
     def test_answer_with_child_errors_are_correctly_mapped(self):
         survey = load_schema_file("test_radio.json")

--- a/tests/app/validation/test_response_required.py
+++ b/tests/app/validation/test_response_required.py
@@ -1,0 +1,78 @@
+import unittest
+from unittest.mock import Mock
+
+from app.validation.validators import ResponseRequired
+from wtforms.validators import StopValidation
+from app.validation.error_messages import error_messages
+
+
+class TestResponseRequiredValidator(unittest.TestCase):
+    def test_response_empty_invalid(self):
+        validator = ResponseRequired()
+
+        mock_form = Mock()
+
+        mock_field = Mock()
+        mock_field.raw_data = ['']
+        mock_field.errors = []
+
+        with self.assertRaises(StopValidation) as ite:
+            validator(mock_form, mock_field)
+
+        self.assertEqual(error_messages['MANDATORY'], str(ite.exception))
+
+    def test_response_blank_invalid(self):
+        validator = ResponseRequired()
+
+        mock_form = Mock()
+
+        mock_field = Mock()
+        mock_field.raw_data = ['                           ']
+        mock_field.errors = []
+
+        with self.assertRaises(StopValidation) as ite:
+            validator(mock_form, mock_field)
+
+        self.assertEqual(error_messages['MANDATORY'], str(ite.exception))
+
+    def test_required_empty(self):
+
+        validator = ResponseRequired()
+
+        mock_form = Mock()
+
+        mock_field = Mock()
+        mock_field.raw_data = ['Here is some valid input']
+
+        try:
+            validator(mock_form, mock_field)
+        except StopValidation:
+            self.fail("Response that needs further validation raised StopValidation")
+
+    def test_required_contains_content(self):
+
+        validator = ResponseRequired()
+
+        mock_form = Mock()
+
+        mock_field = Mock()
+        mock_field.raw_data = ['           Here is some valid input             ']
+
+        try:
+            validator(mock_form, mock_field)
+        except StopValidation:
+            self.fail("Response that needs further validation raised StopValidation")
+
+    def test_response_blank_valid_when_whitespace_on(self):
+        validator = ResponseRequired(strip_whitespace=False)
+
+        mock_form = Mock()
+
+        mock_field = Mock()
+        mock_field.raw_data = ['                      ']
+        mock_field.errors = []
+
+        try:
+            validator(mock_form, mock_field)
+        except StopValidation:
+            self.fail("Response that needs further validation raised StopValidation")


### PR DESCRIPTION
### What is the context of this PR?

Adds a response required validator that validates that input was provided for a field. This is a copy of the InputRequired validator provided by wtforms, which checks that form-input data was provided, but additionally adds a kwarg to strip whitespace, as is already available on the Optional() validator wtforms provides. Oddly, stripping whitespace is not  an option for DataRequired or InputRequired validators in wtforms.

Fixes #941.

### How to review 
See if you agree with approach, tests pass.
