### PR TITLE
Add support for dumping data by authorised users

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -183,6 +183,10 @@ def add_blueprints(application):
     application.register_blueprint(flush_blueprint)
     flush_blueprint.config = application.config.copy()
 
+    from app.views.dump import dump_blueprint
+    application.register_blueprint(dump_blueprint)
+    dump_blueprint.config = application.config.copy()
+
     from app.views.errors import errors_blueprint
     application.register_blueprint(errors_blueprint)
     errors_blueprint.config = application.config.copy()

--- a/app/authentication/roles.py
+++ b/app/authentication/roles.py
@@ -1,0 +1,35 @@
+from functools import wraps
+from flask_login import current_user
+from werkzeug.exceptions import Forbidden
+from app.globals import get_metadata
+
+
+def role_required(role):
+    """
+    If you decorate a view with this, it will ensure that the current user has
+    the specified role before calling the actual view. (If they are
+    not, it raises a Forbidden exception) For
+    example::
+
+        @app.route('/dump')
+        @login_required
+        @role_required('dumper')
+        def dump():
+            pass
+
+    This decorator should be used after the flask_login.login_required
+    decorator to ensure that the user is logged in before their role is checked.
+
+    :param role: The role required by the function being decorated
+    """
+    def role_required_decorator(func):
+        @wraps(func)
+        def role_required_wrapper(*args, **kwargs):
+            metadata = get_metadata(current_user)
+            roles = metadata and metadata.get('roles', []) or []
+            if current_user.is_authenticated and role in roles:
+                return func(*args, **kwargs)
+            else:
+                raise Forbidden
+        return role_required_wrapper
+    return role_required_decorator

--- a/app/parser/metadata_parser.py
+++ b/app/parser/metadata_parser.py
@@ -61,6 +61,7 @@ metadata_fields = {
     "language_code": MetadataField(mandatory=False),
     "tx_id": MetadataField(mandatory=False, validator=uuid_4_parser, generator=id_generator),
     "variant_flags": MetadataField(mandatory=False),
+    "roles": MetadataField(mandatory=False),
 }
 
 

--- a/app/views/dev_mode.py
+++ b/app/views/dev_mode.py
@@ -38,6 +38,7 @@ def dev_mode():
         language_code = form.get("language_code")
         sexual_identity = form.get("sexual_identity") == "true"
         variant_flags = {"sexual_identity": sexual_identity}
+        roles = ['dumper']
         payload = create_payload(user=user,
                                  exp_time=exp_time,
                                  eq_id=eq_id,
@@ -54,7 +55,8 @@ def dev_mode():
                                  employment_date=employment_date,
                                  region_code=region_code,
                                  language_code=language_code,
-                                 variant_flags=variant_flags)
+                                 variant_flags=variant_flags,
+                                 roles=roles)
 
         return redirect("/session?token=" + generate_token(payload).decode())
 
@@ -111,24 +113,25 @@ def create_payload(**metadata):
     exp = time.time() + float(metadata['exp_time'])
 
     payload = {
-        "user_id": metadata['user'],
+        'user_id': metadata['user'],
         'iat': str(int(iat)),
         'exp': str(int(exp)),
         'jti': str(uuid4()),
-        "eq_id": metadata['eq_id'],
-        "period_str": metadata['period_str'],
-        "period_id": metadata['period_id'],
-        "form_type": metadata['form_type'],
-        "collection_exercise_sid": metadata['collection_exercise_sid'],
-        "ref_p_start_date": metadata['ref_p_start_date'],
-        "ru_ref": metadata['ru_ref'],
-        "ru_name": metadata['ru_name'],
-        "return_by": metadata['return_by'],
-        "trad_as": metadata['trad_as'],
-        "employment_date": metadata['employment_date'],
-        "region_code": metadata['region_code'],
-        "language_code": metadata['language_code'],
-        "variant_flags": metadata['variant_flags'],
+        'eq_id': metadata['eq_id'],
+        'period_str': metadata['period_str'],
+        'period_id': metadata['period_id'],
+        'form_type': metadata['form_type'],
+        'collection_exercise_sid': metadata['collection_exercise_sid'],
+        'ref_p_start_date': metadata['ref_p_start_date'],
+        'ru_ref': metadata['ru_ref'],
+        'ru_name': metadata['ru_name'],
+        'return_by': metadata['return_by'],
+        'trad_as': metadata['trad_as'],
+        'employment_date': metadata['employment_date'],
+        'region_code': metadata['region_code'],
+        'language_code': metadata['language_code'],
+        'variant_flags': metadata['variant_flags'],
+        'roles': metadata.get('roles', []),
     }
     if metadata.get('ref_p_end_date'):
         payload["ref_p_end_date"] = metadata['ref_p_end_date']

