### PR TITLE
MWSS Production Schema

### DIFF
--- a/app/data/1_0005.json
+++ b/app/data/1_0005.json
@@ -12,30 +12,36 @@
                         "number of employees",
                         "reasons for any changes to total gross pay or employee numbers"
                     ]
-                },
+                }
+            ],
+            "id": "introduction-group",
+            "title": "Introduction"
+        },
+        {
+            "blocks": [
                 {
-                    "id": "pay-pattern-block-2",
+                    "id": "pay-pattern-frequency",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "pay-pattern-section-2",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "pay-pattern-frequency-section",
                             "number": "1",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "pay-pattern-answer-2-0",
+                                            "id": "pay-pattern-frequency-answer",
                                             "label": "Please select all that apply",
                                             "mandatory": true,
                                             "options": [
                                                 {
                                                     "label": "Weekly",
+                                                    "q_code": "133w",
                                                     "value": "Weekly"
                                                 },
                                                 {
                                                     "label": "Fortnightly",
+                                                    "q_code": "134f",
                                                     "value": "Fortnightly"
                                                 },
                                                 {
@@ -45,19 +51,25 @@
                                                 },
                                                 {
                                                     "label": "Four weekly",
-                                                    "q_code": "132",
+                                                    "q_code": "131",
                                                     "value": "Four weekly"
                                                 },
                                                 {
                                                     "label": "Five weekly",
+                                                    "q_code": "132",
                                                     "value": "Five weekly"
                                                 }
                                             ],
-                                            "type": "Checkbox"
+                                            "type": "Checkbox",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please select all that apply to continue."
+                                                }
+                                            }
                                         }
                                     ],
                                     "description": "<p>If your pay pattern is different from the options available, please contact the Survey Contact Line on 0300 1234 931.</p>",
-                                    "id": "pay-pattern-question-2",
+                                    "id": "pay-pattern-frequency-question",
                                     "number": "1.1",
                                     "title": "Please indicate how frequently employees are paid:",
                                     "type": "General"
@@ -69,23 +81,22 @@
                     "type": "Questionnaire"
                 }
             ],
-            "id": "pay-pattern-section-2-group-3",
+            "id": "pay-pattern",
             "title": "Pay Pattern"
         },
         {
             "blocks": [
                 {
-                    "id": "weekly-pay-block-3",
+                    "id": "weekly-pay-introduction",
                     "sections": [
                         {
-                            "description": "<p>You have now completed this section.</p><p>The next section covers Weekly pay.</p><p>Please exclude the following from your figures for this section:</p><p><ul><li>trainees on government schemes</li><li>director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable)</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
-                            "id": "weekly-pay-section-3",
+                            "description": "<p>The next section covers Weekly pay.</p><p>Please exclude the following from your figures for this section:</p><p><ul><li>trainees on government schemes</li><li>director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable)</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
+                            "id": "weekly-pay-introduction-section",
                             "number": "2",
                             "questions": [
                                 {
                                     "answers": [],
-                                    "description": "",
-                                    "id": "weekly-pay-question-3",
+                                    "id": "weekly-pay-introduction-question",
                                     "title": "",
                                     "type": "General"
                                 }
@@ -96,37 +107,36 @@
                     "type": "Interstitial"
                 },
                 {
-                    "id": "weekly-pay-block-4",
+                    "id": "weekly-pay-paid-employees",
                     "sections": [
                         {
-                            "description": "",
-                            "id": "weekly-pay-section-4",
+                            "id": "weekly-pay-paid-employees-section",
                             "number": "2",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "weekly-pay-answer-4-0",
+                                            "id": "weekly-pay-paid-employees-answer",
                                             "label": "Total number of weekly paid employees",
                                             "mandatory": true,
-                                            "options": [],
                                             "q_code": "40",
-                                            "type": "PositiveInteger"
+                                            "type": "PositiveInteger",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a value, even if that value is 0."
+                                                }
+                                            }
                                         }
                                     ],
                                     "description": "<p>If the last week of the month is affected by holidays please use a more representative week.</p>",
                                     "guidance": [
                                         {
-                                            "description": "",
                                             "list": [
                                                 "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received pay in the relevant period"
                                             ],
                                             "title": "Include:"
                                         },
                                         {
-                                            "description": "",
                                             "list": [
                                                 "trainees on government schemes",
                                                 "employees working abroad unless paid directly from this business\u2019s GB payroll",
@@ -135,9 +145,9 @@
                                             "title": "Exclude:"
                                         }
                                     ],
-                                    "id": "weekly-pay-question-4",
+                                    "id": "weekly-pay-paid-employees-question",
                                     "number": "2.1",
-                                    "title": "What was the number of <em>weekly paid</em> employees paid in the last week of <em>December 2016</em>?",
+                                    "title": "What was the number of <em>weekly paid</em> employees paid in the last week of {{exercise.period_str}}?",
                                     "type": "General"
                                 }
                             ],
@@ -147,11 +157,10 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "weekly-pay-block-5",
+                    "id": "weekly-pay-gross-pay",
                     "sections": [
                         {
-                            "description": "",
-                            "id": "weekly-pay-section-5",
+                            "id": "weekly-pay-gross-pay-section",
                             "number": "2",
                             "questions": [
                                 {
@@ -159,19 +168,21 @@
                                         {
                                             "description": "Please round to the nearest pound. Do not include pence.",
                                             "guidance": "<p>Exclude:</p><p><ul><li>trainees on government schemes</li><li>director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable)</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
-                                            "id": "weekly-pay-answer-5-0",
+                                            "id": "weekly-pay-gross-pay-answer",
                                             "label": "Total gross weekly pay",
                                             "mandatory": true,
-                                            "options": [],
                                             "q_code": "50",
                                             "type": "Currency",
-                                            "alias": "weekly_total_gross"
+                                            "alias": "weekly_total_gross",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a value, even if that value is 0."
+                                                }
+                                            }
                                         }
                                     ],
-                                    "description": "",
                                     "guidance": [
                                         {
-                                            "description": "",
                                             "list": [
                                                 "overtime and shift allowance payments",
                                                 "advanced holiday pay",
@@ -182,16 +193,15 @@
                                             "title": "Include:"
                                         },
                                         {
-                                            "description": "",
                                             "list": [
                                                 "any redundancy pay and pay in lieu of notice payments"
                                             ],
                                             "title": "Exclude:"
                                         }
                                     ],
-                                    "id": "weekly-pay-question-5",
+                                    "id": "weekly-pay-gross-pay-question",
                                     "number": "2.2",
-                                    "title": "What was the <em>total gross weekly pay</em> paid to employees in the last week of <em>December 2016</em>?",
+                                    "title": "What was the <em>total gross weekly pay</em> paid to employees in the last week of {{exercise.period_str}}?",
                                     "type": "General"
                                 }
                             ],
@@ -201,50 +211,58 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "weekly-pay-block-6",
+                    "id": "weekly-pay-breakdown",
                     "sections": [
                         {
-                            "description": "",
-                            "id": "weekly-pay-section-6",
+                            "id": "weekly-pay-breakdown-section",
                             "number": "2",
                             "questions": [
                                 {
                                     "answers": [
                                         {
                                             "description": "Please round to the nearest pound. Do not include pence.",
-                                            "guidance": "",
-                                            "id": "weekly-pay-answer-6-0",
+                                            "id": "weekly-pay-breakdown-holiday-answer",
                                             "label": "Holiday pay, paid in advance (estimate if necessary)",
                                             "mandatory": true,
-                                            "options": [],
                                             "q_code": "60",
-                                            "type": "Currency"
+                                            "type": "Currency",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a value, even if that value is 0."
+                                                }
+                                            }
                                         },
                                         {
                                             "description": "Please round to the nearest pound. Do not include pence.",
-                                            "guidance": "",
-                                            "id": "weekly-pay-answer-6-1",
+                                            "id": "weekly-pay-breakdown-arrears-answer",
                                             "label": "Arrears of pay owing to pay awards",
                                             "mandatory": true,
-                                            "options": [],
                                             "q_code": "70",
-                                            "type": "Currency"
+                                            "type": "Currency",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a value, even if that value is 0."
+                                                }
+                                            }
                                         },
                                         {
                                             "description": "Please round to the nearest pound. Do not include pence.",
                                             "guidance": "<p>Include:</p><p><ul><li>performance pay (for example productivity bonuses)</li><li>long service awards</li><li>appearance money (sporting professionals)</li></ul>Exclude:</p><p><ul><li>trainees on government schemes</li><li>director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable)</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
-                                            "id": "weekly-pay-answer-6-2",
+                                            "id": "weekly-pay-breakdown-prp-answer",
                                             "label": "Bonuses, commissions or annual profit from profit related pay schemes",
                                             "mandatory": true,
-                                            "options": [],
                                             "q_code": "80",
-                                            "type": "Currency"
+                                            "type": "Currency",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a value, even if that value is 0."
+                                                }
+                                            }
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "weekly-pay-question-6",
+                                    "id": "weekly-pay-breakdown-question",
                                     "number": "2.3",
-                                    "title": "Of the {{answers.weekly_total_gross|format_currency}} paid to <em>weekly paid</em> employees in the <em>last week of December 2016</em>, what amount was:",
+                                    "title": "Of the <em>{{answers.weekly_total_gross|format_currency}}</em> paid to <em>weekly paid employees</em> in the last week of {{exercise.period_str}}, what amount was:",
                                     "type": "General"
                                 }
                             ],
@@ -254,20 +272,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "weekly-pay-block-7",
+                    "id": "weekly-pay-significant-changes-paid-employees",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "weekly-pay-section-7",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "weekly-pay-significant-changes-paid-employees-section",
                             "number": "2",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "weekly-pay-answer-7-0",
-                                            "label": "",
+                                            "id": "weekly-pay-significant-changes-paid-employees-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -279,13 +294,13 @@
                                                     "value": "No"
                                                 }
                                             ],
+                                            "q_code": "90w",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "<p>Please note: what constitutes a 'significant change' is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                                     "guidance": [
                                         {
-                                            "description": "",
                                             "list": [
                                                 "redundancies",
                                                 "changes in the number of temporary staff"
@@ -293,7 +308,7 @@
                                             "title": "Include:"
                                         }
                                     ],
-                                    "id": "weekly-pay-question-7",
+                                    "id": "weekly-pay-significant-changes-paid-employees-question",
                                     "number": "2.4",
                                     "title": "Did any significant changes occur to the <em>number of weekly paid employees</em>?",
                                     "type": "General"
@@ -306,10 +321,10 @@
                     "routing_rules": [
                         {
                             "goto": {
-                                "id": "weekly-pay-block-8",
+                                "id": "weekly-pay-significant-changes-redundancies",
                                 "when": [
                                     {
-                                        "id": "weekly-pay-answer-7-0",
+                                        "id": "weekly-pay-significant-changes-paid-employees-answer",
                                         "condition": "equals",
                                         "value": "Yes"
                                     }
@@ -318,10 +333,10 @@
                         },
                         {
                             "goto": {
-                                "id": "weekly-pay-block-10",
+                                "id": "weekly-pay-significant-changes-gross-pay",
                                 "when": [
                                     {
-                                        "id": "weekly-pay-answer-7-0",
+                                        "id": "weekly-pay-significant-changes-paid-employees-answer",
                                         "condition": "equals",
                                         "value": "No"
                                     }
@@ -331,20 +346,17 @@
                     ]
                 },
                 {
-                    "id": "weekly-pay-block-8",
+                    "id": "weekly-pay-significant-changes-redundancies",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "weekly-pay-section-8",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "weekly-pay-significant-changes-redundancies-section",
                             "number": "2",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "weekly-pay-answer-8-0",
-                                            "label": "",
+                                            "id": "weekly-pay-significant-changes-redundancies-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -356,14 +368,13 @@
                                                     "value": "No"
                                                 }
                                             ],
-                                            "q_code": "90",
+                                            "q_code": "91w",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "weekly-pay-question-8",
+                                    "id": "weekly-pay-significant-changes-redundancies-question",
                                     "number": "2.5",
-                                    "title": "Did any significant changes occur to the number of <em>redundancies</em> among  <em>weekly paid employees</em>?",
+                                    "title": "Did any significant changes occur to the number of <em>redundancies</em> among <em>weekly paid employees</em>?",
                                     "type": "General"
                                 }
                             ],
@@ -373,20 +384,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "weekly-pay-block-9",
+                    "id": "weekly-pay-significant-changes-temp-employees",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "weekly-pay-section-9",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "weekly-pay-significant-changes-temp-employees-section",
                             "number": "2",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "weekly-pay-answer-9-0",
-                                            "label": "",
+                                            "id": "weekly-pay-significant-changes-temp-employees-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -402,12 +410,11 @@
                                                     "value": "No significant change"
                                                 }
                                             ],
-                                            "q_code": "90",
+                                            "q_code": "92w",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "weekly-pay-question-9",
+                                    "id": "weekly-pay-significant-changes-temp-employees-question",
                                     "number": "2.6",
                                     "title": "Did any significant changes occur to the <em>number of temporary weekly paid employees</em>?",
                                     "type": "General"
@@ -419,20 +426,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "weekly-pay-block-10",
+                    "id": "weekly-pay-significant-changes-gross-pay",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "weekly-pay-section-10",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "weekly-pay-significant-changes-gross-pay-section",
                             "number": "2",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "weekly-pay-answer-10-0",
-                                            "label": "",
+                                            "id": "weekly-pay-significant-changes-gross-pay-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -444,13 +448,13 @@
                                                     "value": "No"
                                                 }
                                             ],
+                                            "q_code": "93w",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "<p>Please note: what constitutes a ‘significant change' is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                                     "guidance": [
                                         {
-                                            "description": "",
                                             "list": [
                                                 "more or less overtime",
                                                 "new pay rates",
@@ -459,9 +463,9 @@
                                             "title": "Include:"
                                         }
                                     ],
-                                    "id": "weekly-pay-question-10",
+                                    "id": "weekly-pay-significant-changes-gross-pay-question",
                                     "number": "2.7",
-                                    "title": "Did any significant changes occur to the <em>total gross pay</em> paid to  <em>weekly paid employees</em>?",
+                                    "title": "Did any significant changes occur to the <em>total gross pay</em> paid to <em>weekly paid employees</em>?",
                                     "type": "General"
                                 }
                             ],
@@ -472,10 +476,10 @@
                     "routing_rules": [
                         {
                             "goto": {
-                                "id": "weekly-pay-block-11",
+                                "id": "weekly-pay-significant-changes-overtime",
                                 "when": [
                                     {
-                                        "id": "weekly-pay-answer-10-0",
+                                        "id": "weekly-pay-significant-changes-gross-pay-answer",
                                         "condition": "equals",
                                         "value": "Yes"
                                     }
@@ -484,10 +488,10 @@
                         },
                         {
                             "goto": {
-                                "id": "weekly-pay-block-15",
+                                "id": "weekly-pay-significant-changes-other",
                                 "when": [
                                     {
-                                        "id": "weekly-pay-answer-10-0",
+                                        "id": "weekly-pay-significant-changes-gross-pay-answer",
                                         "condition": "equals",
                                         "value": "No"
                                     }
@@ -497,20 +501,17 @@
                     ]
                 },
                 {
-                    "id": "weekly-pay-block-11",
+                    "id": "weekly-pay-significant-changes-overtime",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "weekly-pay-section-11",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "weekly-pay-significant-changes-overtime-section",
                             "number": "2",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "weekly-pay-answer-11-0",
-                                            "label": "",
+                                            "id": "weekly-pay-significant-changes-overtime-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -526,12 +527,11 @@
                                                     "value": "No significant change"
                                                 }
                                             ],
-                                            "q_code": "90",
+                                            "q_code": "94w",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "weekly-pay-question-11",
+                                    "id": "weekly-pay-significant-changes-overtime-question",
                                     "number": "2.8",
                                     "title": "Did any significant changes occur to the <em>amount of overtime</em> paid to <em>weekly paid employees</em>?",
                                     "type": "General"
@@ -543,20 +543,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "weekly-pay-block-12",
+                    "id": "weekly-pay-significant-changes-pay-rates",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "weekly-pay-section-12",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "weekly-pay-significant-changes-pay-rates-section",
                             "number": "2",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "weekly-pay-answer-12-0",
-                                            "label": "",
+                                            "id": "weekly-pay-significant-changes-pay-rates-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -568,14 +565,13 @@
                                                     "value": "No"
                                                 }
                                             ],
-                                            "q_code": "90",
+                                            "q_code": "95w",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "weekly-pay-question-12",
+                                    "id": "weekly-pay-significant-changes-pay-rates-question",
                                     "number": "2.9",
-                                    "title": "Did any significant changes occur to the <em>pay rates</em> of <em>weekly paid employees?</em>",
+                                    "title": "Did any significant changes occur to the <em>pay rates</em> of <em>weekly paid employees</em>?",
                                     "type": "General"
                                 }
                             ],
@@ -586,10 +582,10 @@
                     "routing_rules": [
                         {
                             "goto": {
-                                "id": "weekly-pay-block-13",
+                                "id": "weekly-pay-significant-changes-pay-rates-increase",
                                 "when": [
                                     {
-                                        "id": "weekly-pay-answer-12-0",
+                                        "id": "weekly-pay-significant-changes-pay-rates-answer",
                                         "condition": "equals",
                                         "value": "Yes"
                                     }
@@ -598,10 +594,10 @@
                         },
                         {
                             "goto": {
-                                "id": "weekly-pay-block-14",
+                                "id": "weekly-pay-significant-changes-industrial-action",
                                 "when": [
                                     {
-                                        "id": "weekly-pay-answer-12-0",
+                                        "id": "weekly-pay-significant-changes-pay-rates-answer",
                                         "condition": "equals",
                                         "value": "No"
                                     }
@@ -611,48 +607,48 @@
                     ]
                 },
                 {
-                    "id": "weekly-pay-block-13",
+                    "id": "weekly-pay-significant-changes-pay-rates-increase",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "weekly-pay-section-13",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "weekly-pay-significant-changes-pay-rates-increase-section",
                             "number": "2",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "weekly-pay-answer-13-0",
+                                            "id": "weekly-pay-significant-changes-pay-rates-increase-percent-increase-answer",
                                             "label": "Percentage increase of new pay rates",
                                             "mandatory": false,
-                                            "options": [],
                                             "q_code": "100",
-                                            "type": "Percentage"
+                                            "type": "Percentage",
+                                            "validation": {
+                                                "messages": {
+                                                    "INTEGER_TOO_LARGE": "The maximum value allowed is 100. Please correct your answer."
+                                                }
+                                            }
                                         },
                                         {
-                                            "description": "Please use the format dd/mm/yyyy",
-                                            "guidance": "",
-                                            "id": "weekly-pay-answer-13-1",
+                                            "id": "weekly-pay-significant-changes-pay-rates-increase-date-from-answer",
                                             "label": "If your figures are back dated, from when:",
                                             "mandatory": false,
-                                            "options": [],
                                             "q_code": "110",
-                                            "type": "Date"
+                                            "type": "Date",
+                                            "validation": {
+                                                "messages": {
+                                                    "INVALID_DATE": "The date entered is not valid. Please correct your answer."
+                                                }
+                                            }
                                         },
                                         {
-                                            "description": "Please enter the percentage or number  of staff affected",
-                                            "guidance": "",
-                                            "id": "weekly-pay-answer-13-2",
+                                            "id": "weekly-pay-significant-changes-pay-rates-increase-percent-employees-answer",
                                             "label": "What was the percentage or number of weekly paid employees who received this new pay rate?",
                                             "mandatory": false,
-                                            "options": [],
                                             "q_code": "120",
                                             "type": "PositiveInteger"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "weekly-pay-question-13",
+                                    "id": "weekly-pay-significant-changes-pay-rates-increase-question",
                                     "number": "2.10",
                                     "title": "Please enter the percentage increase of new pay rates, if possible:",
                                     "type": "General"
@@ -664,20 +660,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "weekly-pay-block-14",
+                    "id": "weekly-pay-significant-changes-industrial-action",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "weekly-pay-section-14",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "weekly-pay-significant-changes-industrial-action-section",
                             "number": "2",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "weekly-pay-answer-14-0",
-                                            "label": "",
+                                            "id": "weekly-pay-significant-changes-industrial-action-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -689,14 +682,13 @@
                                                     "value": "No"
                                                 }
                                             ],
-                                            "q_code": "90",
+                                            "q_code": "96w",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "weekly-pay-question-14",
+                                    "id": "weekly-pay-significant-changes-industrial-action-question",
                                     "number": "2.11",
-                                    "title": "Did <em>industrial action</em> significantly affect total gross pay paid to  <em>weekly paid employees</em>?",
+                                    "title": "Did <em>industrial action</em> significantly affect total gross pay paid to <em>weekly paid employees</em>?",
                                     "type": "General"
                                 }
                             ],
@@ -706,20 +698,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "weekly-pay-block-15",
+                    "id": "weekly-pay-significant-changes-other",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "weekly-pay-section-15",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "weekly-pay-significant-changes-other-section",
                             "number": "2",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "weekly-pay-answer-15-0",
-                                            "label": "",
+                                            "id": "weekly-pay-significant-changes-other-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -731,12 +720,11 @@
                                                     "value": "No"
                                                 }
                                             ],
-                                            "q_code": "90",
+                                            "q_code": "97w",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "weekly-pay-question-15",
+                                    "id": "weekly-pay-significant-changes-other-question",
                                     "number": "2.12",
                                     "title": "Did any other significant changes occur to the pay or number of <em>weekly paid employees</em>?",
                                     "type": "General"
@@ -748,30 +736,31 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "weekly-pay-block-16",
+                    "id": "weekly-pay-significant-changes-other-specify",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "weekly-pay-section-16",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "weekly-pay-significant-changes-other-specify-section",
                             "number": "2",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "weekly-pay-answer-16-0",
+                                            "id": "weekly-pay-significant-changes-other-specify-answer",
                                             "label": "Comments",
                                             "mandatory": true,
-                                            "options": [],
-                                            "q_code": "300",
-                                            "type": "TextArea"
+                                            "q_code": "300w",
+                                            "type": "TextArea",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a comment to continue."
+                                                }
+                                            }
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "weekly-pay-question-16",
+                                    "id": "weekly-pay-significant-changes-other-specify-question",
                                     "number": "2.13",
-                                    "title": "Please specify any other significant changes to the pay or number of  <em>weekly paid employees</em>:",
+                                    "title": "Please specify any other significant changes to the pay or number of <em>weekly paid employees</em>:",
                                     "type": "General"
                                 }
                             ],
@@ -783,7 +772,7 @@
                         {
                             "when": [
                                 {
-                                    "id": "weekly-pay-answer-15-0",
+                                    "id": "weekly-pay-significant-changes-other-answer",
                                     "condition": "equals",
                                     "value": "No"
                                 }
@@ -792,13 +781,13 @@
                     ]
                 }
             ],
