### PR TITLE
Change question q_code 120/220 to TextField so respondent can enter number or %

### DIFF
--- a/app/data/1_0005.json
+++ b/app/data/1_0005.json
@@ -548,7 +548,7 @@
                                     "label": "What was the percentage or number of weekly paid employees who received this new pay rate?",
                                     "mandatory": false,
                                     "q_code": "120",
-                                    "type": "PositiveInteger"
+                                    "type": "TextField"
                                 }
                             ],
                             "id": "weekly-pay-significant-changes-pay-rates-increase-question",
@@ -1149,7 +1149,7 @@
                                     "label": "What was the percentage or number of fortnightly paid employees who received this new pay rate?",
                                     "mandatory": false,
                                     "q_code": "120f",
-                                    "type": "PositiveInteger"
+                                    "type": "TextField"
                                 }
                             ],
                             "id": "fortnightly-pay-significant-changes-pay-rates-increase-question",
@@ -1739,7 +1739,7 @@
                                     "label": "What was the percentage or number of calendar monthly paid employees who received this new pay rate?",
                                     "mandatory": false,
                                     "q_code": "220",
-                                    "type": "PositiveInteger"
+                                    "type": "TextField"
                                 }
                             ],
                             "id": "calendar-monthly-pay-significant-changes-pay-rates-increase-question",
@@ -2329,7 +2329,7 @@
                                     "label": "What was the percentage or number of four weekly paid employees who received this new pay rate?",
                                     "mandatory": false,
                                     "q_code": "220w4",
-                                    "type": "PositiveInteger"
+                                    "type": "TextField"
                                 }
                             ],
                             "id": "four-weekly-pay-significant-changes-pay-rates-increase-question",
@@ -2920,7 +2920,7 @@
                                     "label": "What was the percentage or number of five weekly paid employees who received this new pay rate?",
                                     "mandatory": false,
                                     "q_code": "220w5",
-                                    "type": "PositiveInteger"
+                                    "type": "TextField"
                                 }
                             ],
                             "id": "five-weekly-pay-significant-changes-pay-rates-increase-question",


### PR DESCRIPTION
### What is the context of this PR?
https://trello.com/c/xFLWeChE/820-production-questionnaire-mwss

MWSS failed PO approval because for question q_codes 120/220x the respondent needs to be able to enter a % sign to indicate if the value is a number or percentage. This PR changes the field to a TextField in the absence of a better field/solution.

### How to review 
- Check MWSS; can you enter "5%" into the question on screen 2.10/3.10/4.10 etc.

![image](https://cloud.githubusercontent.com/assets/14041600/23671523/7bc5ccca-0363-11e7-8542-f697e2a7db98.png)
