### PR TITLE
Display 'No answer provided' on summary for empty answers

### DIFF
--- a/app/data/test_textarea.json
+++ b/app/data/test_textarea.json
@@ -16,7 +16,7 @@
     "groups": [{
         "blocks": [{
             "type": "Questionnaire",
-            "id": "block",
+            "id": "textarea-block",
             "sections": [{
                 "description": "",
                 "id": "section",
@@ -39,8 +39,12 @@
             }],
             "routing_rules": [],
             "title": ""
+        },
+        {
+            "type": "Summary",
+            "id": "textarea-summary"
         }],
-        "id": "group",
+        "id": "textarea-group",
         "title": ""
     }]
 }

--- a/app/templates/summary.html
+++ b/app/templates/summary.html
@@ -36,7 +36,7 @@
 
           <div class="summary__answer">
             <div class="summary__answer-text" id="{{answer.id}}-answer" data-qa="{{answer.id}}-answer">
-              {%- if answer.value is none -%}
+              {%- if answer.value is none or answer.value == '' -%}
                 {{not_answered}}
               {%- else -%}
                 {% include theme(['partials/summary/' ~ answer.type ~ '.html', 'partials/summary/default.html']) %}

--- a/tests/functional/generate_pages.py
+++ b/tests/functional/generate_pages.py
@@ -50,6 +50,18 @@ ANSWER_GETTER = r"""  get{answerName}(value) {
 
 """
 
+ANSWER_LABEL_GETTER = r"""  get{answerName}Label() {
+    return browser.element('#label-{answerId}')
+  }
+
+"""
+
+ANSWER_ELEMENT_GETTER = r"""  get{answerName}Element() {
+    return browser.element('[name="{answerId}"]')
+  }
+
+"""
+
 DROP_DOWN_SETTER = r"""  set{answerName}(value) {
     browser.selectByValue('[name="{answerId}"]', value)
     return this
@@ -178,6 +190,8 @@ def process_answer(question_type, answer, page_spec):
         else:
             page_spec.write(ANSWER_SETTER.replace("{answerName}", answer_name).replace("{answerId}", answer['id']))
             page_spec.write(ANSWER_GETTER.replace("{answerName}", answer_name).replace("{answerId}", answer['id']))
+            page_spec.write(ANSWER_LABEL_GETTER.replace("{answerName}", answer_name).replace("{answerId}", answer['id']))
+            page_spec.write(ANSWER_ELEMENT_GETTER.replace("{answerName}", answer_name).replace("{answerId}", answer['id']))
 
     else:
         raise Exception('Answer type [%s] not configured' % answer['type'])

--- a/tests/functional/pages/surveys/answers/textarea-block.page.js
+++ b/tests/functional/pages/surveys/answers/textarea-block.page.js
@@ -1,0 +1,30 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class TextareaBlockPage extends QuestionPage {
+
+  constructor() {
+    super('textarea-block')
+  }
+
+  setAnswer(value) {
+    browser.setValue('[name="answer"]', value)
+    return this
+  }
+
+  getAnswer(value) {
+    return browser.element('[name="answer"]').getValue()
+  }
+
+  getAnswerLabel() {
+    return browser.element('#label-answer')
+  }
+
+  getAnswerElement() {
+    return browser.element('[name="answer"]')
+  }
+
+}
+
+export default new TextareaBlockPage()

--- a/tests/functional/pages/surveys/answers/textarea-summary.page.js
+++ b/tests/functional/pages/surveys/answers/textarea-summary.page.js
@@ -1,0 +1,15 @@
+import QuestionPage from '../question.page'
+
+class TextareaSummaryPage extends QuestionPage {
+
+  constructor() {
+    super('textarea-summary')
+  }
+
+  getAnswer() {
+    return browser.element('[data-qa="answer-answer"]').getText()
+  }
+
+}
+
+export default new TextareaSummaryPage()

--- a/tests/functional/spec/textarea.spec.js
+++ b/tests/functional/spec/textarea.spec.js
@@ -1,13 +1,26 @@
 import {openQuestionnaire} from '../helpers'
 
-import TextFieldPage from '../pages/surveys/answers/textfield.page.js'
-
+import TextareaBlock from '../pages/surveys/answers/textarea-block.page.js'
+import TextareaSummary from '../pages/surveys/answers/textarea-summary.page.js'
 
 describe('Textarea', function() {
 
   it('Given a textarea option, a user should be able to click the label of the textarea to focus', function() {
     openQuestionnaire('test_textarea.json')
-    TextFieldPage.label.click()
-    expect(browser.hasFocus(TextFieldPage.textfield.selector)).to.be.true
+    TextareaBlock.getAnswerLabel().click()
+    expect(browser.hasFocus(TextareaBlock.getAnswerElement().selector)).to.be.true
   })
+
+  it('Given a textarea option, When no text is entered, Then the summary should display "No answer provided"', function() {
+    openQuestionnaire('test_textarea.json')
+    TextareaBlock.submit()
+    expect(TextareaSummary.getAnswer()).to.contain('No answer provided')
+  })
+
+  it('Given a textarea option, When some text is entered, Then the summary should display the text', function() {
+    openQuestionnaire('test_textarea.json')
+    TextareaBlock.setAnswer('Some text').submit()
+    expect(TextareaSummary.getAnswer()).to.contain('Some text')
+  })
+
 })


### PR DESCRIPTION
### What is the context of this PR?
Fixes the summary screen to display 'No answer provided' for empty textarea fields e.g. the comments field on RSI/MCI surveys.

Fixes #1022 

### How to review 
- Complete an RSI/MCI survey and don't enter any content in the comments field, verify 'No answer provided' is displayed on the summary screen.
- Complete an RSI/MCI survey and enter some content in the comments field, verify the content is displayed on the summary screen.