-            "id": "weekly-pay-section-16-group-17",
+            "id": "weekly-pay",
             "title": "Weekly Pay",
             "skip_condition": [
                 {
                     "when": [
                         {
-                            "id": "pay-pattern-answer-2-0",
+                            "id": "pay-pattern-frequency-answer",
                             "condition": "not contains",
                             "value": "Weekly"
                         }
@@ -807,28 +796,27 @@
                 {
                     "when": [
                         {
-                            "id": "pay-pattern-answer-2-0",
+                            "id": "pay-pattern-frequency-answer",
                             "condition": "not set"
                         }
                     ]
                 }
             ],
-            "completed_id": "weekly-pay-block-15"
+            "completed_id": "weekly-pay-significant-changes-other"
         },
         {
             "blocks": [
                 {
-                    "id": "fortnightly-pay-block-17",
+                    "id": "fortnightly-pay-introduction",
                     "sections": [
                         {
-                            "description": "<p>You have now completed the previous section.</p><p>The next section covers Fortnightly Pay.</p><p>Please exclude the following from your figures for this section:</p><p><ul><li>trainees on government schemes</li><li>director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
-                            "id": "fortnightly-pay-section-17",
+                            "description": "<p>The next section covers Fortnightly Pay.</p><p>Please exclude the following from your figures for this section:</p><p><ul><li>trainees on government schemes</li><li>director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
+                            "id": "fortnightly-pay-introduction-section",
                             "number": "3",
                             "questions": [
                                 {
                                     "answers": [],
-                                    "description": "",
-                                    "id": "fortnightly-pay-question-17",
+                                    "id": "fortnightly-pay-introduction-question",
                                     "title": "",
                                     "type": "General"
                                 }
@@ -839,36 +827,36 @@
                     "type": "Interstitial"
                 },
                 {
-                    "id": "fortnightly-pay-block-18",
+                    "id": "fortnightly-pay-paid-employees",
                     "sections": [
                         {
-                            "description": "",
-                            "id": "fortnightly-pay-section-18",
+                            "id": "fortnightly-pay-paid-employees-section",
                             "number": "3",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "fortnightly-pay-answer-18-0",
+                                            "id": "fortnightly-pay-paid-employees-answer",
                                             "label": "Total number of fortnightly paid employees",
                                             "mandatory": true,
-                                            "options": [],
-                                            "type": "PositiveInteger"
+                                            "q_code": "40f",
+                                            "type": "PositiveInteger",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a value, even if that value is 0."
+                                                }
+                                            }
                                         }
                                     ],
                                     "description": "<p>If the last week of the month is affected by holidays please use a more representative week.</p>",
                                     "guidance": [
                                         {
-                                            "description": "",
                                             "list": [
                                                 "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received pay in the relevant period"
                                             ],
                                             "title": "Include:"
                                         },
                                         {
-                                            "description": "",
                                             "list": [
                                                 "trainees on government schemes",
                                                 "employees working abroad unless paid directly from this business\u2019s GB payroll",
@@ -877,9 +865,9 @@
                                             "title": "Exclude:"
                                         }
                                     ],
-                                    "id": "fortnightly-pay-question-18",
+                                    "id": "fortnightly-pay-paid-employees-question",
                                     "number": "3.1",
-                                    "title": "What was the number of <em>fortnightly paid</em> employees paid in the <em>last week of December 2016</em>?",
+                                    "title": "What was the number of <em>fortnightly paid employees</em> paid in the last week of {{exercise.period_str}}?",
                                     "type": "General"
                                 }
                             ],
@@ -889,11 +877,10 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "fortnightly-pay-block-19",
+                    "id": "fortnightly-pay-gross-pay",
                     "sections": [
                         {
-                            "description": "",
-                            "id": "fortnightly-pay-section-19",
+                            "id": "fortnightly-pay-gross-pay-section",
                             "number": "3",
                             "questions": [
                                 {
@@ -901,18 +888,21 @@
                                         {
                                             "description": "Please round to the nearest pound. Do not include pence.",
                                             "guidance": "<p>Exclude:</p><p><ul><li>trainees on government schemes</li><li>director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable)</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings (councillors)</li></ul></p>",
-                                            "id": "fortnightly-pay-answer-19-0",
+                                            "id": "fortnightly-pay-gross-pay-answer",
                                             "label": "Total gross fortnightly pay including advanced holiday pay, pay award arrears, and bonuses or commissions",
                                             "mandatory": true,
-                                            "options": [],
+                                            "q_code": "50f",
                                             "type": "Currency",
-                                            "alias": "fortnightly_total_gross"
+                                            "alias": "fortnightly_total_gross",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a value, even if that value is 0."
+                                                }
+                                            }
                                         }
                                     ],
-                                    "description": "",
                                     "guidance": [
                                         {
-                                            "description": "",
                                             "list": [
                                                 "overtime and shift allowance payments",
                                                 "advanced holiday pay",
@@ -923,16 +913,15 @@
                                             "title": "Include:"
                                         },
                                         {
-                                            "description": "",
                                             "list": [
                                                 "any redundancy pay and pay in lieu of notice payments"
                                             ],
                                             "title": "Exclude:"
                                         }
                                     ],
-                                    "id": "fortnightly-pay-question-19",
+                                    "id": "fortnightly-pay-gross-pay-question",
                                     "number": "3.2",
-                                    "title": "What was the <em>total gross fortnightly pay</em> paid to employees in the <em>last week of December 2016</em>?",
+                                    "title": "What was the <em>total gross fortnightly pay</em> paid to employees in the last week of {{exercise.period_str}}?",
                                     "type": "General"
                                 }
                             ],
@@ -942,47 +931,58 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "fortnightly-pay-block-20",
+                    "id": "fortnightly-pay-breakdown",
                     "sections": [
                         {
-                            "description": "",
-                            "id": "fortnightly-pay-section-20",
+                            "id": "fortnightly-pay-breakdown-section",
                             "number": "3",
                             "questions": [
                                 {
                                     "answers": [
                                         {
                                             "description": "Please round to the nearest pound. Do not include pence.",
-                                            "guidance": "",
-                                            "id": "fortnightly-pay-answer-20-0",
+                                            "id": "fortnightly-pay-breakdown-holiday-answer",
                                             "label": "Holiday pay, paid in advance (estimate if necessary)",
                                             "mandatory": true,
-                                            "options": [],
-                                            "type": "Currency"
+                                            "q_code": "60f",
+                                            "type": "Currency",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a value, even if that value is 0."
+                                                }
+                                            }
                                         },
                                         {
                                             "description": "Please round to the nearest pound. Do not include pence.",
-                                            "guidance": "",
-                                            "id": "fortnightly-pay-answer-20-1",
+                                            "id": "fortnightly-pay-breakdown-arrears-answer",
                                             "label": "Arrears of pay owing to pay awards",
                                             "mandatory": true,
-                                            "options": [],
-                                            "type": "Currency"
+                                            "q_code": "70f",
+                                            "type": "Currency",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a value, even if that value is 0."
+                                                }
+                                            }
                                         },
                                         {
                                             "description": "Please round to the nearest pound. Do not include pence.",
                                             "guidance": "<p>Include:</p><p><ul><li>performance pay (for example, productivity bonuses)</li><li>long service awards</li><li>appearance money (sporting professionals)</li></ul></p>",
-                                            "id": "fortnightly-pay-answer-20-2",
+                                            "id": "fortnightly-pay-breakdown-prp-answer",
                                             "label": "Bonuses, commissions or annual profit from profit related pay schemes",
                                             "mandatory": true,
-                                            "options": [],
-                                            "type": "Currency"
+                                            "q_code": "80f",
+                                            "type": "Currency",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a value, even if that value is 0."
+                                                }
+                                            }
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "fortnightly-pay-question-20",
+                                    "id": "fortnightly-pay-breakdown-question",
                                     "number": "3.3",
-                                    "title": "Of the {{answers.fortnightly_total_gross|format_currency}} paid to <em>fortnightly paid</em> employees in the <em>last week of December 2016</em>, what amount was:",
+                                    "title": "Of the <em>{{answers.fortnightly_total_gross|format_currency}}</em> paid to <em>fortnightly paid employees</em> in the last week of {{exercise.period_str}}, what amount was:",
                                     "type": "General"
                                 }
                             ],
@@ -992,20 +992,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "fortnightly-pay-block-21",
+                    "id": "fortnightly-pay-significant-changes-paid-employees",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "fortnightly-pay-section-21",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "fortnightly-pay-significant-changes-paid-employees-section",
                             "number": "3",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "fortnightly-pay-answer-21-0",
-                                            "label": "",
+                                            "id": "fortnightly-pay-significant-changes-paid-employees-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -1017,13 +1014,13 @@
                                                     "value": "No"
                                                 }
                                             ],
+                                            "q_code": "90f",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "<p>Please note: what constitutes a ‘significant change' is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                                     "guidance": [
                                         {
-                                            "description": "",
                                             "list": [
                                                 "redundancies",
                                                 "changes in the number of temporary staff"
@@ -1031,7 +1028,7 @@
                                             "title": "Include:"
                                         }
                                     ],
-                                    "id": "fortnightly-pay-question-21",
+                                    "id": "fortnightly-pay-significant-changes-paid-employees-question",
                                     "number": "3.4",
                                     "title": "Did any significant changes occur to the <em>number of fortnightly paid employees</em>?",
                                     "type": "General"
@@ -1044,10 +1041,10 @@
                     "routing_rules": [
                         {
                             "goto": {
-                                "id": "fortnightly-pay-block-22",
+                                "id": "fortnightly-pay-significant-changes-redundancies",
                                 "when": [
                                     {
-                                        "id": "fortnightly-pay-answer-21-0",
+                                        "id": "fortnightly-pay-significant-changes-paid-employees-answer",
                                         "condition": "equals",
                                         "value": "Yes"
                                     }
@@ -1056,10 +1053,10 @@
                         },
                         {
                             "goto": {
-                                "id": "fortnightly-pay-block-24",
+                                "id": "fortnightly-pay-significant-changes-gross-pay",
                                 "when": [
                                     {
-                                        "id": "fortnightly-pay-answer-21-0",
+                                        "id": "fortnightly-pay-significant-changes-paid-employees-answer",
                                         "condition": "equals",
                                         "value": "No"
                                     }
@@ -1069,20 +1066,17 @@
                     ]
                 },
                 {
-                    "id": "fortnightly-pay-block-22",
+                    "id": "fortnightly-pay-significant-changes-redundancies",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "fortnightly-pay-section-22",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "fortnightly-pay-significant-changes-redundancies-section",
                             "number": "3",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "fortnightly-pay-answer-22-0",
-                                            "label": "",
+                                            "id": "fortnightly-pay-significant-changes-redundancies-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -1094,13 +1088,13 @@
                                                     "value": "No"
                                                 }
                                             ],
+                                            "q_code": "91f",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "fortnightly-pay-question-22",
+                                    "id": "fortnightly-pay-significant-changes-redundancies-question",
                                     "number": "3.5",
-                                    "title": "Did any significant changes occur to the number of <em>redundancies</em> among  <em>fortnightly paid employees</em>?",
+                                    "title": "Did any significant changes occur to the number of <em>redundancies</em> among <em>fortnightly paid employees</em>?",
                                     "type": "General"
                                 }
                             ],
@@ -1110,20 +1104,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "fortnightly-pay-block-23",
+                    "id": "fortnightly-pay-significant-changes-temp-employees",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "fortnightly-pay-section-23",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "fortnightly-pay-significant-changes-temp-employees-section",
                             "number": "3",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "fortnightly-pay-answer-23-0",
-                                            "label": "",
+                                            "id": "fortnightly-pay-significant-changes-temp-employees-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -1139,11 +1130,11 @@
                                                     "value": "No significant change"
                                                 }
                                             ],
+                                            "q_code": "92f",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "fortnightly-pay-question-23",
+                                    "id": "fortnightly-pay-significant-changes-temp-employees-question",
                                     "number": "3.6",
                                     "title": "Did any significant changes occur to the <em>number of temporary fortnightly paid employees</em>?",
                                     "type": "General"
@@ -1155,20 +1146,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "fortnightly-pay-block-24",
+                    "id": "fortnightly-pay-significant-changes-gross-pay",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "fortnightly-pay-section-24",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "fortnightly-pay-significant-changes-gross-pay-section",
                             "number": "3",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "fortnightly-pay-answer-24-0",
-                                            "label": "",
+                                            "id": "fortnightly-pay-significant-changes-gross-pay-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -1180,13 +1168,13 @@
                                                     "value": "No"
                                                 }
                                             ],
+                                            "q_code": "93f",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "<p>Please note: what constitutes a ‘significant change' is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                                     "guidance": [
                                         {
-                                            "description": "",
                                             "list": [
                                                 "more or less overtime",
                                                 "new pay rates",
@@ -1195,9 +1183,9 @@
                                             "title": "Include:"
                                         }
                                     ],
-                                    "id": "fortnightly-pay-question-24",
+                                    "id": "fortnightly-pay-significant-changes-gross-pay-question",
                                     "number": "3.7",
-                                    "title": "Did any significant changes occur to the <em>total gross pay</em> paid to  <em>fortnightly paid employees</em>?",
+                                    "title": "Did any significant changes occur to the <em>total gross pay</em> paid to <em>fortnightly paid employees</em>?",
                                     "type": "General"
                                 }
                             ],
@@ -1208,10 +1196,10 @@
                     "routing_rules": [
                         {
                             "goto": {
-                                "id": "fortnightly-pay-block-25",
+                                "id": "fortnightly-pay-significant-changes-overtime",
                                 "when": [
                                     {
-                                        "id": "fortnightly-pay-answer-24-0",
+                                        "id": "fortnightly-pay-significant-changes-gross-pay-answer",
                                         "condition": "equals",
                                         "value": "Yes"
                                     }
@@ -1220,10 +1208,10 @@
                         },
                         {
                             "goto": {
-                                "id": "fortnightly-pay-block-29",
+                                "id": "fortnightly-pay-significant-changes-other",
                                 "when": [
                                     {
-                                        "id": "fortnightly-pay-answer-24-0",
+                                        "id": "fortnightly-pay-significant-changes-gross-pay-answer",
                                         "condition": "equals",
                                         "value": "No"
                                     }
@@ -1233,20 +1221,17 @@
                     ]
                 },
                 {
-                    "id": "fortnightly-pay-block-25",
+                    "id": "fortnightly-pay-significant-changes-overtime",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "fortnightly-pay-section-25",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "fortnightly-pay-significant-changes-overtime-section",
                             "number": "3",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "fortnightly-pay-answer-25-0",
-                                            "label": "",
+                                            "id": "fortnightly-pay-significant-changes-overtime-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -1262,11 +1247,11 @@
                                                     "value": "No significant change"
                                                 }
                                             ],
+                                            "q_code": "94f",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "fortnightly-pay-question-25",
+                                    "id": "fortnightly-pay-significant-changes-overtime-question",
                                     "number": "3.8",
                                     "title": "Did any significant changes occur to the <em>amount of overtime</em> paid to <em>fortnightly paid employees</em>?",
                                     "type": "General"
@@ -1278,20 +1263,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "fortnightly-pay-block-26",
+                    "id": "fortnightly-pay-significant-changes-pay-rates",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "fortnightly-pay-section-26",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "fortnightly-pay-significant-changes-pay-rates-section",
                             "number": "3",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "fortnightly-pay-answer-26-0",
-                                            "label": "",
+                                            "id": "fortnightly-pay-significant-changes-pay-rates-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -1303,13 +1285,13 @@
                                                     "value": "No"
                                                 }
                                             ],
+                                            "q_code": "95f",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "fortnightly-pay-question-26",
+                                    "id": "fortnightly-pay-significant-changes-pay-rates-question",
                                     "number": "3.9",
-                                    "title": "Did any significant changes occur to the <em>pay rates</em> of <em>fortnightly  paid employees?</em>",
+                                    "title": "Did any significant changes occur to the <em>pay rates</em> of <em>fortnightly paid employees</em>?",
                                     "type": "General"
                                 }
                             ],
@@ -1320,10 +1302,10 @@
                     "routing_rules": [
                         {
                             "goto": {
-                                "id": "fortnightly-pay-block-27",
+                                "id": "fortnightly-pay-significant-changes-pay-rates-increase",
                                 "when": [
                                     {
-                                        "id": "fortnightly-pay-answer-26-0",
+                                        "id": "fortnightly-pay-significant-changes-pay-rates-answer",
                                         "condition": "equals",
                                         "value": "Yes"
                                     }
@@ -1332,10 +1314,10 @@
                         },
                         {
                             "goto": {
-                                "id": "fortnightly-pay-block-28",
+                                "id": "fortnightly-pay-significant-changes-industrial-action",
                                 "when": [
                                     {
-                                        "id": "fortnightly-pay-answer-26-0",
+                                        "id": "fortnightly-pay-significant-changes-pay-rates-answer",
                                         "condition": "equals",
                                         "value": "No"
                                     }
@@ -1345,45 +1327,48 @@
                     ]
                 },
                 {
-                    "id": "fortnightly-pay-block-27",
+                    "id": "fortnightly-pay-significant-changes-pay-rates-increase",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "fortnightly-pay-section-27",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "fortnightly-pay-significant-changes-pay-rates-increase-section",
                             "number": "3",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "fortnightly-pay-answer-27-0",
+                                            "id": "fortnightly-pay-significant-changes-pay-rates-increase-percent-increase-answer",
                                             "label": "Percentage increase of new pay rates",
                                             "mandatory": false,
-                                            "options": [],
-                                            "type": "Percentage"
+                                            "q_code": "100f",
+                                            "type": "Percentage",
+                                            "validation": {
+                                                "messages": {
+                                                    "INTEGER_TOO_LARGE": "The maximum value allowed is 100. Please correct your answer."
+                                                }
+                                            }
                                         },
                                         {
-                                            "description": "Please use the format dd/mm/yyyy",
-                                            "guidance": "",
-                                            "id": "fortnightly-pay-answer-27-1",
+                                            "id": "fortnightly-pay-significant-changes-pay-rates-increase-date-from-answer",
                                             "label": "If your figures are back dated, from when:",
                                             "mandatory": false,
-                                            "options": [],
-                                            "type": "Date"
+                                            "q_code": "110f",
+                                            "type": "Date",
+                                            "validation": {
+                                                "messages": {
+                                                    "INVALID_DATE": "The date entered is not valid. Please correct your answer."
+                                                }
+                                            }
                                         },
                                         {
-                                            "description": "Please enter the percentage or  number of staff affected",
-                                            "guidance": "",
-                                            "id": "fortnightly-pay-answer-27-2",
-                                            "label": "What was the percentage or  number of fortnightly paid employees who received this new pay rate?",
+                                            "id": "fortnightly-pay-significant-changes-pay-rates-increase-percent-employees-answer",
+                                            "label": "What was the percentage or number of fortnightly paid employees who received this new pay rate?",
                                             "mandatory": false,
-                                            "options": [],
+                                            "q_code": "120f",
                                             "type": "PositiveInteger"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "fortnightly-pay-question-27",
+                                    "id": "fortnightly-pay-significant-changes-pay-rates-increase-question",
                                     "number": "3.10",
                                     "title": "Please enter the percentage increase of new pay rates if possible:",
                                     "type": "General"
@@ -1395,20 +1380,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "fortnightly-pay-block-28",
+                    "id": "fortnightly-pay-significant-changes-industrial-action",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "fortnightly-pay-section-28",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "fortnightly-pay-significant-changes-industrial-action-section",
                             "number": "3",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "fortnightly-pay-answer-28-0",
-                                            "label": "",
+                                            "id": "fortnightly-pay-significant-changes-industrial-action-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -1420,13 +1402,13 @@
                                                     "value": "No"
                                                 }
                                             ],
+                                            "q_code": "96f",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "fortnightly-pay-question-28",
+                                    "id": "fortnightly-pay-significant-changes-industrial-action-question",
                                     "number": "3.11",
-                                    "title": "Did <em>industrial action</em> significantly affect total gross pay paid to  <em>fortnightly paid employees</em>?",
+                                    "title": "Did <em>industrial action</em> significantly affect total gross pay paid to <em>fortnightly paid employees</em>?",
                                     "type": "General"
                                 }
                             ],
@@ -1436,20 +1418,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "fortnightly-pay-block-29",
+                    "id": "fortnightly-pay-significant-changes-other",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "fortnightly-pay-section-29",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "fortnightly-pay-significant-changes-other-section",
                             "number": "3",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "fortnightly-pay-answer-29-0",
-                                            "label": "",
+                                            "id": "fortnightly-pay-significant-changes-other-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -1461,14 +1440,13 @@
                                                     "value": "No"
                                                 }
                                             ],
-                                            "q_code": "90",
+                                            "q_code": "97f",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "fortnightly-pay-question-29",
+                                    "id": "fortnightly-pay-significant-changes-other-question",
                                     "number": "3.12",
-                                    "title": "Did any other significant changes occur to the pay or number of <em>fortnightly</em><em> paid employees</em>?",
+                                    "title": "Did any other significant changes occur to the pay or number of <em>fortnightly paid employees</em>?",
                                     "type": "General"
                                 }
                             ],
@@ -1478,27 +1456,29 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "fortnightly-pay-block-30",
+                    "id": "fortnightly-pay-significant-changes-other-specify",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "fortnightly-pay-section-30",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "fortnightly-pay-significant-changes-other-specify-section",
                             "number": "3",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "fortnightly-pay-answer-30-0",
+                                            "id": "fortnightly-pay-significant-changes-other-specify-answer",
                                             "label": "Comments",
                                             "mandatory": true,
-                                            "options": [],
-                                            "type": "TextArea"
+                                            "q_code": "300f",
+                                            "type": "TextArea",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a comment to continue."
+                                                }
+                                            }
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "fortnightly-pay-question-30",
+                                    "id": "fortnightly-pay-significant-changes-other-specify-question",
                                     "number": "3.13",
                                     "title": "Please specify any other significant changes to the pay or number of <em>fortnightly paid employees</em>:",
                                     "type": "General"
@@ -1512,7 +1492,7 @@
                         {
                             "when": [
                                 {
-                                    "id": "fortnightly-pay-answer-29-0",
+                                    "id": "fortnightly-pay-significant-changes-other-answer",
                                     "condition": "equals",
                                     "value": "No"
                                 }
@@ -1521,13 +1501,13 @@
                     ]
                 }
             ],
-            "id": "fortnightly-pay-section-30-group-31",
+            "id": "fortnightly-pay",
             "title": "Fortnightly Pay",
             "skip_condition": [
                 {
                     "when": [
                         {
-                            "id": "pay-pattern-answer-2-0",
+                            "id": "pay-pattern-frequency-answer",
                             "condition": "not contains",
                             "value": "Fortnightly"
                         }
@@ -1536,27 +1516,27 @@
                 {
                     "when": [
                         {
-                            "id": "pay-pattern-answer-2-0",
+                            "id": "pay-pattern-frequency-answer",
                             "condition": "not set"
                         }
                     ]
                 }
             ],
-            "completed_id": "fortnightly-pay-block-29"
+            "completed_id": "fortnightly-pay-significant-changes-other"
         },
         {
             "blocks": [
                 {
-                    "id": "calendar-monthly-pay-block-31",
+                    "id": "calendar-monthly-pay-introduction",
                     "sections": [
                         {
-                            "description": "<p>You have now completed the previous section.</p><p>The next section covers Calendar Monthly pay.</p><p>Please exclude the following from your figures for this section:</p><p><ul><li>trainees on government schemes</li><li>director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable)</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
-                            "id": "calendar-monthly-pay-section-31",
+                            "description": "<p>The next section covers Calendar Monthly pay.</p><p>Please exclude the following from your figures for this section:</p><p><ul><li>trainees on government schemes</li><li>director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable)</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
+                            "id": "calendar-monthly-pay-introduction-section",
+                            "number": "4",
                             "questions": [
                                 {
                                     "answers": [],
-                                    "description": "",
-                                    "id": "calendar-monthly-pay-question-31",
+                                    "id": "calendar-monthly-pay-introduction-question",
                                     "title": "",
                                     "type": "General"
                                 }
@@ -1567,37 +1547,37 @@
                     "type": "Interstitial"
                 },
                 {
-                    "id": "calendar-monthly-pay-block-32",
+                    "id": "calendar-monthly-pay-paid-employees",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "calendar-monthly-pay-section-32",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "calendar-monthly-pay-paid-employees-section",
                             "number": "4",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "calendar-monthly-pay-answer-32-0",
+                                            "id": "calendar-monthly-pay-paid-employees-answer",
                                             "label": "Total number of calendar monthly paid employees",
                                             "mandatory": true,
-                                            "options": [],
-                                            "q_code": "140",
-                                            "type": "PositiveInteger"
+                                            "q_code": "140m",
+                                            "type": "PositiveInteger",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a value, even if that value is 0."
+                                                }
+                                            }
                                         }
                                     ],
                                     "description": "<p>If there are two pay days in the same month only give details for one.</p>",
                                     "guidance": [
                                         {
-                                            "description": "",
                                             "list": [
                                                 "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received monthly pay in the relevant period"
                                             ],
                                             "title": "Include:"
                                         },
                                         {
-                                            "description": "",
                                             "list": [
                                                 "trainees on government schemes",
                                                 "employees working abroad unless paid directly from this business\u2019s GB payroll",
@@ -1606,9 +1586,9 @@
                                             "title": "Exclude:"
                                         }
                                     ],
-                                    "id": "calendar-monthly-pay-question-32",
+                                    "id": "calendar-monthly-pay-paid-employees-question",
                                     "number": "4.1",
-                                    "title": "What was the number of <em>calendar monthly paid</em> employees paid in <em>December 2016</em>?",
+                                    "title": "What was the number of <em>calendar monthly paid employees</em> paid in {{exercise.period_str}}?",
                                     "type": "General"
                                 }
                             ],
@@ -1618,11 +1598,11 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "calendar-monthly-pay-block-33",
+                    "id": "calendar-monthly-pay-gross-pay",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "calendar-monthly-pay-section-33",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "calendar-monthly-pay-gross-pay-section",
                             "number": "4",
                             "questions": [
                                 {
@@ -1630,19 +1610,21 @@
                                         {
                                             "description": "Please round to the nearest pound. Do not include pence.",
                                             "guidance": "<p>Exclude:</p><p><ul><li>trainees on government schemes</li><li>director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable)</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
-                                            "id": "calendar-monthly-pay-answer-33-0",
+                                            "id": "calendar-monthly-pay-gross-pay-answer",
                                             "label": "Total gross calendar monthly pay including advanced holiday pay, pay award arrears, and bonuses or commissions",
                                             "mandatory": true,
-                                            "options": [],
                                             "q_code": "151",
                                             "type": "Currency",
-                                            "alias": "monthly_total_gross"
+                                            "alias": "monthly_total_gross",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a value, even if that value is 0."
+                                                }
+                                            }
                                         }
                                     ],
-                                    "description": "",
                                     "guidance": [
                                         {
-                                            "description": "",
                                             "list": [
                                                 "overtime and shift allowance payments",
                                                 "pay awards",
@@ -1652,16 +1634,15 @@
                                             "title": "Include:"
                                         },
                                         {
-                                            "description": "",
                                             "list": [
                                                 "any redundancy pay and pay in lieu of notice payments"
                                             ],
                                             "title": "Exclude:"
                                         }
                                     ],
-                                    "id": "calendar-monthly-pay-question-33",
+                                    "id": "calendar-monthly-pay-gross-pay-question",
                                     "number": "4.2",
-                                    "title": "What was the <em>total gross calendar monthly pay</em> paid to employees in <em>December 2016</em>?",
+                                    "title": "What was the <em>total gross calendar monthly pay</em> paid to employees in {{exercise.period_str}}?",
                                     "type": "General"
                                 }
                             ],
@@ -1671,40 +1652,46 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "calendar-monthly-pay-block-34",
+                    "id": "calendar-monthly-pay-breakdown",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "calendar-monthly-pay-section-34",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "calendar-monthly-pay-breakdown-section",
                             "number": "4",
                             "questions": [
                                 {
                                     "answers": [
                                         {
                                             "description": "Please round to the nearest pound. Do not include pence.",
-                                            "guidance": "",
-                                            "id": "calendar-monthly-pay-answer-34-0",
+                                            "id": "calendar-monthly-pay-breakdown-arrears-answer",
                                             "label": "Arrears of pay owing to pay awards",
                                             "mandatory": true,
-                                            "options": [],
                                             "q_code": "171",
-                                            "type": "Currency"
+                                            "type": "Currency",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a value, even if that value is 0."
+                                                }
+                                            }
                                         },
                                         {
                                             "description": "Please round to the nearest pound. Do not include pence.",
                                             "guidance": "<p>Include:</p><p><ul><li>performance pay (for example productivity bonuses)</li><li>long service awards</li><li>appearance money (sporting professionals)</li></ul></p>",
-                                            "id": "calendar-monthly-pay-answer-34-1",
+                                            "id": "calendar-monthly-pay-breakdown-prp-answer",
                                             "label": "Bonuses, commissions or annual profit from profit related pay schemes",
                                             "mandatory": true,
-                                            "options": [],
                                             "q_code": "181",
-                                            "type": "Currency"
+                                            "type": "Currency",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a value, even if that value is 0."
+                                                }
+                                            }
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "calendar-monthly-pay-question-34",
+                                    "id": "calendar-monthly-pay-breakdown-question",
                                     "number": "4.3",
-                                    "title": "Of the {{answers.monthly_total_gross|format_currency}} paid to <em>calendar monthly paid</em>  employees in <em>December 2016</em>, what amount was:",
+                                    "title": "Of the <em>{{answers.monthly_total_gross|format_currency}}</em> paid to <em>calendar monthly paid employees</em> in {{exercise.period_str}}, what amount was:",
                                     "type": "General"
                                 }
                             ],
@@ -1714,20 +1701,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "calendar-monthly-pay-block-35",
+                    "id": "calendar-monthly-pay-significant-changes-paid-employees",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "calendar-monthly-pay-section-35",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "calendar-monthly-pay-significant-changes-paid-employees-section",
                             "number": "4",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "calendar-monthly-pay-answer-35-0",
-                                            "label": "",
+                                            "id": "calendar-monthly-pay-significant-changes-paid-employees-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -1739,13 +1723,13 @@
                                                     "value": "No"
                                                 }
                                             ],
+                                            "q_code": "190m",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "<p>Please note: what constitutes a ‘significant change' is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                                     "guidance": [
                                         {
-                                            "description": "",
                                             "list": [
                                                 "redundancies",
                                                 "changes in the number of temporary staff"
@@ -1753,7 +1737,7 @@
                                             "title": "Include:"
                                         }
                                     ],
-                                    "id": "calendar-monthly-pay-question-35",
+                                    "id": "calendar-monthly-pay-significant-changes-paid-employees-question",
                                     "number": "4.4",
                                     "title": "Did any significant changes occur to the <em>number of calendar monthly paid employees</em>?",
                                     "type": "General"
