### PR TITLE
Exit run.sh on error

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -3,6 +3,8 @@
 # NOTE: This script expects to be run from the project root with
 # ./scripts/run.sh
 
+set -e
+
 if [ "$EQ_RUN_DOCKER_UP" = True ]; then
     echo "Running Docker compose"
     docker-compose --version

--- a/tests/integration/session/test_timeout.py
+++ b/tests/integration/session/test_timeout.py
@@ -72,7 +72,7 @@ class TestTimeout(IntegrationTestCase):
         self.assertEqual(resp.status_code, 200)
 
         content = resp.get_data(True)
-        self.assertIn('window.__EQ_SESSION_TIMEOUT__ = 4', content)
+        self.assertIn('window.__EQ_SESSION_TIMEOUT__ = 6', content)
 
     def test_schema_defined_timeout_cant_be_higher_than_server(self):
         # Given


### PR DESCRIPTION
### What is the context of this PR?
Wrapper script `run.sh` will carry on if unit tests fail. `set -e` will stop on error.

### How to review 
1. Cause a test to fail by editing an assertion
1. Run `EQ_RUN_LOCAL_TESTS=True EQ_RUN_LOCAL=True EQ_RUN_FUNCTIONAL_TESTS=True TRAVIS=True  ./scripts/run.sh`

Expect the script to exit
