### PR TITLE
Prevent apache restarts on logrotate

### DIFF
--- a/.ebextensions/deploy.config
+++ b/.ebextensions/deploy.config
@@ -7,3 +7,8 @@ packages:
 commands:
     01-upgrade-pip:
         command: "/opt/python/run/venv/bin/pip  install --upgrade pip"
+
+files:
+    "/etc/logrotate.elasticbeanstalk.hourly/logrotate.elasticbeanstalk.httpd.conf":
+        content: |
+           # The content of this file has been removed to prevent log rotation


### PR DESCRIPTION
### What is the context of this PR?
Changed log rotate to not rotate which prevents apache process being restarted to switch to a new file.

### How to review 
Run in AWS and confirm that Logs are still being delivered to CloudWatch and that on the hour the apache process is not restarted.

Fixes https://github.com/ONSdigital/eq-survey-runner/issues/1007