### PR TITLE
Remove questionnaire id from schema definitions

### DIFF
--- a/app/data/0_rogue_one.json
+++ b/app/data/0_rogue_one.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "23",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "023",

--- a/app/data/0_star_wars.json
+++ b/app/data/0_star_wars.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "0",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "0",

--- a/app/data/1_0001.json
+++ b/app/data/1_0001.json
@@ -4971,7 +4971,6 @@
         "NOT_INTEGER": "The value you have entered is invalid. Please enter a numeric value."
     },
     "navigation": true,
-    "questionnaire_id": "0001",
     "schema_version": "0.0.1",
     "survey_id": "144",
     "theme": "ukis",

--- a/app/data/1_0005.json
+++ b/app/data/1_0005.json
@@ -3127,7 +3127,6 @@
         "NOT_INTEGER": "The value you have entered is invalid. Please enter a numeric value."
     },
     "navigation": true,
-    "questionnaire_id": "0005",
     "schema_version": "0.0.1",
     "survey_id": "134",
     "theme": "default",

--- a/app/data/1_0102.json
+++ b/app/data/1_0102.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "23",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "023",

--- a/app/data/1_0112.json
+++ b/app/data/1_0112.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "23",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "023",

--- a/app/data/1_0203.json
+++ b/app/data/1_0203.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "23",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "023",

--- a/app/data/1_0205.json
+++ b/app/data/1_0205.json
@@ -2,7 +2,6 @@
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
-    "questionnaire_id": "23",
     "survey_id": "023",
     "title": "Monthly Business Survey - Retail Sales Index",
     "description": "MCI Description",

--- a/app/data/1_0213.json
+++ b/app/data/1_0213.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "23",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "023",

--- a/app/data/1_0215.json
+++ b/app/data/1_0215.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "23",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "023",

--- a/app/data/2_0001.json
+++ b/app/data/2_0001.json
@@ -97,7 +97,6 @@
         "INTEGER_TOO_LARGE": "The maximum value allowed is 9999999999. Please correct your answer."
     },
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "0001",
     "schema_version": "0.0.1",
     "survey_id": "139",
     "theme": "default",

--- a/app/data/census_communal.json
+++ b/app/data/census_communal.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "",
     "schema_version": "0.0.1",
     "data_version": "0.0.2",
     "survey_id": "census",

--- a/app/data/census_household.json
+++ b/app/data/census_household.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "",
     "schema_version": "0.0.1",
     "data_version": "0.0.2",
     "survey_id": "census",

--- a/app/data/census_individual.json
+++ b/app/data/census_individual.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "",
     "schema_version": "0.0.1",
     "data_version": "0.0.2",
     "survey_id": "census",

--- a/app/data/multiple_answers.json
+++ b/app/data/multiple_answers.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "23",
     "schema_version": "0.0.1",
     "data_version": "0.0.2",
     "survey_id": "023",

--- a/app/data/schema/schema-v1.json
+++ b/app/data/schema/schema-v1.json
@@ -168,7 +168,6 @@
         "mime_type",
         "schema_version",
         "data_version",
-        "questionnaire_id",
         "survey_id",
         "title",
         "groups",
@@ -187,9 +186,6 @@
                 "0.0.1",
                 "0.0.2"
             ]
