### PR TITLE
Track jti claim to prevent replay attacks

### DIFF
--- a/app/authentication/authenticator.py
+++ b/app/authentication/authenticator.py
@@ -9,7 +9,7 @@ from app.authentication.session_storage import session_storage
 from app.authentication.user import User
 from app.authentication.user_id_generator import UserIDGenerator
 from app.globals import get_questionnaire_store
-from app.parser.metadata_parser import is_valid_metadata, parse_metadata
+from app.parser.metadata_parser import is_valid_metadata
 
 logger = get_logger()
 
@@ -47,39 +47,24 @@ def load_user():
         return None
 
 
-def jwt_login(request):
+def store_session(metadata):
     """
-    Login using a JWT token, this must be an encrypted JWT.
-    :param request: The flask request
+    Store new session and metadata
+    :param metadata: metadata parsed from jwt token
     """
     # clear the session entry in the database
     session_storage.clear()
     # also clear the secure cookie data
     session.clear()
 
-    encrypted_token = request.args.get('token')
-
-    if encrypted_token is None:
-        raise NoTokenException("Please provide a token")
-
-    decrypted_token = jwt_decrypt(encrypted_token)
-
-    # once we've decrypted the token correct
-    # check we have the required user data
-    _check_user_data(decrypted_token)
-
     # get the hashed user id for eq
-    user_id = UserIDGenerator.generate_id(decrypted_token)
-    user_ik = UserIDGenerator.generate_ik(decrypted_token)
+    user_id = UserIDGenerator.generate_id(metadata)
+    user_ik = UserIDGenerator.generate_ik(metadata)
 
     # store the user id in the session
     session_storage.store_user_id(user_id)
     # store the user ik in the cookie
     session_storage.store_user_ik(user_ik)
-
-    # store the meta data
-    metadata = parse_metadata(decrypted_token)
-    logger.bind(tx_id=metadata["tx_id"])
 
     questionnaire_store = get_questionnaire_store(user_id, user_ik)
     questionnaire_store.metadata = metadata
@@ -87,13 +72,16 @@ def jwt_login(request):
     logger.info("user authenticated")
 
 
-def jwt_decrypt(encrypted_token):
+def decrypt_token(encrypted_token):
+    logger.debug("decrypting token")
+    if encrypted_token is None:
+        raise NoTokenException("Please provide a token")
     decoder = JWTDecryptor()
     decrypted_token = decoder.decrypt_jwt_token(encrypted_token)
-    return decrypted_token
 
-
-def _check_user_data(token):
-    valid, field = is_valid_metadata(token)
+    valid, field = is_valid_metadata(decrypted_token)
     if not valid:
         raise InvalidTokenException("Missing value {}".format(field))
+
+    logger.debug("token decrypted")
+    return decrypted_token

--- a/app/authentication/jti_claim_storage.py
+++ b/app/authentication/jti_claim_storage.py
@@ -1,0 +1,51 @@
+from uuid import UUID
+
+from sqlalchemy.exc import IntegrityError
+from structlog import get_logger
+
+from app.data_model.database import UsedJtiClaim, commit_or_rollback, db_session
+
+logger = get_logger()
+
+
+class JtiTokenUsed(Exception):
+
+    def __init__(self, jti_claim):
+        super(JtiTokenUsed, self).__init__()
+        self.jti_claim = jti_claim
+
+    def __str__(self, *args, **kwargs):
+        return "jti claim '{jti_claim}' has already been used".format(jti_claim=self.jti_claim)
+
+
+def _is_valid(jti_claim):
+    try:
+        UUID(jti_claim, version=4)
+    except ValueError:
+        return False
+    return True
+
+
+def use_jti_claim(jti_claim):
+    """
+    Use a jti claim
+    :param jti_claim: jti claim to mark as used.
+    :raises ValueError: when jti_claim is None.
+    :raises TypeError: when jti_claim is not a valid uuid4.
+    :raises JtiTokenUsed: when jti_claim has already been used.
+    """
+    if jti_claim is None:
+        raise ValueError
+    if not _is_valid(jti_claim):
+        logger.info("jti claim is invalid", jti_claim=jti_claim)
+        raise TypeError
+
+    try:
+        with commit_or_rollback(db_session):
+            jti = UsedJtiClaim(jti_claim)
+            # pylint: disable=maybe-no-member
+            # db_session has an add function but it is wrapped in a session_scope which confuses pylint
+            db_session.add(jti)
+    except IntegrityError as e:
+        logger.error("jti claim has already been used", jti_claim=jti_claim)
+        raise JtiTokenUsed(jti_claim) from e

