### PR TITLE
Add save and continue to summary page

### DIFF
--- a/app/helpers/form_helper.py
+++ b/app/helpers/form_helper.py
@@ -84,7 +84,7 @@ def post_form_for_location(block_json, location, answer_store, request_form, err
 
 
 def disable_mandatory_answers(block_json):
-    for section_json in block_json['sections']:
+    for section_json in block_json.get('sections', []):
         for question_json in section_json['questions']:
             for answer_json in question_json['answers']:
                 if 'mandatory' in answer_json and answer_json['mandatory'] is True:

--- a/app/templates/summary.html
+++ b/app/templates/summary.html
@@ -1,3 +1,4 @@
+{% import 'macros/helpers.html' as helpers %}
 {% extends theme('layouts/_onecol.html') -%}
 
 {% block page_title -%}{{_("Summary")}} - {{survey_title}}{% endblock -%}
@@ -59,6 +60,9 @@
   <form method="POST" autocomplete="off" novalidate>
     {{ form.csrf_token }}
     <button class="btn btn--primary btn--lg u-mr-s qa-btn-submit-answers venus" type="submit">Submit answers</button>
+      <div class="u-mb-m">
+        <button class="btn btn--link mars js-btn-save" type="submit" name="action[save_sign_out]" {{helpers.track('click', 'Navigation', 'Save and complete later click')}}>{% block save_sign_out_button_text %}Save and complete later{% endblock %}</button>
+      </div>
   </form>
 </div>
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -16,7 +16,7 @@ import {fonts} from './gulp/fonts'
 
 const getEnv = () => {
   var env = yargs.argv.env
-  if (env.startsWith("http")) {
+  if (env && env.startsWith("http")) {
     return env
   }
   const envs = {

--- a/tests/functional/spec/timeout.spec.js
+++ b/tests/functional/spec/timeout.spec.js
@@ -61,4 +61,20 @@ describe('Session timeout', function() {
     expect(TimeoutSummaryPage.getTimeoutAnswer()).to.equal('foo')
   })
 
+  it('Given I am on the summary page, when I click save and sign out, then I will be signed out and redirected to a page confirming I have been signed out', function(done) {
+    // Given
+    let userId = getRandomString(10)
+    let collectionId = getRandomString(10)
+    openQuestionnaire('test_timeout.json', userId, collectionId)
+    TimeoutBlockPage.setTimeoutAnswer('foo')
+      .submit()
+
+    // When
+    browser.waitForVisible(dialog, 5000)
+    browser.click('.js-timeout-save')
+
+    // Then
+    expect(browser.getUrl()).to.contain('signed-out')
+  })
+
 })


### PR DESCRIPTION
### What is the context of this PR?
Fixes #1004 meaning users will be signed out when timing out on summary.

By adding save and complete later link to the summary this fixes the issue.

### How to review 
See #1004 on how steps to reproduce issue and confirm actual behaviour is expected 