### PR TITLE
Fix previous link relationship question

### DIFF
--- a/app/questionnaire/path_finder.py
+++ b/app/questionnaire/path_finder.py
@@ -221,6 +221,15 @@ class PathFinder:
         :return: The previous location as a dict
         :return:
         """
+
+        if current_location.group_id == 'who-lives-here-relationship':
+            return self._relationship_previous_location(current_location.group_instance)
+
+        is_first_block_for_group = SchemaHelper.is_first_block_id_for_group(self.survey_json, current_location.group_id, current_location.block_id)
+
+        if is_first_block_for_group or current_location.block_id == 'thank-you':
+            return None
+
         location_path = self.get_location_path(current_location.group_id, current_location.group_instance)
         current_location_index = PathFinder._get_current_location_index(location_path, current_location)
 
@@ -243,3 +252,11 @@ class PathFinder:
                 return incomplete_blocks[0]
 
         return location_path[0]
+
+    @staticmethod
+    def _relationship_previous_location(current_group_instance):
+        if current_group_instance == 0:
+            previous_location = Location('who-lives-here', 0, 'overnight-visitors')
+        else:
+            previous_location = Location('who-lives-here-relationship', current_group_instance - 1, 'household-relationships')
+        return previous_location

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -521,9 +521,7 @@ def _build_template(current_location, context=None, template=None, display_navig
 
     previous_url = None
 
-    is_first_block_for_group = SchemaHelper.is_first_block_id_for_group(g.schema_json, current_location.group_id, current_location.block_id)
-
-    if previous_location is not None and not is_first_block_for_group and not current_location.block_id == 'thank-you':
+    if previous_location is not None:
         previous_url = previous_location.url(metadata)
 
     if user_logout:

--- a/tests/app/questionnaire/test_path_finder.py
+++ b/tests/app/questionnaire/test_path_finder.py
@@ -208,6 +208,7 @@ class TestPathFinder(unittest.TestCase):  # pylint: disable=too-many-public-meth
 
         self.assertEqual(expected_next_location, next_location)
 
+    @pytest.mark.xfail(reason="The first group should go back to the introduction, however we block previous on the first block in a group", strict=True)
     def test_get_previous_location_introduction(self):
         survey = load_schema_file("0_star_wars.json")
 
@@ -217,7 +218,7 @@ class TestPathFinder(unittest.TestCase):  # pylint: disable=too-many-public-meth
 
         previous_location = path_finder.get_previous_location(current_location=first_location)
 
-        self.assertEqual('introduction', previous_location.block_id)
+        self.assertEqual('introduction', previous_location)
 
     def test_previous_with_conditional_path(self):
         survey = load_schema_file("0_star_wars.json")
@@ -519,16 +520,24 @@ class TestPathFinder(unittest.TestCase):  # pylint: disable=too-many-public-meth
 
         self.assertEqual(expected_path, path_finder.get_routing_path())
 
-    def test_repeating_groups_previous_location_introduction(self):
-        survey = load_schema_file("test_repeating_household.json")
+    def test_repeating_groups_previous_location_first_instance(self):
+        survey = load_schema_file("census_household.json")
 
         expected_path = [
-            Location('multiple-questions-group', 0, 'introduction'),
-            Location('multiple-questions-group', 0, 'household-composition'),
-        ]
-
+             Location('who-lives-here', 0, 'overnight-visitors'),
+             Location('who-lives-here-relationship', 0, 'household-relationships'),
+         ]
         path_finder = PathFinder(survey)
+        self.assertEqual(path_finder.get_previous_location(current_location=expected_path[1]), expected_path[0])
 
+    def test_repeating_groups_previous_location_second_instance(self):
+        survey = load_schema_file("census_household.json")
+
+        expected_path = [
+             Location('who-lives-here-relationship', 0, 'household-relationships'),
+             Location('who-lives-here-relationship', 1, 'household-relationships'),
+         ]
+        path_finder = PathFinder(survey)
         self.assertEqual(path_finder.get_previous_location(current_location=expected_path[1]), expected_path[0])
 
     def test_repeating_groups_previous_location(self):

--- a/tests/integration/questionnaire/test_questionnaire_previous_link.py
+++ b/tests/integration/questionnaire/test_questionnaire_previous_link.py
@@ -74,3 +74,43 @@ class TestQuestionnairePreviousLink(IntegrationTestCase):
         self.assertTrue(final_url.endswith('thank-you'))
         self.assertNotIn('Previous', content)
 
+    def test_previous_link_on_relationship(self):
+
+        # Given the census questionnaire.
+        self.token = create_token('household', 'census')
+        self.client.get('/session?token=' + self.token.decode(), follow_redirects=True)
+
+        # When we complete the who lives here section and the other questions needed to build the path.
+        post_data = {
+            'permanent-or-family-home-answer': 'Yes'
+        }
+
+        self.client.post('/questionnaire/census/household/789/who-lives-here/0/permanent-or-family-home', data=post_data)
+
+        post_data = {
+            'household-0-first-name': 'Joe',
+            'household-0-middle-names': '',
+            'household-0-last-name': 'Bloggs',
+            'household-1-first-name': 'Jane',
+            'household-1-middle-names': '',
+            'household-1-last-name': 'Bloggs',
+            'household-2-first-name': 'Holly',
+            'household-2-middle-names': '',
+            'household-2-last-name': 'Bloggs',
+        }
+
+        self.client.post('/questionnaire/census/household/789/who-lives-here/0/household-composition', data=post_data, follow_redirects=True)
+
+        post_data = {
+            'overnight-visitors-answer': '0'
+        }
+        resp = self.client.post('questionnaire/census/household/789/who-lives-here/0/overnight-visitors', data=post_data, follow_redirects=True)
+
+        # Then there should be a previous link on all repeating household blocks.
+        content = resp.get_data(True)
+        self.assertIn('Previous', content)
+
+        resp = self.client.get('questionnaire/census/household/789/who-lives-here-relationship/1/household-relationships')
+        content = resp.get_data(True)
+        self.assertIn('Previous', content)
+


### PR DESCRIPTION
### What is the context of this PR?
The household relationship grid questions in census needs to have a previous button, both on the first block (returns to overnight-visitors) and any repeating blocks (instance before). Although not ideal after talking to Andrew we decided to hard code it for now

### How to review 
With Census, fill in multiple people (>2) on the who lives here page, navigate to relationship grid, making sure the first block and all repeating blocks have a previous working button
