### PR TITLE
Session timeout should save answers

### DIFF
--- a/app/data/test_timeout.json
+++ b/app/data/test_timeout.json
@@ -44,6 +44,10 @@
                         }
                     ],
                     "title": ""
+                },
+                {
+                    "type": "Summary",
+                    "id": "summary"
                 }
             ]
         }

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -192,6 +192,7 @@ def get_sign_out(eq_id, form_type, collection_id):  # pylint: disable=unused-arg
                                                 analytics_ua_id=settings.EQ_UA_ID,
                                                 survey_id=g.schema_json['survey_id'])
     session_storage.clear()
+    logout_user()
     return signed_out_template
 
 
@@ -204,7 +205,8 @@ def get_timeout_continue(eq_id, form_type, collection_id):  # pylint: disable=un
 @questionnaire_blueprint.route('session-expired', methods=["GET"])
 @login_required
 def get_session_expired(eq_id, form_type, collection_id):  # pylint: disable=unused-argument
-    _delete_user_data()
+    session_storage.clear()
+    logout_user()
     theme = g.schema_json.get('theme', None)
     logger.debug("theme selected", theme=theme)
     return render_theme_template(theme, template_name='session-expired.html',

--- a/tests/functional/pages/surveys/timeout/timeout-block.page.js
+++ b/tests/functional/pages/surveys/timeout/timeout-block.page.js
@@ -1,0 +1,22 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class TimeoutBlockPage extends QuestionPage {
+
+  constructor() {
+    super('timeout-block')
+  }
+
+  setTimeoutAnswer(value) {
+    browser.setValue('[name="timeout-answer"]', value)
+    return this
+  }
+
+  getTimeoutAnswer(value) {
+    return browser.element('[name="timeout-answer"]').getValue()
+  }
+
+}
+
+export default new TimeoutBlockPage()

--- a/tests/functional/pages/surveys/timeout/timeout-summary.page.js
+++ b/tests/functional/pages/surveys/timeout/timeout-summary.page.js
@@ -1,0 +1,15 @@
+import SummaryPage from '../../summary.page'
+
+class TimeoutSummaryPage {
+
+  isOpen() {
+    return SummaryPage.isOpen()
+  }
+
+  getTimeoutAnswer() {
+    return browser.element('[data-qa="timeout-answer-answer"]').getText()
+  }
+
+}
+
+export default new TimeoutSummaryPage()

--- a/tests/functional/spec/timeout.spec.js
+++ b/tests/functional/spec/timeout.spec.js
@@ -1,5 +1,7 @@
 import {expect} from 'chai'
-import {openQuestionnaire} from '../helpers'
+import {openQuestionnaire, getRandomString} from '../helpers'
+import TimeoutBlockPage from '../pages/surveys/timeout/timeout-block.page'
+import TimeoutSummaryPage from '../pages/surveys/timeout/timeout-summary.page'
 
 const dialog = '#dialog'
 
@@ -26,15 +28,37 @@ describe('Session timeout', function() {
   })
 
   it('Given the timeout pop-up has appeared, when I choose to "Save and sign out", then I am redirected to a page confirming I have been signed out and that all data saved will be retained ', function(done) {
-    openQuestionnaire('test_timeout.json')
+    // Given
+    let userId = getRandomString(10)
+    let collectionId = getRandomString(10)
+    openQuestionnaire('test_timeout.json', userId, collectionId)
+    TimeoutBlockPage.setTimeoutAnswer('foo')
     browser.waitForVisible(dialog, 5000)
+
+    // When
     browser.click('.js-timeout-save')
+
+    // Then
     expect(browser.waitUntil(() => browser.getUrl().includes('signed-out'))).to.be.true
+    openQuestionnaire('test_timeout.json', userId, collectionId)
+    expect(TimeoutBlockPage.getTimeoutAnswer()).to.equal('foo')
   })
 
   it('Given the timeout pop-up has appeared, when I ignore it, then I will be signed out and redirected to a page confirming I have been signed out and that all data saved will be retained', function(done) {
-    openQuestionnaire('test_timeout.json')
+    // Given
+    let userId = getRandomString(10)
+    let collectionId = getRandomString(10)
+    openQuestionnaire('test_timeout.json', userId, collectionId)
+    TimeoutBlockPage.setTimeoutAnswer('foo')
+      .submit()
+
+    // When
     expect(browser.waitUntil(() => browser.getUrl().includes('session-expired'), 7000)).to.be.true
+
+    // Then
+    openQuestionnaire('test_timeout.json', userId, collectionId)
+    expect(TimeoutSummaryPage.isOpen(), 'Should resume on summary page').to.be.true
+    expect(TimeoutSummaryPage.getTimeoutAnswer()).to.equal('foo')
   })
 
 })

--- a/tests/integration/questionnaire/test_questionnaire_session_expired.py
+++ b/tests/integration/questionnaire/test_questionnaire_session_expired.py
@@ -1,0 +1,16 @@
+from tests.integration.create_token import create_token
+from tests.integration.integration_test_case import IntegrationTestCase
+
+
+class TestSessionExpired(IntegrationTestCase):
+
+    def test_session_expired_should_log_user_out(self):
+        # Given
+        token = create_token('0205', '1')
+        resp = self.client.get('/session?token=' + token.decode(), follow_redirects=False)
+
+        # When
+        self.client.get('/questionnaire/1/0205/789/session-expired')
+
+        resp = self.client.get(resp.location)
+        self.assertEqual(resp.status_code, 401)


### PR DESCRIPTION
### What is the context of this PR?
Session timeout should save answers when user clicks save and sign out. 
If a user times out before clicking save and sign out all answers but the latest page they had timed out on should be saved

### How to review 
Verify timeout.spec.js tests the scenario correctly
