### PR TITLE
Eq 881 confirmation in navigation

### DIFF
--- a/app/data/1_0001.json
+++ b/app/data/1_0001.json
@@ -4960,9 +4960,8 @@
                 }],
                 "type": "Confirmation"
             }],
-            "hide_in_navigation": true,
             "id": "ready-to-submit",
-            "title": "You are now ready to submit this survey"
+            "title": "Submit answers"
         }
     ],
     "mime_type": "application/json/ons/eq",

--- a/app/data/1_0005.json
+++ b/app/data/1_0005.json
@@ -3114,9 +3114,8 @@
                     }]
                 }]
             }],
-            "hide_in_navigation": true,
             "id": "confirmation-group",
-            "title": "Confirmation"
+            "title": "Submit answers"
         }
     ],
     "legal_basis": "StatisticsOfTradeAct",

--- a/app/data/census_household.json
+++ b/app/data/census_household.json
@@ -4171,8 +4171,7 @@
         },
         {
             "id": "questionnaire-completed",
-            "title": "Questionnaire Completed",
-            "hide_in_navigation": true,
+            "title": "Submit answers",
             "blocks": [{
                 "type": "Confirmation",
                 "id": "confirmation",

--- a/app/data/test_final_confirmation.json
+++ b/app/data/test_final_confirmation.json
@@ -15,39 +15,44 @@
         "NOT_INTEGER": "Please enter an integer"
     },
     "groups": [{
-        "blocks": [{
-                "type": "Introduction",
-                "id": "introduction",
-                "title": "Introduction",
-                "description": ""
-            },
-            {
-                "type": "Questionnaire",
-                "id": "breakfast",
-                "sections": [{
-                    "description": "",
-                    "id": "breakfast-section",
-                    "questions": [{
-                        "answers": [{
-                            "guidance": "",
-                            "id": "breakfast-answer",
-                            "label": "What is your favourite breakfast food",
-                            "mandatory": false,
-                            "options": [],
-                            "q_code": "0",
-                            "type": "TextField"
-                        }],
+            "blocks": [{
+                    "type": "Introduction",
+                    "id": "introduction",
+                    "title": "Introduction",
+                    "description": ""
+                },
+                {
+                    "type": "Questionnaire",
+                    "id": "breakfast",
+                    "sections": [{
                         "description": "",
-                        "id": "breakfast-question",
+                        "id": "breakfast-section",
                         "title": "What is your favourite breakfast food",
-                        "type": "General"
+                        "questions": [{
+                            "answers": [{
+                                "guidance": "",
+                                "id": "breakfast-answer",
+                                "label": "What is your favourite breakfast food",
+                                "mandatory": false,
+                                "options": [],
+                                "q_code": "0",
+                                "type": "TextField"
+                            }],
+                            "description": "",
+                            "id": "breakfast-question",
+                            "title": "What is your favourite breakfast food",
+                            "type": "General"
+                        }]
                     }],
-                    "title": "What is your favourite breakfast food"
-                }],
-                "routing_rules": [],
-                "title": ""
-            },
-            {
+                    "routing_rules": [],
+                    "title": ""
+                }
+            ],
+            "id": "final-confirmation",
+            "title": "First group"
+        },
+        {
+            "blocks": [{
                 "type": "Confirmation",
                 "id": "confirmation",
                 "title": "Thank you for your answers, do you wish to submit",
@@ -56,9 +61,9 @@
                     "id": "questionnaire-completed-section",
                     "questions": []
                 }]
-            }
-        ],
-        "id": "final-confirmation",
-        "title": ""
-    }]
+            }],
+            "id": "confirmation-group",
+            "title": "Submit answers"
+        }
+    ]
 }

--- a/app/data/test_navigation_confirmation.json
+++ b/app/data/test_navigation_confirmation.json
@@ -452,12 +452,12 @@
         },
         {
             "blocks": [{
-                "type": "Summary",
-                "id": "summary",
+                "type": "Confirmation",
+                "id": "confirmation",
                 "title": "Summary"
             }],
-            "id": "summary-group",
-            "title": "Summary"
+            "id": "confirmation-group",
+            "title": "Submit answers"
         }
     ]
 }

--- a/app/data/test_percentage.json
+++ b/app/data/test_percentage.json
@@ -15,7 +15,7 @@
     },
     "navigation": true,
     "groups": [{
-        "blocks": [{
+            "blocks": [{
                 "type": "Questionnaire",
                 "id": "block",
                 "sections": [{
@@ -41,13 +41,17 @@
                 }],
                 "routing_rules": [],
                 "title": ""
-            },
-            {
+            }],
+            "id": "group",
+            "title": ""
+        },
+        {
+            "blocks": [{
                 "type": "Summary",
                 "id": "summary"
-            }
-        ],
-        "id": "group",
-        "title": ""
-    }]
+            }],
+            "id": "summary-group",
+            "title": "Summary"
+        }
+    ]
 }

--- a/app/data/test_repeating_household.json
+++ b/app/data/test_repeating_household.json
@@ -141,8 +141,7 @@
                 "id": "summary"
             }],
             "id": "summary-group",
-            "title": "",
-            "hide_in_navigation": true
+            "title": "Summary"
         }
     ]
 }