--- a/app/authentication/user_id_generator.py
+++ b/app/authentication/user_id_generator.py
@@ -16,8 +16,8 @@ logger = get_logger()
 class UserIDGenerator(object):
 
     @staticmethod
-    def generate_id(token):
-        collection_exercise_sid, eq_id, form_type, ru_ref = UserIDGenerator._get_token_data(token)
+    def generate_id(metadata):
+        collection_exercise_sid, eq_id, form_type, ru_ref = UserIDGenerator._get_token_data(metadata)
 
         logger.debug("generating user id", ru_ref=ru_ref, ce_id=collection_exercise_sid, eq_id=eq_id, form_type=form_type)
         salt = to_bytes(settings.EQ_SERVER_SIDE_STORAGE_USER_ID_SALT)
@@ -41,14 +41,14 @@ class UserIDGenerator(object):
         return binascii.hexlify(generated_key)
 
     @staticmethod
-    def _get_token_data(token):
-        ru_ref = token.get("ru_ref")
-        collection_exercise_sid = token.get("collection_exercise_sid")
-        eq_id = token.get("eq_id")
-        form_type = token.get("form_type")
+    def _get_token_data(metadata):
+        ru_ref = metadata.get("ru_ref")
+        collection_exercise_sid = metadata.get("collection_exercise_sid")
+        eq_id = metadata.get("eq_id")
+        form_type = metadata.get("form_type")
 
         if ru_ref and collection_exercise_sid and eq_id and form_type:
             return collection_exercise_sid, eq_id, form_type, ru_ref
         else:
-            logger.error("missing values for ru_ref, collection_exercise_sid, form_type or eq_id", jwt_token=token)
+            logger.error("missing values for ru_ref, collection_exercise_sid, form_type or eq_id", metadata=metadata)
             raise InvalidTokenException("Missing values in JWT token")

--- a/app/data_model/database.py
+++ b/app/data_model/database.py
@@ -60,6 +60,19 @@ class EQSession(base):
         return "<EQSession('%s', '%s', '%s')>" % (self.eq_session_id, self.user_id, self.timestamp)
 
 
+class UsedJtiClaim(base):
+    __tablename__ = "used_jti_claim"
+    jti_claim = Column("jti_claim", String, primary_key=True)
+    used_at = Column("used_at", DateTime)
+
+    def __init__(self, jti_claim):
+        self.jti_claim = jti_claim
+        self.used_at = datetime.datetime.now()
+
+    def __repr__(self):
+        return "<UsedJtiClaim('%s', '%s')>" % (self.jti_claim, self.used_at)
+
+
 def _create_session_and_engine():
     logger.info("setting up database...")
     logger.debug("creating database engine")

