### PR TITLE
Dont count before getting database resource

### DIFF
--- a/app/authentication/authenticator.py
+++ b/app/authentication/authenticator.py
@@ -33,8 +33,9 @@ def load_user():
     Checks for the present of the JWT in the users sessions
     :return: A user object if a JWT token is available in the session
     """
-    if session_storage.has_user_id():
-        user = User(session_storage.get_user_id(), session_storage.get_user_ik())
+    user_id = session_storage.get_user_id()
+    if user_id:
+        user = User(user_id, session_storage.get_user_ik())
         questionnaire_store = get_questionnaire_store(user.user_id, user.user_ik)
         metadata = questionnaire_store.metadata
         logger.bind(tx_id=metadata["tx_id"])

--- a/app/authentication/session_storage.py
+++ b/app/authentication/session_storage.py
@@ -38,21 +38,6 @@ class SessionStorage:
             # session has a add function but it is wrapped in a session_scope which confuses pylint
             db_session.add(eq_session)
 
-    @staticmethod
-    def has_user_id():
-        """
-        Checks if a user has a stored id
-        :return: boolean value
-        """
-        if EQ_SESSION_ID in session:
-            eq_session_id = session[EQ_SESSION_ID]
-
-            # pylint: disable=maybe-no-member
-            # SQLAlchemy doing declarative magic which makes session scope query property available
-            count = EQSession.query.filter(EQSession.eq_session_id == eq_session_id).count()
-            logger.debug("count number of sessions", session_id=eq_session_id, number_of_sessions=count)
-            return count > 0
-
     def clear(self):
         """
         Removes a user id from the session
@@ -79,7 +64,10 @@ class SessionStorage:
         if EQ_SESSION_ID in session:
             eq_session_id = session[EQ_SESSION_ID]
             eq_session = self._get_user_session(eq_session_id)
-            return eq_session.user_id
+            if eq_session:
+                return eq_session.user_id
+            else:
+                return None
         else:
             return None
 

--- a/app/data_model/questionnaire_store.py
+++ b/app/data_model/questionnaire_store.py
@@ -13,8 +13,8 @@ class QuestionnaireStore:
         self.answer_store = AnswerStore()
         self.completed_blocks = []
 
-        if self._storage.exists():
-            raw_data = self._storage.get_user_data()
+        raw_data = self._storage.get_user_data()
+        if raw_data:
             self._initial_data = self._deserialise(raw_data)
             data_copy = self._deserialise(raw_data)
             self._set_data(data_copy)

--- a/app/storage/encrypted_questionnaire_storage.py
+++ b/app/storage/encrypted_questionnaire_storage.py
@@ -35,7 +35,7 @@ class EncryptedQuestionnaireStorage(QuestionnaireStorage):
 
     def get_user_data(self):
         data = super(EncryptedQuestionnaireStorage, self).get_user_data()
-        if 'data' in data:
+        if data is not None and 'data' in data:
             decrypted_data = self.decrypt_data(self.user_id, self.user_ik, data)
             return decrypted_data
 

--- a/app/storage/questionnaire_storage.py
+++ b/app/storage/questionnaire_storage.py
@@ -17,9 +17,9 @@ class QuestionnaireStorage:
         self.user_id = user_id
 
     def add_or_update(self, data):
-        if self.exists():
+        questionnaire_state = self._get()
+        if questionnaire_state:
             logger.debug("updating questionnaire data", user_id=self.user_id)
-            questionnaire_state = self._get()
             questionnaire_state.set_data(data)
         else:
             logger.debug("creating questionnaire data", user_id=self.user_id)
@@ -31,7 +31,10 @@ class QuestionnaireStorage:
             db_session.add(questionnaire_state)
 
     def get_user_data(self):
-        return self._get().get_data()
+        questionnaire_state = self._get()
+        if questionnaire_state:
+            return questionnaire_state.get_data()
+        return None
 
     def _get(self):
         logger.debug("getting questionnaire data", user_id=self.user_id)
@@ -39,17 +42,10 @@ class QuestionnaireStorage:
         # SQLAlchemy doing declarative magic which makes session scope query property available
         return QuestionnaireState.query.filter(QuestionnaireState.user_id == self.user_id).first()
 
-    def exists(self):
-        logger.debug("counting entries", user_id=self.user_id)
-        # pylint: disable=maybe-no-member
-        # SQLAlchemy doing declarative magic which makes session scope query property available
-        count = QuestionnaireState.query.filter(QuestionnaireState.user_id == self.user_id).count()
-        return count > 0
-
     def delete(self):
         logger.debug("deleting users data", user_id=self.user_id)