--- a/app/questionnaire/path_finder.py
+++ b/app/questionnaire/path_finder.py
@@ -177,14 +177,15 @@ class PathFinder:
             return routing_path[current_location_index - 1]
         return None
 
-    def get_latest_location(self, completed_blocks=None):
+    def get_latest_location(self, completed_blocks=None, routing_path=None):
         """
         Returns the latest 'location' based on the location path and previously completed blocks
 
         :param completed_blocks:
+        :param routing_path:
         :return:
         """
-        routing_path = self.get_routing_path()
+        routing_path = self.get_routing_path() if routing_path is None else routing_path
         if completed_blocks:
             incomplete_blocks = [item for item in routing_path if item not in completed_blocks]
 

--- a/tests/functional/pages/surveys/household_composition/household-composition.page.js
+++ b/tests/functional/pages/surveys/household_composition/household-composition.page.js
@@ -21,6 +21,11 @@ class HouseholdCompositionPage extends QuestionPage {
     return this
   }
 
+  setFullName(index, value) {
+    browser.setValue(this.getInputSelector(index, 'household-full-name'), value)
+    return this
+  }
+
   getInputSelector(index, name) {
     return 'input[name="' + this.getInputFieldName(index, name) + '"]'
   }

--- a/tests/functional/spec/final-confirmation.spec.js
+++ b/tests/functional/spec/final-confirmation.spec.js
@@ -31,17 +31,4 @@ describe('Final confirmation before submit', function () {
         expect(ThankYou.getMainHeading()).to.contain('Submission Successful')
     })
 
-
-    it('Given I successfully complete a questionnaire and am on the confirmation page, when I click change answers, then I should be returned to the questionnaire', function () {
-        //Given
-        startQuestionnaire(confirmation_schema)
-        FinalConfirmationSurveyPage.setBreakfastFood('Bacon').submit()
-
-        // When
-        Confirmation.changeAnswers()
-
-        //Then
-        expect(FinalConfirmationSurveyPage.isOpen()).to.be.true
-    })
-
 })

--- a/tests/functional/spec/navigation.spec.js
+++ b/tests/functional/spec/navigation.spec.js
@@ -1,7 +1,6 @@
 import landingPage from '../pages/landing.page'
 import PercentagePage from '../pages/surveys/percentage/percentage.page'
 import FinalConfirmationSurveyPage from '../pages/surveys/confirmation/final-confirmation-survey.page'
-import SummaryPage from '../pages/summary.page'
 import {
   openQuestionnaire,
   startQuestionnaire,
@@ -11,6 +10,7 @@ import {
   closeMobileNavigation,
   isViewSectionsVisible
 } from '../helpers'
+import SummaryPage from '../pages/summary.page'
 
 
 describe('Navigation', function() {

--- a/tests/integration/questionnaire/test_questionnaire_final_confirmation.py
+++ b/tests/integration/questionnaire/test_questionnaire_final_confirmation.py
@@ -16,7 +16,7 @@ class TestQuestionnaireFinalConfirmation(IntegrationTestCase):
         post_data = {
             'action[start_questionnaire]': 'Start Questionnaire'
         }
-        resp = self.get_and_post_with_csrf_token(base_url + '14ba4707-321d-441d-8d21-b8367366e766/0/introduction', data=post_data, follow_redirects=False)
+        resp = self.get_and_post_with_csrf_token(base_url + 'final-confirmation/0/introduction', data=post_data, follow_redirects=False)
         self.assertEqual(resp.status_code, 302)
 
         block_one_url = resp.location
@@ -48,11 +48,12 @@ class TestQuestionnaireFinalConfirmation(IntegrationTestCase):
         post_data = {
             'action[start_questionnaire]': 'Start Questionnaire'
         }
-        resp = self.client.post(base_url + '14ba4707-321d-441d-8d21-b8367366e766/0/introduction', data=post_data, follow_redirects=False)
+        resp = self.get_and_post_with_csrf_token(base_url + 'final-confirmation/0/introduction', data=post_data,
+                                                 follow_redirects=False)
         self.assertEqual(resp.status_code, 302)
 
         block_one_url = resp.location
 
-        resp = self.client.get(base_url + '14ba4707-321d-441d-8d21-b8367366e766/0/confirmation', follow_redirects=False)
+        resp = self.client.get(base_url + 'confirmation-group/0/confirmation', follow_redirects=False)
         self.assertEqual(resp.location, block_one_url)
         self.assertEqual(resp.status_code, 302)

--- a/tests/integration/questionnaire/test_questionnaire_previous_link.py
+++ b/tests/integration/questionnaire/test_questionnaire_previous_link.py
@@ -41,7 +41,7 @@ class TestQuestionnairePreviousLink(IntegrationTestCase):
 
         content = resp.get_data(True)
         self.assertFalse(resp_url.endswith('thank-you'))
-        self.assertIn('Previous', content)
+        self.assertNotIn('Previous', content)
 
     def test_previous_link_doesnt_appear_on_thank_you(self):
         # Given


### PR DESCRIPTION
### What is the context of this PR?
Adds a link in the navigation menu once all sections are completed.
For surveys with Summary pages it will display a "Summary" link.
For surveys with a Confirmation page it will display a "Submit answers" link.

### How to review 
Test the functionality against the acceptance criteria in the Trello card.
Ensure that the correct link is displayed for surveys with/without Summary/Confirmation pages respectively.
All existing tests should continue to pass.