@@ -1766,10 +1750,10 @@
                     "routing_rules": [
                         {
                             "goto": {
-                                "id": "calendar-monthly-pay-block-36",
+                                "id": "calendar-monthly-pay-significant-changes-redundancies",
                                 "when": [
                                     {
-                                        "id": "calendar-monthly-pay-answer-35-0",
+                                        "id": "calendar-monthly-pay-significant-changes-paid-employees-answer",
                                         "condition": "equals",
                                         "value": "Yes"
                                     }
@@ -1778,10 +1762,10 @@
                         },
                         {
                             "goto": {
-                                "id": "calendar-monthly-pay-block-38",
+                                "id": "calendar-monthly-pay-significant-changes-gross-pay",
                                 "when": [
                                     {
-                                        "id": "calendar-monthly-pay-answer-35-0",
+                                        "id": "calendar-monthly-pay-significant-changes-paid-employees-answer",
                                         "condition": "equals",
                                         "value": "No"
                                     }
@@ -1791,20 +1775,17 @@
                     ]
                 },
                 {
-                    "id": "calendar-monthly-pay-block-36",
+                    "id": "calendar-monthly-pay-significant-changes-redundancies",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "calendar-monthly-pay-section-36",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "calendar-monthly-pay-significant-changes-redundancies-section",
                             "number": "4",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "calendar-monthly-pay-answer-36-0",
-                                            "label": "",
+                                            "id": "calendar-monthly-pay-significant-changes-redundancies-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -1816,14 +1797,13 @@
                                                     "value": "No"
                                                 }
                                             ],
-                                            "q_code": "190",
+                                            "q_code": "191m",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "calendar-monthly-pay-question-36",
+                                    "id": "calendar-monthly-pay-significant-changes-redundancies-question",
                                     "number": "4.5",
-                                    "title": "Did any significant changes occur to the number of <em>redundancies</em> among  <em>calendar monthly paid employees</em>?",
+                                    "title": "Did any significant changes occur to the number of <em>redundancies</em> among <em>calendar monthly paid employees</em>?",
                                     "type": "General"
                                 }
                             ],
@@ -1833,20 +1813,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "calendar-monthly-pay-block-37",
+                    "id": "calendar-monthly-pay-significant-changes-temp-employees",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "calendar-monthly-pay-section-37",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "calendar-monthly-pay-significant-changes-temp-employees-section",
                             "number": "4",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "calendar-monthly-pay-answer-37-0",
-                                            "label": "",
+                                            "id": "calendar-monthly-pay-significant-changes-temp-employees-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -1862,12 +1839,11 @@
                                                     "value": "No significant change"
                                                 }
                                             ],
-                                            "q_code": "190",
+                                            "q_code": "192m",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "calendar-monthly-pay-question-37",
+                                    "id": "calendar-monthly-pay-significant-changes-temp-employees-question",
                                     "number": "4.6",
                                     "title": "Did any significant changes occur to the <em>number of temporary calendar monthly paid employees</em>?",
                                     "type": "General"
@@ -1879,20 +1855,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "calendar-monthly-pay-block-38",
+                    "id": "calendar-monthly-pay-significant-changes-gross-pay",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "calendar-monthly-pay-section-38",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "calendar-monthly-pay-significant-changes-gross-pay-section",
                             "number": "4",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "calendar-monthly-pay-answer-38-0",
-                                            "label": "",
+                                            "id": "calendar-monthly-pay-significant-changes-gross-pay-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -1904,13 +1877,13 @@
                                                     "value": "No"
                                                 }
                                             ],
+                                            "q_code": "193m",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "<p>Please note: what constitutes a ‘significant change' is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                                     "guidance": [
                                         {
-                                            "description": "",
                                             "list": [
                                                 "more or less overtime",
                                                 "new pay rates",
@@ -1919,9 +1892,9 @@
                                             "title": "Include:"
                                         }
                                     ],
-                                    "id": "calendar-monthly-pay-question-38",
+                                    "id": "calendar-monthly-pay-significant-changes-gross-pay-question",
                                     "number": "4.7",
-                                    "title": "Did any significant changes occur to the <em>total gross pay</em> paid to  <em>calendar monthly paid employees</em>?",
+                                    "title": "Did any significant changes occur to the <em>total gross pay</em> paid to <em>calendar monthly paid employees</em>?",
                                     "type": "General"
                                 }
                             ],
@@ -1932,10 +1905,10 @@
                     "routing_rules": [
                         {
                             "goto": {
-                                "id": "calendar-monthly-pay-block-39",
+                                "id": "calendar-monthly-pay-significant-changes-overtime",
                                 "when": [
                                     {
-                                        "id": "calendar-monthly-pay-answer-38-0",
+                                        "id": "calendar-monthly-pay-significant-changes-gross-pay-answer",
                                         "condition": "equals",
                                         "value": "Yes"
                                     }
@@ -1944,10 +1917,10 @@
                         },
                         {
                             "goto": {
-                                "id": "calendar-monthly-pay-block-43",
+                                "id": "calendar-monthly-pay-significant-changes-other",
                                 "when": [
                                     {
-                                        "id": "calendar-monthly-pay-answer-38-0",
+                                        "id": "calendar-monthly-pay-significant-changes-gross-pay-answer",
                                         "condition": "equals",
                                         "value": "No"
                                     }
@@ -1957,20 +1930,17 @@
                     ]
                 },
                 {
-                    "id": "calendar-monthly-pay-block-39",
+                    "id": "calendar-monthly-pay-significant-changes-overtime",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "calendar-monthly-pay-section-39",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "calendar-monthly-pay-significant-changes-overtime-section",
                             "number": "4",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "calendar-monthly-pay-answer-39-0",
-                                            "label": "",
+                                            "id": "calendar-monthly-pay-significant-changes-overtime-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -1986,12 +1956,11 @@
                                                     "value": "No significant change"
                                                 }
                                             ],
-                                            "q_code": "190",
+                                            "q_code": "194m",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "calendar-monthly-pay-question-39",
+                                    "id": "calendar-monthly-pay-significant-changes-overtime-question",
                                     "number": "4.8",
                                     "title": "Did any significant changes occur to the <em>amount of overtime</em> paid to <em>calendar monthly paid employees</em>?",
                                     "type": "General"
@@ -2003,20 +1972,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "calendar-monthly-pay-block-40",
+                    "id": "calendar-monthly-pay-significant-changes-pay-rates",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "calendar-monthly-pay-section-40",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "calendar-monthly-pay-significant-changes-pay-rates-section",
                             "number": "4",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "calendar-monthly-pay-answer-40-0",
-                                            "label": "",
+                                            "id": "calendar-monthly-pay-significant-changes-pay-rates-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -2028,12 +1994,11 @@
                                                     "value": "No"
                                                 }
                                             ],
-                                            "q_code": "190",
+                                            "q_code": "195m",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "calendar-monthly-pay-question-40",
+                                    "id": "calendar-monthly-pay-significant-changes-pay-rates-question",
                                     "number": "4.9",
                                     "title": "Did any significant changes occur to the <em>pay rates</em> of <em>calendar monthly paid employees</em>?",
                                     "type": "General"
@@ -2046,10 +2011,10 @@
                     "routing_rules": [
                         {
                             "goto": {
-                                "id": "calendar-monthly-pay-block-41",
+                                "id": "calendar-monthly-pay-significant-changes-pay-rates-increase",
                                 "when": [
                                     {
-                                        "id": "calendar-monthly-pay-answer-40-0",
+                                        "id": "calendar-monthly-pay-significant-changes-pay-rates-answer",
                                         "condition": "equals",
                                         "value": "Yes"
                                     }
@@ -2058,10 +2023,10 @@
                         },
                         {
                             "goto": {
-                                "id": "calendar-monthly-pay-block-42",
+                                "id": "calendar-monthly-pay-significant-changes-industrial-action",
                                 "when": [
                                     {
-                                        "id": "calendar-monthly-pay-answer-40-0",
+                                        "id": "calendar-monthly-pay-significant-changes-pay-rates-answer",
                                         "condition": "equals",
                                         "value": "No"
                                     }
@@ -2071,48 +2036,48 @@
                     ]
                 },
                 {
-                    "id": "calendar-monthly-pay-block-41",
+                    "id": "calendar-monthly-pay-significant-changes-pay-rates-increase",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "calendar-monthly-pay-section-41",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "calendar-monthly-pay-significant-changes-pay-rates-increase-section",
                             "number": "4",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "calendar-monthly-pay-answer-41-0",
+                                            "id": "calendar-monthly-pay-significant-changes-pay-rates-increase-percent-increase-answer",
                                             "label": "Percentage increase of new pay rates",
                                             "mandatory": false,
-                                            "options": [],
                                             "q_code": "200",
-                                            "type": "Percentage"
+                                            "type": "Percentage",
+                                            "validation": {
+                                                "messages": {
+                                                    "INTEGER_TOO_LARGE": "The maximum value allowed is 100. Please correct your answer."
+                                                }
+                                            }
                                         },
                                         {
-                                            "description": "Please use the format dd/mm/yyyy",
-                                            "guidance": "",
-                                            "id": "calendar-monthly-pay-answer-41-1",
+                                            "id": "calendar-monthly-pay-significant-changes-pay-rates-increase-date-from-answer",
                                             "label": "If your figures are back dated, from when:",
                                             "mandatory": false,
-                                            "options": [],
                                             "q_code": "210",
-                                            "type": "Date"
+                                            "type": "Date",
+                                            "validation": {
+                                                "messages": {
+                                                    "INVALID_DATE": "The date entered is not valid. Please correct your answer."
+                                                }
+                                            }
                                         },
                                         {
-                                            "description": "Please enter the percentage or number of staff affected",
-                                            "guidance": "",
-                                            "id": "calendar-monthly-pay-answer-41-2",
-                                            "label": "What was the percentage or  number of calendar monthly paid employees who received this new pay rate?",
+                                            "id": "calendar-monthly-pay-significant-changes-pay-rates-increase-percent-employees-answer",
+                                            "label": "What was the percentage or number of calendar monthly paid employees who received this new pay rate?",
                                             "mandatory": false,
-                                            "options": [],
                                             "q_code": "220",
                                             "type": "PositiveInteger"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "calendar-monthly-pay-question-41",
+                                    "id": "calendar-monthly-pay-significant-changes-pay-rates-increase-question",
                                     "number": "4.10",
                                     "title": "Please enter the percentage increase of new pay rates, if possible:",
                                     "type": "General"
@@ -2124,20 +2089,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "calendar-monthly-pay-block-42",
+                    "id": "calendar-monthly-pay-significant-changes-industrial-action",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "calendar-monthly-pay-section-42",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "calendar-monthly-pay-significant-changes-industrial-action-section",
                             "number": "4",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "calendar-monthly-pay-answer-42-0",
-                                            "label": "",
+                                            "id": "calendar-monthly-pay-significant-changes-industrial-action-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -2149,13 +2111,13 @@
                                                     "value": "No"
                                                 }
                                             ],
+                                            "q_code": "196m",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "calendar-monthly-pay-question-42",
+                                    "id": "calendar-monthly-pay-significant-changes-industrial-action-question",
                                     "number": "4.11",
-                                    "title": "Did <em>industrial action</em> significantly affect total gross pay paid to  <em>calendar monthly paid employees</em>?",
+                                    "title": "Did <em>industrial action</em> significantly affect total gross pay paid to <em>calendar monthly paid employees</em>?",
                                     "type": "General"
                                 }
                             ],
@@ -2165,20 +2127,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "calendar-monthly-pay-block-43",
+                    "id": "calendar-monthly-pay-significant-changes-other",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "calendar-monthly-pay-section-43",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "calendar-monthly-pay-significant-changes-other-section",
                             "number": "4",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "calendar-monthly-pay-answer-43-0",
-                                            "label": "",
+                                            "id": "calendar-monthly-pay-significant-changes-other-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -2190,12 +2149,11 @@
                                                     "value": "No"
                                                 }
                                             ],
-                                            "q_code": "90",
+                                            "q_code": "197m",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "calendar-monthly-pay-question-43",
+                                    "id": "calendar-monthly-pay-significant-changes-other-question",
                                     "number": "4.12",
                                     "title": "Did any other significant changes occur to the pay or number of <em>calendar monthly paid employees</em>?",
                                     "type": "General"
@@ -2207,29 +2165,31 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "calendar-monthly-pay-block-44",
+                    "id": "calendar-monthly-pay-significant-changes-other-specify",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "calendar-monthly-pay-section-44",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "calendar-monthly-pay-significant-changes-other-specify-section",
                             "number": "4",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "calendar-monthly-pay-answer-44-0",
+                                            "id": "calendar-monthly-pay-significant-changes-other-specify-answer",
                                             "label": "Comments",
                                             "mandatory": true,
-                                            "options": [],
-                                            "type": "TextArea"
+                                            "q_code": "300m",
+                                            "type": "TextArea",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a comment to continue."
+                                                }
+                                            }
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "calendar-monthly-pay-question-44",
+                                    "id": "calendar-monthly-pay-significant-changes-other-specify-question",
                                     "number": "4.13",
-                                    "title": "Please specify any other significant changes to the pay or number of  <em>calendar monthly paid employees</em>:",
+                                    "title": "Please specify any other significant changes to the pay or number of <em>calendar monthly paid employees</em>:",
                                     "type": "General"
                                 }
                             ],
@@ -2241,7 +2201,7 @@
                         {
                             "when": [
                                 {
-                                    "id": "calendar-monthly-pay-answer-43-0",
+                                    "id": "calendar-monthly-pay-significant-changes-other-answer",
                                     "condition": "equals",
                                     "value": "No"
                                 }
@@ -2250,13 +2210,13 @@
                     ]
                 }
             ],
-            "id": "calendar-monthly-pay-section-44-group-45",
+            "id": "calendar-monthly",
             "title": "Calendar Monthly Pay",
             "skip_condition": [
                 {
                     "when": [
                         {
-                            "id": "pay-pattern-answer-2-0",
+                            "id": "pay-pattern-frequency-answer",
                             "condition": "not contains",
                             "value": "Calendar monthly"
                         }
@@ -2265,28 +2225,27 @@
                 {
                     "when": [
                         {
-                            "id": "pay-pattern-answer-2-0",
+                            "id": "pay-pattern-frequency-answer",
                             "condition": "not set"
                         }
                     ]
                 }
             ],
-            "completed_id": "calendar-monthly-pay-block-43"
+            "completed_id": "calendar-monthly-pay-significant-changes-other"
         },
         {
             "blocks": [
                 {
-                    "id": "four-weekly-pay-block-45",
+                    "id": "four-weekly-pay-introduction",
                     "sections": [
                         {
-                            "description": "<p>You have now completed this section.</p><p>The next section covers Four Weekly pay.</p><p>Please exclude the following from your figures for this section:</p><p><ul><li>trainees on government schemes</li><li>director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
-                            "id": "four-weekly-pay-section-45",
+                            "description": "<p>The next section covers Four Weekly pay.</p><p>Please exclude the following from your figures for this section:</p><p><ul><li>trainees on government schemes</li><li>director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
+                            "id": "four-weekly-pay-introduction-section",
                             "number": "5",
                             "questions": [
                                 {
                                     "answers": [],
-                                    "description": "",
-                                    "id": "four-weekly-pay-question-45",
+                                    "id": "four-weekly-pay-introduction-question",
                                     "title": "",
                                     "type": "General"
                                 }
@@ -2297,36 +2256,37 @@
                     "type": "Interstitial"
                 },
                 {
-                    "id": "four-weekly-pay-block-46",
+                    "id": "four-weekly-pay-paid-employees",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "four-weekly-pay-section-46",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "four-weekly-pay-paid-employees-section",
                             "number": "5",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "four-weekly-pay-answer-46-0",
+                                            "id": "four-weekly-pay-paid-employees-answer",
                                             "label": "Total number of four weekly paid employees",
                                             "mandatory": true,
-                                            "options": [],
-                                            "type": "PositiveInteger"
+                                            "q_code": "140w4",
+                                            "type": "PositiveInteger",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a value, even if that value is 0."
+                                                }
+                                            }
                                         }
                                     ],
                                     "description": "<p>If there are two pay days in the same month only give details for one.</p>",
                                     "guidance": [
                                         {
-                                            "description": "",
                                             "list": [
                                                 "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received monthly pay in the relevant period"
                                             ],
                                             "title": "Include:"
                                         },
                                         {
-                                            "description": "",
                                             "list": [
                                                 "trainees on government schemes",
                                                 "employees working abroad unless paid directly from this business\u2019s GB payroll",
@@ -2335,9 +2295,9 @@
                                             "title": "Exclude:"
                                         }
                                     ],
-                                    "id": "four-weekly-pay-question-46",
+                                    "id": "four-weekly-pay-paid-employees-question",
                                     "number": "5.1",
-                                    "title": "What was the number of <em>four weekly paid employees</em> paid in <em>December 2016</em>?",
+                                    "title": "What was the number of <em>four weekly paid employees</em> paid in {{exercise.period_str}}?",
                                     "type": "General"
                                 }
                             ],
@@ -2347,11 +2307,11 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "four-weekly-pay-block-47",
+                    "id": "four-weekly-pay-gross-pay",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "four-weekly-pay-section-47",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "four-weekly-pay-gross-pay-section",
                             "number": "5",
                             "questions": [
                                 {
@@ -2359,18 +2319,21 @@
                                         {
                                             "description": "Please round to the nearest pound. Do not include pence.",
                                             "guidance": "<p>Exclude:</p><p><ul><li>trainees on government schemes director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable)</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
-                                            "id": "four-weekly-pay-answer-47-0",
+                                            "id": "four-weekly-pay-gross-pay-answer",
                                             "label": "Total gross four weekly pay including advanced holiday pay, pay award arrears, and bonuses or commissions",
                                             "mandatory": true,
-                                            "options": [],
+                                            "q_code": "152",
                                             "type": "Currency",
-                                            "alias": "four_weekly_total_gross"
+                                            "alias": "four_weekly_total_gross",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a value, even if that value is 0."
+                                                }
+                                            }
                                         }
                                     ],
-                                    "description": "",
                                     "guidance": [
                                         {
-                                            "description": "",
                                             "list": [
                                                 "overtime and shift allowance payments",
                                                 "pay awards",
@@ -2380,16 +2343,15 @@
                                             "title": "Include:"
                                         },
                                         {
-                                            "description": "",
                                             "list": [
                                                 "any redundancy pay and pay in lieu of notice payments"
                                             ],
                                             "title": "Exclude:"
                                         }
                                     ],
-                                    "id": "four-weekly-pay-question-47",
+                                    "id": "four-weekly-pay-gross-pay-question",
                                     "number": "5.2",
-                                    "title": "What was the <em>total gross four weekly pay</em> paid to employees in <em>December 2016</em>?",
+                                    "title": "What was the <em>total gross four weekly pay</em> paid to employees in {{exercise.period_str}}?",
                                     "type": "General"
                                 }
                             ],
@@ -2399,38 +2361,46 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "four-weekly-pay-block-48",
+                    "id": "four-weekly-pay-breakdown",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "four-weekly-pay-section-48",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "four-weekly-pay-breakdown-section",
                             "number": "5",
                             "questions": [
                                 {
                                     "answers": [
                                         {
                                             "description": "Please round to the nearest pound. Do not include pence.",
-                                            "guidance": "",
-                                            "id": "four-weekly-pay-answer-48-0",
+                                            "id": "four-weekly-pay-breakdown-arrears-answer",
                                             "label": "Arrears of pay owing to pay awards",
                                             "mandatory": true,
-                                            "options": [],
-                                            "type": "Currency"
+                                            "q_code": "172",
+                                            "type": "Currency",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a value, even if that value is 0."
+                                                }
+                                            }
                                         },
                                         {
                                             "description": "Please round to the nearest pound. Do not include pence.",
                                             "guidance": "<p>Include:</p><p><ul><li>performance pay (for example productivity bonuses)</li><li>long service awards</li><li>appearance money (sporting professionals)</li></ul></p>",
-                                            "id": "four-weekly-pay-answer-48-1",
+                                            "id": "four-weekly-pay-breakdown-prp-answer",
                                             "label": "Bonuses, commissions or annual profit from profit related pay schemes",
                                             "mandatory": true,
-                                            "options": [],
-                                            "type": "Currency"
+                                            "q_code": "182",
+                                            "type": "Currency",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a value, even if that value is 0."
+                                                }
+                                            }
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "four-weekly-pay-question-48",
+                                    "id": "four-weekly-pay-breakdown-question",
                                     "number": "5.3",
-                                    "title": "Of the {{answers.four_weekly_total_gross|format_currency}} paid to <em>four weekly paid</em> employees in <em>December 2016</em>, what amount was:",
+                                    "title": "Of the <em>{{answers.four_weekly_total_gross|format_currency}}</em> paid to <em>four weekly paid employees</em> in {{exercise.period_str}}, what amount was:",
                                     "type": "General"
                                 }
                             ],
@@ -2440,20 +2410,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "four-weekly-pay-block-49",
+                    "id": "four-weekly-pay-significant-changes-paid-employees",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "four-weekly-pay-section-49",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "four-weekly-pay-significant-changes-paid-employees-section",
                             "number": "5",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "four-weekly-pay-answer-49-0",
-                                            "label": "",
+                                            "id": "four-weekly-pay-significant-changes-paid-employees-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -2465,13 +2432,13 @@
                                                     "value": "No"
                                                 }
                                             ],
+                                            "q_code": "190w4",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "<p>Please note: what constitutes a ‘significant change' is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                                     "guidance": [
                                         {
-                                            "description": "",
                                             "list": [
                                                 "redundancies",
                                                 "changes in the number of temporary staff"
@@ -2479,7 +2446,7 @@
                                             "title": "Include:"
                                         }
                                     ],
-                                    "id": "four-weekly-pay-question-49",
+                                    "id": "four-weekly-pay-significant-changes-paid-employees-question",
                                     "number": "5.4",
                                     "title": "Did any significant changes occur to the <em>number of four weekly paid employees</em>?",
                                     "type": "General"
@@ -2492,10 +2459,10 @@
                     "routing_rules": [
                         {
                             "goto": {
-                                "id": "four-weekly-pay-block-50",
+                                "id": "four-weekly-pay-significant-changes-redundancies",
                                 "when": [
                                     {
-                                        "id": "four-weekly-pay-answer-49-0",
+                                        "id": "four-weekly-pay-significant-changes-paid-employees-answer",
                                         "condition": "equals",
                                         "value": "Yes"
                                     }
@@ -2504,10 +2471,10 @@
                         },
                         {
                             "goto": {
-                                "id": "four-weekly-pay-block-52",
+                                "id": "four-weekly-pay-significant-changes-gross-pay",
                                 "when": [
                                     {
-                                        "id": "four-weekly-pay-answer-49-0",
+                                        "id": "four-weekly-pay-significant-changes-paid-employees-answer",
                                         "condition": "equals",
                                         "value": "No"
                                     }
@@ -2517,20 +2484,17 @@
                     ]
                 },
                 {
-                    "id": "four-weekly-pay-block-50",
+                    "id": "four-weekly-pay-significant-changes-redundancies",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "four-weekly-pay-section-50",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "four-weekly-pay-significant-changes-redundancies-section",
                             "number": "5",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "four-weekly-pay-answer-50-0",
-                                            "label": "",
+                                            "id": "four-weekly-pay-significant-changes-redundancies-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -2542,13 +2506,13 @@
                                                     "value": "No"
                                                 }
                                             ],
+                                            "q_code": "191w4",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "four-weekly-pay-question-50",
+                                    "id": "four-weekly-pay-significant-changes-redundancies-question",
                                     "number": "5.5",
-                                    "title": "Did any significant changes occur to the number of <em>redundancies</em> among  <em>four weekly paid employees</em>?",
+                                    "title": "Did any significant changes occur to the number of <em>redundancies</em> among <em>four weekly paid employees</em>?",
                                     "type": "General"
                                 }
                             ],
@@ -2558,20 +2522,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "four-weekly-pay-block-51",
+                    "id": "four-weekly-pay-significant-changes-temp-employees",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "four-weekly-pay-section-51",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "four-weekly-pay-significant-changes-temp-employees-section",
                             "number": "5",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "four-weekly-pay-answer-51-0",
-                                            "label": "",
+                                            "id": "four-weekly-pay-significant-changes-temp-employees-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -2587,11 +2548,11 @@
                                                     "value": "No significant change"
                                                 }
                                             ],
+                                            "q_code": "192w4",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "four-weekly-pay-question-51",
+                                    "id": "four-weekly-pay-significant-changes-temp-employees-question",
                                     "number": "5.6",
                                     "title": "Did any significant changes occur to the <em>number of temporary four weekly paid employees</em>?",
                                     "type": "General"
@@ -2603,20 +2564,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "four-weekly-pay-block-52",
+                    "id": "four-weekly-pay-significant-changes-gross-pay",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "four-weekly-pay-section-52",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "four-weekly-pay-significant-changes-gross-pay-section",
                             "number": "5",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "four-weekly-pay-answer-52-0",
-                                            "label": "",
+                                            "id": "four-weekly-pay-significant-changes-gross-pay-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -2628,13 +2586,13 @@
                                                     "value": "No"
                                                 }
                                             ],
+                                            "q_code": "193w4",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "<p>Please note: what constitutes a ‘significant change' is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                                     "guidance": [
                                         {
-                                            "description": "",
                                             "list": [
                                                 "more or less overtime",
                                                 "new pay rates",
@@ -2643,9 +2601,9 @@
                                             "title": "Include:"
                                         }
                                     ],
-                                    "id": "four-weekly-pay-question-52",
+                                    "id": "four-weekly-pay-significant-changes-gross-pay-question",
                                     "number": "5.7",
-                                    "title": "Did any significant changes occur to the <em>total gross pay</em> paid to  <em>four weekly paid employees</em>?",
+                                    "title": "Did any significant changes occur to the <em>total gross pay</em> paid to <em>four weekly paid employees</em>?",
                                     "type": "General"
                                 }
                             ],
