### PR TITLE
Non mandatory date of birth field retains date

### DIFF
--- a/tests/app/views/test_questionnaire.py
+++ b/tests/app/views/test_questionnaire.py
@@ -90,6 +90,32 @@ class TestQuestionnaire(unittest.TestCase):
             'value': '11/2014',
         }, self.question_store.answer_store.answers)
 
+    def test_update_questionnaire_store_with_empty_day_month_year_date(self):
+
+        g.schema_json = load_schema_file("test_dates.json")
+
+        location = Location("dates", 0, "date-block")
+
+        form_data = {
+            'non-mandatory-date-answer': {'day': '', 'month': '', 'year': ''},
+        }
+
+        update_questionnaire_store_with_form_data(self.question_store, location, form_data)
+        self.assertEqual([], self.question_store.answer_store.answers)
+
+    def test_update_questionnaire_store_with_empty_month_year_date(self):
+
+        g.schema_json = load_schema_file("test_dates.json")
+
+        location = Location("dates", 0, "date-block")
+
+        form_data = {
+            'month-year-answer': {'month': '', 'year': ''},
+        }
+
+        update_questionnaire_store_with_form_data(self.question_store, location, form_data)
+        self.assertEqual([], self.question_store.answer_store.answers)
+
     def test_update_questionnaire_store_with_answer_data(self):
         g.schema_json = load_schema_file("census_household.json")
 

--- a/tests/integration/questionnaire/test_questionnaire_change_answer.py
+++ b/tests/integration/questionnaire/test_questionnaire_change_answer.py
@@ -1,0 +1,60 @@
+from tests.integration.integration_test_case import IntegrationTestCase
+
+
+class TestQuestionnaireChangeAnswer(IntegrationTestCase):
+
+    def test_change_non_mandatory_date_from_answered_to_not_answered(self):
+
+        # Given the test_dates questionnaire with a non-mandatory date answered.
+        self.launchSurvey('test', 'dates')
+
+        post_data = {
+            'date-range-from-day': '1',
+            'date-range-from-month': '1',
+            'date-range-from-year': '2017',
+            'date-range-to-day': '2',
+            'date-range-to-month': '1',
+            'date-range-to-year': '2017',
+            'month-year-answer-month': '1',
+            'month-year-answer-year': '2016',
+            'single-date-answer-day': '1',
+            'single-date-answer-month': '1',
+            'single-date-answer-year': '2016',
+
+            # non-mandatory date answered
+            'non-mandatory-date-answer-day': '22',
+            'non-mandatory-date-answer-month': '2',
+            'non-mandatory-date-answer-year': '2099',
+        }
+
+        self.post(post_data)
+        self.assertInPage('22 February 2099')
+        self.assertNotInPage('No answer provided')
+
+        # When we change the non-mandatory date from answered to not answered
+        self.get('questionnaire/test/dates/789/dates/0/date-block')
+
+        post_data = {
+            'date-range-from-day': '1',
+            'date-range-from-month': '1',
+            'date-range-from-year': '2017',
+            'date-range-to-day': '2',
+            'date-range-to-month': '1',
+            'date-range-to-year': '2017',
+            'month-year-answer-month': '1',
+            'month-year-answer-year': '2016',
+            'single-date-answer-day': '1',
+            'single-date-answer-month': '1',
+            'single-date-answer-year': '2016',
+
+            # non-mandatory date not answered
+            'non-mandatory-date-answer-day': '',
+            'non-mandatory-date-answer-month': '',
+            'non-mandatory-date-answer-year': '',
+        }
+
+        self.post(post_data)
+
+        # Then the original value is replaced with 'No answer provided' on the summary page
+        self.assertNotInPage('22 February 2099')
+        self.assertInPage('No answer provided')


### PR DESCRIPTION
### What is the context of this PR?
Non mandatory date of birth field retains date even after respondent deletes the date. A check to see if the dict keys all contain empty values, if they do we can remove the answer from the store

### How to review 
Using test_dates.json, fill out all of the questionnaire, including the last question. Check the summary page is right. Using previous, change the answer to the last question, taking out all values. Submit and make sure the summary screen changes to 'No answer provided'. Hit previous again and make sure the last question is still empty.
