### PR TITLE
Limit repeats for minus_one rule

### DIFF
--- a/app/questionnaire/rules.py
+++ b/app/questionnaire/rules.py
@@ -52,9 +52,9 @@ def evaluate_repeat(repeat_rule, answer_store):
     :return: The number of times to repeat
     """
     repeat_functions = {
-        'answer_value': _get_answer_value(),
+        'answer_value': _get_answer_value,
         'answer_count': len,
-        'answer_count_minus_one': _get_answer_count_minus_one(),
+        'answer_count_minus_one': _get_answer_count_or_repeat_limit_minus_one,
     }
     if 'answer_id' in repeat_rule and 'type' in repeat_rule:
         repeat_index = repeat_rule['answer_id']
@@ -69,13 +69,14 @@ def evaluate_repeat(repeat_rule, answer_store):
         return no_of_repeats
 
 
-def _get_answer_value():
-    return lambda filtered_answers: int(
-        filtered_answers[0]['value'] if len(filtered_answers) == 1 and filtered_answers[0]['value'] else 0)
+def _get_answer_value(filtered_answers):
+    return int(filtered_answers[0]['value'] if len(filtered_answers) == 1 and filtered_answers[0]['value'] else 0)
 
 
-def _get_answer_count_minus_one():
-    return lambda filtered_answers: len(filtered_answers) - 1 if len(filtered_answers) > 0 else 0
+def _get_answer_count_or_repeat_limit_minus_one(filtered_answers):
+    max_repeat_minus_one = settings.EQ_MAX_NUM_REPEATS - 1
+    answers_minus_one = len(filtered_answers) - 1 if len(filtered_answers) > 0 else 0
+    return min(answers_minus_one, max_repeat_minus_one)
 
 
 def evaluate_skip_condition(skip_condition, metadata, answer_store, group_instance=0):

--- a/tests/app/questionnaire/test_rules.py
+++ b/tests/app/questionnaire/test_rules.py
@@ -411,3 +411,18 @@ class TestRules(TestCase):  # pylint: disable=too-many-public-methods
         number_of_repeats = evaluate_repeat(repeat, answer_store)
 
         self.assertEqual(number_of_repeats, 1)
+
+    def test_should_minus_one_from_maximum_repeats(self):
+        # Given
+        repeat = {
+            'answer_id': 'my_answer',
+            'type': 'answer_count_minus_one'
+        }
+        answer_store = AnswerStore()
+        for i in range(27):
+            answer_store.add(Answer(answer_id='my_answer', value='3', answer_instance=i))
+
+        # When
+        number_of_repeats = evaluate_repeat(repeat, answer_store)
+
+        self.assertEqual(number_of_repeats, 24)

--- a/tests/integration/downstream/test_downstream_data_typing.py
+++ b/tests/integration/downstream/test_downstream_data_typing.py
@@ -1,5 +1,6 @@
 from tests.integration.create_token import create_token
 from tests.integration.downstream.downstream_test_case import DownstreamTestCase
+from tests.integration.navigation import navigate_to_page
 from tests.integration.star_wars import star_wars_test_urls, BLOCK_2_DEFAULT_ANSWERS
 from tests.integration.star_wars.star_wars_tests import StarWarsTestCase
 
@@ -20,7 +21,7 @@ class TestDownstreamDataTyping(DownstreamTestCase, StarWarsTestCase):
 
         # Second page
         second_page = resp.location
-        resp = self.navigate_to_page(second_page)
+        resp = navigate_to_page(self.client, second_page)
         content = resp.get_data(True)
 
         # Pipe Test for section title
@@ -43,7 +44,7 @@ class TestDownstreamDataTyping(DownstreamTestCase, StarWarsTestCase):
 
         # third page
         third_page = resp.location
-        resp = self.navigate_to_page(third_page)
+        resp = navigate_to_page(self.client, third_page)
         content = resp.get_data(True)
 
         self.assertRegex(content, "Finally, which  is your favourite film?")
@@ -63,7 +64,7 @@ class TestDownstreamDataTyping(DownstreamTestCase, StarWarsTestCase):
 
         summary_url = resp.location
 
-        self.navigate_to_page(summary_url)
+        navigate_to_page(self.client, summary_url)
 
         self.complete_survey('star_wars')
 

--- a/tests/integration/household_composition/test_household_question.py
+++ b/tests/integration/household_composition/test_household_question.py
@@ -2,6 +2,7 @@ from werkzeug.datastructures import MultiDict
 
 from tests.integration.create_token import create_token
 from tests.integration.integration_test_case import IntegrationTestCase
+from tests.integration.navigation import navigate_to_page
 
 
 class TestHouseholdQuestion(IntegrationTestCase):
@@ -127,7 +128,7 @@ class TestHouseholdQuestion(IntegrationTestCase):
 
         self.assertEqual(resp.status_code, 200)
 
-        resp = self.navigate_to_page(page)
+        resp = navigate_to_page(self.client, page)
         content = resp.get_data(True)
         form_data.add("household-0-first-name", 'John')
         form_data.add("household-2-first-name", 'Joe')
@@ -179,11 +180,6 @@ class TestHouseholdQuestion(IntegrationTestCase):
         self.assertEqual(resp.status_code, 302)
 
         return resp.location
-
-    def navigate_to_page(self, page):
-        resp = self.client.get(page, follow_redirects=False)
-        self.assertEqual(resp.status_code, 200)
-        return resp
 
     def household_answer_correct(self, resp_url, answer):
         form_data = MultiDict()

--- a/tests/integration/household_composition/test_repeating_household.py
+++ b/tests/integration/household_composition/test_repeating_household.py
@@ -2,6 +2,7 @@ from werkzeug.datastructures import MultiDict
 
 from tests.integration.create_token import create_token
 from tests.integration.integration_test_case import IntegrationTestCase
+from tests.integration.navigation import navigate_to_page
 
 
 class TestRepeatingHousehold(IntegrationTestCase):
@@ -39,35 +40,35 @@ class TestRepeatingHousehold(IntegrationTestCase):
         person1_age_page = resp.location
 
         # And provide details
-        self.navigate_to_page(person1_age_page)
+        navigate_to_page(self.client, person1_age_page)
         form_data = MultiDict()
         form_data.add("what-is-your-age", '9990')
         form_data.add("action[save_continue]", '')
         resp = self.client.post(person1_age_page, data=form_data, follow_redirects=False)
         person1_shoe_size_page = resp.location
 
-        self.navigate_to_page(person1_shoe_size_page)
+        navigate_to_page(self.client, person1_shoe_size_page)
         form_data = MultiDict()
         form_data.add("what-is-your-shoe-size", '9991')
         form_data.add("action[save_continue]", '')
         resp = self.client.post(person1_shoe_size_page, data=form_data, follow_redirects=False)
         person2_age_page = resp.location
 
-        self.navigate_to_page(person2_age_page)
+        navigate_to_page(self.client, person2_age_page)
         form_data = MultiDict()
         form_data.add("what-is-your-age", '9992')
         form_data.add("action[save_continue]", '')
         resp = self.client.post(person2_age_page, data=form_data, follow_redirects=False)
         person2_shoe_size_page = resp.location
 
-        self.navigate_to_page(person2_shoe_size_page)
+        navigate_to_page(self.client, person2_shoe_size_page)
         form_data = MultiDict()
         form_data.add("what-is-your-shoe-size", '9993')
         form_data.add("action[save_continue]", '')
         self.client.post(person2_shoe_size_page, data=form_data, follow_redirects=False)
 
         # When I go back to household composition page and make changes and submit
-        self.navigate_to_page(household_composition_page)
+        navigate_to_page(self.client, household_composition_page)
         form_data = MultiDict()
 
         form_data.add("household-0-first-name", 'Joe')
@@ -120,14 +121,14 @@ class TestRepeatingHousehold(IntegrationTestCase):
         person1_age_page = resp.location
 
         # And provide details
-        self.navigate_to_page(person1_age_page)
+        navigate_to_page(self.client, person1_age_page)
         form_data = MultiDict()
         form_data.add("what-is-your-age", '18')
         form_data.add("action[save_continue]", '')
         self.client.post(person1_age_page, data=form_data, follow_redirects=False)
 
         # When I go back to household composition page and submit without any changes
-        self.navigate_to_page(household_composition_page)
+        navigate_to_page(self.client, household_composition_page)
 
         resp = self.client.post(household_composition_page, data=household_data, follow_redirects=True)
 
@@ -136,8 +137,3 @@ class TestRepeatingHousehold(IntegrationTestCase):
         self.assertRegex(content, 'Joe Bloggs')
         self.assertRegex(content, 'What is their age')
         self.assertRegex(content, '18')
-
-    def navigate_to_page(self, page):
-        resp = self.client.get(page, follow_redirects=False)
-        self.assertEqual(resp.status_code, 200)
-        return resp

--- a/tests/integration/household_composition/test_repeating_relationship.py
+++ b/tests/integration/household_composition/test_repeating_relationship.py
@@ -1,0 +1,37 @@
+from tests.integration.create_token import create_token
+from tests.integration.integration_test_case import IntegrationTestCase
+
+
+class TestRepeatingRelationship(IntegrationTestCase):
+
+    def setUp(self):
+        super(TestRepeatingRelationship, self).setUp()
+
+        self.token = create_token('household', 'census')
+        resp = self.client.get('/session?token=' + self.token.decode(), follow_redirects=False)
+        is_home = {'permanent-or-family-home-answer': 'Yes'}
+        resp = self.client.post(resp.location, data=is_home, follow_redirects=False)
+        self.household_composition_location = resp.location
+
+    def test_should_ask_twenty_four_relationships_when_twenty_five_max_limit_and_twenty_six_people_added(self):
+        # Given
+        answer_id = 'household-{instance}-first-name'
+        save_continue = {'action[save_continue]': ''}
+        twenty_six_people = save_continue.copy()
+        for i in range(27):
+            twenty_six_people[answer_id.format(instance=i)] = 'Joe'
+
+        # When
+        resp = self.client.post(self.household_composition_location, data=twenty_six_people, follow_redirects=False)
+        self.answer_mandatory_visitors_question(resp, save_continue)
+
+        # Then
+        last_relationship_page = 'questionnaire/census/household/789/who-lives-here-relationship/23/household-relationships'
+        resp = self.client.post(last_relationship_page, data=save_continue, follow_redirects=False)
+        self.assertIn('who-lives-here-completed', resp.location)
+
+    def answer_mandatory_visitors_question(self, resp, save_continue):
+        self.client.post(resp.location, data=save_continue, follow_redirects=False)
+        visitors = save_continue.copy()
+        visitors['overnight-visitors-answer'] = 0
+        self.client.post(resp.location, data=save_continue, follow_redirects=False)

--- a/tests/integration/navigation.py
+++ b/tests/integration/navigation.py
@@ -1,0 +1,5 @@
+def navigate_to_page(client, page):
+    resp = client.get(page, follow_redirects=False)
+    if resp.status_code != 200:
+        raise RuntimeError('Expected 200 response but got {code}'.format(code=resp.status_code))
+    return resp

--- a/tests/integration/star_wars/star_wars_tests.py
+++ b/tests/integration/star_wars/star_wars_tests.py
@@ -1,5 +1,6 @@
 from tests.integration.create_token import create_token
 from tests.integration.integration_test_case import IntegrationTestCase
+from tests.integration.navigation import navigate_to_page
 from tests.integration.star_wars import star_wars_test_urls
 
 
@@ -30,7 +31,7 @@ class StarWarsTestCase(IntegrationTestCase):
 
     def _default_routing(self, current_page):
         # navigate back to first page
-        self.navigate_to_page(current_page)
+        navigate_to_page(self.client, current_page)
 
         form_data = {
 
@@ -104,11 +105,6 @@ class StarWarsTestCase(IntegrationTestCase):
 
     def submit_page(self, page, form_data):
         resp = self.client.post(page, data=form_data, follow_redirects=False)
-        return resp
-
-    def navigate_to_page(self, page):
-        resp = self.client.get(page, follow_redirects=False)
-        self.assertEqual(resp.status_code, 200)
         return resp
 
     def complete_survey(self, form_type):

--- a/tests/integration/star_wars/test_conditional_display.py
+++ b/tests/integration/star_wars/test_conditional_display.py
@@ -1,3 +1,4 @@
+from tests.integration.navigation import navigate_to_page
 from tests.integration.star_wars import star_wars_test_urls, BLOCK_2_DEFAULT_ANSWERS, BLOCK_8_DEFAULT_ANSWERS
 from tests.integration.star_wars.star_wars_tests import StarWarsTestCase
 
@@ -39,7 +40,7 @@ class TestConditionalDisplay(StarWarsTestCase):
         self.assertIn(star_wars_test_urls.STAR_WARS_QUIZ_2, resp.location)
 
         second_page = resp.location
-        resp = self.navigate_to_page(second_page)
+        resp = navigate_to_page(self.client, second_page)
 
         # Check we are on the next page
         content = resp.get_data(True)
@@ -59,7 +60,7 @@ class TestConditionalDisplay(StarWarsTestCase):
         resp = self.submit_page(second_page, form_data)
 
         third_page = resp.location
-        resp = self.navigate_to_page(third_page)
+        resp = navigate_to_page(self.client, third_page)
 
         content = resp.get_data(True)
         self.assertIn('What is the name of Jar Jar Binks', content)
@@ -71,7 +72,7 @@ class TestConditionalDisplay(StarWarsTestCase):
 
         summary_url = resp.location
 
-        resp = self.navigate_to_page(summary_url)
+        resp = navigate_to_page(self.client, summary_url)
 
         # We are on the review answers page
         content = resp.get_data(True)
@@ -93,7 +94,7 @@ class TestConditionalDisplay(StarWarsTestCase):
         self.assertIn(star_wars_test_urls.STAR_WARS_QUIZ_2, resp.location)
 
         second_page = resp.location
-        resp = self.navigate_to_page(second_page)
+        resp = navigate_to_page(self.client, second_page)
 
         # Check we are on the next page
         content = resp.get_data(True)
@@ -113,7 +114,7 @@ class TestConditionalDisplay(StarWarsTestCase):
         resp = self.submit_page(second_page, form_data)
 
         third_page = resp.location
-        resp = self.navigate_to_page(third_page)
+        resp = navigate_to_page(self.client, third_page)
 
         content = resp.get_data(True)
         self.assertNotIn('What is the name of Jar Jar Binks', content)
@@ -132,7 +133,7 @@ class TestConditionalDisplay(StarWarsTestCase):
 
         summary_url = resp.location
 
-        resp = self.navigate_to_page(summary_url)
+        resp = navigate_to_page(self.client, summary_url)
 
         # We are on the review answers page
         content = resp.get_data(True)

--- a/tests/integration/star_wars/test_dark_side_path.py
+++ b/tests/integration/star_wars/test_dark_side_path.py
@@ -1,3 +1,4 @@
+from tests.integration.navigation import navigate_to_page
 from tests.integration.star_wars import BLOCK_2_DEFAULT_ANSWERS
 from tests.integration.star_wars.star_wars_tests import StarWarsTestCase
 
@@ -14,7 +15,7 @@ class TestDarkSidePath(StarWarsTestCase):
 
         # Second page
         second_page = resp.location
-        resp = self.navigate_to_page(second_page)
+        resp = navigate_to_page(self.client, second_page)
 
         content = resp.get_data(True)
 

--- a/tests/integration/star_wars/test_empty_submission_fails.py
+++ b/tests/integration/star_wars/test_empty_submission_fails.py
@@ -1,3 +1,4 @@
+from tests.integration.navigation import navigate_to_page
 from tests.integration.star_wars import star_wars_test_urls, BLOCK_2_DEFAULT_ANSWERS, BLOCK_7_DEFAULT_ANSWERS, \
     BLOCK_8_DEFAULT_ANSWERS
 from tests.integration.star_wars.star_wars_tests import StarWarsTestCase
@@ -21,7 +22,7 @@ class TestEmptySubmissionFails(StarWarsTestCase):
 
         # go to the first page
         first_page = resp.location
-        self.navigate_to_page(first_page)
+        navigate_to_page(self.client, first_page)
 
         # Form submission with no errors
         resp = self.submit_page(first_page, BLOCK_2_DEFAULT_ANSWERS)
@@ -29,7 +30,7 @@ class TestEmptySubmissionFails(StarWarsTestCase):
 
         # Second page
         second_page = resp.location
-        resp = self.navigate_to_page(second_page)
+        resp = navigate_to_page(self.client, second_page)
         content = resp.get_data(True)
 
         # Pipe Test for section title
@@ -43,7 +44,7 @@ class TestEmptySubmissionFails(StarWarsTestCase):
 
         # third page
         third_page = resp.location
-        resp = self.navigate_to_page(third_page)
+        resp = navigate_to_page(self.client, third_page)
         content = resp.get_data(True)
 
         self.assertRegex(content, "Finally, which  is your favourite film?")
@@ -55,7 +56,7 @@ class TestEmptySubmissionFails(StarWarsTestCase):
 
         summary_url = resp.location
 
-        resp = self.navigate_to_page(summary_url)
+        resp = navigate_to_page(self.client, summary_url)
 
         # We are on the review answers page
         content = resp.get_data(True)

--- a/tests/integration/star_wars/test_light_side_path.py
+++ b/tests/integration/star_wars/test_light_side_path.py
@@ -1,3 +1,4 @@
+from tests.integration.navigation import navigate_to_page
 from tests.integration.star_wars import star_wars_test_urls, BLOCK_2_DEFAULT_ANSWERS, BLOCK_7_DEFAULT_ANSWERS, \
     BLOCK_8_DEFAULT_ANSWERS
 from tests.integration.star_wars.star_wars_tests import StarWarsTestCase
@@ -17,7 +18,7 @@ class TestLightSidePath(StarWarsTestCase):
 
         # Second page
         second_page = resp.location
-        resp = self.navigate_to_page(second_page)
+        resp = navigate_to_page(self.client, second_page)
         content = resp.get_data(True)
 
         # Pipe Test for section title
@@ -31,7 +32,7 @@ class TestLightSidePath(StarWarsTestCase):
 
         # third page
         third_page = resp.location
-        resp = self.navigate_to_page(third_page)
+        resp = navigate_to_page(self.client, third_page)
         content = resp.get_data(True)
 
         self.assertRegex(content, "Finally, which  is your favourite film?")
@@ -43,7 +44,7 @@ class TestLightSidePath(StarWarsTestCase):
 
         summary_url = resp.location
 
-        resp = self.navigate_to_page(summary_url)
+        resp = navigate_to_page(self.client, summary_url)
 
         # We are on the review answers page
         content = resp.get_data(True)

--- a/tests/integration/star_wars/test_navigation.py
+++ b/tests/integration/star_wars/test_navigation.py
@@ -1,3 +1,4 @@
+from tests.integration.navigation import navigate_to_page
 from tests.integration.star_wars import star_wars_test_urls, BLOCK_7_DEFAULT_ANSWERS, BLOCK_8_DEFAULT_ANSWERS, \
     BLOCK_2_DEFAULT_ANSWERS
 from tests.integration.star_wars.star_wars_tests import StarWarsTestCase
@@ -13,10 +14,10 @@ class TestNavigation(StarWarsTestCase):
 
         introduction = star_wars_test_urls.STAR_WARS_INTRODUCTION
 
-        resp = self.navigate_to_page(introduction)
+        resp = navigate_to_page(self.client, introduction)
 
         # navigate back to first page
-        self.navigate_to_page(first_page)
+        navigate_to_page(self.client, first_page)
 
         # Form submission with no errors
         resp = self.submit_page(first_page, BLOCK_2_DEFAULT_ANSWERS)
@@ -37,7 +38,7 @@ class TestNavigation(StarWarsTestCase):
 
         # third page
         third_page = resp.location
-        resp = self.navigate_to_page(third_page)
+        resp = navigate_to_page(self.client, third_page)
         content = resp.get_data(True)
 
         self.assertRegex(content, "Finally, which  is your favourite film?")
@@ -49,7 +50,7 @@ class TestNavigation(StarWarsTestCase):
 
         summary_url = resp.location
 
-        resp = self.navigate_to_page(summary_url)
+        resp = navigate_to_page(self.client, summary_url)
 
         # We are on the review answers page
         content = resp.get_data(True)

--- a/tests/integration/star_wars/test_piping.py
+++ b/tests/integration/star_wars/test_piping.py
@@ -1,3 +1,4 @@
+from tests.integration.navigation import navigate_to_page
 from tests.integration.star_wars import BLOCK_2_DEFAULT_ANSWERS
 from tests.integration.star_wars.star_wars_tests import StarWarsTestCase
 
@@ -15,7 +16,7 @@ class TestPiping(StarWarsTestCase):
         # On to page two
         second_page = resp.location
 
-        resp = self.navigate_to_page(second_page)
+        resp = navigate_to_page(self.client, second_page)
 
         # We are in the Questionnaire
         content = resp.get_data(True)
@@ -33,7 +34,7 @@ class TestPiping(StarWarsTestCase):
 
         # Second page
         second_page = resp.location
-        resp = self.navigate_to_page(second_page)
+        resp = navigate_to_page(self.client, second_page)
         content = resp.get_data(True)
 
         # Pipe Test for section title

--- a/tests/integration/star_wars/test_radio_boxes.py
+++ b/tests/integration/star_wars/test_radio_boxes.py
@@ -1,3 +1,4 @@
+from tests.integration.navigation import navigate_to_page
 from tests.integration.star_wars import star_wars_test_urls, BLOCK_2_DEFAULT_ANSWERS
 from tests.integration.star_wars.star_wars_tests import StarWarsTestCase
 
@@ -32,7 +33,7 @@ class TestEmptyRadioBoxes(StarWarsTestCase):
         # There are no validation errors
         self.assertRegex(resp.location, star_wars_test_urls.STAR_WARS_QUIZ_2)
         summary_url = resp.location
-        resp = self.navigate_to_page(summary_url)
+        resp = navigate_to_page(self.client, summary_url)
 
         # Check we are on the next page
         content = resp.get_data(True)

--- a/tests/integration/star_wars/test_theme_selection.py
+++ b/tests/integration/star_wars/test_theme_selection.py
@@ -1,3 +1,4 @@
+from tests.integration.navigation import navigate_to_page
 from .test_light_side_path import TestLightSidePath
 
 
@@ -15,7 +16,7 @@ class TestThemeSelection(TestLightSidePath):
         self.login()
 
         first_page = self.start_questionnaire_and_navigate_routing()
-        resp = self.navigate_to_page(first_page)
+        resp = navigate_to_page(self.client, first_page)
 
         # We are in the Questionnaire
         content = resp.get_data(True)


### PR DESCRIPTION
### What is the context of this PR?
Repeating relationship question should have a maximum number of 24
repeats if limit is 25 and relationships needed to be answers reduces by
one per page.

Relationship group uses answer_count_minus_one repeat rule. It is
consistent for minus_one rule to apply to the maximum repeats.

### How to review 
1. Load census_household schema
1. Add 26 people to household composition on who-lives-here/0/household-composition
1. Go through relationship questions until one relationship left to answer (who-lives-here-relationship/23/household-relationships)
1. Click next

Expected
Next screen is `You have successfully completed the ‘Who lives here?’ section`

Fixes https://github.com/ONSdigital/eq-survey-runner/issues/883