--- a/app/views/dump.py
+++ b/app/views/dump.py
@@ -1,0 +1,33 @@
+from flask_login import current_user
+from flask_login import login_required
+from flask import Blueprint, jsonify
+
+
+from app.authentication.roles import role_required
+from app.globals import get_answer_store, get_metadata
+from app.submitter.converter import convert_answers
+from app.utilities.schema import get_schema
+from app.questionnaire.path_finder import PathFinder
+
+
+dump_blueprint = Blueprint('dump', __name__)
+
+
+@dump_blueprint.route('/dump/answers', methods=['GET'])
+@login_required
+@role_required('dumper')
+def dump_answers():
+    response = {'answers': get_answer_store(current_user).answers or []}
+    return jsonify(response), 200
+
+
+@dump_blueprint.route('/dump/submission', methods=['GET'])
+@login_required
+@role_required('dumper')
+def dump_submission():
+    answer_store = get_answer_store(current_user)
+    metadata = get_metadata(current_user)
+    schema = get_schema(metadata)
+    routing_path = PathFinder(schema, answer_store, metadata).get_routing_path()
+    response = {'submission': convert_answers(metadata, schema, answer_store, routing_path)}
+    return jsonify(response), 200

--- a/tests/app/authentication/test_roles.py
+++ b/tests/app/authentication/test_roles.py
@@ -1,0 +1,236 @@
+import sys
+from unittest import TestCase
+from mock import patch
+from werkzeug.exceptions import Forbidden
+
+
+class TestRoleRequired(TestCase):
+
+    def setUp(self):
+        # Create a patched get_metadata
+        self.get_metadata_patcher = patch('app.globals.get_metadata', autospec=True)
+        self.addCleanup(self.get_metadata_patcher.stop)
+        self.mock_get_metadata = self.get_metadata_patcher.start()
+
+        # Create a patched current_user
+        self.get_current_user_patcher = patch('flask_login.current_user', autospec=True)
+        self.addCleanup(self.get_current_user_patcher.stop)
+        self.mock_current_user = self.get_current_user_patcher.start()
+
+        # Between tests we have to remove the imported module
+        # otherwise the Mocks for get_metadata and current_user
+        # are cached and can't be replaced.
+        if 'app.authentication.roles' in sys.modules:
+            del sys.modules['app.authentication.roles']
+
+        # The import of app.authentication.roles.role_required must be
+        # performed after get_metadata and current_user have been patched
+        # otherwise the original functions are cached and not patched correctly
+        from app.authentication.roles import role_required
+        self.role_required = role_required
+
+    def test_role_required_unauthenticated_no_metadata(self):
+        # Given I am not authenticated and have no metadata
+        self.mock_get_metadata.return_value = None
+        self.mock_current_user.is_authenticated = False
+
+        # And I have decorated a function with role_required
+        wrapper = self.role_required('dumper')
+        wrapped_func = wrapper(lambda: 'not called')
+
+        # When I call the decorated function
+        # Then a Forbidden exception is raised
+        with self.assertRaises(Forbidden):
+            wrapped_func()
+
+    def test_role_required_authenticated_no_metadata(self):
+        # Given I am authenticated but have no metadata
+        self.mock_get_metadata.return_value = None
+        self.mock_current_user.is_authenticated = True
+
+        # And I have decorated a function with role_required
+        wrapper = self.role_required('dumper')
+        wrapped_func = wrapper(lambda: 'not called')
+
+        # When I call the decorated function
+        # Then a Forbidden exception is raised
+        with self.assertRaises(Forbidden):
+            wrapped_func()
+
+    def test_role_required_authenticated_with_empty_metadata(self):
+        # Given I am authenticated but my metadata is empty
+        self.mock_get_metadata.return_value = {}
+        self.mock_current_user.is_authenticated = True
+
+        # And I have decorated a function with role_required
+        wrapper = self.role_required('dumper')
+        wrapped_func = wrapper(lambda: 'not called')
+
+        # When I call the decorated function
+        # Then a Forbidden exception is raised
+        with self.assertRaises(Forbidden):
+            wrapped_func()
+
+    def test_role_required_authenticated_with_metadata_none_roles(self):
+        # Given I am authenticated but my metadata contains a
+        # roles list set to None
+        self.mock_get_metadata.return_value = {'roles': None}
+        self.mock_current_user.is_authenticated = True
+
+        # And I have decorated a function with role_required
+        wrapper = self.role_required('dumper')
+        wrapped_func = wrapper(lambda: 'not called')
+
+        # When I call the decorated function
+        # Then a Forbidden exception is raised
+        with self.assertRaises(Forbidden):
+            wrapped_func()
+
+    def test_role_required_authenticated_with_metadata_empty_roles(self):
+        # Given I am authenticated and my metadata contains an empty
+        # roles list
+        self.mock_get_metadata.return_value = {'roles': []}
+        self.mock_current_user.is_authenticated = True
+
+        # And I have decorated a function with role_required
+        wrapper = self.role_required('dumper')
+        wrapped_func = wrapper(lambda: 'not called')
+
+        # When I call the decorated function
+        # Then a Forbidden exception is raised
+        with self.assertRaises(Forbidden):
+            wrapped_func()
+
+    def test_role_required_authenticated_with_metadata_wrong_role(self):
+        # Given I am authenticated and my metadata contains a single role.
+        self.mock_get_metadata.return_value = {'roles': ['flusher']}
+        self.mock_current_user.is_authenticated = True
+
+        # And I have decorated a function with role_required, specifying a
+        # role that isn't in the metadata roles list.
+        wrapper = self.role_required('dumper')
+        wrapped_func = wrapper(lambda: 'not called')
+
+        # When I call the decorated function
+        # Then a Forbidden exception is raised
+        with self.assertRaises(Forbidden):
+            wrapped_func()
+
+    def test_role_required_authenticated_with_metadata_matching_role(self):
+        # Given I am authenticated and my metadata contains a single role.
+        self.mock_get_metadata.return_value = {'roles': ['dumper']}
+        self.mock_current_user.is_authenticated = True
+
+        # And I have decorated a function with role_required, specifying a
+        # role that is listed in the metadata roles list.
+        wrapper = self.role_required('dumper')
+        wrapped_func = wrapper(lambda: 'single was called')
+
+        # When I call the decorated function
+        # Then the function is executed and returns a value
+        self.assertEqual(wrapped_func(), 'single was called')
+
+    def test_role_required_authenticated_with_metadata_matching_multiple_role(self):
+        # Given I am authenticated but my metadata contains multiples roles
+        self.mock_get_metadata.return_value = {'roles': ['flusher', 'other', 'dumper']}
+        self.mock_current_user.is_authenticated = True
+
+        # And I have decorated a function with role_required, specifying a
+        # role that is listed in the metadata roles list.
+        wrapper = self.role_required('other')
+        wrapped_func = wrapper(lambda: 'other was called')
+
+        # When I call the decorated function
+        # Then the function is executed and returns a value
+        self.assertEqual(wrapped_func(), 'other was called')
+
+    def test_role_required_wrapped_with_positional_arguments(self):
+        # Given I am authenticated and my metadata contains roles
+        self.mock_get_metadata.return_value = {'roles': ['flusher', 'other', 'dumper']}
+        self.mock_current_user.is_authenticated = True
+
+        # And I have decorated a function that takes multiple positional arguments
+        # with role_required, specifying a role that is listed in the metadata
+        # roles list.
+        wrapper = self.role_required('other')
+        wrapped_func = wrapper(lambda arg1, arg2, arg3: [arg1, arg2, arg3])
+
+        # When I call the decorated function with arguments
+        # Then the function is executed and returns the arguments supplied
+        self.assertListEqual(wrapped_func(1, 2, 3), [1, 2, 3])
+
+    def test_role_required_wrapped_with_keyword_arguments(self):
+        # Given I am authenticated and my metadata contains roles
+        self.mock_get_metadata.return_value = {'roles': ['flusher', 'other', 'dumper']}
+        self.mock_current_user.is_authenticated = True
+
+        # And I have decorated a function that takes multiple positional arguments
+        # with role_required, specifying a role that is listed in the metadata
+        # roles list.
+        wrapper = self.role_required('other')
+        wrapped_func = wrapper(lambda arg1=None, arg2=None: [arg1, arg2])
+
+        # When I call the decorated function with arguments
+        # Then the function is executed and returns the arguments supplied
+        self.assertListEqual(wrapped_func(arg1='y', arg2='z'), ['y', 'z'])
+
+    def test_role_required_wrapped_with_positional_and_keyword_arguments(self):
+        # Given I am authenticated and my metadata contains roles
+        self.mock_get_metadata.return_value = {'roles': ['flusher', 'other', 'dumper']}
+        self.mock_current_user.is_authenticated = True
+
+        # And I have decorated a function that takes multiple positional arguments
+        # with role_required, specifying a role that is listed in the metadata
+        # roles list.
+        wrapper = self.role_required('other')
+        wrapped_func = wrapper(lambda arg1, arg2=None: [arg1, arg2])
+
+        # When I call the decorated function with both positional and keyword arguments
+        # Then the function is executed and returns the arguments supplied
+        self.assertListEqual(wrapped_func('i', arg2=2), ['i', 2])
+
+    def test_role_required_unauthenticated_wrapped_with_arguments(self):
+        # Given I am not authenticated
+        self.mock_get_metadata.return_value = {}
+        self.mock_current_user.is_authenticated = False
+
+        # And I have decorated a function that takes multiple arguments
+        wrapper = self.role_required('other')
+        wrapped_func = wrapper(lambda arg1, arg2, arg3: [arg1, arg2, arg3])
+
+        # When I call the decorated function with arguments
+        # Then a Forbidden exception is raised
+        with self.assertRaises(Forbidden):
+            wrapped_func('a', 'b', 'c')
+
+    def test_role_required_unauthenticated_wrapped_with_keyword_arguments(self):
+        # Given I am not authenticated
+        self.mock_get_metadata.return_value = {'roles': ['flusher', 'other', 'dumper']}
+        self.mock_current_user.is_authenticated = False
+
+        # And I have decorated a function that takes multiple positional arguments
+        # with role_required, specifying a role that is listed in the metadata
+        # roles list.
+        wrapper = self.role_required('other')
+        wrapped_func = wrapper(lambda arg1=None, arg2=None: [arg1, arg2])
+
+        # When I call the decorated function with keyword arguments
+        # Then a Forbidden exception is raised
+        with self.assertRaises(Forbidden):
+            wrapped_func(arg1='y', arg2='z')
+
+    def test_role_required_unauthenticated_wrapped_with_positional_and_keyword_arguments(self):
+        # Given I am not authenticated
+        self.mock_get_metadata.return_value = {'roles': ['flusher', 'other', 'dumper']}
+        self.mock_current_user.is_authenticated = False
+
+        # And I have decorated a function that takes multiple positional arguments
+        # with role_required, specifying a role that is listed in the metadata
+        # roles list.
+        wrapper = self.role_required('other')
+        wrapped_func = wrapper(lambda arg1, arg2=None: [arg1, arg2])
+
+        # When I call the decorated function with keyword arguments
+        # Then a Forbidden exception is raised
+        with self.assertRaises(Forbidden):
+            wrapped_func('p', arg2=9)

