### PR TITLE
Resolve Issue #1013 None radio values don't work as expected

### DIFF
--- a/app/data/test_checkbox.json
+++ b/app/data/test_checkbox.json
@@ -27,6 +27,11 @@
                                 "label": "",
                                 "mandatory": true,
                                 "options": [{
+                                        "label": "None",
+                                        "value": "None",
+                                        "q_code": "0"
+                                    },
+                                    {
                                         "label": "Cheese",
                                         "value": "Cheese",
                                         "q_code": "1"
@@ -95,6 +100,10 @@
                                 "label": "",
                                 "mandatory": false,
                                 "options": [{
+                                        "label": "None",
+                                        "value": "None"
+                                    },
+                                    {
                                         "label": "Cheese",
                                         "value": "Cheese"
                                     },

--- a/app/data/test_radio.json
+++ b/app/data/test_radio.json
@@ -27,6 +27,10 @@
                                 "label": "What is your favourite breakfast food",
                                 "mandatory": true,
                                 "options": [{
+                                        "label": "None",
+                                        "value": "None"
+                                    },
+                                    {
                                         "label": "Bacon",
                                         "value": "Bacon"
                                     },
@@ -88,6 +92,10 @@
                                 "label": "What is your favourite breakfast food",
                                 "mandatory": false,
                                 "options": [{
+                                        "label": "None",
+                                        "value": "None"
+                                    },
+                                    {
                                         "label": "Toast",
                                         "value": "Toast"
                                     },

--- a/app/forms/fields.py
+++ b/app/forms/fields.py
@@ -104,14 +104,31 @@ def get_select_multiple_field(answer, label, guidance, error_messages):
     )
 
 
+def _coerce_str_unless_none(value):
+    """
+    Coerces a value using str() unless that value is None
+    :param value: Any value that can be coerced using str() or None
+    :return: str(value) or None if value is None
+    """
+    return str(value) if value is not None else None
+
+
 def get_select_field(answer, label, guidance, error_messages):
     validate_with = get_mandatory_validator(answer, error_messages)
+
+    # We use a custom coerce function to avoid a defect where Python NoneType
+    # is coerced to the string 'None' which clashes with legitimate Radio field
+    # values of 'None'; i.e. there is no way to differentiate between the user
+    # not providing an answer and them selecting the 'None' option otherwise.
+    # https://github.com/ONSdigital/eq-survey-runner/issues/1013
+    # See related WTForms PR: https://github.com/wtforms/wtforms/pull/288
 
     return SelectField(
         label=label,
         description=guidance,
         choices=build_choices(answer['options']),
         validators=validate_with,
+        coerce=_coerce_str_unless_none,
     )
 
 

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -343,10 +343,9 @@ def update_questionnaire_store_with_form_data(questionnaire_store, location, ans
                 elif is_month_year and answer_value['month']:
                     date_str = "{:02d}/{}".format(int(answer_value['month']), answer_value['year'])
                     answer = Answer(answer_id=answer_id, value=date_str, location=location)
-            elif answer_value != 'None' and answer_value is not None:
-                # Necessary because default select casts to string value 'None'
+            elif answer_value is not None:
                 answer = Answer(answer_id=answer_id, value=answer_value, location=location)
-            elif answer_value is None:
+            else:
                 # Remove previously populated answers that are now empty
                 questionnaire_store.answer_store.remove(
                     location=location,

--- a/tests/app/forms/test_fields.py
+++ b/tests/app/forms/test_fields.py
@@ -2,7 +2,7 @@ import unittest
 
 from wtforms import validators, StringField, TextAreaField, FormField, SelectField, SelectMultipleField
 
-from app.forms.fields import CustomIntegerField, get_field, get_mandatory_validator
+from app.forms.fields import CustomIntegerField, get_field, get_mandatory_validator, _coerce_str_unless_none
 from app.validation.error_messages import error_messages
 from app.validation.validators import ResponseRequired
 
@@ -153,9 +153,19 @@ class TestFields(unittest.TestCase):
         expected_choices = [(option['label'], option['value']) for option in radio_json['options']]
 
         self.assertTrue(unbound_field.field_class == SelectField)
+        self.assertTrue(unbound_field.kwargs['coerce'], _coerce_str_unless_none)
         self.assertEquals(unbound_field.kwargs['label'], radio_json['label'])
         self.assertEquals(unbound_field.kwargs['description'], radio_json['guidance'])
         self.assertEquals(unbound_field.kwargs['choices'], expected_choices)
+
+    def test__coerce_str_unless_none(self):
+        # pylint: disable=protected-access
+        self.assertEquals(_coerce_str_unless_none(1), '1')
+        self.assertEquals(_coerce_str_unless_none('bob'), 'bob')
+        self.assertEquals(_coerce_str_unless_none(12323245), '12323245')
+        self.assertEquals(_coerce_str_unless_none('9887766'), '9887766')
+        self.assertEquals(_coerce_str_unless_none('None'), 'None')
+        self.assertEquals(_coerce_str_unless_none(None), None)
 
     def test_checkbox_field(self):
         checkbox_json = {

--- a/tests/app/forms/test_questionnaire_form.py
+++ b/tests/app/forms/test_questionnaire_form.py
@@ -106,6 +106,69 @@ class TestQuestionnaireForm(unittest.TestCase):
         self.assertEqual(form.data, expected_form_data)
         self.assertEqual(form.question_errors['reporting-period-question'], expected_message)
 
+    def test_form_radio_options_no_selection(self):
+        # Given I have not selected a radio option, When I load a form,
+        # Then no radio options should be selected by default
+        survey = load_schema_file("test_radio.json")
+        block_json = SchemaHelper.get_block(survey, "radio-mandatory")
+        error_messages = SchemaHelper.get_messages(survey)
+
+        # Given
+        data = {}
+
+        # When
+        form = generate_form(block_json, data, error_messages)
+
+        # Then
+        for option in form['radio-mandatory-answer']:
+            self.assertFalse(option.checked)
+
+    def test_form_radio_options_select_none(self):
+        # Given I have selected the None radio option, When I load a form,
+        # Then the None radio option should be selected And no other options should be selected.
+        survey = load_schema_file("test_radio.json")
+        block_json = SchemaHelper.get_block(survey, "radio-mandatory")
+        error_messages = SchemaHelper.get_messages(survey)
+
+        # Given
+        data = {
+            'radio-mandatory-answer': 'None'
+        }
+
+        # When
+        form = generate_form(block_json, data, error_messages)
+
+        # Then
+        options = [option for option in form['radio-mandatory-answer']]
+
+        self.assertTrue(options[0].checked)  # None
+
+        for option in options[1:]:
+            self.assertFalse(option.checked)  # All others
+
+    def test_form_radio_options_select_none(self):
+        # Given I have selected the Bacon radio option, When I load a form,
+        # Then the Bacon radio option should be selected And no other options should be selected.
+        survey = load_schema_file("test_radio.json")
+        block_json = SchemaHelper.get_block(survey, "radio-mandatory")
+        error_messages = SchemaHelper.get_messages(survey)
+
+        # Given
+        data = {
+            'radio-mandatory-answer': 'Bacon'
+        }
+
+        # When
+        form = generate_form(block_json, data, error_messages)
+
+        # Then
+        options = [option for option in form['radio-mandatory-answer']]
+
+        self.assertFalse(options[0].checked)  # None
+        self.assertTrue(options[1].checked)  # Bacon
+        for option in options[2:]:
+            self.assertFalse(option.checked)  # All others
+
     def test_form_errors_are_correctly_mapped(self):
         survey = load_schema_file("1_0112.json")
 
@@ -191,7 +254,7 @@ class TestQuestionnaireForm(unittest.TestCase):
         form = generate_form(block_json, {}, error_messages)
 
         self.assertFalse(form.option_has_other("mandatory-checkbox-answer", 1))
-        self.assertTrue(form.option_has_other("mandatory-checkbox-answer", 5))
+        self.assertTrue(form.option_has_other("mandatory-checkbox-answer", 6))
 
     def test_get_other_answer(self):
         survey = load_schema_file("test_checkbox.json")
@@ -202,7 +265,7 @@ class TestQuestionnaireForm(unittest.TestCase):
             "other-answer-mandatory": "Some data"
         }, error_messages)
 
-        field = form.get_other_answer("mandatory-checkbox-answer", 5)
+        field = form.get_other_answer("mandatory-checkbox-answer", 6)
 
         self.assertEqual("Some data", field.data)
 

--- a/tests/app/helpers/test_schema_helper.py
+++ b/tests/app/helpers/test_schema_helper.py
@@ -90,7 +90,7 @@ class TestSchemaHelper(unittest.TestCase):
 
         expected = {
             'mandatory-checkbox-answer': {
-                'index': 5,
+                'index': 6,
                 'child_answer_id': 'other-answer-mandatory'
             }
         }

--- a/tests/functional/pages/surveys/radio/radio-mandatory.page.js
+++ b/tests/functional/pages/surveys/radio/radio-mandatory.page.js
@@ -8,24 +8,49 @@ class RadioMandatoryPage extends MultipleChoiceWithOtherPage {
     super('radio-mandatory')
   }
 
-  clickRadioMandatoryAnswerBacon() {
+  clickRadioMandatoryAnswerNone() {
     browser.element('[id="radio-mandatory-answer-0"]').click()
     return this
   }
 
-  clickRadioMandatoryAnswerEggs() {
+  RadioMandatoryAnswerNoneIsSelected() {
+    return browser.element('[id="radio-mandatory-answer-0"]').isSelected()
+  }
+
+  clickRadioMandatoryAnswerBacon() {
     browser.element('[id="radio-mandatory-answer-1"]').click()
     return this
   }
 
-  clickRadioMandatoryAnswerSausage() {
+  RadioMandatoryAnswerBaconIsSelected() {
+    return browser.element('[id="radio-mandatory-answer-1"]').isSelected()
+  }
+
+  clickRadioMandatoryAnswerEggs() {
     browser.element('[id="radio-mandatory-answer-2"]').click()
     return this
   }
 
-  clickRadioMandatoryAnswerOther() {
+  RadioMandatoryAnswerEggsIsSelected() {
+    return browser.element('[id="radio-mandatory-answer-2"]').isSelected()
+  }
+
+  clickRadioMandatoryAnswerSausage() {
     browser.element('[id="radio-mandatory-answer-3"]').click()
     return this
+  }
+
+  RadioMandatoryAnswerSausageIsSelected() {
+    return browser.element('[id="radio-mandatory-answer-3"]').isSelected()
+  }
+
+  clickRadioMandatoryAnswerOther() {
+    browser.element('[id="radio-mandatory-answer-4"]').click()
+    return this
+  }
+
+  RadioMandatoryAnswerOtherIsSelected() {
+    return browser.element('[id="radio-mandatory-answer-4"]').isSelected()
   }
 
   setRadioMandatoryAnswerOtherText(value) {

--- a/tests/functional/pages/surveys/radio/radio-non-mandatory.page.js
+++ b/tests/functional/pages/surveys/radio/radio-non-mandatory.page.js
@@ -8,24 +8,49 @@ class RadioNonMandatoryPage extends MultipleChoiceWithOtherPage {
     super('radio-non-mandatory')
   }
 
-  clickRadioNonMandatoryAnswerToast() {
+  clickRadioNonMandatoryAnswerNone() {
     browser.element('[id="radio-non-mandatory-answer-0"]').click()
     return this
   }
 
-  clickRadioNonMandatoryAnswerCoffee() {
+  RadioNonMandatoryAnswerNoneIsSelected() {
+    return browser.element('[id="radio-non-mandatory-answer-0"]').isSelected()
+  }
+
+  clickRadioNonMandatoryAnswerToast() {
     browser.element('[id="radio-non-mandatory-answer-1"]').click()
     return this
   }
 
-  clickRadioNonMandatoryAnswerTea() {
+  RadioNonMandatoryAnswerToastIsSelected() {
+    return browser.element('[id="radio-non-mandatory-answer-1"]').isSelected()
+  }
+
+  clickRadioNonMandatoryAnswerCoffee() {
     browser.element('[id="radio-non-mandatory-answer-2"]').click()
     return this
   }
 
-  clickRadioNonMandatoryAnswerOther() {
+  RadioNonMandatoryAnswerCoffeeIsSelected() {
+    return browser.element('[id="radio-non-mandatory-answer-2"]').isSelected()
+  }
+
+  clickRadioNonMandatoryAnswerTea() {
     browser.element('[id="radio-non-mandatory-answer-3"]').click()
     return this
+  }
+
+  RadioNonMandatoryAnswerTeaIsSelected() {
+    return browser.element('[id="radio-non-mandatory-answer-3"]').isSelected()
+  }
+
+  clickRadioNonMandatoryAnswerOther() {
+    browser.element('[id="radio-non-mandatory-answer-4"]').click()
+    return this
+  }
+
+  RadioNonMandatoryAnswerOtherIsSelected() {
+    return browser.element('[id="radio-non-mandatory-answer-4"]').isSelected()
   }
 
   setRadioNonMandatoryAnswerOtherText(value) {

--- a/tests/functional/pages/surveys/radio/summary.page.js
+++ b/tests/functional/pages/surveys/radio/summary.page.js
@@ -2,8 +2,12 @@ import SummaryPage from '../../summary.page'
 
 class RadioSummaryPage extends SummaryPage {
 
-  getMandatoryAnswer() {
+  getMandatoryOtherAnswer() {
     return browser.element('[data-qa="other-answer-mandatory-answer"]').getText()
+  }
+
+  getMandatoryAnswer() {
+    return browser.element('[data-qa="radio-mandatory-answer-answer"]').getText()
   }
 
 }

--- a/tests/functional/spec/radio.spec.js
+++ b/tests/functional/spec/radio.spec.js
@@ -1,6 +1,6 @@
 import {openQuestionnaire} from '../helpers'
 import RadioMandatoryPage from '../pages/surveys/radio/radio-mandatory.page'
-import RadioNonMandatory from '../pages/surveys/radio/radio-non-mandatory.page'
+import RadioNonMandatoryPage from '../pages/surveys/radio/radio-non-mandatory.page'
 import SummaryPage from '../pages/surveys/radio/summary.page'
 
 
@@ -25,11 +25,11 @@ describe('Radio button with "other" option', function() {
 
     // When
     RadioMandatoryPage.clickOther().setOtherInputField('Hello').submit()
-    RadioNonMandatory.submit(); // Skip second page.
+    RadioNonMandatoryPage.submit(); // Skip second page.
 
 
     //Then
-    expect(SummaryPage.getMandatoryAnswer()).to.contain('Hello')
+    expect(SummaryPage.getMandatoryOtherAnswer()).to.contain('Hello')
   })
 
   it('Given a mandatory radio answer, when I select "Other" and submit without completing the other input field, then an error must be displayed.', function() {
@@ -53,22 +53,94 @@ describe('Radio button with "other" option', function() {
     RadioMandatoryPage.clickOther().setOtherInputField('Other Text').submit()
 
     //Then
-    expect(RadioNonMandatory.errorExists()).to.be.false
+    expect(RadioNonMandatoryPage.errorExists()).to.be.false
   })
 
-  it('Given I have previously added text in other texfiled and saved, when I change the awnser to a diffrent answer, then the text entered in other field must be wiped.', function() {
+  it('Given I have previously added text in other textfield and saved, when I change the answer to a different answer, then the text entered in other field must be wiped.', function() {
     //Given
     openQuestionnaire(radio_schema);
 
     //When
     RadioMandatoryPage.clickOther().setOtherInputField('Other Text').submit()
-    RadioNonMandatory.clickTopPrevious()
+    RadioNonMandatoryPage.clickTopPrevious()
     RadioMandatoryPage.clickRadioMandatoryAnswerBacon().submit()
-    RadioNonMandatory.clickTopPrevious()
+    RadioNonMandatoryPage.clickTopPrevious()
 
     //Then
     RadioMandatoryPage.clickOther()
     expect(RadioMandatoryPage.getOtherInputField()).to.equal('')
   })
 
+  it('Given I have previously selected the None option and saved, When I return to the screen, Then my choice is remembered.', function() {
+    // https://github.com/ONSdigital/eq-survey-runner/issues/1013
+    // Given
+    openQuestionnaire(radio_schema);
+
+    expect(RadioMandatoryPage.RadioMandatoryAnswerNoneIsSelected()).to.be.false
+    RadioMandatoryPage.clickRadioMandatoryAnswerNone()
+    expect(RadioMandatoryPage.RadioMandatoryAnswerNoneIsSelected()).to.be.true
+    RadioMandatoryPage.submit()
+
+    // When
+    RadioNonMandatoryPage.clickTopPrevious()
+
+    // Then
+    expect(RadioMandatoryPage.RadioMandatoryAnswerNoneIsSelected()).to.be.true
+  })
+
+  it('Given I have previously selected an option and saved, When I return to the screen and change my answer twice, Then my new choice is remembered and is shown on the Summary screen.', function() {
+    // Given
+    openQuestionnaire(radio_schema);
+
+    // Nothing should be selected by default
+    expect(RadioMandatoryPage.RadioMandatoryAnswerNoneIsSelected()).to.be.false
+    expect(RadioMandatoryPage.RadioMandatoryAnswerBaconIsSelected()).to.be.false
+    expect(RadioMandatoryPage.RadioMandatoryAnswerEggsIsSelected()).to.be.false
+    expect(RadioMandatoryPage.RadioMandatoryAnswerSausageIsSelected()).to.be.false
+    expect(RadioMandatoryPage.RadioMandatoryAnswerOtherIsSelected()).to.be.false
+
+    // choose Eggs first
+    RadioMandatoryPage.clickRadioMandatoryAnswerEggs()
+    expect(RadioMandatoryPage.RadioMandatoryAnswerEggsIsSelected()).to.be.true
+    RadioMandatoryPage.submit()
+
+    // When I return to the screen
+    RadioNonMandatoryPage.clickTopPrevious()
+
+    // Then my choice is remembered (Eggs)
+    expect(RadioMandatoryPage.RadioMandatoryAnswerNoneIsSelected()).to.be.false
+    expect(RadioMandatoryPage.RadioMandatoryAnswerBaconIsSelected()).to.be.false
+    expect(RadioMandatoryPage.RadioMandatoryAnswerEggsIsSelected()).to.be.true
+    expect(RadioMandatoryPage.RadioMandatoryAnswerSausageIsSelected()).to.be.false
+    expect(RadioMandatoryPage.RadioMandatoryAnswerOtherIsSelected()).to.be.false
+
+    // When I change my answer to the None option
+    RadioMandatoryPage.clickRadioMandatoryAnswerNone()
+    expect(RadioMandatoryPage.RadioMandatoryAnswerNoneIsSelected()).to.be.true
+    expect(RadioMandatoryPage.RadioMandatoryAnswerBaconIsSelected()).to.be.false
+    expect(RadioMandatoryPage.RadioMandatoryAnswerEggsIsSelected()).to.be.false
+    expect(RadioMandatoryPage.RadioMandatoryAnswerSausageIsSelected()).to.be.false
+    expect(RadioMandatoryPage.RadioMandatoryAnswerOtherIsSelected()).to.be.false
+    RadioMandatoryPage.submit()
+
+    // Then my choice is remembered when I return
+    RadioNonMandatoryPage.clickTopPrevious()
+    expect(RadioMandatoryPage.RadioMandatoryAnswerNoneIsSelected()).to.be.true
+    expect(RadioMandatoryPage.RadioMandatoryAnswerBaconIsSelected()).to.be.false
+    expect(RadioMandatoryPage.RadioMandatoryAnswerEggsIsSelected()).to.be.false
+    expect(RadioMandatoryPage.RadioMandatoryAnswerSausageIsSelected()).to.be.false
+    expect(RadioMandatoryPage.RadioMandatoryAnswerOtherIsSelected()).to.be.false
+
+    // When I change my answer for the last time to Sausage
+    RadioMandatoryPage.clickRadioMandatoryAnswerSausage()
+
+    // When I go to the summary
+    RadioMandatoryPage.submit()
+
+    // skipping non-mandatory page
+    RadioNonMandatoryPage.submit()
+
+    // Then my answer is shown
+    expect(SummaryPage.getMandatoryAnswer()).to.contain('Sausage')
+  })
 })


### PR DESCRIPTION
### What is the context of this PR?
Fixes #1013

WTForms defaults to use a coerce function on Radio (Selector) fields of `str()`; this will convert Python `NoneType` to `'None'` string which means WTForms cannot tell the difference between the user not choosing any option `data=None` and choosing an option that happens to have a value of `value='None'` in HTML (i.e. `data='None'`).

This PR changes the coerce function for radio fields to be aware of `NoneType` in Python to avoid converting it to the string `'None'` to avoid this clash. This fixes #1013 which is caused by a Survey that contains a Radio field with a `'None'` option.

I have updated the Selenium tests and test_radio.json to exercise a number of scenarios around this (choosing None, changing the answer, checking the summary screen etc.)

I also added a None option to test_checkbox.json - but it doesn't appear affected by the same issue (presumably because it processes lists `[]` not just a single value).

### How to review 
- Run Selenium tests (or rely on Travis pass)
- Run some manual testing with radio fields 
- Check issue #1013 is resolved.