### PR TITLE
eq-920 Mobile nav no JS

### DIFF
--- a/app/assets/js/app/modules/nav.js
+++ b/app/assets/js/app/modules/nav.js
@@ -42,14 +42,12 @@ domready(() => {
     btn.innerHTML = openLabel
     if (e && e.target === btn) {
       e.preventDefault()
-      e.target.blur()
     }
     addOpenListeners()
   }
 
   const open = (e) => {
     e.preventDefault()
-    e.target.blur()
     document.body.classList.add(classOpen)
     btn.removeEventListener('click', open)
     btn.innerHTML = closeLabel

--- a/app/assets/styles/partials/components/_buttons.scss
+++ b/app/assets/styles/partials/components/_buttons.scss
@@ -143,7 +143,6 @@
     content: "";
     position: absolute;
     right: 0;
-    bottom: 1px;
     background-size: auto;
     background-position: center;
     background-repeat: no-repeat;
@@ -153,6 +152,8 @@
 
   &::before {
     opacity: 1;
+    bottom: 3px;
+    right: 2px;
     background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTZweCIgaGVpZ2h0PSIxM3B4IiB2aWV3Qm94PSIyOTAgNTEgMTYgMTMiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+DQogICAgPGcgaWQ9Ikdyb3VwLTIiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDI5MC4wMDAwMDAsIDUxLjAwMDAwMCkiPg0KICAgICAgICA8cmVjdCBpZD0iUmVjdGFuZ2xlLTIiIGZpbGw9IiM0QTRBNEEiIHg9IjAiIHk9IjAiIHdpZHRoPSIxNiIgaGVpZ2h0PSIyLjA5NTIzODEiPjwvcmVjdD4NCiAgICAgICAgPHJlY3QgaWQ9IlJlY3RhbmdsZS0yIiBmaWxsPSIjNEE0QTRBIiB4PSIwIiB5PSI1LjIzODA5NTI0IiB3aWR0aD0iMTYiIGhlaWdodD0iMi4wOTUyMzgxIj48L3JlY3Q+DQogICAgICAgIDxyZWN0IGlkPSJSZWN0YW5nbGUtMiIgZmlsbD0iIzRBNEE0QSIgeD0iMCIgeT0iMTAuNDc2MTkwNSIgd2lkdGg9IjE2IiBoZWlnaHQ9IjIuMDk1MjM4MSI+PC9yZWN0Pg0KICAgIDwvZz4NCjwvc3ZnPg');
     background-size: auto;
   }
@@ -162,6 +163,8 @@
     transform: scaleY(0);
     background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjRweCIgaGVpZ2h0PSIyNXB4IiB2aWV3Qm94PSIyOTAgNDUgMjQgMjUiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+DQogICAgPGcgaWQ9Ikdyb3VwLTIiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDI5MC4wMDAwMDAsIDQ1LjAwMDAwMCkiPg0KICAgICAgICA8ZyBpZD0iR3JvdXAtMyIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTIuMDAwMDAwLCAxMi41MDAwMDApIHJvdGF0ZSgtMzE1LjAwMDAwMCkgdHJhbnNsYXRlKC0xMi4wMDAwMDAsIC0xMi41MDAwMDApIHRyYW5zbGF0ZSg0LjAwMDAwMCwgNC4wMDAwMDApIiBmaWxsPSIjNEE0QTRBIj4NCiAgICAgICAgICAgIDxyZWN0IGlkPSJSZWN0YW5nbGUtMiIgeD0iMCIgeT0iNyIgd2lkdGg9IjE2IiBoZWlnaHQ9IjIuMDk1MjM4MSI+PC9yZWN0Pg0KICAgICAgICAgICAgPHJlY3QgaWQ9IlJlY3RhbmdsZS0yIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSg4LjAwMDAwMCwgOC4wNDc2MTkpIHJvdGF0ZSgtOTAuMDAwMDAwKSB0cmFuc2xhdGUoLTguMDAwMDAwLCAtOC4wNDc2MTkpICIgeD0iMCIgeT0iNyIgd2lkdGg9IjE2IiBoZWlnaHQ9IjIuMDk1MjM4MSI+PC9yZWN0Pg0KICAgICAgICA8L2c+DQogICAgPC9nPg0KPC9zdmc+');
     background-size: auto;
+    right: 2px;
+    bottom: 2px;
   }
 
   .has-nav-open & {

--- a/app/assets/styles/partials/components/_nav.scss
+++ b/app/assets/styles/partials/components/_nav.scss
@@ -17,9 +17,8 @@
   }
   .nav__item {
     margin: 0;
-    padding: 0.5rem 0;
+    padding: 0.5rem 1rem 0.5rem 2rem;
     position: relative;
-    padding-left: 2rem;
     margin-left: -2.5rem;
     border-left: 0.5rem solid transparent;
   }

--- a/app/assets/styles/partials/objects/_page.scss
+++ b/app/assets/styles/partials/objects/_page.scss
@@ -1,3 +1,5 @@
+$nav-width: 14rem;
+
 .page {
   display: flex;
   min-height: 100%;
@@ -22,14 +24,6 @@
   }
 }
 
