### PR TITLE
Run tests fails if either script fails

### DIFF
--- a/application.py
+++ b/application.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-from logging.handlers import RotatingFileHandler
 
 from flask_script import Manager
 from flask_script import Server

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -5,6 +5,8 @@
 # NOTE: This script expects to be run from the project root with
 # ./scripts/run_tests.sh
 
+set -e
+
 ./scripts/run_tests_unit.sh
 ./scripts/run_tests_functional.sh
 


### PR DESCRIPTION
### What is the context of this PR?
If the unit test script `run_tests_unit.sh` fails but `run_tests_functional.sh` passes travis will still pass. Setting exit on error in run_tests script to fail fast.

### How to review 
1. Change code to fail flake8 or unit test.
1. Functional tests should not run