### PR TITLE
Add logging

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,6 +3,7 @@ import logging
 import os
 import sys
 from datetime import timedelta
+from uuid import uuid4
 
 from flask import Flask
 from flask import url_for
@@ -75,6 +76,11 @@ def create_app():
     setup_secure_cookies(application)
 
     setup_babel(application)
+
+    @application.before_request
+    def before_request():  # pylint: disable=unused-variable
+        request_id = str(uuid4())
+        logger.new(request_id=request_id)
 
     @application.after_request
     def apply_caching(response):  # pylint: disable=unused-variable

--- a/app/submitter/submitter.py
+++ b/app/submitter/submitter.py
@@ -52,7 +52,8 @@ class Submitter(object):
 class LogSubmitter(Submitter):
 
     def send_message(self, message, queue):
-        logger.info("message submitted", message=message)
+        logger.info("sending message")
+        logger.info("message payload", message=message)
         return True
 
 
@@ -62,21 +63,24 @@ class RabbitMQSubmitter(Submitter):
 
     def _connect(self):
         try:
+            logger.info("attempt to open connection", server="primary", category="rabbitmq")
             self.connection = BlockingConnection(URLParameters(settings.EQ_RABBITMQ_URL))
         except AMQPError as e:
-            logger.error("unable to open rabbit mq connection", exc_info=e, rabbit_url=settings.EQ_RABBITMQ_URL)
+            logger.error("unable to open connection", exc_info=e, server="primary", category="rabbitmq")
             try:
+                logger.info("attempt to open connection", server="secondary", category="rabbitmq")
                 self.connection = BlockingConnection(URLParameters(settings.EQ_RABBITMQ_URL_SECONDARY))
             except AMQPError as err:
-                logger.error("unable to open rabbit mq connection", exc_info=e, rabbit_url=settings.EQ_RABBITMQ_URL_SECONDARY)
+                logger.error("unable to open connection", exc_info=e, server="secondary", category="rabbitmq")
                 raise err
 
     def _disconnect(self):
         try:
             if self.connection:
+                logger.info("attempt to close connection", category="rabbitmq")
                 self.connection.close()
         except AMQPError as e:
-            logger.error("unable to close rabbit mq connection", exc_info=e, rabbit_url=settings.EQ_RABBITMQ_URL)
+            logger.error("unable to close connection", exc_info=e, category="rabbitmq")
 
     def send_message(self, message, queue):
         """
@@ -86,7 +90,8 @@ class RabbitMQSubmitter(Submitter):
         :return: a boolean value indicating if it was successful
         """
         message_as_string = str(message)
-        logger.info("sending message to rabbit mq", message=message_as_string)
+        logger.info("sending message", category="rabbitmq")
+        logger.info("message payload", message=message_as_string, category="rabbitmq")
         try:
             self._connect()
             channel = self.connection.channel()
@@ -99,12 +104,12 @@ class RabbitMQSubmitter(Submitter):
                                                   delivery_mode=2,
                                               ))
             if published:
-                logger.info("sent message to rabbit mq")
+                logger.info("sent message", category="rabbitmq")
             else:
-                logger.error("unable to send message to rabbit mq", message=message_as_string)
+                logger.error("unable to send message", category="rabbitmq")
             return published
         except AMQPError as e:
-            logger.error("unable to send message to rabbit mq", exc_info=e, message=message_as_string)
+            logger.error("unable to send message", exc_info=e, category="rabbitmq")
             return False
         finally:
             self._disconnect()

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -41,13 +41,13 @@ questionnaire_blueprint = Blueprint(name='questionnaire',
 
 @questionnaire_blueprint.before_request
 @login_required
-def check_survey_state():
+def before_request():
     metadata = get_metadata(current_user)
-    logger.new(tx_id=metadata['tx_id'])
+    logger.bind(tx_id=metadata['tx_id'])
     g.schema_json = get_schema(metadata)
     values = request.view_args
-    logger.debug('questionnaire request', eq_id=values['eq_id'], form_type=values['form_type'],
-                 ce_id=values['collection_id'], method=request.method, url_path=request.full_path)
+    logger.info('questionnaire request', eq_id=values['eq_id'], form_type=values['form_type'],
+                ce_id=values['collection_id'], method=request.method, url_path=request.full_path)
 
     _check_same_survey(values['eq_id'], values['form_type'], values['collection_id'])
 

--- a/app/views/session.py
+++ b/app/views/session.py
@@ -32,13 +32,14 @@ def login():
     it will be placed in the users session
     :return: a 302 redirect to the next location for the user
     """
-    logger.new()
     decrypted_token = decrypt_token(request.args.get('token'))
     metadata = parse_metadata(decrypted_token)
     eq_id = metadata["eq_id"]
     form_type = metadata["form_type"]
     tx_id = metadata["tx_id"]
-    logger.bind(eq_id=eq_id, form_type=form_type, tx_id=tx_id)
+    ru_ref = metadata["ru_ref"]
+    logger.bind(eq_id=eq_id, form_type=form_type, tx_id=tx_id, ru_ref=ru_ref)
+    logger.info("decrypted token and parsed metadata")
 
     if not eq_id or not form_type:
         logger.error("missing eq id or form type in jwt")

--- a/tests/app/submitter/test_submitter.py
+++ b/tests/app/submitter/test_submitter.py
@@ -64,7 +64,7 @@ class TestSubmitter(TestCase):
 
             # Then
             self.assertTrue(published)
-            logger.error.assert_called_once_with('unable to close rabbit mq connection', rabbit_url='amqp://localhost:5672/%2F', exc_info=error)
+            logger.error.assert_called_once_with('unable to close connection', category='rabbitmq', exc_info=error)
 
     def test_when_fail_to_publish_message_then_returns_false(self):
         # Given


### PR DESCRIPTION
Adds additional logging to enable better cross service monitoring and tracing of requests

- Logs the payload and the result of queueing the response in RabbitMQ separately - we need the payload (encrypted) as a last ditch backup should the queues fail, but it can't be fed into Splunk as it's too large.
- Logs ru_ref, collection_exercise_sid, and tx_id in a single event on launch
- Logs out each request visited with a tx_id
- Logs a unique `request_id` for each request

### How to review 
Run and verify the log output matches the changes listed above

