### PR TITLE
Remove view sections button from intro and thank-you pages.

### DIFF
--- a/app/data/test_percentage.json
+++ b/app/data/test_percentage.json
@@ -17,6 +17,7 @@
       "NEGATIVE_INTEGER": "Number cannot be less than zero",
       "NOT_INTEGER": "Please enter an integer"
     },
+    "navigation" : true,
     "groups": [
         {
             "blocks": [

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -196,7 +196,7 @@ def post_household_composition(eq_id, form_type, collection_id, group_id):
 def get_introduction(eq_id, form_type, collection_id):  # pylint: disable=unused-argument
     group_id = SchemaHelper.get_first_group_id(g.schema_json)
     current_location = Location(group_id, group_instance=0, block_id='introduction')
-    return _build_template(current_location, get_introduction_context(g.schema_json))
+    return _build_template(current_location, get_introduction_context(g.schema_json), display_navigation=False)
 
 
 @questionnaire_blueprint.route('<block_id>', methods=["POST"])
@@ -267,7 +267,7 @@ def get_confirmation(eq_id, form_type, collection_id):  # pylint: disable=unused
 def get_thank_you(eq_id, form_type, collection_id):  # pylint: disable=unused-argument
     group_id = SchemaHelper.get_last_group_id(g.schema_json)
     current_location = Location(group_id, group_instance=0, block_id='thank-you')
-    thank_you_page = _build_template(current_location=current_location)
+    thank_you_page = _build_template(current_location=current_location, display_navigation=False)
     # Delete user data on request of thank you page.
     _delete_user_data()
     return thank_you_page
@@ -472,7 +472,7 @@ def _render_schema(current_location):
     return renderer.render(block_json, **block_context)
 
 
-def _build_template(current_location, context=None, template=None):
+def _build_template(current_location, context=None, template=None, display_navigation=True):
     metadata = get_metadata(current_user)
     metadata_context = build_metadata_context(metadata)
 
@@ -480,7 +480,8 @@ def _build_template(current_location, context=None, template=None):
     completed_blocks = get_completed_blocks(current_user)
 
     navigation = Navigation(g.schema_json, answer_store, metadata, completed_blocks)
-    front_end_navigation = navigation.build_navigation(current_location.group_id, current_location.group_instance)
+    front_end_navigation = navigation.build_navigation(current_location.group_id, current_location.group_instance) \
+        if display_navigation else None
 
     path_finder = PathFinder(g.schema_json, answer_store, metadata)
     previous_location = path_finder.get_previous_location(current_location)

--- a/tests/functional/helpers.js
+++ b/tests/functional/helpers.js
@@ -86,3 +86,8 @@ export const closeMobileNavigation = () => {
     return !browser.isVisibleWithinViewport('#section-nav')
   })
 }
+
+export const isViewSectionsVisible = () => {
+  let viewSectionsLink = '#menu-btn'
+  return browser.isExisting(viewSectionsLink) && browser.isVisibleWithinViewport(viewSectionsLink)
+}

--- a/tests/functional/pages/surveys/percentage/percentage.page.js
+++ b/tests/functional/pages/surveys/percentage/percentage.page.js
@@ -1,0 +1,11 @@
+import QuestionPage from '../question.page'
+
+class PercentagePage extends QuestionPage {
+
+  constructor() {
+    super('block')
+  }
+
+}
+
+export default new PercentagePage()

--- a/tests/functional/spec/navigation.spec.js
+++ b/tests/functional/spec/navigation.spec.js
@@ -1,9 +1,14 @@
 import chai from 'chai'
+import landingPage from '../pages/landing.page'
+import PercentagePage from '../pages/surveys/percentage/percentage.page'
+import SummaryPage from '../pages/summary.page'
 import {
   startQuestionnaire,
+  openQuestionnaire,
   setMobileViewport,
   openMobileNavigation,
-  closeMobileNavigation
+  closeMobileNavigation,
+  isViewSectionsVisible
 } from '../helpers'
 
 const expect = chai.expect
@@ -26,5 +31,30 @@ describe('Navigation', function() {
     navIsNotVisible = closeMobileNavigation()
     // Then
     expect(navIsNotVisible).to.be.true
+  })
+
+  it('Given survey launched on mobile device, When on Introduction page, Then view sections link should not be displayed.', function() {
+    // Given
+    setMobileViewport()
+
+    // When
+    openQuestionnaire('test_percentage.json')
+
+    // Then
+    expect(isViewSectionsVisible()).to.be.false
+  })
+
+  it('Given survey launched on mobile device, When on Thank-You page, Then view sections link should not be displayed.', function() {
+    // Given
+    setMobileViewport()
+    startQuestionnaire('test_percentage.json')
+
+    // When
+    expect(isViewSectionsVisible()).to.be.true
+    PercentagePage.submit()
+    SummaryPage.submit()
+
+    // Then
+    expect(isViewSectionsVisible()).to.be.false
   })
 })


### PR DESCRIPTION
### What is the context of this PR?
Fixes #921.

### How to review 
Re-test the defect.
Verify that the view sections link is no longer displayed on both the introduction and successful submission pages for UKIS.
All existing tests and checks should pass.
