### PR TITLE
Escaping quotes and backslash in answers

### DIFF
--- a/app/templating/schema_context.py
+++ b/app/templating/schema_context.py
@@ -25,7 +25,10 @@ def _map_alias_to_answers(aliases, answer_store):
         matching_answers = []
 
         answers = answer_store.filter(answer_id=answer_info['answer_id'], limit=settings.EQ_MAX_NUM_REPEATS)
-        matching_answers.extend([answer['value'] for answer in answers])
+
+        for answer in answers:
+            safe_answer = json_safe(answer['value'])
+            matching_answers.append(safe_answer)
 
         number_of_matches = len(matching_answers)
 
@@ -52,7 +55,14 @@ def _build_exercise(metadata):
 
 def _build_respondent(metadata):
     return {
-        "ru_name": metadata["ru_name"],
-        "trad_as": metadata["trad_as"],
-        "trad_as_or_ru_name": metadata["trad_as"] or metadata["ru_name"],
+        "ru_name": json_safe(metadata["ru_name"]),
+        "trad_as": json_safe(metadata["trad_as"]),
+        "trad_as_or_ru_name": json_safe(metadata["trad_as"] or metadata["ru_name"]),
     }
+
+
+def json_safe(data):
+    if isinstance(data, str):
+        return data.replace('\\', r'\\').replace('"', r'\"')
+    else:
+        return data

--- a/tests/app/templating/test_schema_context.py
+++ b/tests/app/templating/test_schema_context.py
@@ -5,7 +5,7 @@ from app.templating.schema_context import build_schema_context
 from tests.app.framework.survey_runner_test_case import SurveyRunnerTestCase
 
 
