### PR TITLE
Allow functional test to be run on remote environments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,11 @@ NEW_RELIC_LICENSE_KEY - Enable new relic monitoring by supplying a New Relic lic
 NEW_RELIC_APP_NAME - The name to display for the application in New Relic
 ```
 
+The following env variables can be used when running tests
+```
+EQ_FUNCTIONAL_TEST_ENV - the pre-configured environment [local, docker, preprod] or the url of the environment that should be targeted
+```
+
 ## JWT Integration
 Integration with the survey runner requires the use of a signed JWT using public and private key pair (see https://jwt.io,
 https://tools.ietf.org/html/rfc7519, https://tools.ietf.org/html/rfc7515).

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -15,12 +15,16 @@ import a11ym from './gulp/a11ym'
 import {fonts} from './gulp/fonts'
 
 const getEnv = () => {
+  var env = yargs.argv.env
+  if (env.startsWith("http")) {
+    return env
+  }
   const envs = {
     local: 'http://localhost:5000',
     docker: 'http://localhost',
-    preprod: 'https://preprod-surveys.eq.ons.digital'
+    preprod: 'https://eq.onsdigital.uk',
   }
-  return envs[yargs.argv.env] || envs['local']
+  return envs[env] || envs['local']
 }
 
 gulp.task('test:a11ym', (done) => {

--- a/tests/functional/config.js
+++ b/tests/functional/config.js
@@ -57,6 +57,9 @@ const phantomjsConfig = {
   waitforTimeout: 3000,
   capabilities: [phantomjs],
   maxInstances: 4,
+  phantomjsOpts: {
+    ignoreSslErrors: true
+  },
   before: function() {
     browser.setViewportSize({
       width: 1280,


### PR DESCRIPTION
### What is the context of this PR?
This PR adds the ability for the functional tests to be run against a defined environment

### How to review 
Run the following script but add your dev environment url
`REMOTE_ADDRESS=concourse-surveys.dev.eq.ons.digital EQ_FUNCTIONAL_TEST_ENV=remote TRAVIS=true sh scripts/run_tests_functional.sh`