### PR TITLE
eq-900 Disable autocomplete

### DIFF
--- a/app/templates/introduction.html
+++ b/app/templates/introduction.html
@@ -81,7 +81,7 @@
     <div class="venus lock__text">We will treat your data securely and confidentially</div>
   </div>
 
-  <form class="form" method="POST" novalidate>
+  <form class="form" method="POST" autocomplete="off" novalidate>
     <button class="btn btn--primary btn--lg qa-btn-get-started" type="submit" name="action[start_questionnaire]">Start survey</button>
   </form>
 

--- a/app/templates/questionnaire.html
+++ b/app/templates/questionnaire.html
@@ -36,7 +36,7 @@
 
     {% endif %}
 
-    <form action="{{form_action|default('')}}" class="form qa-questionnaire-form" role="form" method="POST" novalidate>
+    <form action="{{form_action|default('')}}" class="form qa-questionnaire-form" role="form" method="POST" autocomplete="off" novalidate>
 
       <div class="group" id="{{current_location.group_id}}">
 

--- a/app/templates/summary.html
+++ b/app/templates/summary.html
@@ -55,7 +55,7 @@
   {% endfor %}
   </div>
 
-  <form action="submit-answers" method="POST" novalidate>
+  <form action="submit-answers" method="POST" autocomplete="off" novalidate>
     <button class="btn btn--primary btn--lg u-mr-s qa-btn-submit-answers venus" type="submit" name="action[submit_answers]">Submit answers</button>
   </form>
 </div>

--- a/app/themes/census/templates/introduction.html
+++ b/app/themes/census/templates/introduction.html
@@ -18,7 +18,7 @@
     <p class="mars">The individual questions must be completed for every person who usually lives in this household. The householder can complete the survey on behalf of the individuals who usually live in their household or ask them to answer independently.</p>
     <p>If any member of this household aged 16 or over wishes to complete their own questionnaire a separate form can be requested here.</p>
   </div>
-  <form action="" class="form" role="form" method="POST" novalidate="">
+  <form action="" class="form" role="form" method="POST" autocomplete="off" novalidate>
     <button class="btn btn--lg qa-btn-get-started" type="submit" name="action[start_questionnaire]">Start survey</button>
   </form>
   <div class="lock u-mb-s u-mb-m@s">


### PR DESCRIPTION
### What is the context of this PR?

Disables autocomplete on forms as per the [Trello card](https://trello.com/c/KMDyIWLY/900-disable-auto-complete)

### How to review 

#### Before checking out this branch
- Ensure autocomplete is enabled in your browser
- Visit any survey where you are able to confirm autocomplete it working (eg. census household names)

#### After checkout
- Revisit survey where autocomplete was previously working
- Confirm autocomplete no longer suggests responses