### PR TITLE
Fixes #1032; Fixes #1036; page title issues

### DIFF
--- a/app/templates/session-expired.html
+++ b/app/templates/session-expired.html
@@ -1,7 +1,7 @@
 {% extends theme('layouts/_twocol.html') %}
 {% import 'macros/helpers.html' as helpers %}
 
-{% block page_title %}{{_("Session expired")}} - {{survey_title}}{% endblock %}
+{% block page_title %}{{_("Session expired")}}{% endblock %}
 
 {% block main %}
 

--- a/app/templating/template_renderer.py
+++ b/app/templating/template_renderer.py
@@ -30,8 +30,11 @@ class TemplateRenderer:
     @staticmethod
     def safe_content(content):
         if content is not None:
-            return re.sub(r'\{\{[^}]+\}\}', '…', content)
-        else:
-            return None
+            # Replace piping with ellipsis
+            content = re.sub(r'\{\{[^}]+\}\}', '…', content)
+            # Strip HTML Tags
+            content = re.sub(r'</?[^>]+>', '', content)
+
+        return content
 
 renderer = TemplateRenderer()

--- a/tests/app/templating/test_template_renderer.py
+++ b/tests/app/templating/test_template_renderer.py
@@ -134,3 +134,31 @@ class TestTemplateRenderer(unittest.TestCase):
         safe_content = TemplateRenderer.safe_content(content)
 
         self.assertEqual(safe_content, 'Is … correct?')
+
+    def test_should_replace_simple_html_tags(self):
+        content = 'This <em>string contains</em> <p><strong>some</strong></p><i>HTML</i>tags?'
+
+        safe_content = TemplateRenderer.safe_content(content)
+
+        self.assertEqual(safe_content, 'This string contains someHTMLtags?')
+
+    def test_should_replace_complex_broken_html_tags(self):
+        content = 'This <div style="bleh" a=2>string contains <a href="http://www.ons.gov.uk/not_found">a link</a>'
+
+        safe_content = TemplateRenderer.safe_content(content)
+
+        self.assertEqual(safe_content, 'This string contains a link')
+
+    def test_should_replace_broken_html_tags(self):
+        content = '</lzz> This <em>string contains<p><strong><i><div> some</strong></p><i> HTML </i>tags?'
+
+        safe_content = TemplateRenderer.safe_content(content)
+
+        self.assertEqual(safe_content, ' This string contains some HTML tags?')
+
+    def test_should_replace_html_tags_and_jinja_templates_together(self):
+        content = 'Is {{ format_something(meta.survey.start_date|length)}} really <strong>correct</strong>?'
+
+        safe_content = TemplateRenderer.safe_content(content)
+
+        self.assertEqual(safe_content, 'Is … really correct?')

--- a/tests/integration/questionnaire/test_questionnaire_page_titles.py
+++ b/tests/integration/questionnaire/test_questionnaire_page_titles.py
@@ -78,7 +78,10 @@ class TestQuestionnairePageTitles(IntegrationTestCase):
         # Then
         self.assertEqual(extraction.title, 'Signed out - Final confirmation to submit')
 
-    def test_should_have_survey_in_page_title_when_session_expired(self):
+    def test_session_expired_page_title(self):
+        """
+        Checks https://github.com/ONSdigital/eq-survey-runner/issues/1032
+        """
         # Given
         token = create_token('final_confirmation', 'test')
         self.client.get('/session?token=' + token.decode(), follow_redirects=False)
@@ -88,7 +91,7 @@ class TestQuestionnairePageTitles(IntegrationTestCase):
         extraction = Extractor().extract(resp.get_data(True))
 
         # Then
-        self.assertEqual(extraction.title, 'Session expired - Final confirmation to submit')
+        self.assertEqual(extraction.title, 'Session expired')
 
     def test_should_have_survey_in_page_title_when_error(self):
         # Given
@@ -114,3 +117,15 @@ class TestQuestionnairePageTitles(IntegrationTestCase):
 
         # Then
         self.assertEqual(extraction.title, 'Favourite food - Interstitial Pages')
+
+    def test_html_stripped_from_page_titles(self):
+        """
+        Checks for https://github.com/ONSdigital/eq-survey-runner/issues/1036
+        """
+        # Given
+        token = create_token('markup', 'test')
+        resp = self.client.get('/session?token=' + token.decode(), follow_redirects=True)
+        # When
+        # Then
+        extraction = Extractor().extract(resp.get_data(True))
+        self.assertEqual(extraction.title, 'This is a title with emphasis - Markup test')


### PR DESCRIPTION
### What is the context of this PR?
Fixes #1032 
Fixes #1036 

- Strips HTML out of page titles
- Session expired doesn't attempt to show survey title as it is unreliable (user logged out)

### How to review 
- Check page titles in the `test_markup.json` - see the `<em>` tags aren't shown anymore
- Expire a session (save and sign out) and see page title is clean "Session expired"