### PR TITLE
Enable trading as name to be piped into questions

### DIFF
--- a/app/data/1_0005.json
+++ b/app/data/1_0005.json
@@ -257,7 +257,7 @@
                                 "q_code": "90w",
                                 "type": "Radio"
                             }],
-                            "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "guidance": [{
                                 "list": [
                                     "redundancies",
@@ -383,7 +383,7 @@
                                 "q_code": "93w",
                                 "type": "Radio"
                             }],
-                            "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "guidance": [{
                                 "list": [
                                     "more or less overtime",
@@ -858,7 +858,7 @@
                                 "q_code": "90f",
                                 "type": "Radio"
                             }],
-                            "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "guidance": [{
                                 "list": [
                                     "redundancies",
@@ -984,7 +984,7 @@
                                 "q_code": "93f",
                                 "type": "Radio"
                             }],
-                            "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "guidance": [{
                                 "list": [
                                     "more or less overtime",
@@ -1448,7 +1448,7 @@
                                 "q_code": "190m",
                                 "type": "Radio"
                             }],
-                            "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "guidance": [{
                                 "list": [
                                     "redundancies",
@@ -1574,7 +1574,7 @@
                                 "q_code": "193m",
                                 "type": "Radio"
                             }],
-                            "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "guidance": [{
                                 "list": [
                                     "more or less overtime",
@@ -2038,7 +2038,7 @@
                                 "q_code": "190w4",
                                 "type": "Radio"
                             }],
-                            "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "guidance": [{
                                 "list": [
                                     "redundancies",
@@ -2164,7 +2164,7 @@
                                 "q_code": "193w4",
                                 "type": "Radio"
                             }],
-                            "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "guidance": [{
                                 "list": [
                                     "more or less overtime",
@@ -2629,7 +2629,7 @@
                                 "q_code": "190w5",
                                 "type": "Radio"
                             }],
-                            "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "guidance": [{
                                 "list": [
                                     "redundancies",
@@ -2755,7 +2755,7 @@
                                 "q_code": "193w5",
                                 "type": "Radio"
                             }],
-                            "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "guidance": [{
                                 "list": [
                                     "more or less overtime",

--- a/app/data/2_0001.json
+++ b/app/data/2_0001.json
@@ -76,7 +76,7 @@
                                         }
                                     ],
                                     "id": "number-of-employees-question",
-                                    "title": "On {{exercise.start_date|format_date}} what was the number of employees for {{respondent.ru_name}}?",
+                                    "title": "On {{exercise.start_date|format_date}} what was the number of employees for {{respondent.trad_as_or_ru_name}}?",
                                     "type": "General"
                                 }
                             ],

--- a/app/templating/schema_context.py
+++ b/app/templating/schema_context.py
@@ -54,4 +54,5 @@ def _build_respondent(metadata):
     return {
         "ru_name": metadata["ru_name"],
         "trad_as": metadata["trad_as"],
+        "trad_as_or_ru_name": metadata["trad_as"] or metadata["ru_name"],
     }

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -181,6 +181,10 @@ gulp.task('lint:json', () => {
       quiet: false,
       fail: true
     }))
+    .on('error', (err) => {
+      gutil.log('Linting failed try running `yarn format`')
+      throw err
+    })
 })
 
 gulp.task('format:json', () => {

--- a/tests/app/templating/test_schema_context.py
+++ b/tests/app/templating/test_schema_context.py
@@ -5,7 +5,7 @@ from app.templating.schema_context import build_schema_context
 from tests.app.framework.survey_runner_test_case import SurveyRunnerTestCase
 
 
-class TestMetadataContext(SurveyRunnerTestCase):
+class TestSchemaContext(SurveyRunnerTestCase):
 
     metadata = {
         'return_by': '2016-10-10',
@@ -212,3 +212,24 @@ class TestMetadataContext(SurveyRunnerTestCase):
 
         context_answers = schema_context['answers']
         self.assertEqual(len(context_answers['repeating_answer_alias']), 25)
+
+    def test_respondent_display_name_is_trading_as_when_trading_as_supplied(self):
+        schema_context = build_schema_context(self.metadata, {}, self.answer_store)
+
+        self.assertEqual(schema_context['respondent']['trad_as_or_ru_name'], self.metadata['trad_as'])
+
+    def test_respondent_display_name_is_ru_name_as_when_trading_as_not_supplied(self):
+        metadata = self.metadata.copy()
+        metadata['trad_as'] = None
+
+        schema_context = build_schema_context(metadata, {}, self.answer_store)
+
+        self.assertEqual(schema_context['respondent']['trad_as_or_ru_name'], metadata['ru_name'])
+
+    def test_respondent_display_name_is_ru_name_as_when_trading_as_empty(self):
+        metadata = self.metadata.copy()
+        metadata['trad_as'] = ""
+
+        schema_context = build_schema_context(metadata, {}, self.answer_store)
+
+        self.assertEqual(schema_context['respondent']['trad_as_or_ru_name'], metadata['ru_name'])


### PR DESCRIPTION
### What is the context of this PR?
Create a way of dynamically populated trad_as or ru_name from the metadata. See [trello](https://trello.com/c/JLIbPCgI/975-enable-trading-as-name-to-be-piped-into-questions)

### How to review 
- Open qbs with trad_as and ru_name
Expect to see trad_as populated

- Open qbs with only ru_name
Expect to see ru_name populated

- Open mwss with trad_as and ru_name
Expect to see trad_as populated

- Open mwss with only ru_name
Expect to see ru_name populated