--- a/tests/app/views/test_dump.py
+++ b/tests/app/views/test_dump.py
@@ -1,0 +1,211 @@
+import json
+from tests.integration.integration_test_case import IntegrationTestCase
+
+
+class TestDumpAnswers(IntegrationTestCase):
+
+    def test_dump_answers_not_authenticated(self):
+        # Given I am not an authenticated user
+        # When I attempt to dump the answer store
+        response = self.client.get('/dump/answers')
+
+        # Then I receive a 401 Unauthorised response code
+        self.assertEqual(401, response.status_code)
+
+    def test_dump_answers_authenticated_missing_role(self):
+        # Given I am an authenticated user who has launched a survey
+        # but does not have the 'dumper' role in my metadata
+        self.launchSurvey('test', 'radio')
+
+        # When I attempt to dump the answer store
+        response = self.client.get('/dump/answers')
+
+        # Then I receive a 403 Forbidden response code
+        self.assertEqual(403, response.status_code)
+
+        # And the response data contains Forbidden
+        actual = response.get_data(True)
+        self.assertIn('Forbidden', actual)
+
+    def test_dump_answers_authenticated_with_role_no_answers(self):
+        # Given I am an authenticated user who has launched a survey
+        # and does have the 'dumper' role in my metadata
+        _, response = self.launchSurvey('test', 'radio', roles=['dumper'])
+
+        # When I haven't submitted any answers
+        # And I attempt to dump the answer store
+        response = self.client.get('/dump/answers')
+
+        # Then I get a 200 OK response
+        self.assertEqual(200, response.status_code)
+
+        # And the JSON response contains an empty array
+        actual = json.loads(response.get_data(True))
+        expected = {'answers': []}
+
+        self.assertDictEqual(actual, expected)
+
+    def test_dump_answers_authenticated_with_role_with_answers(self):
+        # Given I am an authenticated user who has launched a survey
+        # and does have the 'dumper' role in my metadata
+        url, response = self.launchSurvey('test', 'radio', roles=['dumper'])
+
+        # When I submit an answer
+        post_data = {
+            'csrf_token': self.extract_csrf_token(response.get_data(True)),
+            'radio-mandatory-answer': 'Bacon',
+            'action[save_continue]': ''
+        }
+        self.postRedirectGet(url, post_data)
+
+        # And I attempt to dump the answer store
+        response = self.client.get('/dump/answers')
+
+        # Then I get a 200 OK response
+        self.assertEqual(200, response.status_code)
+
+        # And the JSON response contains the data I submitted
+        actual = json.loads(response.get_data(True))
+        expected = {
+            'answers': [
+                {
+                    'value': '', 'answer_instance': 0,
+                    'block_id': 'radio-mandatory',
+                    'group_instance': 0,
+                    'group_id': 'radio',
+                    'answer_id': 'other-answer-mandatory'
+                },
+                {
+                    'value': 'Bacon',
+                    'answer_instance': 0,
+                    'block_id': 'radio-mandatory',
+                    'group_instance': 0,
+                    'group_id': 'radio',
+                    'answer_id': 'radio-mandatory-answer'
+                }
+            ]
+        }
+
+        # Enable full dictionary diffs on test failure
+        self.maxDiff = None
+
+        # Data in the answer store doesn't seem to be in a consistent order
+        # between test runs so we have to compare like this.
+        self.assertCountEqual(actual['answers'], expected['answers'])
+
+
+class TestDumpSubmission(IntegrationTestCase):
+
+    def test_dump_submission_not_authenticated(self):
+        # Given I am not an authenticated user
+        # When I attempt to dump the submission payload
+        response = self.client.get('/dump/submission')
+
+        # Then I receive a 401 Unauthorised response code
+        self.assertEqual(401, response.status_code)
+
+    def test_dump_submission_authenticated_missing_role(self):
+        # Given I am an authenticated user who has launched a survey
+        # but does not have the 'dumper' role in my metadata
+        self.launchSurvey('test', 'radio')
+
+        # When I attempt to dump the submission payload
+        response = self.client.get('/dump/submission')
+
+        # Then I receive a 403 Forbidden response code
+        self.assertEqual(403, response.status_code)
+
+        # And the response data contains Forbidden
+        actual = response.get_data(True)
+        self.assertIn('Forbidden', actual)
+
+    def test_dump_submission_authenticated_with_role_no_answers(self):
+        # Given I am an authenticated user who has launched a survey
+        # and does have the 'dumper' role in my metadata
+        _, response = self.launchSurvey('test', 'radio', roles=['dumper'])
+
+        # When I haven't submitted any answers
+        # And I attempt to dump the submission payload
+        response = self.client.get('/dump/submission')
+
+        # Then I get a 200 OK response
+        self.assertEqual(200, response.status_code)
+
+        # And the JSON response contains the data I submitted
+        actual = json.loads(response.get_data(True))
+
+        # tx_id and submitted_at are dynamic; so copy them over
+        expected = {
+            'submission': {
+                'version': '0.0.1',
+                'survey_id': '0',
+                'origin': 'uk.gov.ons.edc.eq',
+                'type': 'uk.gov.ons.edc.eq:surveyresponse',
+                'tx_id': actual['submission']['tx_id'],
+                'submitted_at': actual['submission']['submitted_at'],
+                'collection': {
+                    'period': '201604',
+                    'exercise_sid': '789',
+                    'instrument_id': 'radio'
+                },
+                'data': {},
+                'metadata': {
+                    'ru_ref': '123456789012A',
+                    'user_id': 'integration-test'
+                }
+            }
+        }
+
+        # Enable full dictionary diffs on test failure
+        self.maxDiff = None
+        self.assertDictEqual(actual, expected)
+
+    def test_dump_submission_authenticated_with_role_with_answers(self):
+        # Given I am an authenticated user who has launched a survey
+        # and does have the 'dumper' role in my metadata
+        url, response = self.launchSurvey('test', 'radio', roles=['dumper'])
+
+        # When I submit an answer
+        post_data = {
+            'csrf_token': self.extract_csrf_token(response.get_data(True)),
+            'radio-mandatory-answer': 'Bacon',
+            'action[save_continue]': ''
+        }
+        self.postRedirectGet(url, post_data)
+
+        # And I attempt to dump the submission payload
+        response = self.client.get('/dump/submission')
+
+        # Then I get a 200 OK response
+        self.assertEqual(200, response.status_code)
+
+        # And the JSON response contains the data I submitted
+        actual = json.loads(response.get_data(True))
+
+        # tx_id and submitted_at are dynamic; so copy them over
+        expected = {
+            'submission': {
+                'version': '0.0.1',
+                'survey_id': '0',
+                'origin': 'uk.gov.ons.edc.eq',
+                'type': 'uk.gov.ons.edc.eq:surveyresponse',
+                'tx_id': actual['submission']['tx_id'],
+                'submitted_at': actual['submission']['submitted_at'],
+                'collection': {
+                    'period': '201604',
+                    'exercise_sid': '789',
+                    'instrument_id': 'radio'
+                },
+                'data': {
+                    '20': 'Bacon'
+                },
+                'metadata': {
+                    'ru_ref': '123456789012A',
+                    'user_id': 'integration-test'
+                }
+            }
+        }
+
+        # Enable full dictionary diffs on test failure
+        self.maxDiff = None
+        self.assertDictEqual(actual, expected)

