### PR TITLE
default EQ_SECRET_KEY for developers

### DIFF
--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -29,6 +29,10 @@ if [ -z "$EQ_RABBITMQ_ENABLED" ]; then
   export EQ_RABBITMQ_ENABLED=False
 fi
 
+if [ -z "$EQ_SECRET_KEY" ]; then
+  export EQ_SECRET_KEY="SuperSecretDeveloperKey"
+fi
+
 # Use default environment vars for localhost if not already set
 
 echo "Environment variables in use:"


### PR DESCRIPTION
### What is the context of this PR?
Default EQ_SECRET_KEY for developers so that sessions are still valid between server restarts

### How to review 
Start a survey, Stop and start the app, Carry on with the survey and it should not error.