-        if self.exists():
-            questionnaire_state = self._get()
+        questionnaire_state = self._get()
+        if questionnaire_state:
             with commit_or_rollback(db_session):
                 # pylint: disable=maybe-no-member
                 # session has a delete function but it is wrapped in a session_scope which confuses pylint

--- a/tests/app/authentication/test_authenticator.py
+++ b/tests/app/authentication/test_authenticator.py
@@ -11,7 +11,6 @@ class TestAuthenticator(unittest.TestCase):
         with patch('app.authentication.authenticator.session_storage') as session_storage, \
              patch('app.authentication.authenticator.get_questionnaire_store', return_value=MagicMock()):
             # Given
-            session_storage.has_user_id = Mock(return_value=True)
             session_storage.get_user_id = Mock(return_value='user_id')
             session_storage.get_user_ik = Mock(return_value='user_ik')
 
@@ -25,7 +24,7 @@ class TestAuthenticator(unittest.TestCase):
     def test_check_session_with_no_user_id_in_session(self):
         with patch('app.authentication.authenticator.session_storage') as session_storage:
             # Given
-            session_storage.has_user_id = Mock(return_value=False)
+            session_storage.get_user_id = Mock(return_value=None)
 
             # When
             user = load_user()
@@ -37,7 +36,6 @@ class TestAuthenticator(unittest.TestCase):
         with patch('app.authentication.authenticator.session_storage') as session_storage, \
              patch('app.authentication.authenticator.get_questionnaire_store', return_value=MagicMock()):
             # Given
-            session_storage.has_user_id = Mock(return_value=True)
             session_storage.get_user_id = Mock(return_value='user_id')
             session_storage.get_user_ik = Mock(return_value='user_ik')
 
@@ -52,7 +50,6 @@ class TestAuthenticator(unittest.TestCase):
         with patch('app.authentication.authenticator.session_storage') as session_storage, \
              patch('app.authentication.authenticator.get_questionnaire_store', return_value=MagicMock()):
             # Given
-            session_storage.has_user_id = Mock(return_value=True)
             session_storage.get_user_id = Mock(return_value='user_id')
             session_storage.get_user_ik = Mock(return_value='user_ik')
 

--- a/tests/app/authentication/test_session_management.py
+++ b/tests/app/authentication/test_session_management.py
@@ -20,19 +20,19 @@ class BaseSessionManagerTest(unittest.TestCase):
 
     def test_has_token_empty(self):
         with self.application.test_request_context():
-            self.assertFalse(self.session_manager.has_user_id())
+            self.assertIsNone(self.session_manager.get_user_id())
 
     def test_has_token(self):
         with self.application.test_request_context():
             self.session_manager.store_user_id("test")
-            self.assertTrue(self.session_manager.has_user_id())
+            self.assertIsNotNone(self.session_manager.get_user_id())
 
     def test_remove_token(self):
         with self.application.test_request_context():
             self.session_manager.store_user_id("test")
-            self.assertTrue(self.session_manager.has_user_id())
+            self.assertIsNotNone(self.session_manager.get_user_id())
             self.session_manager.clear()
-            self.assertFalse(self.session_manager.has_user_id())
+            self.assertIsNone(self.session_manager.get_user_id())
 
 
 if __name__ == '__main__':

--- a/tests/app/storage/test_questionnaire_storage.py
+++ b/tests/app/storage/test_questionnaire_storage.py
@@ -16,7 +16,7 @@ class TestQuestionnaireStorage(unittest.TestCase):
     def test_store(self):
         data = {'test': 'test'}
         self.assertIsNone(self.storage.add_or_update(data))
-        self.assertTrue(self.storage.exists())
+        self.assertIsNotNone(self.storage._get())
 
     def test_get(self):
         data = {'test': 'test'}
@@ -28,7 +28,7 @@ class TestQuestionnaireStorage(unittest.TestCase):
         self.storage.add_or_update(data)
         self.assertEqual(data, self.storage.get_user_data())
         self.storage.delete()
-        self.assertFalse(self.storage.exists())
+        self.assertIsNone(self.storage._get())
 
     def test_store_rollback(self):
         # Given


### PR DESCRIPTION
### What is the context of this PR?
Removes doing a count query before a select for database resources, as we can determine from the return of the  select if the resource exists. In all instances if the count returned a positive number the select was done anyway. 

### How to review 
- Run the application and verify it works as expected (logging in, saving data, retreiving previous answers)
- Run the unit tests and functional tests and verify they all pass