@@ -2656,10 +2614,10 @@
                     "routing_rules": [
                         {
                             "goto": {
-                                "id": "four-weekly-pay-block-53",
+                                "id": "four-weekly-pay-significant-changes-overtime",
                                 "when": [
                                     {
-                                        "id": "four-weekly-pay-answer-52-0",
+                                        "id": "four-weekly-pay-significant-changes-gross-pay-answer",
                                         "condition": "equals",
                                         "value": "Yes"
                                     }
@@ -2668,10 +2626,10 @@
                         },
                         {
                             "goto": {
-                                "id": "four-weekly-pay-block-57",
+                                "id": "four-weekly-pay-significant-changes-other",
                                 "when": [
                                     {
-                                        "id": "four-weekly-pay-answer-52-0",
+                                        "id": "four-weekly-pay-significant-changes-gross-pay-answer",
                                         "condition": "equals",
                                         "value": "No"
                                     }
@@ -2681,20 +2639,17 @@
                     ]
                 },
                 {
-                    "id": "four-weekly-pay-block-53",
+                    "id": "four-weekly-pay-significant-changes-overtime",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "four-weekly-pay-section-53",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "four-weekly-pay-significant-changes-overtime-section",
                             "number": "5",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "four-weekly-pay-answer-53-0",
-                                            "label": "",
+                                            "id": "four-weekly-pay-significant-changes-overtime-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -2710,11 +2665,11 @@
                                                     "value": "No significant change"
                                                 }
                                             ],
+                                            "q_code": "194w4",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "four-weekly-pay-question-53",
+                                    "id": "four-weekly-pay-significant-changes-overtime-question",
                                     "number": "5.8",
                                     "title": "Did any significant changes occur to the <em>amount of overtime</em> paid to <em>four weekly paid employees</em>?",
                                     "type": "General"
@@ -2726,20 +2681,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "four-weekly-pay-block-54",
+                    "id": "four-weekly-pay-significant-changes-pay-rates",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "four-weekly-pay-section-54",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "four-weekly-pay-significant-changes-pay-rates-section",
                             "number": "5",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "four-weekly-pay-answer-54-0",
-                                            "label": "",
+                                            "id": "four-weekly-pay-significant-changes-pay-rates-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -2751,11 +2703,11 @@
                                                     "value": "No"
                                                 }
                                             ],
+                                            "q_code": "195w4",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "four-weekly-pay-question-54",
+                                    "id": "four-weekly-pay-significant-changes-pay-rates-question",
                                     "number": "5.9",
                                     "title": "Did any significant changes occur to the <em>pay rates</em> of <em>four weekly paid employees</em>?",
                                     "type": "General"
@@ -2768,10 +2720,10 @@
                     "routing_rules": [
                         {
                             "goto": {
-                                "id": "four-weekly-pay-block-55",
+                                "id": "four-weekly-pay-significant-changes-pay-rates-increase",
                                 "when": [
                                     {
-                                        "id": "four-weekly-pay-answer-54-0",
+                                        "id": "four-weekly-pay-significant-changes-pay-rates-answer",
                                         "condition": "equals",
                                         "value": "Yes"
                                     }
@@ -2780,10 +2732,10 @@
                         },
                         {
                             "goto": {
-                                "id": "four-weekly-pay-block-56",
+                                "id": "four-weekly-pay-significant-changes-industrial-action",
                                 "when": [
                                     {
-                                        "id": "four-weekly-pay-answer-54-0",
+                                        "id": "four-weekly-pay-significant-changes-pay-rates-answer",
                                         "condition": "equals",
                                         "value": "No"
                                     }
@@ -2793,45 +2745,48 @@
                     ]
                 },
                 {
-                    "id": "four-weekly-pay-block-55",
+                    "id": "four-weekly-pay-significant-changes-pay-rates-increase",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "four-weekly-pay-section-55",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "four-weekly-pay-significant-changes-pay-rates-increase-section",
                             "number": "5",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "four-weekly-pay-answer-55-0",
+                                            "id": "four-weekly-pay-significant-changes-pay-rates-increase-percent-increase-answer",
                                             "label": "Percentage increase of new pay rates",
                                             "mandatory": false,
-                                            "options": [],
-                                            "type": "Percentage"
+                                            "q_code": "200w4",
+                                            "type": "Percentage",
+                                            "validation": {
+                                                "messages": {
+                                                    "INTEGER_TOO_LARGE": "The maximum value allowed is 100. Please correct your answer."
+                                                }
+                                            }
                                         },
                                         {
-                                            "description": "Please use the format dd/mm/yyyy",
-                                            "guidance": "",
-                                            "id": "four-weekly-pay-answer-55-1",
+                                            "id": "four-weekly-pay-significant-changes-pay-rates-increase-date-from-answer",
                                             "label": "If your figures are back dated, from when:",
                                             "mandatory": false,
-                                            "options": [],
-                                            "type": "Date"
+                                            "q_code": "210w4",
+                                            "type": "Date",
+                                            "validation": {
+                                                "messages": {
+                                                    "INVALID_DATE": "The date entered is not valid. Please correct your answer."
+                                                }
+                                            }
                                         },
                                         {
-                                            "description": "Please enter the percentage or number of staff affected",
-                                            "guidance": "",
-                                            "id": "four-weekly-pay-answer-55-2",
+                                            "id": "four-weekly-pay-significant-changes-pay-rates-increase-percent-employees-answer",
                                             "label": "What was the percentage or number of four weekly paid employees who received this new pay rate?",
                                             "mandatory": false,
-                                            "options": [],
+                                            "q_code": "220w4",
                                             "type": "PositiveInteger"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "four-weekly-pay-question-55",
+                                    "id": "four-weekly-pay-significant-changes-pay-rates-increase-question",
                                     "number": "5.10",
                                     "title": "Please enter the percentage increase of new pay rates if possible:",
                                     "type": "General"
@@ -2843,20 +2798,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "four-weekly-pay-block-56",
+                    "id": "four-weekly-pay-significant-changes-industrial-action",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "four-weekly-pay-section-56",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "four-weekly-pay-significant-changes-industrial-action-section",
                             "number": "5",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "four-weekly-pay-answer-56-0",
-                                            "label": "",
+                                            "id": "four-weekly-pay-significant-changes-industrial-action-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -2868,13 +2820,13 @@
                                                     "value": "No"
                                                 }
                                             ],
+                                            "q_code": "196w4",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "four-weekly-pay-question-56",
+                                    "id": "four-weekly-pay-significant-changes-industrial-action-question",
                                     "number": "5.11",
-                                    "title": "Did <em>industrial action</em> significantly affect total gross pay paid to  <em>four weekly paid employees</em>?",
+                                    "title": "Did <em>industrial action</em> significantly affect total gross pay paid to <em>four weekly paid employees</em>?",
                                     "type": "General"
                                 }
                             ],
@@ -2884,20 +2836,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "four-weekly-pay-block-57",
+                    "id": "four-weekly-pay-significant-changes-other",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "four-weekly-pay-section-57",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "four-weekly-pay-significant-changes-other-section",
                             "number": "5",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "four-weekly-pay-answer-57-0",
-                                            "label": "",
+                                            "id": "four-weekly-pay-significant-changes-other-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -2909,12 +2858,11 @@
                                                     "value": "No"
                                                 }
                                             ],
-                                            "q_code": "90",
+                                            "q_code": "197w4",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "four-weekly-pay-question-57",
+                                    "id": "four-weekly-pay-significant-changes-other-question",
                                     "number": "5.12",
                                     "title": "Did any other significant changes occur to the pay or number of <em>four weekly paid employees</em>?",
                                     "type": "General"
@@ -2926,29 +2874,31 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "four-weekly-pay-block-58",
+                    "id": "four-weekly-pay-significant-changes-other-specify",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "four-weekly-pay-section-58",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "four-weekly-pay-significant-changes-other-specify-section",
                             "number": "5",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "four-weekly-pay-answer-58-0",
+                                            "id": "four-weekly-pay-significant-changes-other-specify-answer",
                                             "label": "Comments",
                                             "mandatory": true,
-                                            "options": [],
-                                            "type": "TextArea"
+                                            "q_code": "300w4",
+                                            "type": "TextArea",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a comment to continue."
+                                                }
+                                            }
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "four-weekly-pay-question-58",
+                                    "id": "four-weekly-pay-significant-changes-other-specify-question",
                                     "number": "5.13",
-                                    "title": "Please specify any other significant changes to the pay or number of  <em>four weekly paid employees</em>:",
+                                    "title": "Please specify any other significant changes to the pay or number of <em>four weekly paid employees</em>:",
                                     "type": "General"
                                 }
                             ],
@@ -2960,7 +2910,7 @@
                         {
                             "when": [
                                 {
-                                    "id": "four-weekly-pay-answer-57-0",
+                                    "id": "four-weekly-pay-significant-changes-other-answer",
                                     "condition": "equals",
                                     "value": "No"
                                 }
@@ -2969,13 +2919,13 @@
                     ]
                 }
             ],
-            "id": "four-weekly-pay-section-58-group-59",
+            "id": "four-weekly-pay",
             "title": "Four Weekly Pay",
             "skip_condition": [
                 {
                     "when": [
                         {
-                            "id": "pay-pattern-answer-2-0",
+                            "id": "pay-pattern-frequency-answer",
                             "condition": "not contains",
                             "value": "Four weekly"
                         }
@@ -2984,28 +2934,27 @@
                 {
                     "when": [
                         {
-                            "id": "pay-pattern-answer-2-0",
+                            "id": "pay-pattern-frequency-answer",
                             "condition": "not set"
                         }
                     ]
                 }
             ],
-            "completed_id": "four-weekly-pay-block-57"
+            "completed_id": "four-weekly-pay-significant-changes-other"
         },
         {
             "blocks": [
                 {
-                    "id": "five-weekly-pay-block-59",
+                    "id": "five-weekly-pay-introduction",
                     "sections": [
                         {
-                            "description": "<p>You have now completed the previous section.</p><p>The next section covers Five Weekly Pay.</p><p>Please exclude the following from your figures for this section:</p><p><ul><li>trainees on government schemes</li><li>director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
-                            "id": "five-weekly-pay-section-59",
+                            "description": "<p>The next section covers Five Weekly Pay.</p><p>Please exclude the following from your figures for this section:</p><p><ul><li>trainees on government schemes</li><li>director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
+                            "id": "five-weekly-pay-introduction-section",
                             "number": "6",
                             "questions": [
                                 {
                                     "answers": [],
-                                    "description": "",
-                                    "id": "five-weekly-pay-question-59",
+                                    "id": "five-weekly-pay-introduction-question",
                                     "title": "",
                                     "type": "General"
                                 }
@@ -3016,36 +2965,37 @@
                     "type": "Interstitial"
                 },
                 {
-                    "id": "five-weekly-pay-block-60",
+                    "id": "five-weekly-pay-paid-employees",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "five-weekly-pay-section-60",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "five-weekly-pay-paid-employees-section",
                             "number": "6",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "five-weekly-pay-answer-60-0",
+                                            "id": "five-weekly-pay-paid-employees-answer",
                                             "label": "Total number of five weekly paid employees",
                                             "mandatory": true,
-                                            "options": [],
-                                            "type": "PositiveInteger"
+                                            "q_code": "140w5",
+                                            "type": "PositiveInteger",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a value, even if that value is 0."
+                                                }
+                                            }
                                         }
                                     ],
                                     "description": "<p>If there are two pay dates in the same month only give details for one.</p>",
                                     "guidance": [
                                         {
-                                            "description": "",
                                             "list": [
                                                 "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received monthly pay in the relevant period"
                                             ],
                                             "title": "Include:"
                                         },
                                         {
-                                            "description": "",
                                             "list": [
                                                 "trainees on government schemes",
                                                 "employees working abroad unless paid directly from this business\u2019s GB payroll",
@@ -3054,9 +3004,9 @@
                                             "title": "Exclude:"
                                         }
                                     ],
-                                    "id": "five-weekly-pay-question-60",
+                                    "id": "five-weekly-pay-paid-employees-question",
                                     "number": "6.1",
-                                    "title": "What was the number of <em>five weekly paid employees</em> paid in <em>December 2016</em>?",
+                                    "title": "What was the number of <em>five weekly paid employees</em> paid in {{exercise.period_str}}?",
                                     "type": "General"
                                 }
                             ],
@@ -3066,11 +3016,11 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "five-weekly-pay-block-61",
+                    "id": "five-weekly-pay-gross-pay",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "five-weekly-pay-section-61",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "five-weekly-pay-gross-pay-section",
                             "number": "6",
                             "questions": [
                                 {
@@ -3078,18 +3028,21 @@
                                         {
                                             "description": "Please round to the nearest pound. Do not include pence.",
                                             "guidance": "<p>Exclude:</p><p><ul><li>trainees on government schemes</li><li>director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
-                                            "id": "five-weekly-pay-answer-61-0",
+                                            "id": "five-weekly-pay-gross-pay-answer",
                                             "label": "Total gross five weekly pay",
                                             "mandatory": true,
-                                            "options": [],
+                                            "q_code": "153",
                                             "type": "Currency",
-                                            "alias": "five_weekly_total_gross"
+                                            "alias": "five_weekly_total_gross",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a value, even if that value is 0."
+                                                }
+                                            }
                                         }
                                     ],
-                                    "description": "",
                                     "guidance": [
                                         {
-                                            "description": "",
                                             "list": [
                                                 "overtime and shift allowance payments",
                                                 "advanced holiday pay",
@@ -3100,16 +3053,15 @@
                                             "title": "Include:"
                                         },
                                         {
-                                            "description": "",
                                             "list": [
                                                 "any redundancy pay and pay in lieu of notice payments"
                                             ],
                                             "title": "Exclude:"
                                         }
                                     ],
-                                    "id": "five-weekly-pay-question-61",
+                                    "id": "five-weekly-pay-gross-pay-question",
                                     "number": "6.2",
-                                    "title": "What was the total gross  <em>five weekly pay</em> paid to employees in <em>December 2016</em>?",
+                                    "title": "What was the total gross <em>five weekly pay</em> paid to employees in {{exercise.period_str}}?",
                                     "type": "General"
                                 }
                             ],
@@ -3119,38 +3071,46 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "five-weekly-pay-block-62",
+                    "id": "five-weekly-pay-breakdown",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "five-weekly-pay-section-62",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "five-weekly-pay-breakdown-section",
                             "number": "6",
                             "questions": [
                                 {
                                     "answers": [
                                         {
                                             "description": "Please round to the nearest pound. Do not include pence.",
-                                            "guidance": "",
-                                            "id": "five-weekly-pay-answer-62-0",
+                                            "id": "five-weekly-pay-breakdown-arrears-answer",
                                             "label": "Arrears of pay owing to pay awards",
                                             "mandatory": true,
-                                            "options": [],
-                                            "type": "Currency"
+                                            "q_code": "173",
+                                            "type": "Currency",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a value, even if that value is 0."
+                                                }
+                                            }
                                         },
                                         {
                                             "description": "Please round to the nearest pound. Do not include pence.",
                                             "guidance": "<p>Include:</p><p><ul><li>performance pay (for example productivity bonuses)</li><li>long service awards</li><li>appearance money (sporting professionals)</li></ul></p>",
-                                            "id": "five-weekly-pay-answer-62-1",
+                                            "id": "five-weekly-pay-breakdown-prp-answer",
                                             "label": "Bonuses, commissions or annual profit from profit related pay schemes",
                                             "mandatory": true,
-                                            "options": [],
-                                            "type": "Currency"
+                                            "q_code": "183",
+                                            "type": "Currency",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a value, even if that value is 0."
+                                                }
+                                            }
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "five-weekly-pay-question-62",
+                                    "id": "five-weekly-pay-breakdown-question",
                                     "number": "6.3",
-                                    "title": "Of the {{answers.five_weekly_total_gross|format_currency}} paid to <em>five weekly paid</em> employees in <em>December 2016</em>, what amount was:",
+                                    "title": "Of the <em>{{answers.five_weekly_total_gross|format_currency}}</em> paid to <em>five weekly paid employees</em> in {{exercise.period_str}}, what amount was:",
                                     "type": "General"
                                 }
                             ],
@@ -3160,20 +3120,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "five-weekly-pay-block-63",
+                    "id": "five-weekly-pay-significant-changes-paid-employees",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "five-weekly-pay-section-63",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "five-weekly-pay-significant-changes-paid-employees-section",
                             "number": "6",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "five-weekly-pay-answer-63-0",
-                                            "label": "",
+                                            "id": "five-weekly-pay-significant-changes-paid-employees-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -3185,13 +3142,13 @@
                                                     "value": "No"
                                                 }
                                             ],
+                                            "q_code": "190w5",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "<p>Please note: what constitutes a ‘significant change' is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                                     "guidance": [
                                         {
-                                            "description": "",
                                             "list": [
                                                 "redundancies",
                                                 "changes in the number of temporary staff"
@@ -3199,7 +3156,7 @@
                                             "title": "Include:"
                                         }
                                     ],
-                                    "id": "five-weekly-pay-question-63",
+                                    "id": "five-weekly-pay-significant-changes-paid-employees-question",
                                     "number": "6.4",
                                     "title": "Did any significant changes occur to the <em>number of five weekly paid employees</em>?",
                                     "type": "General"
@@ -3212,10 +3169,10 @@
                     "routing_rules": [
                         {
                             "goto": {
-                                "id": "five-weekly-pay-block-64",
+                                "id": "five-weekly-pay-significant-changes-redundancies",
                                 "when": [
                                     {
-                                        "id": "five-weekly-pay-answer-63-0",
+                                        "id": "five-weekly-pay-significant-changes-paid-employees-answer",
                                         "condition": "equals",
                                         "value": "Yes"
                                     }
@@ -3224,10 +3181,10 @@
                         },
                         {
                             "goto": {
-                                "id": "five-weekly-pay-block-66",
+                                "id": "five-weekly-pay-significant-changes-gross-pay",
                                 "when": [
                                     {
-                                        "id": "five-weekly-pay-answer-63-0",
+                                        "id": "five-weekly-pay-significant-changes-paid-employees-answer",
                                         "condition": "equals",
                                         "value": "No"
                                     }
@@ -3237,20 +3194,17 @@
                     ]
                 },
                 {
-                    "id": "five-weekly-pay-block-64",
+                    "id": "five-weekly-pay-significant-changes-redundancies",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "five-weekly-pay-section-64",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "five-weekly-pay-significant-changes-redundancies-section",
                             "number": "6",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "five-weekly-pay-answer-64-0",
-                                            "label": "",
+                                            "id": "five-weekly-pay-significant-changes-redundancies-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -3262,13 +3216,13 @@
                                                     "value": "No"
                                                 }
                                             ],
+                                            "q_code": "191w5",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "five-weekly-pay-question-64",
+                                    "id": "five-weekly-pay-significant-changes-redundancies-question",
                                     "number": "6.5",
-                                    "title": "Did any significant changes occur to the number of <em>redundancies</em> among  <em>five weekly paid employees</em>?",
+                                    "title": "Did any significant changes occur to the number of <em>redundancies</em> among <em>five weekly paid employees</em>?",
                                     "type": "General"
                                 }
                             ],
@@ -3278,20 +3232,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "five-weekly-pay-block-65",
+                    "id": "five-weekly-pay-significant-changes-temp-employees",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "five-weekly-pay-section-65",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "five-weekly-pay-significant-changes-temp-employees-section",
                             "number": "6",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "five-weekly-pay-answer-65-0",
-                                            "label": "",
+                                            "id": "five-weekly-pay-significant-changes-temp-employees-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -3307,11 +3258,11 @@
                                                     "value": "No significant change"
                                                 }
                                             ],
+                                            "q_code": "192w5",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "five-weekly-pay-question-65",
+                                    "id": "five-weekly-pay-significant-changes-temp-employees-question",
                                     "number": "6.6",
                                     "title": "Did any significant changes occur to the <em>number of temporary five weekly paid employees</em>?",
                                     "type": "General"
@@ -3323,20 +3274,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "five-weekly-pay-block-66",
+                    "id": "five-weekly-pay-significant-changes-gross-pay",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "five-weekly-pay-section-66",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "five-weekly-pay-significant-changes-gross-pay-section",
                             "number": "6",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "five-weekly-pay-answer-66-0",
-                                            "label": "",
+                                            "id": "five-weekly-pay-significant-changes-gross-pay-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -3348,13 +3296,13 @@
                                                     "value": "No"
                                                 }
                                             ],
+                                            "q_code": "193w5",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "<p>Please note: what constitutes a ‘significant change' is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                                     "guidance": [
                                         {
-                                            "description": "",
                                             "list": [
                                                 "more or less overtime",
                                                 "new pay rates",
@@ -3363,9 +3311,9 @@
                                             "title": "Include:"
                                         }
                                     ],
-                                    "id": "five-weekly-pay-question-66",
+                                    "id": "five-weekly-pay-significant-changes-gross-pay-question",
                                     "number": "6.7",
-                                    "title": "Did any significant changes occur to the <em>total gross pay</em> paid to  <em>five weekly paid employees</em>?",
+                                    "title": "Did any significant changes occur to the <em>total gross pay</em> paid to <em>five weekly paid employees</em>?",
                                     "type": "General"
                                 }
                             ],
@@ -3376,10 +3324,10 @@
                     "routing_rules": [
                         {
                             "goto": {
-                                "id": "five-weekly-pay-block-67",
+                                "id": "five-weekly-pay-significant-changes-overtime",
                                 "when": [
                                     {
-                                        "id": "five-weekly-pay-answer-66-0",
+                                        "id": "five-weekly-pay-significant-changes-gross-pay-answer",
                                         "condition": "equals",
                                         "value": "Yes"
                                     }
@@ -3388,10 +3336,10 @@
                         },
                         {
                             "goto": {
-                                "id": "five-weekly-pay-block-71",
+                                "id": "five-weekly-pay-significant-changes-other",
                                 "when": [
                                     {
-                                        "id": "five-weekly-pay-answer-66-0",
+                                        "id": "five-weekly-pay-significant-changes-gross-pay-answer",
                                         "condition": "equals",
                                         "value": "No"
                                     }
@@ -3401,20 +3349,17 @@
                     ]
                 },
                 {
-                    "id": "five-weekly-pay-block-67",
+                    "id": "five-weekly-pay-significant-changes-overtime",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "five-weekly-pay-section-67",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "five-weekly-pay-significant-changes-overtime-section",
                             "number": "6",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "five-weekly-pay-answer-67-0",
-                                            "label": "",
+                                            "id": "five-weekly-pay-significant-changes-overtime-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -3430,11 +3375,11 @@
                                                     "value": "No significant change"
                                                 }
                                             ],
+                                            "q_code": "194w5",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "five-weekly-pay-question-67",
+                                    "id": "five-weekly-pay-significant-changes-overtime-question",
                                     "number": "6.8",
                                     "title": "Did any significant changes occur to the <em>amount of overtime</em> paid to <em>five weekly paid employees</em>?",
                                     "type": "General"
@@ -3446,20 +3391,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "five-weekly-pay-block-68",
+                    "id": "five-weekly-pay-significant-changes-pay-rates",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "five-weekly-pay-section-68",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "five-weekly-pay-significant-changes-pay-rates-section",
                             "number": "6",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "five-weekly-pay-answer-68-0",
-                                            "label": "",
+                                            "id": "five-weekly-pay-significant-changes-pay-rates-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -3471,13 +3413,13 @@
                                                     "value": "No"
                                                 }
                                             ],
+                                            "q_code": "195w5",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "five-weekly-pay-question-68",
+                                    "id": "five-weekly-pay-significant-changes-pay-rates-question",
                                     "number": "6.9",
-                                    "title": "Did any significant changes occur to the <em>pay rates</em> of <em>five weekly paid employees?</em>",
+                                    "title": "Did any significant changes occur to the <em>pay rates</em> of <em>five weekly paid employees</em>?",
                                     "type": "General"
                                 }
                             ],
@@ -3488,10 +3430,10 @@
                     "routing_rules": [
                         {
                             "goto": {
-                                "id": "five-weekly-pay-block-69",
+                                "id": "five-weekly-pay-significant-changes-pay-rates-increase",
                                 "when": [
                                     {
-                                        "id": "five-weekly-pay-answer-68-0",
+                                        "id": "five-weekly-pay-significant-changes-pay-rates-answer",
                                         "condition": "equals",
                                         "value": "Yes"
                                     }
@@ -3500,10 +3442,10 @@
                         },
                         {
                             "goto": {
-                                "id": "five-weekly-pay-block-70",
+                                "id": "five-weekly-pay-significant-changes-industrial-action",
                                 "when": [
                                     {
-                                        "id": "five-weekly-pay-answer-68-0",
+                                        "id": "five-weekly-pay-significant-changes-pay-rates-answer",
                                         "condition": "equals",
                                         "value": "No"
                                     }
@@ -3513,45 +3455,48 @@
                     ]
                 },
                 {
-                    "id": "five-weekly-pay-block-69",
+                    "id": "five-weekly-pay-significant-changes-pay-rates-increase",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "five-weekly-pay-section-69",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "five-weekly-pay-significant-changes-pay-rates-increase-section",
                             "number": "6",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "five-weekly-pay-answer-69-0",
+                                            "id": "five-weekly-pay-significant-changes-pay-rates-increase-percent-increase-answer",
                                             "label": "Percentage increase of new pay rates",
                                             "mandatory": false,
-                                            "options": [],
-                                            "type": "Percentage"
+                                            "q_code": "200w5",
+                                            "type": "Percentage",
+                                            "validation": {
+                                                "messages": {
+                                                    "INTEGER_TOO_LARGE": "The maximum value allowed is 100. Please correct your answer."
+                                                }
+                                            }
                                         },
                                         {
-                                            "description": "Please use the format dd/mm/yyyy",
-                                            "guidance": "",
-                                            "id": "five-weekly-pay-answer-69-1",
+                                            "id": "five-weekly-pay-significant-changes-pay-rates-increase-date-from-answer",
                                             "label": "If your figures are back dated, from when:",
                                             "mandatory": false,
-                                            "options": [],
-                                            "type": "Date"
+                                            "q_code": "210w5",
+                                            "type": "Date",
+                                            "validation": {
+                                                "messages": {
+                                                    "INVALID_DATE": "The date entered is not valid. Please correct your answer."
+                                                }
+                                            }
                                         },
                                         {
-                                            "description": "Please enter the percentage or number of staff affected",
-                                            "guidance": "",
-                                            "id": "five-weekly-pay-answer-69-2",
+                                            "id": "five-weekly-pay-significant-changes-pay-rates-increase-percent-employees-answer",
                                             "label": "What was the percentage or number of five weekly paid employees who received this new pay rate?",
                                             "mandatory": false,
-                                            "options": [],
+                                            "q_code": "220w5",
                                             "type": "PositiveInteger"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "five-weekly-pay-question-69",
+                                    "id": "five-weekly-pay-significant-changes-pay-rates-increase-question",
                                     "number": "6.10",
                                     "title": "Please enter the percentage increase of new pay rates if possible:",
                                     "type": "General"
@@ -3563,20 +3508,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "five-weekly-pay-block-70",
+                    "id": "five-weekly-pay-significant-changes-industrial-action",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "five-weekly-pay-section-70",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "five-weekly-pay-significant-changes-industrial-action-section",
                             "number": "6",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "five-weekly-pay-answer-70-0",
-                                            "label": "",
+                                            "id": "five-weekly-pay-significant-changes-industrial-action-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -3588,13 +3530,13 @@
                                                     "value": "No"
                                                 }
                                             ],
+                                            "q_code": "196w5",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "five-weekly-pay-question-70",
+                                    "id": "five-weekly-pay-significant-changes-industrial-action-question",
                                     "number": "6.11",
-                                    "title": "Did <em>industrial action</em> significantly affect total gross pay paid to  <em>five weekly paid employees</em>?",
+                                    "title": "Did <em>industrial action</em> significantly affect total gross pay paid to <em>five weekly paid employees</em>?",
                                     "type": "General"
                                 }
                             ],
@@ -3604,20 +3546,17 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "five-weekly-pay-block-71",
+                    "id": "five-weekly-pay-significant-changes-other",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "five-weekly-pay-section-71",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "five-weekly-pay-significant-changes-other-section",
                             "number": "6",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "five-weekly-pay-answer-71-0",
-                                            "label": "",
+                                            "id": "five-weekly-pay-significant-changes-other-answer",
                                             "mandatory": true,
                                             "options": [
                                                 {
@@ -3629,12 +3568,11 @@
                                                     "value": "No"
                                                 }
                                             ],
-                                            "q_code": "90",
+                                            "q_code": "197w5",
                                             "type": "Radio"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "five-weekly-pay-question-71",
+                                    "id": "five-weekly-pay-significant-changes-other-question",
                                     "number": "6.12",
                                     "title": "Did any other significant changes occur to the pay or number of <em>five weekly paid employees</em>?",
                                     "type": "General"
@@ -3646,29 +3584,31 @@
                     "type": "Questionnaire"
                 },
                 {
-                    "id": "five-weekly-pay-block-72",
+                    "id": "five-weekly-pay-significant-changes-other-specify",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "five-weekly-pay-section-72",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "five-weekly-pay-significant-changes-other-specify-section",
                             "number": "6",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "five-weekly-pay-answer-72-0",
+                                            "id": "five-weekly-pay-significant-changes-other-specify-answer",
                                             "label": "Comments",
                                             "mandatory": true,
-                                            "options": [],
-                                            "type": "TextArea"
+                                            "q_code": "300w5",
+                                            "type": "TextArea",
+                                            "validation": {
+                                                "messages": {
+                                                    "MANDATORY": "Please enter a comment to continue."
+                                                }
+                                            }
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "five-weekly-pay-question-72",
+                                    "id": "five-weekly-pay-significant-changes-other-specify-question",
                                     "number": "6.13",
-                                    "title": "Please specify any other significant changes to the pay or number of  <em>five weekly paid employees</em>:",
+                                    "title": "Please specify any other significant changes to the pay or number of <em>five weekly paid employees</em>:",
                                     "type": "General"
                                 }
                             ],