-        },
-        "questionnaire_id": {
-            "type": "string"
         },
         "survey_id": {
             "type": "string"

--- a/app/data/test_checkbox.json
+++ b/app/data/test_checkbox.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "0",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "0",

--- a/app/data/test_conditional_routing.json
+++ b/app/data/test_conditional_routing.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "23",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "023",

--- a/app/data/test_currency.json
+++ b/app/data/test_currency.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "0",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "0",

--- a/app/data/test_dates.json
+++ b/app/data/test_dates.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "23",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "023",

--- a/app/data/test_final_confirmation.json
+++ b/app/data/test_final_confirmation.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "0",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "0",

--- a/app/data/test_household_question.json
+++ b/app/data/test_household_question.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "23",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "023",

--- a/app/data/test_interstitial_page.json
+++ b/app/data/test_interstitial_page.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "0",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "0",

--- a/app/data/test_language.json
+++ b/app/data/test_language.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "0",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "0",

--- a/app/data/test_language_cy.json
+++ b/app/data/test_language_cy.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "0",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "0",

--- a/app/data/test_markup.json
+++ b/app/data/test_markup.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "0",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "0",

--- a/app/data/test_metadata_routing.json
+++ b/app/data/test_metadata_routing.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "",

--- a/app/data/test_navigation.json
+++ b/app/data/test_navigation.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "999",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "999",

--- a/app/data/test_navigation_confirmation.json
+++ b/app/data/test_navigation_confirmation.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "999",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "999",

--- a/app/data/test_percentage.json
+++ b/app/data/test_percentage.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "0",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "0",

--- a/app/data/test_question_guidance.json
+++ b/app/data/test_question_guidance.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "0",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "0",

--- a/app/data/test_radio.json
+++ b/app/data/test_radio.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "0",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "0",

--- a/app/data/test_radio_checkbox_descriptions.json
+++ b/app/data/test_radio_checkbox_descriptions.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "0",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "0",

--- a/app/data/test_relationship_household.json
+++ b/app/data/test_relationship_household.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "23",
     "schema_version": "0.0.1",
     "data_version": "0.0.2",
     "survey_id": "023",

--- a/app/data/test_repeating_and_conditional_routing.json
+++ b/app/data/test_repeating_and_conditional_routing.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "23",
     "schema_version": "0.0.1",
     "data_version": "0.0.2",
     "survey_id": "023",

--- a/app/data/test_repeating_household.json
+++ b/app/data/test_repeating_household.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "23",
     "schema_version": "0.0.1",
     "data_version": "0.0.2",
     "survey_id": "023",

--- a/app/data/test_routing_on_multiple_select.json
+++ b/app/data/test_routing_on_multiple_select.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "",

--- a/app/data/test_skip_condition.json
+++ b/app/data/test_skip_condition.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "0",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "0",

--- a/app/data/test_skip_condition_block.json
+++ b/app/data/test_skip_condition_block.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "0",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "0",

--- a/app/data/test_skip_condition_group.json
+++ b/app/data/test_skip_condition_group.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "0",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "0",

--- a/app/data/test_textarea.json
+++ b/app/data/test_textarea.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "0",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "0",
@@ -15,35 +14,36 @@
     },
     "groups": [{
         "blocks": [{
-            "type": "Questionnaire",
-            "id": "textarea-block",
-            "sections": [{
-                "description": "",
-                "id": "section",
-                "questions": [{
-                    "answers": [{
-                        "guidance": "",
-                        "id": "answer",
-                        "label": "Enter your comments",
-                        "mandatory": false,
-                        "options": [],
-                        "q_code": "0",
-                        "type": "TextArea"
-                    }],
+                "type": "Questionnaire",
+                "id": "textarea-block",
+                "sections": [{
                     "description": "",
-                    "id": "question",
-                    "title": "",
-                    "type": "General"
+                    "id": "section",
+                    "questions": [{
+                        "answers": [{
+                            "guidance": "",
+                            "id": "answer",
+                            "label": "Enter your comments",
+                            "mandatory": false,
+                            "options": [],
+                            "q_code": "0",
+                            "type": "TextArea"
+                        }],
+                        "description": "",
+                        "id": "question",
+                        "title": "",
+                        "type": "General"
+                    }],
+                    "title": "Textarea Test"
                 }],
-                "title": "Textarea Test"
-            }],
-            "routing_rules": [],
-            "title": ""
-        },
-        {
-            "type": "Summary",
-            "id": "textarea-summary"
-        }],
+                "routing_rules": [],
+                "title": ""
+            },
+            {
+                "type": "Summary",
+                "id": "textarea-summary"
+            }
+        ],
         "id": "textarea-group",
         "title": ""
     }]

--- a/app/data/test_textfield.json
+++ b/app/data/test_textfield.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "0",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "0",

--- a/app/data/test_timeout.json
+++ b/app/data/test_timeout.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "0",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "0",

--- a/app/data/test_total_breakdown.json
+++ b/app/data/test_total_breakdown.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "0",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "0",

--- a/tests/app/data/test_invalid_routing.json
+++ b/tests/app/data/test_invalid_routing.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "23",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "023",

--- a/tests/app/parser/test_schemas/calculated-answer.json
+++ b/tests/app/parser/test_schemas/calculated-answer.json
@@ -1,6 +1,5 @@
 {
     "mime_type": "application/json/ons/eq",
-    "questionnaire_id": "0",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "0",


### PR DESCRIPTION
### What is the context of this PR?
The questionnaire_id is assigned in the schema and code but never referenced. This is misleading and causes confusion so has been removed.