--- a/app/parser/metadata_parser.py
+++ b/app/parser/metadata_parser.py
@@ -43,6 +43,7 @@ class MetadataField(object):
         return None
 
 metadata_fields = {
+    "jti": MetadataField(mandatory=False),
     "user_id": MetadataField(),
     "ru_ref": MetadataField(),
     "ru_name": MetadataField(),

--- a/app/views/dev_mode.py
+++ b/app/views/dev_mode.py
@@ -1,5 +1,6 @@
 import os
 import time
+from uuid import uuid4
 
 from flask import Blueprint
 from flask import redirect
@@ -113,6 +114,7 @@ def create_payload(**metadata):
         "user_id": metadata['user'],
         'iat': str(int(iat)),
         'exp': str(int(exp)),
+        'jti': str(uuid4()),
         "eq_id": metadata['eq_id'],
         "period_str": metadata['period_str'],
         "period_id": metadata['period_id'],

--- a/app/views/flush.py
+++ b/app/views/flush.py
@@ -1,15 +1,13 @@
-from app.globals import get_answer_store, get_metadata, get_questionnaire_store
-from app.submitter.submitter import SubmitterFactory
-from app.submitter.converter import convert_answers
-from app.utilities.schema import get_schema
+from flask import Blueprint, Response, request, session
 
+from app.authentication.jwt_decoder import JWTDecryptor
 from app.authentication.user import User
 from app.authentication.user_id_generator import UserIDGenerator
-from app.authentication.authenticator import jwt_decrypt
-
+from app.globals import get_answer_store, get_metadata, get_questionnaire_store
 from app.questionnaire.path_finder import PathFinder
-
-from flask import Blueprint, Response, request, session
+from app.submitter.converter import convert_answers
+from app.submitter.submitter import SubmitterFactory
+from app.utilities.schema import get_schema
 
 flush_blueprint = Blueprint('flush', __name__)
 
@@ -25,7 +23,8 @@ def flush_data():
     if encrypted_token is None:
         return Response(status=403)
 
-    decrypted_token = jwt_decrypt(encrypted_token)
+    decoder = JWTDecryptor()
+    decrypted_token = decoder.decrypt_jwt_token(encrypted_token)
 
     roles = decrypted_token.get('roles')
 

--- a/tests/app/authentication/test_use_token.py
+++ b/tests/app/authentication/test_use_token.py
@@ -1,0 +1,48 @@
+from unittest import TestCase
+from uuid import uuid4
+
+from mock import patch
+from sqlalchemy.exc import IntegrityError
+
+from app.authentication.jti_claim_storage import use_jti_claim, JtiTokenUsed
+
+
+class TestJtiClaimStorage(TestCase):
+
+    def test_should_use_token(self):
+        with patch('app.authentication.jti_claim_storage.db_session') as db_session:
+            # Given
+            jti_token = str(uuid4())
+
+            # When
+            use_jti_claim(jti_token)
+
+            # Then
+            self.assertEqual(db_session.add.call_count, 1)
+
+    def test_should_return_raise_value_error(self):
+        # Given
+        token = None
+
+        # When
+        with self.assertRaises(ValueError):
+            use_jti_claim(token)
+
+    def test_should_raise_jti_token_used_when_token_already_exists(self):
+        with patch('app.authentication.jti_claim_storage.db_session') as db_session:
+            # Given
+            jti_token = str(uuid4())
+            db_session.add.side_effect = [IntegrityError('', '', '')]
+
+            # When
+            with self.assertRaises(JtiTokenUsed) as err:
+                use_jti_claim(jti_token)
+
+            # Then
+            self.assertEqual(err.exception.jti_claim, jti_token)
+
+    def test_should_raise_type_error_invalid_uuid(self):
+        jti_token = 'jti_token'
+
+        with self.assertRaises(TypeError):
+            use_jti_claim(jti_token)

--- a/tests/integration/create_token.py
+++ b/tests/integration/create_token.py
@@ -1,7 +1,10 @@
-from app.views.dev_mode import generate_token, create_payload
+import time
+from uuid import uuid4
+
+from app.views.dev_mode import generate_token
 
 PAYLOAD = {
-    'user': "mci-integration-test",
+    'user_id': "mci-integration-test",
     "period_str": "April 2016",
     "period_id": "201604",
     "collection_exercise_sid": "789",
@@ -13,21 +16,19 @@ PAYLOAD = {
     "trad_as": "Integration Tests",
     "employment_date": "1983-06-02",
     "variant_flags": None,
-    "exp_time": 3600  # one hour from now
+    "region_code": None,
+    "language_code": None
 }
 
 
-def create_token(form_type_id, eq_id, start_date=None, end_date=None, employment_date=None, region_code=None, language_code=None):
-
+def create_token(form_type_id, eq_id, **extra_payload):
     payload_vars = PAYLOAD
-    payload_vars['ref_p_start_date'] = start_date or payload_vars['ref_p_start_date']
-    payload_vars['ref_p_end_date'] = end_date or payload_vars['ref_p_end_date']
-    payload_vars['employment_date'] = employment_date or payload_vars['employment_date']
     payload_vars['eq_id'] = eq_id
     payload_vars['form_type'] = form_type_id
-    payload_vars['region_code'] = region_code
-    payload_vars['language_code'] = language_code
+    payload_vars['jti'] = str(uuid4())
+    payload_vars['iat'] = time.time()
+    payload_vars['exp'] = payload_vars['iat'] + float(3600)  # one hour from now
+    for key, value in extra_payload.items():
+        payload_vars[key] = value
 
-    payload = create_payload(**payload_vars)
-
-    return generate_token(payload)
+    return generate_token(payload_vars)

--- a/tests/integration/mci/test_dates_in_questions.py
+++ b/tests/integration/mci/test_dates_in_questions.py
@@ -21,7 +21,7 @@ class TestHappyPath(IntegrationTestCase):
         start_date = "2016-04-01"
         end_date = "2016-04-30"
 
-        token = create_token(form_type_id, eq_id, start_date, end_date)
+        token = create_token(form_type_id, eq_id, ref_p_start_date=start_date, ref_p_end_date=end_date)
         resp = self.client.get('/session?token=' + token.decode(), follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
 
@@ -54,7 +54,7 @@ class TestHappyPath(IntegrationTestCase):
     def try_another_date(self, form_type_id, eq_id):
         # Try another date
         # Get a token
-        token = create_token(form_type_id, eq_id, '2017-08-01', '2017-08-31')
+        token = create_token(form_type_id, eq_id, ref_p_start_date='2017-08-01', ref_p_end_date='2017-08-31')
         resp = self.client.get('/session?token=' + token.decode(), follow_redirects=True)
         self.assertEqual(resp.status_code, 200)
 

--- a/tests/integration/questionnaire/test_questionnaire_save_sign_out.py
+++ b/tests/integration/questionnaire/test_questionnaire_save_sign_out.py
@@ -103,6 +103,7 @@ class TestSaveSignOut(IntegrationTestCase):
         self.get_and_post_with_csrf_token(block_one_url, data=post_data, follow_redirects=False)
 
         # We re-authenticate and check we are on the first page
+        token = create_token('0102', '1')
         resp = self.client.get('/session?token=' + token.decode(), follow_redirects=False)
         block_one_url = resp.headers['Location']
         self.assertRegexpMatches(block_one_url, 'reporting-period')

--- a/tests/integration/session/test_login.py
+++ b/tests/integration/session/test_login.py
@@ -34,3 +34,25 @@ class TestLogin(IntegrationTestCase):
         # Then
         self.assertEqual(resp.status_code, 302)
         self.assertRegex(resp.location, '/questionnaire/1/0205')
+
+    def test_login_with_token_twice_is_unauthorised_when_same_jti_provided(self):
+        # Given
+        token = create_token('0205', '1')
+        self.client.get('/session?token=' + token.decode(), follow_redirects=False)
+
+        # When
+        resp = self.client.get('/session?token=' + token.decode(), follow_redirects=False)
+
+        # Then
+        self.assertEqual(resp.status_code, 401)
+
+    def test_login_with_token_twice_is_authorised_when_no_jti(self):
+        # Given
+        token = create_token('0205', '1', jti=None)
+        self.client.get('/session?token=' + token.decode(), follow_redirects=False)
+
+        # When
+        resp = self.client.get('/session?token=' + token.decode(), follow_redirects=False)
+
+        # Then
+        self.assertEqual(resp.status_code, 302)

--- a/tests/integration/test_schema_cache.py
+++ b/tests/integration/test_schema_cache.py
@@ -18,6 +18,7 @@ class TestApplicationVariables(IntegrationTestCase):
 
             self.assertNotEqual(cache.get('app.utilities.schema.load_and_parse_schema_memver'), None)
 
+            token = create_token('star_wars', '0')
             resp = self.client.get('/session?token=' + token.decode(), follow_redirects=True)
 
             self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
### What is the context of this PR?
JWT rfc defines a token which can be used to prevent repeat attacks.
e.g. login using the same token twice by using the same JWT token before
the JWT token has expiried.
The token is defined here: [jti](https://tools.ietf.org/html/rfc7519#section-4.1.7)

If the jti token is present in the JWT payload we store the jti token in
a postgres table called used_token.
If the same token is seen more than once the authentication request is
rejected as invalid.
If the jti token is not present we do not protect against repeat
attacks. This puts the responsibility on the upstream system.

The tokens are stored in a postgres table and old tokens can be cleared
out by referencing the timestamp column. i.e. `where timestamp > '1
month old'`

### How to review 
##### Developers can walk through the integration test
test_login.test_login_with_token_twice_is_unauthorised_when_same_jti_provided
test_login.test_login_with_token_twice_is_authorised_when_no_jti

##### Testers can manually test using chrome
1. Open the dev page
1. Open chrome console (cmd + option + i)
1. Click on chrome console network tab
1. filter on `session`
1. Right click line and click `Open in new tab` to repeat log in
![image](https://cloud.githubusercontent.com/assets/15050019/23544247/26bcb00e-ffee-11e6-957e-c1fa66d0af7c.png)