--- a/tests/integration/create_token.py
+++ b/tests/integration/create_token.py
@@ -4,25 +4,26 @@ from uuid import uuid4
 from app.views.dev_mode import generate_token
 
 PAYLOAD = {
-    'user_id': "mci-integration-test",
-    "period_str": "April 2016",
-    "period_id": "201604",
-    "collection_exercise_sid": "789",
-    "ru_ref": "123456789012A",
-    "ru_name": "MCI Integration Testing",
-    "ref_p_start_date": "2016-04-01",
-    "ref_p_end_date": "2016-04-30",
-    "return_by": "2016-05-06",
-    "trad_as": "Integration Tests",
-    "employment_date": "1983-06-02",
-    "variant_flags": None,
-    "region_code": None,
-    "language_code": None
+    'user_id': 'integration-test',
+    'period_str': 'April 2016',
+    'period_id': '201604',
+    'collection_exercise_sid': '789',
+    'ru_ref': '123456789012A',
+    'ru_name': 'Integration Testing',
+    'ref_p_start_date': '2016-04-01',
+    'ref_p_end_date': '2016-04-30',
+    'return_by': '2016-05-06',
+    'trad_as': 'Integration Tests',
+    'employment_date': '1983-06-02',
+    'variant_flags': None,
+    'region_code': 'GB-ENG',
+    'language_code': 'en',
+    'roles': [],
 }
 
 
 def create_token(form_type_id, eq_id, **extra_payload):
