### PR TITLE
Update calls to super() to remove classnames and self

### DIFF
--- a/app/authentication/jti_claim_storage.py
+++ b/app/authentication/jti_claim_storage.py
@@ -11,7 +11,7 @@ logger = get_logger()
 class JtiTokenUsed(Exception):
 
     def __init__(self, jti_claim):
-        super(JtiTokenUsed, self).__init__()
+        super().__init__()
         self.jti_claim = jti_claim
 
     def __str__(self, *args, **kwargs):

--- a/app/forms/fields.py
+++ b/app/forms/fields.py
@@ -141,7 +141,7 @@ class CustomIntegerField(IntegerField):
     further validation steps by using a separate IntegerCheck validator
     """
     def __init__(self, **kwargs):
-        super(CustomIntegerField, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.data = None
 
     def process_formdata(self, valuelist):

--- a/app/forms/questionnaire_form.py
+++ b/app/forms/questionnaire_form.py
@@ -21,9 +21,9 @@ class QuestionnaireForm(FlaskForm):
         self.options_with_children = {}
 
         if formdata:
-            super(QuestionnaireForm, self).__init__(formdata=formdata, **kwargs)
+            super().__init__(formdata=formdata, **kwargs)
         else:
-            super(QuestionnaireForm, self).__init__(**kwargs)
+            super().__init__(**kwargs)
 
     def validate(self):
         """

--- a/app/storage/encrypted_questionnaire_storage.py
+++ b/app/storage/encrypted_questionnaire_storage.py
@@ -31,10 +31,10 @@ class EncryptedQuestionnaireStorage(QuestionnaireStorage):
 
     def add_or_update(self, data):
         encrypted_data = self.encrypt_data(data)
-        super(EncryptedQuestionnaireStorage, self).add_or_update(encrypted_data)
+        super().add_or_update(encrypted_data)
 
     def get_user_data(self):
-        data = super(EncryptedQuestionnaireStorage, self).get_user_data()
+        data = super().get_user_data()
         if data is not None and 'data' in data:
             decrypted_data = self.decrypt_data(self.user_id, self.user_ik, data)
             return decrypted_data


### PR DESCRIPTION
### What is the context of this PR?
Python3 doesn't require a class name or self to be passed to super() any more; making the code much easier to read. This PR changes all calls to super() to match the Python3 way.

### How to review 
Check i haven't missed any.