### PR TITLE
Don't output qcodes for empty strings

### DIFF
--- a/app/submitter/converter.py
+++ b/app/submitter/converter.py
@@ -92,7 +92,9 @@ def convert_answers_to_data(answer_store, questionnaire_json, routing_path):
 
             if answer_schema is not None and value is not None and 'parent_answer_id' not in answer_schema:
                 if answer_schema['type'] != 'Checkbox' or any('q_code' not in option for option in answer_schema['options']):
-                    data[answer_schema['q_code']] = _get_answer_data(data, answer_schema['q_code'], value)
+                    answer_data = _get_answer_data(data, answer_schema['q_code'], value)
+                    if answer_data is not None:
+                        data[answer_schema['q_code']] = answer_data
                 else:
                     data.update(_get_checkbox_answer_data(answer_store, answer_schema, value))
     return data
@@ -191,5 +193,7 @@ def _encode_value(value):
         return str(value)
     elif isinstance(value, datetime):
         return value.strftime(settings.SDX_DATE_FORMAT)
+    elif isinstance(value, str) and value == '':
+        return None
     else:
         return value

--- a/tests/app/submitter/test_converter.py
+++ b/tests/app/submitter/test_converter.py
@@ -399,6 +399,55 @@ class TestConverter(SurveyRunnerTestCase):
             self.assertEqual(answer_object['data']['1'], 'Ready salted')
             self.assertEqual(answer_object['data']['4'], 'Bacon')
 
+    def test_converter_q_codes_for_empty_strings(self):
+        with self.application.test_request_context():
+            routing_path = [Location(group_id='favourite-food', group_instance=0, block_id='crisps')]
+            answers = [create_answer('crisps-answer', '', group_id='favourite-food', block_id='crisps')]
+            answers += [create_answer('other-crisps-answer', 'Ready salted', group_id='favourite-food', block_id='crisps')]
+
+            questionnaire = {
+                "survey_id": "999",
+                "data_version": "0.0.1",
+                "groups": [
+                    {
+                        "id": "favourite-food",
+                        "blocks": [
+                            {
+                                "id": "crisps",
+                                "sections": [
+                                    {
+                                        "questions": [{
+                                            "id": 'crisps-question',
+                                            "answers": [
+                                                {
+                                                    "id": "crisps-answer",
+                                                    "type": "TextArea",
+                                                    "options": [],
+                                                    "q_code": "1"
+                                                },
+                                                {
+                                                    "id": "other-crisps-answer",
+                                                    "type": "TextArea",
+                                                    "options": [],
+                                                    "q_code": "2"
+                                                }
+                                            ]
+                                        }]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            # When
+            answer_object = convert_answers(metadata, questionnaire, AnswerStore(answers), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 1)
+            self.assertEqual(answer_object['data']['2'], 'Ready salted')
+
 
 def create_answer(answer_id, value, group_id=None, block_id=None, answer_instance=0, group_instance=0):
     return {


### PR DESCRIPTION
### What is the context of this PR?
Fixes the converter to not add q_codes for empty strings to the downstream format

### How to review 
- Add some debugging to output the downstream payload before encryption
- Complete a 0205 survey with no comments and verify q_code 146 is not in the payload
- Complete a 0205 survey with a comment and verify q_code 146 is in the payload