### PR TITLE
Amend Apache error log format to just log application log line

### DIFF
--- a/app-httpd.conf
+++ b/app-httpd.conf
@@ -3,3 +3,5 @@ Alias /s /opt/python/current/app/static
 Order allow,deny
 Allow from all
 </Directory>
+
+ErrorLogFormat "%M"


### PR DESCRIPTION
### What is the context of this PR?
This removes all of the default Apache error log line content, leaving just the application log line. This is needed so that it can be easily ingested and searched by log search tools like Cloudwatch and Splunk.

### How to review 
Deploy survey runner to AWS and check CloudWatch apache error log contains just JSON in the log lines.