@@ -3680,7 +3620,7 @@
                         {
                             "when": [
                                 {
-                                    "id": "five-weekly-pay-answer-71-0",
+                                    "id": "five-weekly-pay-significant-changes-other-answer",
                                     "condition": "equals",
                                     "value": "No"
                                 }
@@ -3689,13 +3629,13 @@
                     ]
                 }
             ],
-            "id": "five-weekly-pay-section-72-group-73",
+            "id": "five-weekly-pay",
             "title": "Five Weekly Pay",
             "skip_condition": [
                 {
                     "when": [
                         {
-                            "id": "pay-pattern-answer-2-0",
+                            "id": "pay-pattern-frequency-answer",
                             "condition": "not contains",
                             "value": "Five weekly"
                         }
@@ -3704,28 +3644,27 @@
                 {
                     "when": [
                         {
-                            "id": "pay-pattern-answer-2-0",
+                            "id": "pay-pattern-frequency-answer",
                             "condition": "not set"
                         }
                     ]
                 }
             ],
-            "completed_id": "five-weekly-pay-block-71"
+            "completed_id": "five-weekly-pay-significant-changes-other"
         },
         {
             "blocks": [
                 {
-                    "id": "general-comments-block-73",
+                    "id": "general-comments-introduction",
                     "sections": [
                         {
-                            "description": "<p>You have now completed the previous section.</p><p>The next section covers general comments about this survey.</p>",
-                            "id": "general-comments-section-73",
+                            "description": "<p>The next section covers general comments about this survey.</p>",
+                            "id": "general-comments-introduction-section",
                             "number": "7",
                             "questions": [
                                 {
                                     "answers": [],
-                                    "description": "",
-                                    "id": "general-comments-question-73",
+                                    "id": "general-comments-introduction-question",
                                     "title": "",
                                     "type": "General"
                                 }
@@ -3736,27 +3675,24 @@
                     "type": "Interstitial"
                 },
                 {
-                    "id": "general-comments-block-74",
+                    "id": "general-comments",
                     "sections": [
                         {
-                            "description": "<p>1 December 2016 to 31 December 2016</p>",
-                            "id": "general-comments-section-74",
+                            "description": "<p>{{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}</p>",
+                            "id": "general-comments-section",
                             "number": "7",
                             "questions": [
                                 {
                                     "answers": [
                                         {
-                                            "description": "",
-                                            "guidance": "",
-                                            "id": "general-comments-answer-74-0",
+                                            "id": "general-comments-answer",
                                             "label": "Comments",
                                             "mandatory": false,
-                                            "options": [],
+                                            "q_code": "300",
                                             "type": "TextArea"
                                         }
                                     ],
-                                    "description": "",
-                                    "id": "general-comments-question-74",
+                                    "id": "general-comments-question",
                                     "number": "7.1",
                                     "title": "Please write any additional comments you would like to make on the information you have provided.",
                                     "type": "General"
@@ -3766,7 +3702,13 @@
                         }
                     ],
                     "type": "Questionnaire"
-                },
+                }
+            ],
+            "id": "general-comments-group",
+            "title": "General Comments"
+        },
+        {
+            "blocks": [
                 {
                     "type": "Confirmation",
                     "id": "confirmation",
@@ -3793,22 +3735,25 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "type": "Summary",
-                    "id": "summary"
                 }
             ],
-            "id": "general-comments-section-74-group-76",
-            "title": "General Comments"
+            "hide_in_navigation": true,
+            "id": "confirmation-group",
+            "title": "Confirmation"
         }
     ],
     "legal_basis": "StatisticsOfTradeAct",
     "mime_type": "application/json/ons/eq",
+    "messages": {
+        "INTEGER_TOO_LARGE": "The maximum value allowed is 9999999999. Please correct your answer.",
+        "MANDATORY": "Please select an answer to continue.",
+        "NEGATIVE_INTEGER": "The value cannot be negative. Please correct your answer.",
+        "NOT_INTEGER": "The value you have entered is invalid. Please enter a numeric value."
+    },
     "navigation": true,
-    "questionnaire_id": "",
+    "questionnaire_id": "0005",
     "schema_version": "0.0.1",
-    "survey_id": "mwss",
+    "survey_id": "134",
     "theme": "default",
     "title": "Monthly Wages and Salaries Survey"
 }

--- a/app/data/schema/schema-v1.json
+++ b/app/data/schema/schema-v1.json
@@ -7,6 +7,11 @@
             "description": "A lowercase alphanumeric string separated by hyphens.",
             "pattern": "^[a-z0-9][a-z0-9\\-]*[a-z0-9]$"
         },
+        "q_code": {
+            "type": "string",
+            "description": "A question code used by downstream systems to identify answers",
+            "pattern": "^[0-9a-z]+$"
+        },
         "skip_condition": {
             "description": "Allows an element to be skipped when a condition has been met. By adding more than one `when` element it will evaluate as an or rule.",
             "type": "array",
@@ -368,8 +373,7 @@
                                                                         "type": "string"
                                                                     },
                                                                     "q_code": {
-                                                                        "type": "string",
-                                                                        "pattern": "[0-9]+"
+                                                                        "$ref": "#/definitions/q_code"
                                                                     },
                                                                     "label": {
                                                                         "type": "string"
@@ -407,8 +411,7 @@
                                                                                     "type": "string"
                                                                                 },
                                                                                 "q_code": {
-                                                                                    "type": "string",
-                                                                                    "pattern": "[0-9]+"
+                                                                                    "$ref": "#/definitions/q_code"
                                                                                 },
                                                                                 "child_answer_id": {
                                                                                     "type": "string"

--- a/app/templating/schema_context.py
+++ b/app/templating/schema_context.py
@@ -43,6 +43,7 @@ def _build_exercise(metadata):
     return {
         "start_date": to_date(metadata["ref_p_start_date"]),
         "end_date": to_date(metadata["ref_p_end_date"]),
+        "period_str": metadata["period_str"],
         "employment_date": to_date(metadata["employment_date"]),
         "return_by": to_date(metadata["return_by"]),
         "region_code": metadata["region_code"],

--- a/tests/app/templating/test_schema_context.py
+++ b/tests/app/templating/test_schema_context.py
@@ -15,7 +15,7 @@ class TestMetadataContext(SurveyRunnerTestCase):
         'ru_name': 'Mr Bloggs',
         'trad_as': 'Apple',
         'tx_id': '12345678-1234-5678-1234-567812345678',
-        'period_str': '201610',
+        'period_str': 'October 2016',
         'employment_date': '2016-10-09',
         'region_code': 'GB-GBN',
     }
@@ -56,6 +56,7 @@ class TestMetadataContext(SurveyRunnerTestCase):
         exercise = schema_context['exercise']
         self.assertEqual('2016-10-11', exercise['start_date'].date().isoformat())
         self.assertEqual('2016-10-12', exercise['end_date'].date().isoformat())
+        self.assertEqual('October 2016', exercise['period_str'])
         self.assertEqual('2016-10-09', exercise['employment_date'].date().isoformat())
         self.assertEqual('2016-10-10', exercise['return_by'].date().isoformat())
         self.assertEqual('GB-GBN', exercise['region_code'])

--- a/tests/functional/pages/surveys/mwss/calendar-monthly-pay-breakdown.page.js
+++ b/tests/functional/pages/surveys/mwss/calendar-monthly-pay-breakdown.page.js
@@ -1,0 +1,31 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class CalendarMonthlyPayBreakdownPage extends QuestionPage {
+
+  constructor() {
+    super('calendar-monthly-pay-breakdown')
+  }
+
+  setCalendarMonthlyPayBreakdownArrearsAnswer(value) {
+    browser.setValue('[name="calendar-monthly-pay-breakdown-arrears-answer"]', value)
+    return this
+  }
+
+  getCalendarMonthlyPayBreakdownArrearsAnswer(value) {
+    return browser.element('[name="calendar-monthly-pay-breakdown-arrears-answer"]').getValue()
+  }
+
+  setCalendarMonthlyPayBreakdownPrpAnswer(value) {
+    browser.setValue('[name="calendar-monthly-pay-breakdown-prp-answer"]', value)
+    return this
+  }
+
+  getCalendarMonthlyPayBreakdownPrpAnswer(value) {
+    return browser.element('[name="calendar-monthly-pay-breakdown-prp-answer"]').getValue()
+  }
+
+}
+
+export default new CalendarMonthlyPayBreakdownPage()

--- a/tests/functional/pages/surveys/mwss/calendar-monthly-pay-gross-pay.page.js
+++ b/tests/functional/pages/surveys/mwss/calendar-monthly-pay-gross-pay.page.js
@@ -1,0 +1,22 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class CalendarMonthlyPayGrossPayPage extends QuestionPage {
+
+  constructor() {
+    super('calendar-monthly-pay-gross-pay')
+  }
+
+  setCalendarMonthlyPayGrossPayAnswer(value) {
+    browser.setValue('[name="calendar-monthly-pay-gross-pay-answer"]', value)
+    return this
+  }
+
+  getCalendarMonthlyPayGrossPayAnswer(value) {
+    return browser.element('[name="calendar-monthly-pay-gross-pay-answer"]').getValue()
+  }
+
+}
+
+export default new CalendarMonthlyPayGrossPayPage()

--- a/tests/functional/pages/surveys/mwss/calendar-monthly-pay-introduction.page.js
+++ b/tests/functional/pages/surveys/mwss/calendar-monthly-pay-introduction.page.js
@@ -1,0 +1,13 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class CalendarMonthlyPayIntroductionPage extends QuestionPage {
+
+  constructor() {
+    super('calendar-monthly-pay-introduction')
+  }
+
+}
+
+export default new CalendarMonthlyPayIntroductionPage()

--- a/tests/functional/pages/surveys/mwss/calendar-monthly-pay-paid-employees.page.js
+++ b/tests/functional/pages/surveys/mwss/calendar-monthly-pay-paid-employees.page.js
@@ -1,0 +1,22 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class CalendarMonthlyPayPaidEmployeesPage extends QuestionPage {
+
+  constructor() {
+    super('calendar-monthly-pay-paid-employees')
+  }
+
+  setCalendarMonthlyPayPaidEmployeesAnswer(value) {
+    browser.setValue('[name="calendar-monthly-pay-paid-employees-answer"]', value)
+    return this
+  }
+
+  getCalendarMonthlyPayPaidEmployeesAnswer(value) {
+    return browser.element('[name="calendar-monthly-pay-paid-employees-answer"]').getValue()
+  }
+
+}
+
+export default new CalendarMonthlyPayPaidEmployeesPage()

--- a/tests/functional/pages/surveys/mwss/calendar-monthly-pay-significant-changes-gross-pay.page.js
+++ b/tests/functional/pages/surveys/mwss/calendar-monthly-pay-significant-changes-gross-pay.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class CalendarMonthlyPaySignificantChangesGrossPayPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('calendar-monthly-pay-significant-changes-gross-pay')
+  }
+
+  clickCalendarMonthlyPaySignificantChangesGrossPayAnswerYes() {
+    browser.element('[id="calendar-monthly-pay-significant-changes-gross-pay-answer-0"]').click()
+    return this
+  }
+
+  clickCalendarMonthlyPaySignificantChangesGrossPayAnswerNo() {
+    browser.element('[id="calendar-monthly-pay-significant-changes-gross-pay-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new CalendarMonthlyPaySignificantChangesGrossPayPage()

--- a/tests/functional/pages/surveys/mwss/calendar-monthly-pay-significant-changes-industrial-action.page.js
+++ b/tests/functional/pages/surveys/mwss/calendar-monthly-pay-significant-changes-industrial-action.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class CalendarMonthlyPaySignificantChangesIndustrialActionPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('calendar-monthly-pay-significant-changes-industrial-action')
+  }
+
+  clickCalendarMonthlyPaySignificantChangesIndustrialActionAnswerYes() {
+    browser.element('[id="calendar-monthly-pay-significant-changes-industrial-action-answer-0"]').click()
+    return this
+  }
+
+  clickCalendarMonthlyPaySignificantChangesIndustrialActionAnswerNo() {
+    browser.element('[id="calendar-monthly-pay-significant-changes-industrial-action-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new CalendarMonthlyPaySignificantChangesIndustrialActionPage()

--- a/tests/functional/pages/surveys/mwss/calendar-monthly-pay-significant-changes-other-specify.page.js
+++ b/tests/functional/pages/surveys/mwss/calendar-monthly-pay-significant-changes-other-specify.page.js
@@ -1,0 +1,22 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class CalendarMonthlyPaySignificantChangesOtherSpecifyPage extends QuestionPage {
+
+  constructor() {
+    super('calendar-monthly-pay-significant-changes-other-specify')
+  }
+
+  setCalendarMonthlyPaySignificantChangesOtherSpecifyAnswer(value) {
+    browser.setValue('[name="calendar-monthly-pay-significant-changes-other-specify-answer"]', value)
+    return this
+  }
+
+  getCalendarMonthlyPaySignificantChangesOtherSpecifyAnswer(value) {
+    return browser.element('[name="calendar-monthly-pay-significant-changes-other-specify-answer"]').getValue()
+  }
+
+}
+
+export default new CalendarMonthlyPaySignificantChangesOtherSpecifyPage()

--- a/tests/functional/pages/surveys/mwss/calendar-monthly-pay-significant-changes-other.page.js
+++ b/tests/functional/pages/surveys/mwss/calendar-monthly-pay-significant-changes-other.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class CalendarMonthlyPaySignificantChangesOtherPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('calendar-monthly-pay-significant-changes-other')
+  }
+
+  clickCalendarMonthlyPaySignificantChangesOtherAnswerYes() {
+    browser.element('[id="calendar-monthly-pay-significant-changes-other-answer-0"]').click()
+    return this
+  }
+
+  clickCalendarMonthlyPaySignificantChangesOtherAnswerNo() {
+    browser.element('[id="calendar-monthly-pay-significant-changes-other-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new CalendarMonthlyPaySignificantChangesOtherPage()

--- a/tests/functional/pages/surveys/mwss/calendar-monthly-pay-significant-changes-overtime.page.js
+++ b/tests/functional/pages/surveys/mwss/calendar-monthly-pay-significant-changes-overtime.page.js
@@ -1,0 +1,28 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class CalendarMonthlyPaySignificantChangesOvertimePage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('calendar-monthly-pay-significant-changes-overtime')
+  }
+
+  clickCalendarMonthlyPaySignificantChangesOvertimeAnswerMoreOvertime() {
+    browser.element('[id="calendar-monthly-pay-significant-changes-overtime-answer-0"]').click()
+    return this
+  }
+
+  clickCalendarMonthlyPaySignificantChangesOvertimeAnswerLessOvertime() {
+    browser.element('[id="calendar-monthly-pay-significant-changes-overtime-answer-1"]').click()
+    return this
+  }
+
+  clickCalendarMonthlyPaySignificantChangesOvertimeAnswerNoSignificantChange() {
+    browser.element('[id="calendar-monthly-pay-significant-changes-overtime-answer-2"]').click()
+    return this
+  }
+
+}
+
+export default new CalendarMonthlyPaySignificantChangesOvertimePage()

--- a/tests/functional/pages/surveys/mwss/calendar-monthly-pay-significant-changes-paid-employees.page.js
+++ b/tests/functional/pages/surveys/mwss/calendar-monthly-pay-significant-changes-paid-employees.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class CalendarMonthlyPaySignificantChangesPaidEmployeesPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('calendar-monthly-pay-significant-changes-paid-employees')
+  }
+
+  clickCalendarMonthlyPaySignificantChangesPaidEmployeesAnswerYes() {
+    browser.element('[id="calendar-monthly-pay-significant-changes-paid-employees-answer-0"]').click()
+    return this
+  }
+
+  clickCalendarMonthlyPaySignificantChangesPaidEmployeesAnswerNo() {
+    browser.element('[id="calendar-monthly-pay-significant-changes-paid-employees-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new CalendarMonthlyPaySignificantChangesPaidEmployeesPage()

--- a/tests/functional/pages/surveys/mwss/calendar-monthly-pay-significant-changes-pay-rates-increase.page.js
+++ b/tests/functional/pages/surveys/mwss/calendar-monthly-pay-significant-changes-pay-rates-increase.page.js
@@ -1,0 +1,58 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class CalendarMonthlyPaySignificantChangesPayRatesIncreasePage extends QuestionPage {
+
+  constructor() {
+    super('calendar-monthly-pay-significant-changes-pay-rates-increase')
+  }
+
+  setCalendarMonthlyPaySignificantChangesPayRatesIncreasePercentIncreaseAnswer(value) {
+    browser.setValue('[name="calendar-monthly-pay-significant-changes-pay-rates-increase-percent-increase-answer"]', value)
+    return this
+  }
+
+  getCalendarMonthlyPaySignificantChangesPayRatesIncreasePercentIncreaseAnswer(value) {
+    return browser.element('[name="calendar-monthly-pay-significant-changes-pay-rates-increase-percent-increase-answer"]').getValue()
+  }
+
+  setCalendarMonthlyPaySignificantChangesPayRatesIncreaseDateFromAnswerDay(value) {
+    browser.setValue('[name="calendar-monthly-pay-significant-changes-pay-rates-increase-date-from-answer-day"]', value)
+    return this
+  }
+
+  getCalendarMonthlyPaySignificantChangesPayRatesIncreaseDateFromAnswerDay(value) {
+    return browser.element('[name="calendar-monthly-pay-significant-changes-pay-rates-increase-date-from-answer-day"]').getValue()
+  }
+
+  setCalendarMonthlyPaySignificantChangesPayRatesIncreaseDateFromAnswerMonth(value) {
+    browser.selectByValue('[name="calendar-monthly-pay-significant-changes-pay-rates-increase-date-from-answer-month"]', value)
+    return this
+  }
+
+  getCalendarMonthlyPaySignificantChangesPayRatesIncreaseDateFromAnswerMonth(value) {
+    return browser.element('[name="calendar-monthly-pay-significant-changes-pay-rates-increase-date-from-answer-month"]').getValue()
+  }
+
+  setCalendarMonthlyPaySignificantChangesPayRatesIncreaseDateFromAnswerYear(value) {
+    browser.setValue('[name="calendar-monthly-pay-significant-changes-pay-rates-increase-date-from-answer-year"]', value)
+    return this
+  }
+
+  getCalendarMonthlyPaySignificantChangesPayRatesIncreaseDateFromAnswerYear(value) {
+    return browser.element('[name="calendar-monthly-pay-significant-changes-pay-rates-increase-date-from-answer-year"]').getValue()
+  }
+
+  setCalendarMonthlyPaySignificantChangesPayRatesIncreasePercentEmployeesAnswer(value) {
+    browser.setValue('[name="calendar-monthly-pay-significant-changes-pay-rates-increase-percent-employees-answer"]', value)
+    return this
+  }
+
+  getCalendarMonthlyPaySignificantChangesPayRatesIncreasePercentEmployeesAnswer(value) {
+    return browser.element('[name="calendar-monthly-pay-significant-changes-pay-rates-increase-percent-employees-answer"]').getValue()
+  }
+
+}
+
+export default new CalendarMonthlyPaySignificantChangesPayRatesIncreasePage()

--- a/tests/functional/pages/surveys/mwss/calendar-monthly-pay-significant-changes-pay-rates.page.js
+++ b/tests/functional/pages/surveys/mwss/calendar-monthly-pay-significant-changes-pay-rates.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class CalendarMonthlyPaySignificantChangesPayRatesPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('calendar-monthly-pay-significant-changes-pay-rates')
+  }
+
+  clickCalendarMonthlyPaySignificantChangesPayRatesAnswerYes() {
+    browser.element('[id="calendar-monthly-pay-significant-changes-pay-rates-answer-0"]').click()
+    return this
+  }
+
+  clickCalendarMonthlyPaySignificantChangesPayRatesAnswerNo() {
+    browser.element('[id="calendar-monthly-pay-significant-changes-pay-rates-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new CalendarMonthlyPaySignificantChangesPayRatesPage()

--- a/tests/functional/pages/surveys/mwss/calendar-monthly-pay-significant-changes-redundancies.page.js
+++ b/tests/functional/pages/surveys/mwss/calendar-monthly-pay-significant-changes-redundancies.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class CalendarMonthlyPaySignificantChangesRedundanciesPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('calendar-monthly-pay-significant-changes-redundancies')
+  }
+
+  clickCalendarMonthlyPaySignificantChangesRedundanciesAnswerYes() {
+    browser.element('[id="calendar-monthly-pay-significant-changes-redundancies-answer-0"]').click()
+    return this
+  }
+
+  clickCalendarMonthlyPaySignificantChangesRedundanciesAnswerNo() {
+    browser.element('[id="calendar-monthly-pay-significant-changes-redundancies-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new CalendarMonthlyPaySignificantChangesRedundanciesPage()

--- a/tests/functional/pages/surveys/mwss/calendar-monthly-pay-significant-changes-temp-employees.page.js
+++ b/tests/functional/pages/surveys/mwss/calendar-monthly-pay-significant-changes-temp-employees.page.js
@@ -1,0 +1,28 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class CalendarMonthlyPaySignificantChangesTempEmployeesPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('calendar-monthly-pay-significant-changes-temp-employees')
+  }
+
+  clickCalendarMonthlyPaySignificantChangesTempEmployeesAnswerMoreTemporaryStaff() {
+    browser.element('[id="calendar-monthly-pay-significant-changes-temp-employees-answer-0"]').click()
+    return this
+  }
+
+  clickCalendarMonthlyPaySignificantChangesTempEmployeesAnswerFewerTemporaryStaff() {
+    browser.element('[id="calendar-monthly-pay-significant-changes-temp-employees-answer-1"]').click()
+    return this
+  }
+
+  clickCalendarMonthlyPaySignificantChangesTempEmployeesAnswerNoSignificantChange() {
+    browser.element('[id="calendar-monthly-pay-significant-changes-temp-employees-answer-2"]').click()
+    return this
+  }
+
+}
+
+export default new CalendarMonthlyPaySignificantChangesTempEmployeesPage()

--- a/tests/functional/pages/surveys/mwss/confirmation.page.js
+++ b/tests/functional/pages/surveys/mwss/confirmation.page.js
@@ -1,0 +1,13 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class ConfirmationPage extends QuestionPage {
+
+  constructor() {
+    super('confirmation')
+  }
+
+}
+
+export default new ConfirmationPage()

--- a/tests/functional/pages/surveys/mwss/five-weekly-pay-breakdown.page.js
+++ b/tests/functional/pages/surveys/mwss/five-weekly-pay-breakdown.page.js
@@ -1,0 +1,31 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class FiveWeeklyPayBreakdownPage extends QuestionPage {
+
+  constructor() {
+    super('five-weekly-pay-breakdown')
+  }
+
+  setFiveWeeklyPayBreakdownArrearsAnswer(value) {
+    browser.setValue('[name="five-weekly-pay-breakdown-arrears-answer"]', value)
+    return this
+  }
+
+  getFiveWeeklyPayBreakdownArrearsAnswer(value) {
+    return browser.element('[name="five-weekly-pay-breakdown-arrears-answer"]').getValue()
+  }
+
+  setFiveWeeklyPayBreakdownPrpAnswer(value) {
+    browser.setValue('[name="five-weekly-pay-breakdown-prp-answer"]', value)
+    return this
+  }
+
+  getFiveWeeklyPayBreakdownPrpAnswer(value) {
+    return browser.element('[name="five-weekly-pay-breakdown-prp-answer"]').getValue()
+  }
+
+}
+
+export default new FiveWeeklyPayBreakdownPage()

--- a/tests/functional/pages/surveys/mwss/five-weekly-pay-gross-pay.page.js
+++ b/tests/functional/pages/surveys/mwss/five-weekly-pay-gross-pay.page.js
@@ -1,0 +1,22 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class FiveWeeklyPayGrossPayPage extends QuestionPage {
+
+  constructor() {
+    super('five-weekly-pay-gross-pay')
+  }
+
+  setFiveWeeklyPayGrossPayAnswer(value) {
+    browser.setValue('[name="five-weekly-pay-gross-pay-answer"]', value)
+    return this
+  }
+
+  getFiveWeeklyPayGrossPayAnswer(value) {
+    return browser.element('[name="five-weekly-pay-gross-pay-answer"]').getValue()
+  }
+
+}
+
+export default new FiveWeeklyPayGrossPayPage()

--- a/tests/functional/pages/surveys/mwss/five-weekly-pay-introduction.page.js
+++ b/tests/functional/pages/surveys/mwss/five-weekly-pay-introduction.page.js
@@ -1,0 +1,13 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class FiveWeeklyPayIntroductionPage extends QuestionPage {
+
+  constructor() {
+    super('five-weekly-pay-introduction')
+  }
+
+}
+
+export default new FiveWeeklyPayIntroductionPage()

--- a/tests/functional/pages/surveys/mwss/five-weekly-pay-paid-employees.page.js
+++ b/tests/functional/pages/surveys/mwss/five-weekly-pay-paid-employees.page.js
@@ -1,0 +1,22 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class FiveWeeklyPayPaidEmployeesPage extends QuestionPage {
+
+  constructor() {
+    super('five-weekly-pay-paid-employees')
+  }
+
+  setFiveWeeklyPayPaidEmployeesAnswer(value) {
+    browser.setValue('[name="five-weekly-pay-paid-employees-answer"]', value)
+    return this
+  }
+
+  getFiveWeeklyPayPaidEmployeesAnswer(value) {
+    return browser.element('[name="five-weekly-pay-paid-employees-answer"]').getValue()
+  }
+
+}
+
+export default new FiveWeeklyPayPaidEmployeesPage()

--- a/tests/functional/pages/surveys/mwss/five-weekly-pay-significant-changes-gross-pay.page.js
+++ b/tests/functional/pages/surveys/mwss/five-weekly-pay-significant-changes-gross-pay.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class FiveWeeklyPaySignificantChangesGrossPayPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('five-weekly-pay-significant-changes-gross-pay')
+  }
+
+  clickFiveWeeklyPaySignificantChangesGrossPayAnswerYes() {
+    browser.element('[id="five-weekly-pay-significant-changes-gross-pay-answer-0"]').click()
+    return this
+  }
+
+  clickFiveWeeklyPaySignificantChangesGrossPayAnswerNo() {
+    browser.element('[id="five-weekly-pay-significant-changes-gross-pay-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new FiveWeeklyPaySignificantChangesGrossPayPage()

--- a/tests/functional/pages/surveys/mwss/five-weekly-pay-significant-changes-industrial-action.page.js
+++ b/tests/functional/pages/surveys/mwss/five-weekly-pay-significant-changes-industrial-action.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class FiveWeeklyPaySignificantChangesIndustrialActionPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('five-weekly-pay-significant-changes-industrial-action')
+  }
+
+  clickFiveWeeklyPaySignificantChangesIndustrialActionAnswerYes() {
+    browser.element('[id="five-weekly-pay-significant-changes-industrial-action-answer-0"]').click()
+    return this
+  }
+
+  clickFiveWeeklyPaySignificantChangesIndustrialActionAnswerNo() {
+    browser.element('[id="five-weekly-pay-significant-changes-industrial-action-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new FiveWeeklyPaySignificantChangesIndustrialActionPage()

--- a/tests/functional/pages/surveys/mwss/five-weekly-pay-significant-changes-other-specify.page.js
+++ b/tests/functional/pages/surveys/mwss/five-weekly-pay-significant-changes-other-specify.page.js
@@ -1,0 +1,22 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class FiveWeeklyPaySignificantChangesOtherSpecifyPage extends QuestionPage {
+
+  constructor() {
+    super('five-weekly-pay-significant-changes-other-specify')
+  }
+
+  setFiveWeeklyPaySignificantChangesOtherSpecifyAnswer(value) {
+    browser.setValue('[name="five-weekly-pay-significant-changes-other-specify-answer"]', value)
+    return this
+  }
+
+  getFiveWeeklyPaySignificantChangesOtherSpecifyAnswer(value) {
+    return browser.element('[name="five-weekly-pay-significant-changes-other-specify-answer"]').getValue()
+  }
+
+}
+
+export default new FiveWeeklyPaySignificantChangesOtherSpecifyPage()

--- a/tests/functional/pages/surveys/mwss/five-weekly-pay-significant-changes-other.page.js
+++ b/tests/functional/pages/surveys/mwss/five-weekly-pay-significant-changes-other.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class FiveWeeklyPaySignificantChangesOtherPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('five-weekly-pay-significant-changes-other')
+  }
+
+  clickFiveWeeklyPaySignificantChangesOtherAnswerYes() {
+    browser.element('[id="five-weekly-pay-significant-changes-other-answer-0"]').click()
+    return this
+  }
+
+  clickFiveWeeklyPaySignificantChangesOtherAnswerNo() {
+    browser.element('[id="five-weekly-pay-significant-changes-other-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new FiveWeeklyPaySignificantChangesOtherPage()

--- a/tests/functional/pages/surveys/mwss/five-weekly-pay-significant-changes-overtime.page.js
+++ b/tests/functional/pages/surveys/mwss/five-weekly-pay-significant-changes-overtime.page.js
@@ -1,0 +1,28 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class FiveWeeklyPaySignificantChangesOvertimePage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('five-weekly-pay-significant-changes-overtime')
+  }
+
+  clickFiveWeeklyPaySignificantChangesOvertimeAnswerMoreOvertime() {
+    browser.element('[id="five-weekly-pay-significant-changes-overtime-answer-0"]').click()
+    return this
+  }
+
+  clickFiveWeeklyPaySignificantChangesOvertimeAnswerLessOvertime() {
+    browser.element('[id="five-weekly-pay-significant-changes-overtime-answer-1"]').click()
+    return this
+  }
+
+  clickFiveWeeklyPaySignificantChangesOvertimeAnswerNoSignificantChange() {
+    browser.element('[id="five-weekly-pay-significant-changes-overtime-answer-2"]').click()
+    return this
+  }
+
+}
+
+export default new FiveWeeklyPaySignificantChangesOvertimePage()

--- a/tests/functional/pages/surveys/mwss/five-weekly-pay-significant-changes-paid-employees.page.js
+++ b/tests/functional/pages/surveys/mwss/five-weekly-pay-significant-changes-paid-employees.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class FiveWeeklyPaySignificantChangesPaidEmployeesPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('five-weekly-pay-significant-changes-paid-employees')
+  }
+
+  clickFiveWeeklyPaySignificantChangesPaidEmployeesAnswerYes() {
+    browser.element('[id="five-weekly-pay-significant-changes-paid-employees-answer-0"]').click()
+    return this
+  }
+
+  clickFiveWeeklyPaySignificantChangesPaidEmployeesAnswerNo() {
+    browser.element('[id="five-weekly-pay-significant-changes-paid-employees-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new FiveWeeklyPaySignificantChangesPaidEmployeesPage()

--- a/tests/functional/pages/surveys/mwss/five-weekly-pay-significant-changes-pay-rates-increase.page.js
+++ b/tests/functional/pages/surveys/mwss/five-weekly-pay-significant-changes-pay-rates-increase.page.js
@@ -1,0 +1,58 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class FiveWeeklyPaySignificantChangesPayRatesIncreasePage extends QuestionPage {
+
+  constructor() {
+    super('five-weekly-pay-significant-changes-pay-rates-increase')
+  }
+
+  setFiveWeeklyPaySignificantChangesPayRatesIncreasePercentIncreaseAnswer(value) {
+    browser.setValue('[name="five-weekly-pay-significant-changes-pay-rates-increase-percent-increase-answer"]', value)
+    return this
+  }
+
+  getFiveWeeklyPaySignificantChangesPayRatesIncreasePercentIncreaseAnswer(value) {
+    return browser.element('[name="five-weekly-pay-significant-changes-pay-rates-increase-percent-increase-answer"]').getValue()
+  }
+
+  setFiveWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerDay(value) {
+    browser.setValue('[name="five-weekly-pay-significant-changes-pay-rates-increase-date-from-answer-day"]', value)
+    return this
+  }
+
+  getFiveWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerDay(value) {
+    return browser.element('[name="five-weekly-pay-significant-changes-pay-rates-increase-date-from-answer-day"]').getValue()
+  }
+
+  setFiveWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerMonth(value) {
+    browser.selectByValue('[name="five-weekly-pay-significant-changes-pay-rates-increase-date-from-answer-month"]', value)
+    return this
+  }
+
+  getFiveWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerMonth(value) {
+    return browser.element('[name="five-weekly-pay-significant-changes-pay-rates-increase-date-from-answer-month"]').getValue()
+  }
+
+  setFiveWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerYear(value) {
+    browser.setValue('[name="five-weekly-pay-significant-changes-pay-rates-increase-date-from-answer-year"]', value)
+    return this
+  }
+
+  getFiveWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerYear(value) {
+    return browser.element('[name="five-weekly-pay-significant-changes-pay-rates-increase-date-from-answer-year"]').getValue()
+  }
+
+  setFiveWeeklyPaySignificantChangesPayRatesIncreasePercentEmployeesAnswer(value) {
+    browser.setValue('[name="five-weekly-pay-significant-changes-pay-rates-increase-percent-employees-answer"]', value)
+    return this
+  }
+
+  getFiveWeeklyPaySignificantChangesPayRatesIncreasePercentEmployeesAnswer(value) {
+    return browser.element('[name="five-weekly-pay-significant-changes-pay-rates-increase-percent-employees-answer"]').getValue()
+  }
+
+}
+
+export default new FiveWeeklyPaySignificantChangesPayRatesIncreasePage()

--- a/tests/functional/pages/surveys/mwss/five-weekly-pay-significant-changes-pay-rates.page.js
+++ b/tests/functional/pages/surveys/mwss/five-weekly-pay-significant-changes-pay-rates.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class FiveWeeklyPaySignificantChangesPayRatesPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('five-weekly-pay-significant-changes-pay-rates')
+  }
+
+  clickFiveWeeklyPaySignificantChangesPayRatesAnswerYes() {
+    browser.element('[id="five-weekly-pay-significant-changes-pay-rates-answer-0"]').click()
+    return this
+  }
+
+  clickFiveWeeklyPaySignificantChangesPayRatesAnswerNo() {
+    browser.element('[id="five-weekly-pay-significant-changes-pay-rates-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new FiveWeeklyPaySignificantChangesPayRatesPage()

--- a/tests/functional/pages/surveys/mwss/five-weekly-pay-significant-changes-redundancies.page.js
+++ b/tests/functional/pages/surveys/mwss/five-weekly-pay-significant-changes-redundancies.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class FiveWeeklyPaySignificantChangesRedundanciesPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('five-weekly-pay-significant-changes-redundancies')
+  }
+
+  clickFiveWeeklyPaySignificantChangesRedundanciesAnswerYes() {
+    browser.element('[id="five-weekly-pay-significant-changes-redundancies-answer-0"]').click()
+    return this
+  }
+
+  clickFiveWeeklyPaySignificantChangesRedundanciesAnswerNo() {
+    browser.element('[id="five-weekly-pay-significant-changes-redundancies-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new FiveWeeklyPaySignificantChangesRedundanciesPage()

--- a/tests/functional/pages/surveys/mwss/five-weekly-pay-significant-changes-temp-employees.page.js
+++ b/tests/functional/pages/surveys/mwss/five-weekly-pay-significant-changes-temp-employees.page.js
@@ -1,0 +1,28 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class FiveWeeklyPaySignificantChangesTempEmployeesPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('five-weekly-pay-significant-changes-temp-employees')
+  }
+
+  clickFiveWeeklyPaySignificantChangesTempEmployeesAnswerMoreTemporaryStaff() {
+    browser.element('[id="five-weekly-pay-significant-changes-temp-employees-answer-0"]').click()
+    return this
+  }
+
+  clickFiveWeeklyPaySignificantChangesTempEmployeesAnswerFewerTemporaryStaff() {
+    browser.element('[id="five-weekly-pay-significant-changes-temp-employees-answer-1"]').click()
+    return this
+  }
+
+  clickFiveWeeklyPaySignificantChangesTempEmployeesAnswerNoSignificantChange() {
+    browser.element('[id="five-weekly-pay-significant-changes-temp-employees-answer-2"]').click()
+    return this
+  }
+
+}
+
+export default new FiveWeeklyPaySignificantChangesTempEmployeesPage()

--- a/tests/functional/pages/surveys/mwss/fortnightly-pay-breakdown.page.js
+++ b/tests/functional/pages/surveys/mwss/fortnightly-pay-breakdown.page.js
@@ -1,0 +1,40 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class FortnightlyPayBreakdownPage extends QuestionPage {
+
+  constructor() {
+    super('fortnightly-pay-breakdown')
+  }
+
+  setFortnightlyPayBreakdownHolidayAnswer(value) {
+    browser.setValue('[name="fortnightly-pay-breakdown-holiday-answer"]', value)
+    return this
+  }
+
+  getFortnightlyPayBreakdownHolidayAnswer(value) {
+    return browser.element('[name="fortnightly-pay-breakdown-holiday-answer"]').getValue()
+  }
+
+  setFortnightlyPayBreakdownArrearsAnswer(value) {
+    browser.setValue('[name="fortnightly-pay-breakdown-arrears-answer"]', value)
+    return this
+  }
+
+  getFortnightlyPayBreakdownArrearsAnswer(value) {
+    return browser.element('[name="fortnightly-pay-breakdown-arrears-answer"]').getValue()
+  }
+
+  setFortnightlyPayBreakdownPrpAnswer(value) {
+    browser.setValue('[name="fortnightly-pay-breakdown-prp-answer"]', value)
+    return this
+  }
+
+  getFortnightlyPayBreakdownPrpAnswer(value) {
+    return browser.element('[name="fortnightly-pay-breakdown-prp-answer"]').getValue()
+  }
+
+}
+
+export default new FortnightlyPayBreakdownPage()

--- a/tests/functional/pages/surveys/mwss/fortnightly-pay-gross-pay.page.js
+++ b/tests/functional/pages/surveys/mwss/fortnightly-pay-gross-pay.page.js
@@ -1,0 +1,22 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class FortnightlyPayGrossPayPage extends QuestionPage {
+
+  constructor() {
+    super('fortnightly-pay-gross-pay')
+  }
+
+  setFortnightlyPayGrossPayAnswer(value) {
+    browser.setValue('[name="fortnightly-pay-gross-pay-answer"]', value)
+    return this
+  }
+
+  getFortnightlyPayGrossPayAnswer(value) {
+    return browser.element('[name="fortnightly-pay-gross-pay-answer"]').getValue()
+  }
+
+}
+
+export default new FortnightlyPayGrossPayPage()

--- a/tests/functional/pages/surveys/mwss/fortnightly-pay-introduction.page.js
+++ b/tests/functional/pages/surveys/mwss/fortnightly-pay-introduction.page.js
@@ -1,0 +1,13 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class FortnightlyPayIntroductionPage extends QuestionPage {
+
+  constructor() {
+    super('fortnightly-pay-introduction')
+  }
+
+}
+
+export default new FortnightlyPayIntroductionPage()

--- a/tests/functional/pages/surveys/mwss/fortnightly-pay-paid-employees.page.js
+++ b/tests/functional/pages/surveys/mwss/fortnightly-pay-paid-employees.page.js
@@ -1,0 +1,22 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class FortnightlyPayPaidEmployeesPage extends QuestionPage {
+
+  constructor() {
+    super('fortnightly-pay-paid-employees')
+  }
+
+  setFortnightlyPayPaidEmployeesAnswer(value) {
+    browser.setValue('[name="fortnightly-pay-paid-employees-answer"]', value)
+    return this
+  }
+
+  getFortnightlyPayPaidEmployeesAnswer(value) {
+    return browser.element('[name="fortnightly-pay-paid-employees-answer"]').getValue()
+  }
+
+}
+
+export default new FortnightlyPayPaidEmployeesPage()

--- a/tests/functional/pages/surveys/mwss/fortnightly-pay-significant-changes-gross-pay.page.js
+++ b/tests/functional/pages/surveys/mwss/fortnightly-pay-significant-changes-gross-pay.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class FortnightlyPaySignificantChangesGrossPayPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('fortnightly-pay-significant-changes-gross-pay')
+  }
+
+  clickFortnightlyPaySignificantChangesGrossPayAnswerYes() {
+    browser.element('[id="fortnightly-pay-significant-changes-gross-pay-answer-0"]').click()
+    return this
+  }
+
+  clickFortnightlyPaySignificantChangesGrossPayAnswerNo() {
+    browser.element('[id="fortnightly-pay-significant-changes-gross-pay-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new FortnightlyPaySignificantChangesGrossPayPage()

--- a/tests/functional/pages/surveys/mwss/fortnightly-pay-significant-changes-industrial-action.page.js
+++ b/tests/functional/pages/surveys/mwss/fortnightly-pay-significant-changes-industrial-action.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class FortnightlyPaySignificantChangesIndustrialActionPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('fortnightly-pay-significant-changes-industrial-action')
+  }
+
+  clickFortnightlyPaySignificantChangesIndustrialActionAnswerYes() {
+    browser.element('[id="fortnightly-pay-significant-changes-industrial-action-answer-0"]').click()
+    return this
+  }
+
+  clickFortnightlyPaySignificantChangesIndustrialActionAnswerNo() {
+    browser.element('[id="fortnightly-pay-significant-changes-industrial-action-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new FortnightlyPaySignificantChangesIndustrialActionPage()

--- a/tests/functional/pages/surveys/mwss/fortnightly-pay-significant-changes-other-specify.page.js
+++ b/tests/functional/pages/surveys/mwss/fortnightly-pay-significant-changes-other-specify.page.js
@@ -1,0 +1,22 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class FortnightlyPaySignificantChangesOtherSpecifyPage extends QuestionPage {
+
+  constructor() {
+    super('fortnightly-pay-significant-changes-other-specify')
+  }
+
+  setFortnightlyPaySignificantChangesOtherSpecifyAnswer(value) {
+    browser.setValue('[name="fortnightly-pay-significant-changes-other-specify-answer"]', value)
+    return this
+  }
+
+  getFortnightlyPaySignificantChangesOtherSpecifyAnswer(value) {
+    return browser.element('[name="fortnightly-pay-significant-changes-other-specify-answer"]').getValue()
+  }
+
+}
+
+export default new FortnightlyPaySignificantChangesOtherSpecifyPage()

--- a/tests/functional/pages/surveys/mwss/fortnightly-pay-significant-changes-other.page.js
+++ b/tests/functional/pages/surveys/mwss/fortnightly-pay-significant-changes-other.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class FortnightlyPaySignificantChangesOtherPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('fortnightly-pay-significant-changes-other')
+  }
+
+  clickFortnightlyPaySignificantChangesOtherAnswerYes() {
+    browser.element('[id="fortnightly-pay-significant-changes-other-answer-0"]').click()
+    return this
+  }
+
+  clickFortnightlyPaySignificantChangesOtherAnswerNo() {
+    browser.element('[id="fortnightly-pay-significant-changes-other-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new FortnightlyPaySignificantChangesOtherPage()

--- a/tests/functional/pages/surveys/mwss/fortnightly-pay-significant-changes-overtime.page.js
+++ b/tests/functional/pages/surveys/mwss/fortnightly-pay-significant-changes-overtime.page.js
@@ -1,0 +1,28 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class FortnightlyPaySignificantChangesOvertimePage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('fortnightly-pay-significant-changes-overtime')
+  }
+
+  clickFortnightlyPaySignificantChangesOvertimeAnswerMoreOvertime() {
+    browser.element('[id="fortnightly-pay-significant-changes-overtime-answer-0"]').click()
+    return this
+  }
+
+  clickFortnightlyPaySignificantChangesOvertimeAnswerLessOvertime() {
+    browser.element('[id="fortnightly-pay-significant-changes-overtime-answer-1"]').click()
+    return this
+  }
+
+  clickFortnightlyPaySignificantChangesOvertimeAnswerNoSignificantChange() {
+    browser.element('[id="fortnightly-pay-significant-changes-overtime-answer-2"]').click()
+    return this
+  }
+
+}
+
+export default new FortnightlyPaySignificantChangesOvertimePage()

--- a/tests/functional/pages/surveys/mwss/fortnightly-pay-significant-changes-paid-employees.page.js
+++ b/tests/functional/pages/surveys/mwss/fortnightly-pay-significant-changes-paid-employees.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class FortnightlyPaySignificantChangesPaidEmployeesPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('fortnightly-pay-significant-changes-paid-employees')
+  }
+
+  clickFortnightlyPaySignificantChangesPaidEmployeesAnswerYes() {
+    browser.element('[id="fortnightly-pay-significant-changes-paid-employees-answer-0"]').click()
+    return this
+  }
+
+  clickFortnightlyPaySignificantChangesPaidEmployeesAnswerNo() {
+    browser.element('[id="fortnightly-pay-significant-changes-paid-employees-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new FortnightlyPaySignificantChangesPaidEmployeesPage()

--- a/tests/functional/pages/surveys/mwss/fortnightly-pay-significant-changes-pay-rates-increase.page.js
+++ b/tests/functional/pages/surveys/mwss/fortnightly-pay-significant-changes-pay-rates-increase.page.js
@@ -1,0 +1,58 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class FortnightlyPaySignificantChangesPayRatesIncreasePage extends QuestionPage {
+
+  constructor() {
+    super('fortnightly-pay-significant-changes-pay-rates-increase')
+  }
+
+  setFortnightlyPaySignificantChangesPayRatesIncreasePercentIncreaseAnswer(value) {
+    browser.setValue('[name="fortnightly-pay-significant-changes-pay-rates-increase-percent-increase-answer"]', value)
+    return this
+  }
+
+  getFortnightlyPaySignificantChangesPayRatesIncreasePercentIncreaseAnswer(value) {
+    return browser.element('[name="fortnightly-pay-significant-changes-pay-rates-increase-percent-increase-answer"]').getValue()
+  }
+
+  setFortnightlyPaySignificantChangesPayRatesIncreaseDateFromAnswerDay(value) {
+    browser.setValue('[name="fortnightly-pay-significant-changes-pay-rates-increase-date-from-answer-day"]', value)
+    return this
+  }
+
+  getFortnightlyPaySignificantChangesPayRatesIncreaseDateFromAnswerDay(value) {
+    return browser.element('[name="fortnightly-pay-significant-changes-pay-rates-increase-date-from-answer-day"]').getValue()
+  }
+
+  setFortnightlyPaySignificantChangesPayRatesIncreaseDateFromAnswerMonth(value) {
+    browser.selectByValue('[name="fortnightly-pay-significant-changes-pay-rates-increase-date-from-answer-month"]', value)
+    return this
+  }
+
+  getFortnightlyPaySignificantChangesPayRatesIncreaseDateFromAnswerMonth(value) {
+    return browser.element('[name="fortnightly-pay-significant-changes-pay-rates-increase-date-from-answer-month"]').getValue()
+  }
+
+  setFortnightlyPaySignificantChangesPayRatesIncreaseDateFromAnswerYear(value) {
+    browser.setValue('[name="fortnightly-pay-significant-changes-pay-rates-increase-date-from-answer-year"]', value)
+    return this
+  }
+
+  getFortnightlyPaySignificantChangesPayRatesIncreaseDateFromAnswerYear(value) {
+    return browser.element('[name="fortnightly-pay-significant-changes-pay-rates-increase-date-from-answer-year"]').getValue()
+  }
+
+  setFortnightlyPaySignificantChangesPayRatesIncreasePercentEmployeesAnswer(value) {
+    browser.setValue('[name="fortnightly-pay-significant-changes-pay-rates-increase-percent-employees-answer"]', value)
+    return this
+  }
+
+  getFortnightlyPaySignificantChangesPayRatesIncreasePercentEmployeesAnswer(value) {
+    return browser.element('[name="fortnightly-pay-significant-changes-pay-rates-increase-percent-employees-answer"]').getValue()
+  }
+
+}
+
+export default new FortnightlyPaySignificantChangesPayRatesIncreasePage()

--- a/tests/functional/pages/surveys/mwss/fortnightly-pay-significant-changes-pay-rates.page.js
+++ b/tests/functional/pages/surveys/mwss/fortnightly-pay-significant-changes-pay-rates.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class FortnightlyPaySignificantChangesPayRatesPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('fortnightly-pay-significant-changes-pay-rates')
+  }
+
+  clickFortnightlyPaySignificantChangesPayRatesAnswerYes() {
+    browser.element('[id="fortnightly-pay-significant-changes-pay-rates-answer-0"]').click()
+    return this
+  }
+
+  clickFortnightlyPaySignificantChangesPayRatesAnswerNo() {
+    browser.element('[id="fortnightly-pay-significant-changes-pay-rates-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new FortnightlyPaySignificantChangesPayRatesPage()

--- a/tests/functional/pages/surveys/mwss/fortnightly-pay-significant-changes-redundancies.page.js
+++ b/tests/functional/pages/surveys/mwss/fortnightly-pay-significant-changes-redundancies.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class FortnightlyPaySignificantChangesRedundanciesPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('fortnightly-pay-significant-changes-redundancies')
+  }
+
+  clickFortnightlyPaySignificantChangesRedundanciesAnswerYes() {
+    browser.element('[id="fortnightly-pay-significant-changes-redundancies-answer-0"]').click()
+    return this
+  }
+
+  clickFortnightlyPaySignificantChangesRedundanciesAnswerNo() {
+    browser.element('[id="fortnightly-pay-significant-changes-redundancies-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new FortnightlyPaySignificantChangesRedundanciesPage()

--- a/tests/functional/pages/surveys/mwss/fortnightly-pay-significant-changes-temp-employees.page.js
+++ b/tests/functional/pages/surveys/mwss/fortnightly-pay-significant-changes-temp-employees.page.js
@@ -1,0 +1,28 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class FortnightlyPaySignificantChangesTempEmployeesPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('fortnightly-pay-significant-changes-temp-employees')
+  }
+
+  clickFortnightlyPaySignificantChangesTempEmployeesAnswerMoreTemporaryStaff() {
+    browser.element('[id="fortnightly-pay-significant-changes-temp-employees-answer-0"]').click()
+    return this
+  }
+
+  clickFortnightlyPaySignificantChangesTempEmployeesAnswerFewerTemporaryStaff() {
+    browser.element('[id="fortnightly-pay-significant-changes-temp-employees-answer-1"]').click()
+    return this
+  }
+
+  clickFortnightlyPaySignificantChangesTempEmployeesAnswerNoSignificantChange() {
+    browser.element('[id="fortnightly-pay-significant-changes-temp-employees-answer-2"]').click()
+    return this
+  }
+
+}
+
+export default new FortnightlyPaySignificantChangesTempEmployeesPage()

--- a/tests/functional/pages/surveys/mwss/four-weekly-pay-breakdown.page.js
+++ b/tests/functional/pages/surveys/mwss/four-weekly-pay-breakdown.page.js
@@ -1,0 +1,31 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class FourWeeklyPayBreakdownPage extends QuestionPage {
+
+  constructor() {
+    super('four-weekly-pay-breakdown')
+  }
+
+  setFourWeeklyPayBreakdownArrearsAnswer(value) {
+    browser.setValue('[name="four-weekly-pay-breakdown-arrears-answer"]', value)
+    return this
+  }
+
+  getFourWeeklyPayBreakdownArrearsAnswer(value) {
+    return browser.element('[name="four-weekly-pay-breakdown-arrears-answer"]').getValue()
+  }
+
+  setFourWeeklyPayBreakdownPrpAnswer(value) {
+    browser.setValue('[name="four-weekly-pay-breakdown-prp-answer"]', value)
+    return this
+  }
+
+  getFourWeeklyPayBreakdownPrpAnswer(value) {
+    return browser.element('[name="four-weekly-pay-breakdown-prp-answer"]').getValue()
+  }
+
+}
+
+export default new FourWeeklyPayBreakdownPage()

--- a/tests/functional/pages/surveys/mwss/four-weekly-pay-gross-pay.page.js
+++ b/tests/functional/pages/surveys/mwss/four-weekly-pay-gross-pay.page.js
@@ -1,0 +1,22 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class FourWeeklyPayGrossPayPage extends QuestionPage {
+
+  constructor() {
+    super('four-weekly-pay-gross-pay')
+  }
+
+  setFourWeeklyPayGrossPayAnswer(value) {
+    browser.setValue('[name="four-weekly-pay-gross-pay-answer"]', value)
+    return this
+  }
+
+  getFourWeeklyPayGrossPayAnswer(value) {
+    return browser.element('[name="four-weekly-pay-gross-pay-answer"]').getValue()
+  }
+
+}
+
+export default new FourWeeklyPayGrossPayPage()

--- a/tests/functional/pages/surveys/mwss/four-weekly-pay-introduction.page.js
+++ b/tests/functional/pages/surveys/mwss/four-weekly-pay-introduction.page.js
@@ -1,0 +1,13 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class FourWeeklyPayIntroductionPage extends QuestionPage {
+
+  constructor() {
+    super('four-weekly-pay-introduction')
+  }
+
+}
+
+export default new FourWeeklyPayIntroductionPage()

--- a/tests/functional/pages/surveys/mwss/four-weekly-pay-paid-employees.page.js
+++ b/tests/functional/pages/surveys/mwss/four-weekly-pay-paid-employees.page.js
@@ -1,0 +1,22 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class FourWeeklyPayPaidEmployeesPage extends QuestionPage {
+
+  constructor() {
+    super('four-weekly-pay-paid-employees')
+  }
+
+  setFourWeeklyPayPaidEmployeesAnswer(value) {
+    browser.setValue('[name="four-weekly-pay-paid-employees-answer"]', value)
+    return this
+  }
+
+  getFourWeeklyPayPaidEmployeesAnswer(value) {
+    return browser.element('[name="four-weekly-pay-paid-employees-answer"]').getValue()
+  }
+
+}
+
+export default new FourWeeklyPayPaidEmployeesPage()

--- a/tests/functional/pages/surveys/mwss/four-weekly-pay-significant-changes-gross-pay.page.js
+++ b/tests/functional/pages/surveys/mwss/four-weekly-pay-significant-changes-gross-pay.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class FourWeeklyPaySignificantChangesGrossPayPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('four-weekly-pay-significant-changes-gross-pay')
+  }
+
+  clickFourWeeklyPaySignificantChangesGrossPayAnswerYes() {
+    browser.element('[id="four-weekly-pay-significant-changes-gross-pay-answer-0"]').click()
+    return this
+  }
+
+  clickFourWeeklyPaySignificantChangesGrossPayAnswerNo() {
+    browser.element('[id="four-weekly-pay-significant-changes-gross-pay-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new FourWeeklyPaySignificantChangesGrossPayPage()

--- a/tests/functional/pages/surveys/mwss/four-weekly-pay-significant-changes-industrial-action.page.js
+++ b/tests/functional/pages/surveys/mwss/four-weekly-pay-significant-changes-industrial-action.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class FourWeeklyPaySignificantChangesIndustrialActionPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('four-weekly-pay-significant-changes-industrial-action')
+  }
+
+  clickFourWeeklyPaySignificantChangesIndustrialActionAnswerYes() {
+    browser.element('[id="four-weekly-pay-significant-changes-industrial-action-answer-0"]').click()
+    return this
+  }
+
+  clickFourWeeklyPaySignificantChangesIndustrialActionAnswerNo() {
+    browser.element('[id="four-weekly-pay-significant-changes-industrial-action-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new FourWeeklyPaySignificantChangesIndustrialActionPage()

--- a/tests/functional/pages/surveys/mwss/four-weekly-pay-significant-changes-other-specify.page.js
+++ b/tests/functional/pages/surveys/mwss/four-weekly-pay-significant-changes-other-specify.page.js
@@ -1,0 +1,22 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class FourWeeklyPaySignificantChangesOtherSpecifyPage extends QuestionPage {
+
+  constructor() {
+    super('four-weekly-pay-significant-changes-other-specify')
+  }
+
+  setFourWeeklyPaySignificantChangesOtherSpecifyAnswer(value) {
+    browser.setValue('[name="four-weekly-pay-significant-changes-other-specify-answer"]', value)
+    return this
+  }
+
+  getFourWeeklyPaySignificantChangesOtherSpecifyAnswer(value) {
+    return browser.element('[name="four-weekly-pay-significant-changes-other-specify-answer"]').getValue()
+  }
+
+}
+
+export default new FourWeeklyPaySignificantChangesOtherSpecifyPage()

--- a/tests/functional/pages/surveys/mwss/four-weekly-pay-significant-changes-other.page.js
+++ b/tests/functional/pages/surveys/mwss/four-weekly-pay-significant-changes-other.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class FourWeeklyPaySignificantChangesOtherPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('four-weekly-pay-significant-changes-other')
+  }
+
+  clickFourWeeklyPaySignificantChangesOtherAnswerYes() {
+    browser.element('[id="four-weekly-pay-significant-changes-other-answer-0"]').click()
+    return this
+  }
+
+  clickFourWeeklyPaySignificantChangesOtherAnswerNo() {
+    browser.element('[id="four-weekly-pay-significant-changes-other-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new FourWeeklyPaySignificantChangesOtherPage()

--- a/tests/functional/pages/surveys/mwss/four-weekly-pay-significant-changes-overtime.page.js
+++ b/tests/functional/pages/surveys/mwss/four-weekly-pay-significant-changes-overtime.page.js
@@ -1,0 +1,28 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class FourWeeklyPaySignificantChangesOvertimePage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('four-weekly-pay-significant-changes-overtime')
+  }
+
+  clickFourWeeklyPaySignificantChangesOvertimeAnswerMoreOvertime() {
+    browser.element('[id="four-weekly-pay-significant-changes-overtime-answer-0"]').click()
+    return this
+  }
+
+  clickFourWeeklyPaySignificantChangesOvertimeAnswerLessOvertime() {
+    browser.element('[id="four-weekly-pay-significant-changes-overtime-answer-1"]').click()
+    return this
+  }
+
+  clickFourWeeklyPaySignificantChangesOvertimeAnswerNoSignificantChange() {
+    browser.element('[id="four-weekly-pay-significant-changes-overtime-answer-2"]').click()
+    return this
+  }
+
+}
+
+export default new FourWeeklyPaySignificantChangesOvertimePage()

--- a/tests/functional/pages/surveys/mwss/four-weekly-pay-significant-changes-paid-employees.page.js
+++ b/tests/functional/pages/surveys/mwss/four-weekly-pay-significant-changes-paid-employees.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class FourWeeklyPaySignificantChangesPaidEmployeesPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('four-weekly-pay-significant-changes-paid-employees')
+  }
+
+  clickFourWeeklyPaySignificantChangesPaidEmployeesAnswerYes() {
+    browser.element('[id="four-weekly-pay-significant-changes-paid-employees-answer-0"]').click()
+    return this
+  }
+
+  clickFourWeeklyPaySignificantChangesPaidEmployeesAnswerNo() {
+    browser.element('[id="four-weekly-pay-significant-changes-paid-employees-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new FourWeeklyPaySignificantChangesPaidEmployeesPage()

--- a/tests/functional/pages/surveys/mwss/four-weekly-pay-significant-changes-pay-rates-increase.page.js
+++ b/tests/functional/pages/surveys/mwss/four-weekly-pay-significant-changes-pay-rates-increase.page.js
@@ -1,0 +1,58 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class FourWeeklyPaySignificantChangesPayRatesIncreasePage extends QuestionPage {
+
+  constructor() {
+    super('four-weekly-pay-significant-changes-pay-rates-increase')
+  }
+
+  setFourWeeklyPaySignificantChangesPayRatesIncreasePercentIncreaseAnswer(value) {
+    browser.setValue('[name="four-weekly-pay-significant-changes-pay-rates-increase-percent-increase-answer"]', value)
+    return this
+  }
+
+  getFourWeeklyPaySignificantChangesPayRatesIncreasePercentIncreaseAnswer(value) {
+    return browser.element('[name="four-weekly-pay-significant-changes-pay-rates-increase-percent-increase-answer"]').getValue()
+  }
+
+  setFourWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerDay(value) {
+    browser.setValue('[name="four-weekly-pay-significant-changes-pay-rates-increase-date-from-answer-day"]', value)
+    return this
+  }
+
+  getFourWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerDay(value) {
+    return browser.element('[name="four-weekly-pay-significant-changes-pay-rates-increase-date-from-answer-day"]').getValue()
+  }
+
+  setFourWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerMonth(value) {
+    browser.selectByValue('[name="four-weekly-pay-significant-changes-pay-rates-increase-date-from-answer-month"]', value)
+    return this
+  }
+
+  getFourWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerMonth(value) {
+    return browser.element('[name="four-weekly-pay-significant-changes-pay-rates-increase-date-from-answer-month"]').getValue()
+  }
+
+  setFourWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerYear(value) {
+    browser.setValue('[name="four-weekly-pay-significant-changes-pay-rates-increase-date-from-answer-year"]', value)
+    return this
+  }
+
+  getFourWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerYear(value) {
+    return browser.element('[name="four-weekly-pay-significant-changes-pay-rates-increase-date-from-answer-year"]').getValue()
+  }
+
+  setFourWeeklyPaySignificantChangesPayRatesIncreasePercentEmployeesAnswer(value) {
+    browser.setValue('[name="four-weekly-pay-significant-changes-pay-rates-increase-percent-employees-answer"]', value)
+    return this
+  }
+
+  getFourWeeklyPaySignificantChangesPayRatesIncreasePercentEmployeesAnswer(value) {
+    return browser.element('[name="four-weekly-pay-significant-changes-pay-rates-increase-percent-employees-answer"]').getValue()
+  }
+
+}
+
+export default new FourWeeklyPaySignificantChangesPayRatesIncreasePage()

--- a/tests/functional/pages/surveys/mwss/four-weekly-pay-significant-changes-pay-rates.page.js
+++ b/tests/functional/pages/surveys/mwss/four-weekly-pay-significant-changes-pay-rates.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class FourWeeklyPaySignificantChangesPayRatesPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('four-weekly-pay-significant-changes-pay-rates')
+  }
+
+  clickFourWeeklyPaySignificantChangesPayRatesAnswerYes() {
+    browser.element('[id="four-weekly-pay-significant-changes-pay-rates-answer-0"]').click()
+    return this
+  }
+
+  clickFourWeeklyPaySignificantChangesPayRatesAnswerNo() {
+    browser.element('[id="four-weekly-pay-significant-changes-pay-rates-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new FourWeeklyPaySignificantChangesPayRatesPage()

--- a/tests/functional/pages/surveys/mwss/four-weekly-pay-significant-changes-redundancies.page.js
+++ b/tests/functional/pages/surveys/mwss/four-weekly-pay-significant-changes-redundancies.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class FourWeeklyPaySignificantChangesRedundanciesPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('four-weekly-pay-significant-changes-redundancies')
+  }
+
+  clickFourWeeklyPaySignificantChangesRedundanciesAnswerYes() {
+    browser.element('[id="four-weekly-pay-significant-changes-redundancies-answer-0"]').click()
+    return this
+  }
+
+  clickFourWeeklyPaySignificantChangesRedundanciesAnswerNo() {
+    browser.element('[id="four-weekly-pay-significant-changes-redundancies-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new FourWeeklyPaySignificantChangesRedundanciesPage()

--- a/tests/functional/pages/surveys/mwss/four-weekly-pay-significant-changes-temp-employees.page.js
+++ b/tests/functional/pages/surveys/mwss/four-weekly-pay-significant-changes-temp-employees.page.js
@@ -1,0 +1,28 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class FourWeeklyPaySignificantChangesTempEmployeesPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('four-weekly-pay-significant-changes-temp-employees')
+  }
+
+  clickFourWeeklyPaySignificantChangesTempEmployeesAnswerMoreTemporaryStaff() {
+    browser.element('[id="four-weekly-pay-significant-changes-temp-employees-answer-0"]').click()
+    return this
+  }
+
+  clickFourWeeklyPaySignificantChangesTempEmployeesAnswerFewerTemporaryStaff() {
+    browser.element('[id="four-weekly-pay-significant-changes-temp-employees-answer-1"]').click()
+    return this
+  }
+
+  clickFourWeeklyPaySignificantChangesTempEmployeesAnswerNoSignificantChange() {
+    browser.element('[id="four-weekly-pay-significant-changes-temp-employees-answer-2"]').click()
+    return this
+  }
+
+}
+
+export default new FourWeeklyPaySignificantChangesTempEmployeesPage()

--- a/tests/functional/pages/surveys/mwss/general-comments-introduction.page.js
+++ b/tests/functional/pages/surveys/mwss/general-comments-introduction.page.js
@@ -1,0 +1,13 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class GeneralCommentsIntroductionPage extends QuestionPage {
+
+  constructor() {
+    super('general-comments-introduction')
+  }
+
+}
+
+export default new GeneralCommentsIntroductionPage()

--- a/tests/functional/pages/surveys/mwss/general-comments.page.js
+++ b/tests/functional/pages/surveys/mwss/general-comments.page.js
@@ -1,0 +1,22 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class GeneralCommentsPage extends QuestionPage {
+
+  constructor() {
+    super('general-comments')
+  }
+
+  setGeneralCommentsAnswer(value) {
+    browser.setValue('[name="general-comments-answer"]', value)
+    return this
+  }
+
+  getGeneralCommentsAnswer(value) {
+    return browser.element('[name="general-comments-answer"]').getValue()
+  }
+
+}
+
+export default new GeneralCommentsPage()

--- a/tests/functional/pages/surveys/mwss/pay-pattern-frequency.page.js
+++ b/tests/functional/pages/surveys/mwss/pay-pattern-frequency.page.js
@@ -1,0 +1,38 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class PayPatternFrequencyPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('pay-pattern-frequency')
+  }
+
+  clickPayPatternFrequencyAnswerWeekly() {
+    browser.element('[id="pay-pattern-frequency-answer-0"]').click()
+    return this
+  }
+
+  clickPayPatternFrequencyAnswerFortnightly() {
+    browser.element('[id="pay-pattern-frequency-answer-1"]').click()
+    return this
+  }
+
+  clickPayPatternFrequencyAnswerCalendarMonthly() {
+    browser.element('[id="pay-pattern-frequency-answer-2"]').click()
+    return this
+  }
+
+  clickPayPatternFrequencyAnswerFourWeekly() {
+    browser.element('[id="pay-pattern-frequency-answer-3"]').click()
+    return this
+  }
+
+  clickPayPatternFrequencyAnswerFiveWeekly() {
+    browser.element('[id="pay-pattern-frequency-answer-4"]').click()
+    return this
+  }
+
+}
+
+export default new PayPatternFrequencyPage()

--- a/tests/functional/pages/surveys/mwss/weekly-pay-breakdown.page.js
+++ b/tests/functional/pages/surveys/mwss/weekly-pay-breakdown.page.js
@@ -1,0 +1,40 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class WeeklyPayBreakdownPage extends QuestionPage {
+
+  constructor() {
+    super('weekly-pay-breakdown')
+  }
+
+  setWeeklyPayBreakdownHolidayAnswer(value) {
+    browser.setValue('[name="weekly-pay-breakdown-holiday-answer"]', value)
+    return this
+  }
+
+  getWeeklyPayBreakdownHolidayAnswer(value) {
+    return browser.element('[name="weekly-pay-breakdown-holiday-answer"]').getValue()
+  }
+
+  setWeeklyPayBreakdownArrearsAnswer(value) {
+    browser.setValue('[name="weekly-pay-breakdown-arrears-answer"]', value)
+    return this
+  }
+
+  getWeeklyPayBreakdownArrearsAnswer(value) {
+    return browser.element('[name="weekly-pay-breakdown-arrears-answer"]').getValue()
+  }
+
+  setWeeklyPayBreakdownPrpAnswer(value) {
+    browser.setValue('[name="weekly-pay-breakdown-prp-answer"]', value)
+    return this
+  }
+
+  getWeeklyPayBreakdownPrpAnswer(value) {
+    return browser.element('[name="weekly-pay-breakdown-prp-answer"]').getValue()
+  }
+
+}
+
+export default new WeeklyPayBreakdownPage()

--- a/tests/functional/pages/surveys/mwss/weekly-pay-gross-pay.page.js
+++ b/tests/functional/pages/surveys/mwss/weekly-pay-gross-pay.page.js
@@ -1,0 +1,22 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class WeeklyPayGrossPayPage extends QuestionPage {
+
+  constructor() {
+    super('weekly-pay-gross-pay')
+  }
+
+  setWeeklyPayGrossPayAnswer(value) {
+    browser.setValue('[name="weekly-pay-gross-pay-answer"]', value)
+    return this
+  }
+
+  getWeeklyPayGrossPayAnswer(value) {
+    return browser.element('[name="weekly-pay-gross-pay-answer"]').getValue()
+  }
+
+}
+
+export default new WeeklyPayGrossPayPage()

--- a/tests/functional/pages/surveys/mwss/weekly-pay-introduction.page.js
+++ b/tests/functional/pages/surveys/mwss/weekly-pay-introduction.page.js
@@ -1,0 +1,13 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class WeeklyPayIntroductionPage extends QuestionPage {
+
+  constructor() {
+    super('weekly-pay-introduction')
+  }
+
+}
+
+export default new WeeklyPayIntroductionPage()

--- a/tests/functional/pages/surveys/mwss/weekly-pay-paid-employees.page.js
+++ b/tests/functional/pages/surveys/mwss/weekly-pay-paid-employees.page.js
@@ -1,0 +1,22 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class WeeklyPayPaidEmployeesPage extends QuestionPage {
+
+  constructor() {
+    super('weekly-pay-paid-employees')
+  }
+
+  setWeeklyPayPaidEmployeesAnswer(value) {
+    browser.setValue('[name="weekly-pay-paid-employees-answer"]', value)
+    return this
+  }
+
+  getWeeklyPayPaidEmployeesAnswer(value) {
+    return browser.element('[name="weekly-pay-paid-employees-answer"]').getValue()
+  }
+
+}
+
+export default new WeeklyPayPaidEmployeesPage()

--- a/tests/functional/pages/surveys/mwss/weekly-pay-significant-changes-gross-pay.page.js
+++ b/tests/functional/pages/surveys/mwss/weekly-pay-significant-changes-gross-pay.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class WeeklyPaySignificantChangesGrossPayPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('weekly-pay-significant-changes-gross-pay')
+  }
+
+  clickWeeklyPaySignificantChangesGrossPayAnswerYes() {
+    browser.element('[id="weekly-pay-significant-changes-gross-pay-answer-0"]').click()
+    return this
+  }
+
+  clickWeeklyPaySignificantChangesGrossPayAnswerNo() {
+    browser.element('[id="weekly-pay-significant-changes-gross-pay-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new WeeklyPaySignificantChangesGrossPayPage()

--- a/tests/functional/pages/surveys/mwss/weekly-pay-significant-changes-industrial-action.page.js
+++ b/tests/functional/pages/surveys/mwss/weekly-pay-significant-changes-industrial-action.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class WeeklyPaySignificantChangesIndustrialActionPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('weekly-pay-significant-changes-industrial-action')
+  }
+
+  clickWeeklyPaySignificantChangesIndustrialActionAnswerYes() {
+    browser.element('[id="weekly-pay-significant-changes-industrial-action-answer-0"]').click()
+    return this
+  }
+
+  clickWeeklyPaySignificantChangesIndustrialActionAnswerNo() {
+    browser.element('[id="weekly-pay-significant-changes-industrial-action-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new WeeklyPaySignificantChangesIndustrialActionPage()

--- a/tests/functional/pages/surveys/mwss/weekly-pay-significant-changes-other-specify.page.js
+++ b/tests/functional/pages/surveys/mwss/weekly-pay-significant-changes-other-specify.page.js
@@ -1,0 +1,22 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class WeeklyPaySignificantChangesOtherSpecifyPage extends QuestionPage {
+
+  constructor() {
+    super('weekly-pay-significant-changes-other-specify')
+  }
+
+  setWeeklyPaySignificantChangesOtherSpecifyAnswer(value) {
+    browser.setValue('[name="weekly-pay-significant-changes-other-specify-answer"]', value)
+    return this
+  }
+
+  getWeeklyPaySignificantChangesOtherSpecifyAnswer(value) {
+    return browser.element('[name="weekly-pay-significant-changes-other-specify-answer"]').getValue()
+  }
+
+}
+
+export default new WeeklyPaySignificantChangesOtherSpecifyPage()

--- a/tests/functional/pages/surveys/mwss/weekly-pay-significant-changes-other.page.js
+++ b/tests/functional/pages/surveys/mwss/weekly-pay-significant-changes-other.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class WeeklyPaySignificantChangesOtherPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('weekly-pay-significant-changes-other')
+  }
+
+  clickWeeklyPaySignificantChangesOtherAnswerYes() {
+    browser.element('[id="weekly-pay-significant-changes-other-answer-0"]').click()
+    return this
+  }
+
+  clickWeeklyPaySignificantChangesOtherAnswerNo() {
+    browser.element('[id="weekly-pay-significant-changes-other-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new WeeklyPaySignificantChangesOtherPage()

--- a/tests/functional/pages/surveys/mwss/weekly-pay-significant-changes-overtime.page.js
+++ b/tests/functional/pages/surveys/mwss/weekly-pay-significant-changes-overtime.page.js
@@ -1,0 +1,28 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class WeeklyPaySignificantChangesOvertimePage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('weekly-pay-significant-changes-overtime')
+  }
+
+  clickWeeklyPaySignificantChangesOvertimeAnswerMoreOvertime() {
+    browser.element('[id="weekly-pay-significant-changes-overtime-answer-0"]').click()
+    return this
+  }
+
+  clickWeeklyPaySignificantChangesOvertimeAnswerLessOvertime() {
+    browser.element('[id="weekly-pay-significant-changes-overtime-answer-1"]').click()
+    return this
+  }
+
+  clickWeeklyPaySignificantChangesOvertimeAnswerNoSignificantChange() {
+    browser.element('[id="weekly-pay-significant-changes-overtime-answer-2"]').click()
+    return this
+  }
+
+}
+
+export default new WeeklyPaySignificantChangesOvertimePage()

--- a/tests/functional/pages/surveys/mwss/weekly-pay-significant-changes-paid-employees.page.js
+++ b/tests/functional/pages/surveys/mwss/weekly-pay-significant-changes-paid-employees.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class WeeklyPaySignificantChangesPaidEmployeesPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('weekly-pay-significant-changes-paid-employees')
+  }
+
+  clickWeeklyPaySignificantChangesPaidEmployeesAnswerYes() {
+    browser.element('[id="weekly-pay-significant-changes-paid-employees-answer-0"]').click()
+    return this
+  }
+
+  clickWeeklyPaySignificantChangesPaidEmployeesAnswerNo() {
+    browser.element('[id="weekly-pay-significant-changes-paid-employees-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new WeeklyPaySignificantChangesPaidEmployeesPage()

--- a/tests/functional/pages/surveys/mwss/weekly-pay-significant-changes-pay-rates-increase.page.js
+++ b/tests/functional/pages/surveys/mwss/weekly-pay-significant-changes-pay-rates-increase.page.js
@@ -1,0 +1,58 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class WeeklyPaySignificantChangesPayRatesIncreasePage extends QuestionPage {
+
+  constructor() {
+    super('weekly-pay-significant-changes-pay-rates-increase')
+  }
+
+  setWeeklyPaySignificantChangesPayRatesIncreasePercentIncreaseAnswer(value) {
+    browser.setValue('[name="weekly-pay-significant-changes-pay-rates-increase-percent-increase-answer"]', value)
+    return this
+  }
+
+  getWeeklyPaySignificantChangesPayRatesIncreasePercentIncreaseAnswer(value) {
+    return browser.element('[name="weekly-pay-significant-changes-pay-rates-increase-percent-increase-answer"]').getValue()
+  }
+
+  setWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerDay(value) {
+    browser.setValue('[name="weekly-pay-significant-changes-pay-rates-increase-date-from-answer-day"]', value)
+    return this
+  }
+
+  getWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerDay(value) {
+    return browser.element('[name="weekly-pay-significant-changes-pay-rates-increase-date-from-answer-day"]').getValue()
+  }
+
+  setWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerMonth(value) {
+    browser.selectByValue('[name="weekly-pay-significant-changes-pay-rates-increase-date-from-answer-month"]', value)
+    return this
+  }
+
+  getWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerMonth(value) {
+    return browser.element('[name="weekly-pay-significant-changes-pay-rates-increase-date-from-answer-month"]').getValue()
+  }
+
+  setWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerYear(value) {
+    browser.setValue('[name="weekly-pay-significant-changes-pay-rates-increase-date-from-answer-year"]', value)
+    return this
+  }
+
+  getWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerYear(value) {
+    return browser.element('[name="weekly-pay-significant-changes-pay-rates-increase-date-from-answer-year"]').getValue()
+  }
+
+  setWeeklyPaySignificantChangesPayRatesIncreasePercentEmployeesAnswer(value) {
+    browser.setValue('[name="weekly-pay-significant-changes-pay-rates-increase-percent-employees-answer"]', value)
+    return this
+  }
+
+  getWeeklyPaySignificantChangesPayRatesIncreasePercentEmployeesAnswer(value) {
+    return browser.element('[name="weekly-pay-significant-changes-pay-rates-increase-percent-employees-answer"]').getValue()
+  }
+
+}
+
+export default new WeeklyPaySignificantChangesPayRatesIncreasePage()

--- a/tests/functional/pages/surveys/mwss/weekly-pay-significant-changes-pay-rates.page.js
+++ b/tests/functional/pages/surveys/mwss/weekly-pay-significant-changes-pay-rates.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class WeeklyPaySignificantChangesPayRatesPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('weekly-pay-significant-changes-pay-rates')
+  }
+
+  clickWeeklyPaySignificantChangesPayRatesAnswerYes() {
+    browser.element('[id="weekly-pay-significant-changes-pay-rates-answer-0"]').click()
+    return this
+  }
+
+  clickWeeklyPaySignificantChangesPayRatesAnswerNo() {
+    browser.element('[id="weekly-pay-significant-changes-pay-rates-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new WeeklyPaySignificantChangesPayRatesPage()

--- a/tests/functional/pages/surveys/mwss/weekly-pay-significant-changes-redundancies.page.js
+++ b/tests/functional/pages/surveys/mwss/weekly-pay-significant-changes-redundancies.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class WeeklyPaySignificantChangesRedundanciesPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('weekly-pay-significant-changes-redundancies')
+  }
+
+  clickWeeklyPaySignificantChangesRedundanciesAnswerYes() {
+    browser.element('[id="weekly-pay-significant-changes-redundancies-answer-0"]').click()
+    return this
+  }
+
+  clickWeeklyPaySignificantChangesRedundanciesAnswerNo() {
+    browser.element('[id="weekly-pay-significant-changes-redundancies-answer-1"]').click()
+    return this
+  }
+
+}
+
+export default new WeeklyPaySignificantChangesRedundanciesPage()

--- a/tests/functional/pages/surveys/mwss/weekly-pay-significant-changes-temp-employees.page.js
+++ b/tests/functional/pages/surveys/mwss/weekly-pay-significant-changes-temp-employees.page.js
@@ -1,0 +1,28 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class WeeklyPaySignificantChangesTempEmployeesPage extends MultipleChoiceWithOtherPage {
+
+  constructor() {
+    super('weekly-pay-significant-changes-temp-employees')
+  }
+
+  clickWeeklyPaySignificantChangesTempEmployeesAnswerMoreTemporaryStaff() {
+    browser.element('[id="weekly-pay-significant-changes-temp-employees-answer-0"]').click()
+    return this
+  }
+
+  clickWeeklyPaySignificantChangesTempEmployeesAnswerFewerTemporaryStaff() {
+    browser.element('[id="weekly-pay-significant-changes-temp-employees-answer-1"]').click()
+    return this
+  }
+
+  clickWeeklyPaySignificantChangesTempEmployeesAnswerNoSignificantChange() {
+    browser.element('[id="weekly-pay-significant-changes-temp-employees-answer-2"]').click()
+    return this
+  }
+
+}
+
+export default new WeeklyPaySignificantChangesTempEmployeesPage()

--- a/tests/functional/spec/mwss-core.spec.js
+++ b/tests/functional/spec/mwss-core.spec.js
@@ -1,0 +1,242 @@
+import chai from 'chai'
+import {startQuestionnaire} from '../helpers'
+
+import PayPatternFrequency from '../pages/surveys/mwss/pay-pattern-frequency.page.js'
+import WeeklyPayIntroduction from '../pages/surveys/mwss/weekly-pay-introduction.page.js'
+import WeeklyPayPaidEmployees from '../pages/surveys/mwss/weekly-pay-paid-employees.page.js'
+import WeeklyPayGrossPay from '../pages/surveys/mwss/weekly-pay-gross-pay.page.js'
+import WeeklyPayBreakdown from '../pages/surveys/mwss/weekly-pay-breakdown.page.js'
+import WeeklyPaySignificantChangesPaidEmployees from '../pages/surveys/mwss/weekly-pay-significant-changes-paid-employees.page.js'
+import WeeklyPaySignificantChangesRedundancies from '../pages/surveys/mwss/weekly-pay-significant-changes-redundancies.page.js'
+import WeeklyPaySignificantChangesTempEmployees from '../pages/surveys/mwss/weekly-pay-significant-changes-temp-employees.page.js'
+import WeeklyPaySignificantChangesGrossPay from '../pages/surveys/mwss/weekly-pay-significant-changes-gross-pay.page.js'
+import WeeklyPaySignificantChangesOvertime from '../pages/surveys/mwss/weekly-pay-significant-changes-overtime.page.js'
+import WeeklyPaySignificantChangesPayRates from '../pages/surveys/mwss/weekly-pay-significant-changes-pay-rates.page.js'
+import WeeklyPaySignificantChangesPayRatesIncrease from '../pages/surveys/mwss/weekly-pay-significant-changes-pay-rates-increase.page.js'
+import WeeklyPaySignificantChangesIndustrialAction from '../pages/surveys/mwss/weekly-pay-significant-changes-industrial-action.page.js'
+import WeeklyPaySignificantChangesOther from '../pages/surveys/mwss/weekly-pay-significant-changes-other.page.js'
+import WeeklyPaySignificantChangesOtherSpecify from '../pages/surveys/mwss/weekly-pay-significant-changes-other-specify.page.js'
+import FortnightlyPayIntroduction from '../pages/surveys/mwss/fortnightly-pay-introduction.page.js'
+import FortnightlyPayPaidEmployees from '../pages/surveys/mwss/fortnightly-pay-paid-employees.page.js'
+import FortnightlyPayGrossPay from '../pages/surveys/mwss/fortnightly-pay-gross-pay.page.js'
+import FortnightlyPayBreakdown from '../pages/surveys/mwss/fortnightly-pay-breakdown.page.js'
+import FortnightlyPaySignificantChangesPaidEmployees from '../pages/surveys/mwss/fortnightly-pay-significant-changes-paid-employees.page.js'
+import FortnightlyPaySignificantChangesRedundancies from '../pages/surveys/mwss/fortnightly-pay-significant-changes-redundancies.page.js'
+import FortnightlyPaySignificantChangesTempEmployees from '../pages/surveys/mwss/fortnightly-pay-significant-changes-temp-employees.page.js'
+import FortnightlyPaySignificantChangesGrossPay from '../pages/surveys/mwss/fortnightly-pay-significant-changes-gross-pay.page.js'
+import FortnightlyPaySignificantChangesOvertime from '../pages/surveys/mwss/fortnightly-pay-significant-changes-overtime.page.js'
+import FortnightlyPaySignificantChangesPayRates from '../pages/surveys/mwss/fortnightly-pay-significant-changes-pay-rates.page.js'
+import FortnightlyPaySignificantChangesPayRatesIncrease from '../pages/surveys/mwss/fortnightly-pay-significant-changes-pay-rates-increase.page.js'
+import FortnightlyPaySignificantChangesIndustrialAction from '../pages/surveys/mwss/fortnightly-pay-significant-changes-industrial-action.page.js'
+import FortnightlyPaySignificantChangesOther from '../pages/surveys/mwss/fortnightly-pay-significant-changes-other.page.js'
+import FortnightlyPaySignificantChangesOtherSpecify from '../pages/surveys/mwss/fortnightly-pay-significant-changes-other-specify.page.js'
+import CalendarMonthlyPayIntroduction from '../pages/surveys/mwss/calendar-monthly-pay-introduction.page.js'
+import CalendarMonthlyPayPaidEmployees from '../pages/surveys/mwss/calendar-monthly-pay-paid-employees.page.js'
+import CalendarMonthlyPayGrossPay from '../pages/surveys/mwss/calendar-monthly-pay-gross-pay.page.js'
+import CalendarMonthlyPayBreakdown from '../pages/surveys/mwss/calendar-monthly-pay-breakdown.page.js'
+import CalendarMonthlyPaySignificantChangesPaidEmployees from '../pages/surveys/mwss/calendar-monthly-pay-significant-changes-paid-employees.page.js'
+import CalendarMonthlyPaySignificantChangesRedundancies from '../pages/surveys/mwss/calendar-monthly-pay-significant-changes-redundancies.page.js'
+import CalendarMonthlyPaySignificantChangesTempEmployees from '../pages/surveys/mwss/calendar-monthly-pay-significant-changes-temp-employees.page.js'
+import CalendarMonthlyPaySignificantChangesGrossPay from '../pages/surveys/mwss/calendar-monthly-pay-significant-changes-gross-pay.page.js'
+import CalendarMonthlyPaySignificantChangesOvertime from '../pages/surveys/mwss/calendar-monthly-pay-significant-changes-overtime.page.js'
+import CalendarMonthlyPaySignificantChangesPayRates from '../pages/surveys/mwss/calendar-monthly-pay-significant-changes-pay-rates.page.js'
+import CalendarMonthlyPaySignificantChangesPayRatesIncrease from '../pages/surveys/mwss/calendar-monthly-pay-significant-changes-pay-rates-increase.page.js'
+import CalendarMonthlyPaySignificantChangesIndustrialAction from '../pages/surveys/mwss/calendar-monthly-pay-significant-changes-industrial-action.page.js'
+import CalendarMonthlyPaySignificantChangesOther from '../pages/surveys/mwss/calendar-monthly-pay-significant-changes-other.page.js'
+import CalendarMonthlyPaySignificantChangesOtherSpecify from '../pages/surveys/mwss/calendar-monthly-pay-significant-changes-other-specify.page.js'
+import FourWeeklyPayIntroduction from '../pages/surveys/mwss/four-weekly-pay-introduction.page.js'
+import FourWeeklyPayPaidEmployees from '../pages/surveys/mwss/four-weekly-pay-paid-employees.page.js'
+import FourWeeklyPayGrossPay from '../pages/surveys/mwss/four-weekly-pay-gross-pay.page.js'
+import FourWeeklyPayBreakdown from '../pages/surveys/mwss/four-weekly-pay-breakdown.page.js'
+import FourWeeklyPaySignificantChangesPaidEmployees from '../pages/surveys/mwss/four-weekly-pay-significant-changes-paid-employees.page.js'
+import FourWeeklyPaySignificantChangesRedundancies from '../pages/surveys/mwss/four-weekly-pay-significant-changes-redundancies.page.js'
+import FourWeeklyPaySignificantChangesTempEmployees from '../pages/surveys/mwss/four-weekly-pay-significant-changes-temp-employees.page.js'
+import FourWeeklyPaySignificantChangesGrossPay from '../pages/surveys/mwss/four-weekly-pay-significant-changes-gross-pay.page.js'
+import FourWeeklyPaySignificantChangesOvertime from '../pages/surveys/mwss/four-weekly-pay-significant-changes-overtime.page.js'
+import FourWeeklyPaySignificantChangesPayRates from '../pages/surveys/mwss/four-weekly-pay-significant-changes-pay-rates.page.js'
+import FourWeeklyPaySignificantChangesPayRatesIncrease from '../pages/surveys/mwss/four-weekly-pay-significant-changes-pay-rates-increase.page.js'
+import FourWeeklyPaySignificantChangesIndustrialAction from '../pages/surveys/mwss/four-weekly-pay-significant-changes-industrial-action.page.js'
+import FourWeeklyPaySignificantChangesOther from '../pages/surveys/mwss/four-weekly-pay-significant-changes-other.page.js'
+import FourWeeklyPaySignificantChangesOtherSpecify from '../pages/surveys/mwss/four-weekly-pay-significant-changes-other-specify.page.js'
+import FiveWeeklyPayIntroduction from '../pages/surveys/mwss/five-weekly-pay-introduction.page.js'
+import FiveWeeklyPayPaidEmployees from '../pages/surveys/mwss/five-weekly-pay-paid-employees.page.js'
+import FiveWeeklyPayGrossPay from '../pages/surveys/mwss/five-weekly-pay-gross-pay.page.js'
+import FiveWeeklyPayBreakdown from '../pages/surveys/mwss/five-weekly-pay-breakdown.page.js'
+import FiveWeeklyPaySignificantChangesPaidEmployees from '../pages/surveys/mwss/five-weekly-pay-significant-changes-paid-employees.page.js'
+import FiveWeeklyPaySignificantChangesRedundancies from '../pages/surveys/mwss/five-weekly-pay-significant-changes-redundancies.page.js'
+import FiveWeeklyPaySignificantChangesTempEmployees from '../pages/surveys/mwss/five-weekly-pay-significant-changes-temp-employees.page.js'
+import FiveWeeklyPaySignificantChangesGrossPay from '../pages/surveys/mwss/five-weekly-pay-significant-changes-gross-pay.page.js'
+import FiveWeeklyPaySignificantChangesOvertime from '../pages/surveys/mwss/five-weekly-pay-significant-changes-overtime.page.js'
+import FiveWeeklyPaySignificantChangesPayRates from '../pages/surveys/mwss/five-weekly-pay-significant-changes-pay-rates.page.js'
+import FiveWeeklyPaySignificantChangesPayRatesIncrease from '../pages/surveys/mwss/five-weekly-pay-significant-changes-pay-rates-increase.page.js'
+import FiveWeeklyPaySignificantChangesIndustrialAction from '../pages/surveys/mwss/five-weekly-pay-significant-changes-industrial-action.page.js'
+import FiveWeeklyPaySignificantChangesOther from '../pages/surveys/mwss/five-weekly-pay-significant-changes-other.page.js'
+import FiveWeeklyPaySignificantChangesOtherSpecify from '../pages/surveys/mwss/five-weekly-pay-significant-changes-other-specify.page.js'
+import GeneralCommentsIntroduction from '../pages/surveys/mwss/general-comments-introduction.page.js'
+import GeneralComments from '../pages/surveys/mwss/general-comments.page.js'
+import Confirmation from '../pages/surveys/mwss/confirmation.page.js'
+import ThankYou from '../pages/thank-you.page'
+
+
+const expect = chai.expect
+
+describe('MWSS Core', function() {
+
+    it('Given I am completing MWSS, When I have all pay patters, Then I can submit data for every pattern', function() {
+        startQuestionnaire('1_0005.json')
+
+        PayPatternFrequency.clickPayPatternFrequencyAnswerWeekly()
+        PayPatternFrequency.clickPayPatternFrequencyAnswerFortnightly()
+        PayPatternFrequency.clickPayPatternFrequencyAnswerCalendarMonthly()
+        PayPatternFrequency.clickPayPatternFrequencyAnswerFourWeekly()
+        PayPatternFrequency.clickPayPatternFrequencyAnswerFiveWeekly()
+        PayPatternFrequency.submit()
+
+        // Weekly Pay
+        WeeklyPayIntroduction.submit()
+        WeeklyPayPaidEmployees.setWeeklyPayPaidEmployeesAnswer(5).submit()
+        WeeklyPayGrossPay.setWeeklyPayGrossPayAnswer(445566).submit()
+
+        WeeklyPayBreakdown.setWeeklyPayBreakdownHolidayAnswer(112233)
+        WeeklyPayBreakdown.setWeeklyPayBreakdownArrearsAnswer(334455)
+        WeeklyPayBreakdown.setWeeklyPayBreakdownPrpAnswer(556677)
+        WeeklyPayBreakdown.submit()
+
+        WeeklyPaySignificantChangesPaidEmployees.clickWeeklyPaySignificantChangesPaidEmployeesAnswerYes().submit()
+        WeeklyPaySignificantChangesRedundancies.clickWeeklyPaySignificantChangesRedundanciesAnswerYes().submit()
+        WeeklyPaySignificantChangesTempEmployees.clickWeeklyPaySignificantChangesTempEmployeesAnswerFewerTemporaryStaff().submit()
+        WeeklyPaySignificantChangesGrossPay.clickWeeklyPaySignificantChangesGrossPayAnswerYes().submit()
+        WeeklyPaySignificantChangesOvertime.clickWeeklyPaySignificantChangesOvertimeAnswerMoreOvertime().submit()
+        WeeklyPaySignificantChangesPayRates.clickWeeklyPaySignificantChangesPayRatesAnswerYes().submit()
+
+        WeeklyPaySignificantChangesPayRatesIncrease.setWeeklyPaySignificantChangesPayRatesIncreasePercentIncreaseAnswer(50)
+        WeeklyPaySignificantChangesPayRatesIncrease.setWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerDay(1)
+        WeeklyPaySignificantChangesPayRatesIncrease.setWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerMonth(2)
+        WeeklyPaySignificantChangesPayRatesIncrease.setWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerYear(2016)
+        WeeklyPaySignificantChangesPayRatesIncrease.setWeeklyPaySignificantChangesPayRatesIncreasePercentEmployeesAnswer(25)
+        WeeklyPaySignificantChangesPayRatesIncrease.submit()
+
+        WeeklyPaySignificantChangesIndustrialAction.clickWeeklyPaySignificantChangesIndustrialActionAnswerYes().submit()
+        WeeklyPaySignificantChangesOther.clickWeeklyPaySignificantChangesOtherAnswerYes().submit()
+        WeeklyPaySignificantChangesOtherSpecify.setWeeklyPaySignificantChangesOtherSpecifyAnswer('Pipe mania').submit()
+
+
+        // Fortnightly Pay
+        FortnightlyPayIntroduction.submit()
+        FortnightlyPayPaidEmployees.setFortnightlyPayPaidEmployeesAnswer(10).submit()
+        FortnightlyPayGrossPay.setFortnightlyPayGrossPayAnswer(123123).submit()
+
+        FortnightlyPayBreakdown.setFortnightlyPayBreakdownHolidayAnswer(456456)
+        FortnightlyPayBreakdown.setFortnightlyPayBreakdownArrearsAnswer(789789)
+        FortnightlyPayBreakdown.setFortnightlyPayBreakdownPrpAnswer(101010)
+        FortnightlyPayBreakdown.submit()
+
+        FortnightlyPaySignificantChangesPaidEmployees.clickFortnightlyPaySignificantChangesPaidEmployeesAnswerYes().submit()
+        FortnightlyPaySignificantChangesRedundancies.clickFortnightlyPaySignificantChangesRedundanciesAnswerYes().submit()
+        FortnightlyPaySignificantChangesTempEmployees.clickFortnightlyPaySignificantChangesTempEmployeesAnswerFewerTemporaryStaff().submit()
+        FortnightlyPaySignificantChangesGrossPay.clickFortnightlyPaySignificantChangesGrossPayAnswerYes().submit()
+        FortnightlyPaySignificantChangesOvertime.clickFortnightlyPaySignificantChangesOvertimeAnswerMoreOvertime().submit()
+        FortnightlyPaySignificantChangesPayRates.clickFortnightlyPaySignificantChangesPayRatesAnswerYes().submit()
+
+        FortnightlyPaySignificantChangesPayRatesIncrease.setFortnightlyPaySignificantChangesPayRatesIncreasePercentIncreaseAnswer(60)
+        FortnightlyPaySignificantChangesPayRatesIncrease.setFortnightlyPaySignificantChangesPayRatesIncreaseDateFromAnswerDay(2)
+        FortnightlyPaySignificantChangesPayRatesIncrease.setFortnightlyPaySignificantChangesPayRatesIncreaseDateFromAnswerMonth(3)
+        FortnightlyPaySignificantChangesPayRatesIncrease.setFortnightlyPaySignificantChangesPayRatesIncreaseDateFromAnswerYear(2017)
+        FortnightlyPaySignificantChangesPayRatesIncrease.setFortnightlyPaySignificantChangesPayRatesIncreasePercentEmployeesAnswer(30)
+        FortnightlyPaySignificantChangesPayRatesIncrease.submit()
+
+        FortnightlyPaySignificantChangesIndustrialAction.clickFortnightlyPaySignificantChangesIndustrialActionAnswerYes().submit()
+        FortnightlyPaySignificantChangesOther.clickFortnightlyPaySignificantChangesOtherAnswerYes().submit()
+        FortnightlyPaySignificantChangesOtherSpecify.setFortnightlyPaySignificantChangesOtherSpecifyAnswer('Gas leak').submit()
+
+
+        // Calendar Monthly Pay
+        CalendarMonthlyPayIntroduction.submit()
+        CalendarMonthlyPayPaidEmployees.setCalendarMonthlyPayPaidEmployeesAnswer(20).submit()
+        CalendarMonthlyPayGrossPay.setCalendarMonthlyPayGrossPayAnswer(321321).submit()
+
+        CalendarMonthlyPayBreakdown.setCalendarMonthlyPayBreakdownArrearsAnswer(121212)
+        CalendarMonthlyPayBreakdown.setCalendarMonthlyPayBreakdownPrpAnswer(999999)
+        CalendarMonthlyPayBreakdown.submit()
+
+        CalendarMonthlyPaySignificantChangesPaidEmployees.clickCalendarMonthlyPaySignificantChangesPaidEmployeesAnswerYes().submit()
+        CalendarMonthlyPaySignificantChangesRedundancies.clickCalendarMonthlyPaySignificantChangesRedundanciesAnswerYes().submit()
+        CalendarMonthlyPaySignificantChangesTempEmployees.clickCalendarMonthlyPaySignificantChangesTempEmployeesAnswerFewerTemporaryStaff().submit()
+        CalendarMonthlyPaySignificantChangesGrossPay.clickCalendarMonthlyPaySignificantChangesGrossPayAnswerYes().submit()
+        CalendarMonthlyPaySignificantChangesOvertime.clickCalendarMonthlyPaySignificantChangesOvertimeAnswerMoreOvertime().submit()
+        CalendarMonthlyPaySignificantChangesPayRates.clickCalendarMonthlyPaySignificantChangesPayRatesAnswerYes().submit()
+
+        CalendarMonthlyPaySignificantChangesPayRatesIncrease.setCalendarMonthlyPaySignificantChangesPayRatesIncreasePercentIncreaseAnswer(70)
+        CalendarMonthlyPaySignificantChangesPayRatesIncrease.setCalendarMonthlyPaySignificantChangesPayRatesIncreaseDateFromAnswerDay(3)
+        CalendarMonthlyPaySignificantChangesPayRatesIncrease.setCalendarMonthlyPaySignificantChangesPayRatesIncreaseDateFromAnswerMonth(4)
+        CalendarMonthlyPaySignificantChangesPayRatesIncrease.setCalendarMonthlyPaySignificantChangesPayRatesIncreaseDateFromAnswerYear(2018)
+        CalendarMonthlyPaySignificantChangesPayRatesIncrease.setCalendarMonthlyPaySignificantChangesPayRatesIncreasePercentEmployeesAnswer(40)
+        CalendarMonthlyPaySignificantChangesPayRatesIncrease.submit()
+
+        CalendarMonthlyPaySignificantChangesIndustrialAction.clickCalendarMonthlyPaySignificantChangesIndustrialActionAnswerYes().submit()
+        CalendarMonthlyPaySignificantChangesOther.clickCalendarMonthlyPaySignificantChangesOtherAnswerYes().submit()
+        CalendarMonthlyPaySignificantChangesOtherSpecify.setCalendarMonthlyPaySignificantChangesOtherSpecifyAnswer('copper pipe').submit()
+
+
+        // Four Weekly Pay
+        FourWeeklyPayIntroduction.submit()
+        FourWeeklyPayPaidEmployees.setFourWeeklyPayPaidEmployeesAnswer(30).submit()
+        FourWeeklyPayGrossPay.setFourWeeklyPayGrossPayAnswer(98765).submit()
+
+        FourWeeklyPayBreakdown.setFourWeeklyPayBreakdownArrearsAnswer(443322)
+        FourWeeklyPayBreakdown.setFourWeeklyPayBreakdownPrpAnswer(767676)
+        FourWeeklyPayBreakdown.submit()
+
+        FourWeeklyPaySignificantChangesPaidEmployees.clickFourWeeklyPaySignificantChangesPaidEmployeesAnswerYes().submit()
+        FourWeeklyPaySignificantChangesRedundancies.clickFourWeeklyPaySignificantChangesRedundanciesAnswerYes().submit()
+        FourWeeklyPaySignificantChangesTempEmployees.clickFourWeeklyPaySignificantChangesTempEmployeesAnswerFewerTemporaryStaff().submit()
+        FourWeeklyPaySignificantChangesGrossPay.clickFourWeeklyPaySignificantChangesGrossPayAnswerYes().submit()
+        FourWeeklyPaySignificantChangesOvertime.clickFourWeeklyPaySignificantChangesOvertimeAnswerMoreOvertime().submit()
+        FourWeeklyPaySignificantChangesPayRates.clickFourWeeklyPaySignificantChangesPayRatesAnswerYes().submit()
+
+        FourWeeklyPaySignificantChangesPayRatesIncrease.setFourWeeklyPaySignificantChangesPayRatesIncreasePercentIncreaseAnswer(80)
+        FourWeeklyPaySignificantChangesPayRatesIncrease.setFourWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerDay(4)
+        FourWeeklyPaySignificantChangesPayRatesIncrease.setFourWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerMonth(5)
+        FourWeeklyPaySignificantChangesPayRatesIncrease.setFourWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerYear(2019)
+        FourWeeklyPaySignificantChangesPayRatesIncrease.setFourWeeklyPaySignificantChangesPayRatesIncreasePercentEmployeesAnswer(50)
+        FourWeeklyPaySignificantChangesPayRatesIncrease.submit()
+
+        FourWeeklyPaySignificantChangesIndustrialAction.clickFourWeeklyPaySignificantChangesIndustrialActionAnswerYes().submit()
+        FourWeeklyPaySignificantChangesOther.clickFourWeeklyPaySignificantChangesOtherAnswerYes().submit()
+        FourWeeklyPaySignificantChangesOtherSpecify.setFourWeeklyPaySignificantChangesOtherSpecifyAnswer('solder joint').submit()
+
+
+        // Five Weekly Pay
+        FiveWeeklyPayIntroduction.submit()
+        FiveWeeklyPayPaidEmployees.setFiveWeeklyPayPaidEmployeesAnswer(40).submit()
+        FiveWeeklyPayGrossPay.setFiveWeeklyPayGrossPayAnswer(13134).submit()
+
+        FiveWeeklyPayBreakdown.setFiveWeeklyPayBreakdownArrearsAnswer(989)
+        FiveWeeklyPayBreakdown.setFiveWeeklyPayBreakdownPrpAnswer(9112)
+        FiveWeeklyPayBreakdown.submit()
+
+        FiveWeeklyPaySignificantChangesPaidEmployees.clickFiveWeeklyPaySignificantChangesPaidEmployeesAnswerYes().submit()
+        FiveWeeklyPaySignificantChangesRedundancies.clickFiveWeeklyPaySignificantChangesRedundanciesAnswerYes().submit()
+        FiveWeeklyPaySignificantChangesTempEmployees.clickFiveWeeklyPaySignificantChangesTempEmployeesAnswerFewerTemporaryStaff().submit()
+        FiveWeeklyPaySignificantChangesGrossPay.clickFiveWeeklyPaySignificantChangesGrossPayAnswerYes().submit()
+        FiveWeeklyPaySignificantChangesOvertime.clickFiveWeeklyPaySignificantChangesOvertimeAnswerMoreOvertime().submit()
+        FiveWeeklyPaySignificantChangesPayRates.clickFiveWeeklyPaySignificantChangesPayRatesAnswerYes().submit()
+
+        FiveWeeklyPaySignificantChangesPayRatesIncrease.setFiveWeeklyPaySignificantChangesPayRatesIncreasePercentIncreaseAnswer(90)
+        FiveWeeklyPaySignificantChangesPayRatesIncrease.setFiveWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerDay(5)
+        FiveWeeklyPaySignificantChangesPayRatesIncrease.setFiveWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerMonth(6)
+        FiveWeeklyPaySignificantChangesPayRatesIncrease.setFiveWeeklyPaySignificantChangesPayRatesIncreaseDateFromAnswerYear(2020)
+        FiveWeeklyPaySignificantChangesPayRatesIncrease.setFiveWeeklyPaySignificantChangesPayRatesIncreasePercentEmployeesAnswer(60)
+        FiveWeeklyPaySignificantChangesPayRatesIncrease.submit()
+
+        FiveWeeklyPaySignificantChangesIndustrialAction.clickFiveWeeklyPaySignificantChangesIndustrialActionAnswerYes().submit()
+        FiveWeeklyPaySignificantChangesOther.clickFiveWeeklyPaySignificantChangesOtherAnswerYes().submit()
+        FiveWeeklyPaySignificantChangesOtherSpecify.setFiveWeeklyPaySignificantChangesOtherSpecifyAnswer('drill hole').submit()
+
+        GeneralCommentsIntroduction.submit()
+        GeneralComments.setGeneralCommentsAnswer('flux clean').submit()
+        Confirmation.submit()
+
+        expect(ThankYou.isOpen()).to.be.true
+    })
+})


### PR DESCRIPTION
### What is the context of this PR?
- Re-generated MWSS schema from latest Google Slides and merged the differences.
- Added all q_codes (from slides)
- Updated id values in schema to be more meaningful
- Added validation messages (based on previous questionnaires)
- Switched exercise dates to piped values from RRM

### Todo
- [x] Check validation message content is acceptable with DCM - confirmed with Emma Timm; all good.
- [x] Either support PositiveInteger question types displaying a `description` or agree with DCM to remove it from the schema (it currently doesn't display on question 2.10, 3.10, 4.10 etc. "Please enter the percentage or number of staff affected". - Confirmed with Emma Timm; removed content.
- [x] Rename the schema to match the RRM expected id_code (1_0005.json) - Confirmed this is the number.
- [x] Update survey_id and questionnaire_id in schema to correct values (are these used?)
- [x] Rebase and squash
- [x]  Pipe period string  (re-use period_str in the header) in place of [[PIPE MONTH YYYY]] placeholder; will require a code change. - Confirmed with Emma Timm - can use the Period String as suggested.
- [x] Happy path selenium test.
- [x] Code review
