### PR TITLE
Fixes #1043 submit answers shown when not on routing path.

### DIFF
--- a/app/helpers/schema_helper.py
+++ b/app/helpers/schema_helper.py
@@ -30,12 +30,23 @@ class SchemaHelper(object):  # pylint: disable=too-many-public-methods
         return group is not None and group['blocks'][0]['id'] == block_id
 
     @staticmethod
+    def is_summary_or_confirmation(block):
+        return block and 'type' in block and block['type'] in ('Summary', 'Confirmation')
+
+    @staticmethod
     def get_last_block_id(survey_json):
         return survey_json['groups'][-1]['blocks'][-1]['id']
 
     @staticmethod
     def get_last_group_id(survey_json):
         return survey_json['groups'][-1]['id']
+
+    @staticmethod
+    def get_last_block_in_group(group):
+        if group and 'blocks' in group:
+            return group['blocks'][-1]
+
+        return None
 
     @staticmethod
     def get_first_block_id(survey_json):

--- a/tests/app/helpers/test_schema_helper.py
+++ b/tests/app/helpers/test_schema_helper.py
@@ -96,3 +96,69 @@ class TestSchemaHelper(unittest.TestCase):
         }
 
         self.assertEqual(parent_options, expected)
+
+    def test_get_last_block_returns_none_when_no_blocks(self):
+        empty_group = {}
+
+        last_block = SchemaHelper.get_last_block_in_group(empty_group)
+
+        self.assertIsNone(last_block)
+
+    def test_get_last_block_returns_last_block(self):
+        group = {
+            'blocks': [{
+                'id': 'block1',
+            },
+            {
+                'id': 'block2'
+            }]
+        }
+
+        last_block = SchemaHelper.get_last_block_in_group(group)
+
+        self.assertIsNotNone(last_block)
+        self.assertEqual(last_block['id'], 'block2')
+
+    def test_is_summary_or_confirmation_returns_false_when_block_is_none(self):
+        block = None
+
+        is_summary_or_confirmation = SchemaHelper.is_summary_or_confirmation(block)
+
+        self.assertFalse(is_summary_or_confirmation)
+
+    def test_is_summary_or_confirmation_returns_false_when_block_has_no_type(self):
+        block = {
+            'id': 'block-with-no-type',
+        }
+
+        is_summary_or_confirmation = SchemaHelper.is_summary_or_confirmation(block)
+
+        self.assertFalse(is_summary_or_confirmation)
+
+    def test_is_summary_or_confirmation_returns_false_when_type_is_questionnaire(self):
+        block = {
+            'type': 'Questionnaire',
+        }
+
+        is_summary_or_confirmation = SchemaHelper.is_summary_or_confirmation(block)
+
+        self.assertFalse(is_summary_or_confirmation)
+
+    def test_is_summary_or_confirmation_returns_true_when_type_is_summary(self):
+        block = {
+            'type': 'Summary',
+        }
+
+        is_summary_or_confirmation = SchemaHelper.is_summary_or_confirmation(block)
+
+        self.assertTrue(is_summary_or_confirmation)
+
+    def test_is_summary_or_confirmation_returns_true_when_type_is_confirmation(self):
+        block = {
+            'type': 'Confirmation',
+        }
+
+        is_summary_or_confirmation = SchemaHelper.is_summary_or_confirmation(block)
+
+        self.assertTrue(is_summary_or_confirmation)
+

--- a/tests/app/questionnaire/test_navigation.py
+++ b/tests/app/questionnaire/test_navigation.py
@@ -1039,3 +1039,59 @@ class TestNavigation(unittest.TestCase):
         navigation_links = navigation.build_navigation('permanent-or-family-home', 0)
         self.assertNotIn(confirmation_link, navigation_links)
         self.assertEqual(len(navigation_links), 2)
+
+    def test_build_navigation_summary_link_hidden_when_not_on_routing_path(self):
+        survey = load_schema_file("test_navigation.json")
+        metadata = {
+            "eq_id": '1',
+            "collection_exercise_sid": '999',
+            "form_type": "some_form"
+        }
+
+        completed_blocks = [
+            Location('property-details', 0, 'insurance-type'),
+            Location('property-details', 0, 'insurance-address'),
+            Location('property-details', 0, 'property-interstitial'),
+            Location('house-details', 0, 'house-type'),
+            Location('multiple-questions-group', 0, 'household-composition'),
+            Location('repeating-group', 0, 'repeating-block-1'),
+            Location('repeating-group', 0, 'repeating-block-2'),
+            Location('extra-cover', 0, 'extra-cover-block'),
+            Location('extra-cover', 0, 'extra-cover-interstitial'),
+            Location('payment-details', 0, 'credit-card'),
+            Location('payment-details', 0, 'expiry-date'),
+            Location('payment-details', 0, 'security-code'),
+            Location('payment-details', 0, 'security-code-interstitial'),
+            Location('extra-cover-items-group', 0, 'extra-cover-items'),
+        ]
+
+        routing_path = [
+            Location('property-details', 0, 'insurance-type'),
+            Location('property-details', 0, 'insurance-address'),
+            Location('property-details', 0, 'property-interstitial'),
+            Location('house-details', 0, 'house-type'),
+            Location('multiple-questions-group', 0, 'household-composition'),
+            Location('repeating-group', 0, 'repeating-block-1'),
+            Location('repeating-group', 0, 'repeating-block-2'),
+            Location('payment-details', 0, 'credit-card'),
+            Location('payment-details', 0, 'expiry-date'),
+            Location('payment-details', 0, 'security-code'),
+            Location('payment-details', 0, 'security-code-interstitial'),
+            Location('extra-cover', 0, 'extra-cover-block'),
+            Location('extra-cover', 0, 'extra-cover-interstitial'),
+            Location('extra-cover-items-group', 0, 'extra-cover-items'),
+        ]
+
+        navigation = Navigation(survey, AnswerStore(), metadata, completed_blocks, routing_path)
+
+        confirmation_link = {
+            'link_name': 'Summary',
+            'highlight': False,
+            'repeating': False,
+            'completed': False,
+            'link_url': Location('summary-group', 0, 'summary').url(metadata)
+        }
+
+        navigation_links = navigation.build_navigation('property-details', 0)
+        self.assertNotIn(confirmation_link, navigation_links)
+        self.assertEqual(len(navigation_links), 4)


### PR DESCRIPTION
### What is the context of this PR?
Fixes #1043
Fixes the issue by ensuring that the summary / confirmation blocks are on the routing path before displaying the navigation link.

### How to review 
Re-test the defect.
All existing tests should continue to pass.