-    payload_vars = PAYLOAD
+    payload_vars = PAYLOAD.copy()
     payload_vars['eq_id'] = eq_id
     payload_vars['form_type'] = form_type_id
     payload_vars['jti'] = str(uuid4())

--- a/tests/integration/star_wars/test_star_wars_introduction.py
+++ b/tests/integration/star_wars/test_star_wars_introduction.py
@@ -13,7 +13,7 @@ class TestStarWarsIntroduction(StarWarsTestCase):
         self.assertIn('Legal Information', content)
         self.assertIn('>Start survey<', content)
         self.assertRegex(content, '(?s)Trading as.*?Integration Tests')
-        self.assertRegex(content, '(?s)Business name.*?MCI Integration Testing')
+        self.assertRegex(content, '(?s)Business name.*?Integration Testing')
         self.assertRegex(content, '(?s)PLEASE SUBMIT BY.*?6 May 2016')
         self.assertRegex(content, '(?s)PERIOD.*?1 April 2016.*?30 April 2016')
         self.assertIn('questionnaire by 6 May 2016, penalties may be incurred', content)


### PR DESCRIPTION
### What is the context of this PR?
- Added a /dump route Blueprint that allows the answer store or submission data to be dumped as JSON at any time.
- This requires a user to be logged-in and their metadata to contain a 'role' of 'dumper'.
- The /dev page has been updated to always enable the 'dumper' role.
- The 'role' metadata has been persisted to the user's metadata.
- A `role_required` function decorator has been added to `app.authentication.roles` that allows a function to require a role in the user's metadata or will raise a Flask Forbidden exception.

### How to test?
- Start a questionnaire and answer some questions.
- To dump the answer store go to: /dump/answers
- To dump the submission data go to: /dump/submission
- Check that an invalid dump gives an error e.g. /dump/nothing
- Save and complete later and verify you cannot get to /dump/answers or submission anymore (session expired)

- If you try dumping when there are no answer (e.g. on landing page) you'll get a
bad request because the answer store is empty.

### To review:
- The naming of things, is dump correct, what about the role?
- Are we happy to have the dump blueprint in Production?
- Are the URLs meaningful/standard?
- Is the output useful?

### To-do:
- [x] Add tests
- [x] code review
- [x] rebase and squash
