### PR TITLE
Revert apache log format customisation

### DIFF
--- a/app-httpd.conf
+++ b/app-httpd.conf
@@ -3,5 +3,3 @@ Alias /s /opt/python/current/app/static
 Order allow,deny
 Allow from all
 </Directory>
-
-ErrorLogFormat "%M"


### PR DESCRIPTION
The Apache log format customisation to just output the application log line appears to have broken the log shipping from Elastic Beanstalk to CloudWatch. This pull request reverts the previous change so that we log the application JSON log line alongside the Apache log line.

### How to review 
Deploy survey runner to AWS and ensure logs are being shipped to CloudWatch and look something like this:
```
[Fri Mar 10 12:05:12.974906 2017] [:error] [pid 3660]
{
    "tx_id": "...",
    "created": "2017-03-10T12:05:12.974809Z",
    "eq_session_id": "...",
    "level": "debug",
    "service": "eq-survey-runner",
    "event": "finding eq_session_id in database"
}
```