### PR TITLE
CSRF attack should not save answers on page

### DIFF
--- a/app/views/errors.py
+++ b/app/views/errors.py
@@ -41,7 +41,6 @@ def forbidden(error=None):
     return _render_error_page(403)
 
 
-@errors_blueprint.app_errorhandler(404)
 @errors_blueprint.app_errorhandler(QuestionnaireException)
 def page_not_found(error=None):
     log_exception(error, 404)
@@ -64,6 +63,13 @@ def multiple_survey_error(error=None):
 def internal_server_error(error=None):
     log_exception(error, 500)
     return _render_error_page(500)
+
+
+@errors_blueprint.app_errorhandler(403)
+@errors_blueprint.app_errorhandler(404)
+def http_exception(error):
+    log_exception(error, error.code)
+    return _render_error_page(error.code)
 
 
 def log_exception(error, status_code):

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -2,10 +2,13 @@
 #
 # Run all project tests
 #
-# NOTE: This script expects to be run from the project root with
-# ./scripts/run_tests.sh
 
 set -e
+
+if [ ! -f "./scripts/run.sh" ]; then
+    echo "./scripts/run.sh not found. Are you running in the root of eq-survey-runner?"
+    exit 1
+fi
 
 EQ_RUN_LOCAL_TESTS=True EQ_RUN_FUNCTIONAL_TESTS=True EQ_RUN_LOCAL_LINT=True ./scripts/run.sh
 

--- a/tests/app/views/test_dump.py
+++ b/tests/app/views/test_dump.py
@@ -1,4 +1,5 @@
 import json
+
 from tests.integration.integration_test_case import IntegrationTestCase
 
 
@@ -24,7 +25,7 @@ class TestDumpAnswers(IntegrationTestCase):
         self.assertStatusForbidden()
 
         # And the response data contains Forbidden
-        self.assertInPage('Forbidden')
+        self.assertInPage('Error 403')
 
     def test_dump_answers_authenticated_with_role_no_answers(self):
         # Given I am an authenticated user who has launched a survey
@@ -110,7 +111,7 @@ class TestDumpSubmission(IntegrationTestCase):
         self.assertStatusForbidden()
 
         # And the response data contains Forbidden
-        self.assertInPage('Forbidden')
+        self.assertInPage('Error 403')
 
     def test_dump_submission_authenticated_with_role_no_answers(self):
         # Given I am an authenticated user who has launched a survey

--- a/tests/integration/questionnaire/test_questionnaire_csrf.py
+++ b/tests/integration/questionnaire/test_questionnaire_csrf.py
@@ -1,27 +1,121 @@
+import json
+
 from tests.integration.integration_test_case import IntegrationTestCase
 
 
-class TestQuestionnaireInterstitial(IntegrationTestCase):
+class TestQuestionnaireCsrf(IntegrationTestCase):
 
-    def setUp(self):
-        super().setUp()
+    def test_given_on_interstitial_page_when_submit_with_no_csrf_token_then_forbidden(self):
+        # Given
         self.launchSurvey('test', 'interstitial_page')
-        self.assertInPage('Your response is legally required')
-        self.first_url = self.last_url
-
-    def test_form_not_processed_with_no_csrf_token(self):
         self.last_csrf_token = None
-        self.post(action='start_questionnaire')
-        self.assertStatusOK()
-        self.assertEqualUrl(self.first_url)
 
-    def test_form_not_processed_with_incorrect_csrf_token(self):
+        # When
+        self.post(action='start_questionnaire')
+
+        # Then
+        self.assertStatusForbidden()
+        self.assertEqualUrl(self.last_url)
+
+    def test_given_on_interstitial_page_when_submit_with_invalid_csrf_token_then_forbidden(self):
+        # Given
+        self.launchSurvey('test', 'interstitial_page')
         self.last_csrf_token = 'made-up-token'
-        self.post(action='start_questionnaire')
-        self.assertStatusOK()
-        self.assertEqualUrl(self.first_url)
 
-    def test_form_processed_with_correct_csrf_token(self):
+        # When
         self.post(action='start_questionnaire')
