### PR TITLE
Format exceptions in logs into an array of strings

### DIFF
--- a/application.py
+++ b/application.py
@@ -35,9 +35,17 @@ def configure_logging():
     werkzeug_logger = logging.getLogger('werkzeug')
     werkzeug_logger.setLevel(level=levels[EQ_WERKZEUG_LOG_LEVEL])
 
+    def parse_exception(_, __, event_dict):
+        if EQ_DEVELOPER_LOGGING:
+            return event_dict
+        exception = event_dict.get('exception')
+        if exception:
+            event_dict['exception'] = exception.replace("\"", "'").split("\n")
+        return event_dict
+
     # setup file logging
     renderer_processor = ConsoleRenderer() if EQ_DEVELOPER_LOGGING else JSONRenderer()
-    processors = [add_log_level, TimeStamper(key='created', fmt='iso'), add_service, format_exc_info, renderer_processor]
+    processors = [add_log_level, TimeStamper(key='created', fmt='iso'), add_service, format_exc_info, parse_exception, renderer_processor]
     configure(context_class=wrap_dict(dict), logger_factory=LoggerFactory(), processors=processors, cache_logger_on_first_use=True)
 
 


### PR DESCRIPTION
Formats exceptions in logs into an array of strings, making them much more readable. This means log lines that previously looked like this:
```
[Thu Mar 16 08:29:24.836759 2017] [:error] [pid 3767] {"request_id": "29c79b5c-8142-4624-ac9b-e8416b04e2de", "created": "2017-03-16T08:29:24.835755Z", "url": "http://localhost/", "event": "an error has occurred", "service": "eq-survey-runner", "level": "error", "exception": "Traceback (most recent call last):\\n File \\"/opt/python/run/venv/lib/python3.4/site-packages/flask/app.py\\", line 1475, in full_dispatch_request\\n rv = self.dispatch_request()\\n File \\"/opt/python/run/venv/lib/python3.4/site-packages/flask/app.py\\", line 1453, in dispatch_request\\n self.raise_routing_exception(req)\\n File \\"/opt/python/run/venv/lib/python3.4/site-packages/flask/app.py\\", line 1436, in raise_routing_exception\\n raise request.routing_exception\\n File \\"/opt/python/run/venv/lib/python3.4/site-packages/flask/ctx.py\\", line 286, in match_request\\n self.url_adapter.match(return_rule=True)\\n File \\"/opt/python/run/venv/lib/python3.4/site-packages/werkzeug/routing.py\\", line 1563, in match\\n raise NotFound()\\nwerkzeug.exceptions.NotFound: 404: Not Found", "status_code": 404}
```

now look like this:
```
[Thu Mar 16 09:36:53.883753 2017] [:error] [pid 3649]
{
    "created": "2017-03-16T09:36:53.877609Z",
    "service": "eq-survey-runner",
    "level": "error",
    "request_id": "41051bd9-ebbe-40bc-8a6d-4c02a38db0a1",
    "url": "https://andrew-surveys.dev.eq.ons.digital/questionnaire/1/0205/8749225/thank-you",
    "status_code": 500,
    "event": "an error has occurred",
    "exception": [
        "Traceback (most recent call last):",
        "  File '/opt/python/run/venv/lib/python3.4/site-packages/flask/app.py', line 1475, in full_dispatch_request",
        "    rv = self.dispatch_request()",
        "  File '/opt/python/run/venv/lib/python3.4/site-packages/flask/app.py', line 1461, in dispatch_request",
        "    return self.view_functions[rule.endpoint](**req.view_args)",
        "  File '/opt/python/run/venv/lib/python3.4/site-packages/flask_login.py', line 792, in decorated_view",
        "    return func(*args, **kwargs)",
        "  File '/opt/python/current/app/app/views/questionnaire.py', line 172, in get_thank_you",
        "    raise Exception",
        "Exception"
    ],
    "tx_id": "e72c5870-28ea-44ed-a14a-ac84ae7f6de2"
}
```

### How to review 
- Run survey runner and review log output for exceptions (404 not found generates an exception)