### PR TITLE
Fixes navigation missing on confirmation page.

### DIFF
--- a/app/data/test_final_confirmation.json
+++ b/app/data/test_final_confirmation.json
@@ -8,6 +8,7 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to demo final confirmation to submit.",
+    "navigation": true,
     "messages": {
         "INTEGER_TOO_LARGE": "Number is too large",
         "NEGATIVE_INTEGER": "Number cannot be less than zero",

--- a/app/questionnaire/navigation.py
+++ b/app/questionnaire/navigation.py
@@ -29,7 +29,7 @@ class Navigation(object):
         :param current_group_instance:
         :return:
         """
-        if 'navigation' not in self.survey_json:
+        if self.survey_json.get('navigation', False) is False:
             return None
 
         navigation = []

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -445,7 +445,7 @@ def _get_front_end_navigation(answer_store, current_location, metadata):
     completed_blocks = get_completed_blocks(current_user)
     navigation = Navigation(g.schema_json, answer_store, metadata, completed_blocks)
     block_json = SchemaHelper.get_block_for_location(g.schema_json, current_location)
-    if block_json is not None and (block_json['type'] == 'Questionnaire' or block_json['type'] == 'Interstitial'):
+    if block_json is not None and block_json['type'] in ('Questionnaire', 'Interstitial', 'Confirmation'):
         return navigation.build_navigation(current_location.group_id, current_location.group_instance)
     else:
         return None

--- a/tests/app/questionnaire/test_navigation.py
+++ b/tests/app/questionnaire/test_navigation.py
@@ -616,3 +616,49 @@ class TestNavigation(unittest.TestCase):
         user_navigation = navigation.build_navigation('property-details', 0)
         link_names = [d['link_name'] for d in user_navigation]
         self.assertNotIn('House Details', link_names)
+
+    def test_build_navigation_returns_none_when_schema_navigation_is_false(self):
+        # Given
+        survey = load_schema_file("test_navigation.json")
+        survey['navigation'] = False
+        completed_blocks = []
+        metadata = {}
+        navigation = Navigation(survey, AnswerStore(), metadata, completed_blocks)
+
+        # When
+        nav_menu = navigation.build_navigation('group-1', 'group-instance-1')
+
+        # Then
+        self.assertIsNone(nav_menu)
+
+    def test_build_navigation_returns_none_when_no_schema_navigation_property(self):
+        # Given
+        survey = load_schema_file("test_navigation.json")
+        del survey['navigation']
+        completed_blocks = []
+        metadata = {}
+        navigation = Navigation(survey, AnswerStore(), metadata, completed_blocks)
+
+        # When
+        nav_menu = navigation.build_navigation('group-1', 'group-instance-1')
+
+        # Then
+        self.assertIsNone(nav_menu)
+
+    def test_build_navigation_returns_navigation_when_schema_navigation_is_true(self):
+        # Given
+        survey = load_schema_file("test_navigation.json")
+        survey['navigation'] = True
+        completed_blocks = []
+        metadata = {
+            "eq_id": '1',
+            "collection_exercise_sid": '999',
+            "form_type": "some_form"
+        }
+        navigation = Navigation(survey, AnswerStore(), metadata, completed_blocks)
+
+        # When
+        nav_menu = navigation.build_navigation('group-1', 'group-instance-1')
+
+        # Then
+        self.assertIsNotNone(nav_menu)

--- a/tests/functional/spec/navigation.spec.js
+++ b/tests/functional/spec/navigation.spec.js
@@ -1,8 +1,11 @@
 import landingPage from '../pages/landing.page'
 import PercentagePage from '../pages/surveys/percentage/percentage.page'
+import FinalConfirmationSurveyPage from '../pages/surveys/confirmation/final-confirmation-survey.page'
 import SummaryPage from '../pages/summary.page'
 import {
   openQuestionnaire,
+  startQuestionnaire,
+  getBlockId,
   setMobileViewport,
   openMobileNavigation,
   closeMobileNavigation,
@@ -54,4 +57,19 @@ describe('Navigation', function() {
     // Then
     expect(isViewSectionsVisible()).to.be.false
   })
+
+  it('Given survey with navigation enabled, when on Confirmation page, Then navigation should be visible.', function() {
+    // Given
+    setMobileViewport()
+    startQuestionnaire('test_final_confirmation.json')
+
+    // When
+    expect(isViewSectionsVisible()).to.be.true
+    FinalConfirmationSurveyPage.setBreakfastFood('Bacon').submit()
+
+    // Then
+    expect(getBlockId()).to.equal('confirmation')
+    expect(isViewSectionsVisible()).to.be.true
+  })
+
 })


### PR DESCRIPTION
### What is the context of this PR?
Fixes #1002 navigation missing on the confirmation screen.
I also spotted and fixed another issue where if you set navigation to false in the schema, it still displays the navigation as part of this same PR.

### How to review 
Retest the defect.
On the confirmation page (i.e. the page just before the final submission), the navigation menu should be displayed.