+
+        # Then
+        self.assertStatusForbidden()
+        self.assertEqualUrl(self.last_url)
+
+    def test_given_on_introduction_page_when_submit_valid_token_then_redirect_to_next_page(self):
+        # Given
+        self.launchSurvey('test', 'interstitial_page')
+
+        # When
+        self.post(action='start_questionnaire')
+
+        # Then
         self.assertStatusOK()
         self.assertInPage('What is your favourite breakfast food')
+
+    def test_given_answered_question_when_change_answer_with_invalid_csrf_token_then_answers_not_saved(self):
+        # Given
+        self.launchSurvey('test', 'interstitial_page', roles=['dumper'])
+        self.post()
+        self.post({'favourite-breakfast': 'Muesli'})
+
+        # When
+        self.last_csrf_token = 'made-up-token'
+        self.post({'favourite-breakfast': 'Pancakes'})
+
+        # Then
+        self.assertStatusForbidden()
+        self.get('/dump/answers')
+        answers = json.loads(self.getResponseData())
+        self.assertEqual('Muesli', answers['answers'][0]['value'])
+
+    def test_given_valid_answers_on_household_composition_when_answer_with_invalid_csrf_token_then_answers_not_saved(self):
+        # Given
+        self.launchSurvey('census', 'household', roles=['dumper'])
+        post_data = {'first_name': 'Joe'}
+
+        # When
+        self.last_csrf_token = 'made-up-token'
+        self.post(url='/questionnaire/census/household/789/who-lives-here/0/household-composition', post_data=post_data)
+
+        # Then
+        self.assertStatusForbidden()
+        self.get('/dump/answers')
+        answers = json.loads(self.getResponseData())
+        self.assertEqual(0, len(answers['answers']))
+
+    def test_given_valid_answers_when_save_and_sign_out_with_invalid_csrf_token_then_answers_not_saved(self):
+        # Given
+        self.launchSurvey('test', 'interstitial_page', roles=['dumper'])
+        self.post()
+        post_data = {'favourite-breakfast': 'Muesli'}
+
+        # When
+        self.last_csrf_token = 'made-up-token'
+        self.post(post_data=post_data, action='save_sign_out')
+
+        # Then
+        self.assertStatusForbidden()
+        self.get('/dump/answers')
+        answers = json.loads(self.getResponseData())
+        self.assertEqual(0, len(answers['answers']))
+
+    def test_given_csrf_attack_when_refresh_then_on_question(self):
+        # Given
+        self.launchSurvey('test', 'interstitial_page', roles=['dumper'])
+        self.post()
+        self.last_csrf_token = 'made-up-token'
+        self.post({'favourite-breakfast': 'Pancakes'})
+
+        # When
+        self.get(self.last_url)
+
+        # Then
+        self.assertEqual(self.last_response.status_code, 200)
+        self.get('/dump/answers')
+        answers = json.loads(self.getResponseData())
+        self.assertEqual(0, len(answers['answers']))
+
+    def test_given_csrf_attack_when_submit_new_answers_then_answers_saved(self):
+        # Given
+        self.launchSurvey('test', 'interstitial_page', roles=['dumper'])
+        self.post()
+        self.last_csrf_token = 'made-up-token'
+        self.post({'favourite-breakfast': 'Muesli'})
+
+        # When
+        self.get(self.last_url)
+        self.post({'favourite-breakfast': 'Pancakes'})
+
+        # Then
+        self.assertStatusOK()
+        self.get('/dump/answers')
+        answers = json.loads(self.getResponseData())
+        self.assertEqual('Pancakes', answers['answers'][0]['value'])


### PR DESCRIPTION
### What is the context of this PR?
[trello](https://trello.com/c/VLUhPJEE/1006-csrf-behaviour)

If a csrf token is invalid log the user out and do not save the answers.

### How to review 
Tests in test_questionnaire_csrf.py demonstrate how it works.

To manually test
1. Open a questionnaire
1. Open chrome developer console
1. Search for csrf_token
1. Change csrf_token
1. Submit page

Expect to be signed out