-.page__menubtn {
-  float: right;
-  vertical-align: middle;
-  display: inline-block;
-  position: relative;
-  line-height: 1;
-}
-
 .page__previous {
   float: left;
   .has-nav-open & {
@@ -50,36 +44,60 @@
   overflow-x: hidden;
 }
 
-.page__nav.nav {
-  margin: 0 0 1rem;
-  position: absolute;
-  right: -13rem;
-  width: 12rem;
+.page__menubtn {
   display: none;
-  .has-nav-open & {
-    display: block;
+  float: right;
+}
+
+.no-js {
+  .page__nav {
+    margin-bottom: 2rem;
   }
-  @include mq(m) {
-    display: block;
-    right: 0;
+}
+
+.has-js {
+  .page__nav {
+    margin: 0 0 1rem;
+    position: absolute;
+    right: 0-($nav-width + 1rem);
+    width: $nav-width;
+    display: none;
+    top: 0;
+    @include mq(m) {
+      display: block;
+      right: 0;
+      position: relative;
+      width: auto;
+    }
+  }
+
+  .page__menubtn {
+    vertical-align: middle;
+    display: inline-block;
     position: relative;
-    width: auto;
+    line-height: 1;
   }
-}
 
-.page__container {
-  transition: transform 200ms ease-out;
-  .has-nav-open & {
-    transform: translateX(-12rem);
+  .page__container {
+    transition: transform 200ms ease-out;
   }
-}
 
-.page__main {
-  transform: translateX(0);
-  transition: opacity 100ms ease-out;
-  .has-nav-open & {
-    opacity: 0.2;
-    pointer-events: none;
+  .page__main {
+    transform: translateX(0);
+    transition: opacity 100ms ease-out;
+  }
+
+  .has-nav-open {
+    .page__container {
+      transform: translateX(0-($nav-width + 1rem));
+    }
+    .page__main {
+      opacity: 0.2;
+      pointer-events: none;
+    }
+    .page__nav {
+      display: block;
+    }
   }
 }
 

--- a/app/templates/partials/navigation.html
+++ b/app/templates/partials/navigation.html
@@ -1,5 +1,5 @@
 <div class="nav nav--sections nav--vertical js-nav page__nav" id="section-nav">
-  <h2 class="nav__title venus">{{_('Sections')}}</h2>
+  <p class="nav__title venus">{{_('Sections')}}</p>
   <ul class="nav__list js-nav-list">
   {% for nav_item in navigation %}
     <li class="nav__item  pluto {{ 'nav__item--completed' if nav_item.completed }} {{ 'nav__item--current' if nav_item.highlight }}">


### PR DESCRIPTION
### What is the context of this PR?

Fixes #920 by making navigation visible on mobile when a user has Javascript disabled.

#### Bonus content

- removed the automatic defocusing (blur) of the button as this behaviour is bad for accessibility
- tweaked some of the styling of the button
- changed `h2` in nav to `p` following feedback from DAC

### How to review 

- Turn off Javascript
- Reduce viewport width to invoke "mobile" styles
- Check nav is visible