-class TestSchemaContext(SurveyRunnerTestCase):
+class TestSchemaContext(SurveyRunnerTestCase):  # pylint: disable=too-many-public-methods
 
     metadata = {
         'return_by': '2016-10-10',
@@ -233,3 +233,112 @@ class TestSchemaContext(SurveyRunnerTestCase):
         schema_context = build_schema_context(metadata, {}, self.answer_store)
 
         self.assertEqual(schema_context['respondent']['trad_as_or_ru_name'], metadata['ru_name'])
+
+    def test_given_quotes_in_trading_name_when_create_context_then_quotes_are_escaped(self):
+        # Given
+        metadata = self.metadata.copy()
+        metadata['trad_as'] = "\"trading name\""
+
+        # When
+        schema_context = build_schema_context(metadata, {}, self.answer_store)
+
+        # Then
+        self.assertEqual(schema_context['respondent']['trad_as'], r'\"trading name\"')
+
+    def test_given_backslash_in_trading_name_when_create_context_then_backslash_are_escaped(self):
+        # Given
+        metadata = self.metadata.copy()
+        metadata['trad_as'] = "\\trading name\\"
+
+        # When
+        schema_context = build_schema_context(metadata, {}, self.answer_store)
+
+        # Then
+        self.assertEqual(schema_context['respondent']['trad_as'], r'\\trading name\\')
+
+    def test_given_quotes_in_ru_name_when_create_context_then_quotes_are_escaped(self):
+        # Given
+        metadata = self.metadata.copy()
+        metadata['ru_name'] = "\"ru name\""
+
+        # When
+        schema_context = build_schema_context(metadata, {}, self.answer_store)
+
+        # Then
+        self.assertEqual(schema_context['respondent']['ru_name'], r'\"ru name\"')
+
+    def test_given_backslash_in_ru_name_when_create_context_then_backslash_are_escaped(self):
+        # Given
+        metadata = self.metadata.copy()
+        metadata['ru_name'] = "\\ru name\\"
+
+        # When
+        schema_context = build_schema_context(metadata, {}, self.answer_store)
+
+        # Then
+        self.assertEqual(schema_context['respondent']['ru_name'], r'\\ru name\\')
+
+    def test_given_quotes_in_ru_name_or_trading_name_when_create_context_then_quotes_are_escaped(self):
+        # Given
+        metadata = self.metadata.copy()
+        metadata['ru_name'] = '"ru_name"'
+        metadata['trad_as'] = None
+
+        # When
+        schema_context = build_schema_context(metadata, {}, self.answer_store)
+
+        # Then
+        self.assertEqual(schema_context['respondent']['trad_as_or_ru_name'], r'\"ru_name\"')
+
+    def test_given_backslash_in_ru_name_or_trading_name_when_create_context_then_backslash_are_escaped(self):
+        # Given
+        metadata = self.metadata.copy()
+        metadata['trad_as'] = "\\trading name\\"
+
+        # When
+        schema_context = build_schema_context(metadata, {}, self.answer_store)
+
+        # Then
+        self.assertEqual(schema_context['respondent']['trad_as_or_ru_name'], r'\\trading name\\')
+
+    def test_given_quotes_in_answers_when_create_context_quotes_then_are_escaped(self):
+        aliases = {
+            'first_name': {
+                'answer_id': 'answer_id',
+                'repeats': False,
+            },
+        }
+        answers = [{
+            'answer_id': 'answer_id',
+            'answer_instance': 0,
+            'value': '"',
+        }]
+
+        self.answer_store.filter = MagicMock(return_value=answers)
+
+        schema_context = build_schema_context(self.metadata, aliases, self.answer_store)
+
+        context_answers = schema_context['answers']
+        self.assertEqual(len(context_answers), 1)
+        self.assertEqual(context_answers['first_name'], r'\"')
+
+    def test_given_backslash_in_answers_when_create_context_then_backslash_are_escaped(self):
+        aliases = {
+            'first_name': {
+                'answer_id': 'answer_id',
+                'repeats': False,
+            },
+        }
+        answers = [{
+            'answer_id': 'answer_id',
+            'answer_instance': 0,
+            'value': '\\',
+        }]
+
+        self.answer_store.filter = MagicMock(return_value=answers)
+
+        schema_context = build_schema_context(self.metadata, aliases, self.answer_store)
+
+        context_answers = schema_context['answers']
+        self.assertEqual(len(context_answers), 1)
+        self.assertEqual(context_answers['first_name'], r'\\')

--- a/tests/integration/questionnaire/test_questionnaire_piping.py
+++ b/tests/integration/questionnaire/test_questionnaire_piping.py
@@ -1,0 +1,30 @@
+from tests.integration.integration_test_case import IntegrationTestCase
+
+
+class TestQuestionnairePiping(IntegrationTestCase):
+
+    def test_given_quotes_in_answer_when_piped_into_page_then_quotes_on_page(self):
+        # Given
+        self.launchSurvey('census', 'household')
+        self.post({'permanent-or-family-home-answer': 'Yes'})
+
+        # When
+        self.post({'household-0-first-name': 'Joe Bloggs "Junior"'})
+
+        # Then
+        self.get(self.last_url)
+        self.assertStatusOK()
+        self.assertInPage('Joe Bloggs "Junior"')
+
+    def test_given_backslash_in_answer_when_piped_into_page_then_backslash_on_page(self):
+        # Given
+        self.launchSurvey('census', 'household')
+        self.post({'permanent-or-family-home-answer': 'Yes'})
+
+        # When
+        self.post({'household-0-first-name': 'Joe Bloggs\\John Doe'})
+
+        # Then
+        self.get(self.last_url)
+        self.assertStatusOK()
+        self.assertInPage('Joe Bloggs\\John Doe')


### PR DESCRIPTION
### What is the context of this PR?
Fixes #1060 

We use jinja to inject strings into the questionnaire schemas however if
quotes or backslashes are injected it will break.

Quotes nor backslashes can be in JSON without being escaped. Both could
get into the JSON via user answers if they are not escaped before hand.

This fix is a minimal fix for the problem described.

### How to review 
1. Load census
1. Try combinations of special characters on household composition screen

Suggest better alternatives