### PR TITLE
Move delete from thank you to submit

### DIFF
--- a/app/assets/js/app/modules/timeout.js
+++ b/app/assets/js/app/modules/timeout.js
@@ -64,6 +64,7 @@ domready(() => {
   const sessionTimeout = window.__EQ_SESSION_TIMEOUT__
   const promptTime = window.__EQ_SESSION_TIMEOUT_PROMPT__
   const sessionExpiredUrl = window.__EQ_SESSION_EXPIRED_URL__
+  const expireSessionUrl = window.__EQ_EXPIRE_SESSION_URL__
   const sessionContinueUrl = window.__EQ_SESSION_CONTINUE_URL__
 
   const continueBtn = document.querySelector('.js-timeout-continue')
@@ -124,7 +125,10 @@ domready(() => {
     let countDown = timeoutUI.onTick()
     if (countDown < 1) {
       window.clearInterval(this)
-      window.location = sessionExpiredUrl
+      fetch(expireSessionUrl, { method: 'POST' })
+        .then(() => {
+          window.location = sessionExpiredUrl
+        })
     }
 
     if (countDown < promptTime) {

--- a/app/authentication/authenticator.py
+++ b/app/authentication/authenticator.py
@@ -38,7 +38,8 @@ def load_user():
         user = User(user_id, session_storage.get_user_ik())
         questionnaire_store = get_questionnaire_store(user.user_id, user.user_ik)
         metadata = questionnaire_store.metadata
-        logger.bind(tx_id=metadata["tx_id"])
+        if metadata:
+            logger.bind(tx_id=metadata["tx_id"])
         logger.debug("session token exists")
 
         return user
@@ -53,7 +54,8 @@ def store_session(metadata):
     :param metadata: metadata parsed from jwt token
     """
     # clear the session entry in the database
-    session_storage.clear()
+    session_storage.delete_session_from_db()
+
     # also clear the secure cookie data
     session.clear()
 

--- a/app/authentication/session_storage.py
+++ b/app/authentication/session_storage.py
@@ -8,6 +8,7 @@ from app.data_model.database import db_session
 
 USER_ID = "user_id"
 USER_IK = "user_ik"
+SURVEY_COMPLETED_METADATA = "survey_completed_metadata"
 EQ_SESSION_ID = "eq-session-id"
 
 logger = get_logger()
@@ -30,9 +31,9 @@ class SessionStorage:
             # session has a add function but it is wrapped in a session_scope which confuses pylint
             db_session.add(eq_session)
 
-    def clear(self):
+    def delete_session_from_db(self):
         """
-        Removes a user id from the session
+        deletes user session from database
         """
         if EQ_SESSION_ID in session:
             eq_session_id = session[EQ_SESSION_ID]
@@ -88,6 +89,29 @@ class SessionStorage:
         session[USER_IK] = user_ik
 
     @staticmethod
+    def store_survey_completed_metadata(tx_id, period_str, ru_ref):
+        """
+        Store survey_completed_metadata in the cookie for retrieval later
+        """
+        session[SURVEY_COMPLETED_METADATA] = {
+            'tx_id': tx_id,
+            'period_str': period_str,
+            'ru_ref': ru_ref,
+        }
+
+    @staticmethod
+    def has_survey_completed_metadata():
+        """
+        Checks if a user has survey completed metadata
+        :return: boolean value
+        """
+
+        if SURVEY_COMPLETED_METADATA in session:
+            return session[SURVEY_COMPLETED_METADATA] is not None
+        else:
+            return False
+
+    @staticmethod
     def has_user_ik():
         """
         Checks if a user has a stored ik
@@ -97,6 +121,24 @@ class SessionStorage:
             return session[USER_IK] is not None
         else:
             return False
+
+    def remove_user_ik(self):
+        """
+        Removes a user's ik from the session
+        """
+
+        if self.has_user_ik():
+            session.pop(USER_IK)
+
+    def get_survey_completed_metadata(self):
+        """
+        Retrieves survey completed metadata
+        :return: the survey completed metadata
+        """
+        if self.has_survey_completed_metadata():
+            return session[SURVEY_COMPLETED_METADATA]
+        else:
+            return None
 
     def get_user_ik(self):
         """

--- a/app/templates/layouts/_base.html
+++ b/app/templates/layouts/_base.html
@@ -49,6 +49,7 @@
       window.__EQ_SESSION_TIMEOUT__ = {{ session_timeout|default('null') }};
       window.__EQ_SESSION_TIMEOUT_PROMPT__ = {{ session_timeout_prompt|default('null') }};
       window.__EQ_SESSION_CONTINUE_URL__ = '{{ url_prefix }}/timeout-continue';
+      window.__EQ_EXPIRE_SESSION_URL__ = '{{ url_prefix }}/expire-session';
       window.__EQ_SESSION_EXPIRED_URL__ = '{{ url_prefix }}/session-expired';
     </script>
   </head>

--- a/app/templating/metadata_context.py
+++ b/app/templating/metadata_context.py
@@ -47,3 +47,15 @@ def _build_survey_meta(metadata):
         "collection_id": metadata["collection_exercise_sid"],
         "form_type": metadata["form_type"],
     }
+
+
+def build_metadata_context_for_survey_completed(survey_completed_metadata):
+    return {
+        'survey': {
+            'period_str': survey_completed_metadata['period_str'],
+        },
+        'respondent': {
+            'tx_id': convert_tx_id(survey_completed_metadata['tx_id']),
+            'respondent_id': survey_completed_metadata['ru_ref'],
+        },
+    }

--- a/tests/app/authentication/test_database_session_manager.py
+++ b/tests/app/authentication/test_database_session_manager.py
@@ -50,7 +50,7 @@ class TestSessionManager(AppContextTestCase):
     def test_should_not_clear_with_no_session_data(self):
         with self.test_request_context('/status'):
             # Calling clear with no session should be safe to do
-            self.session_storage.clear()
+            self.session_storage.delete_session_from_db()
 
             # No database calls should have been made
             self.assertFalse(self.db_session.delete.called)
@@ -66,7 +66,7 @@ class TestSessionManager(AppContextTestCase):
             self.session_storage._get_user_session = lambda eq_session_id: None
 
             # Call clear with a valid user_id but no session in database
-            self.session_storage.clear()
+            self.session_storage.delete_session_from_db()
 
             # No database calls should have been made
             self.assertFalse(self.db_session.delete.called)
@@ -83,7 +83,7 @@ class TestSessionManager(AppContextTestCase):
             self.session_storage._get_user_session = lambda eq_session_id: eq_session
 
             # Call clear with a valid user_id and valid session in database
-            self.session_storage.clear()
+            self.session_storage.delete_session_from_db()
 
             # Should have attempted to remove it from the database
             self.assertEqual(self.db_session.delete.call_count, 1)
@@ -117,7 +117,7 @@ class TestSessionManager(AppContextTestCase):
 
             # When
             with self.assertRaises(IntegrityError):
-                self.session_storage.clear()
+                self.session_storage.delete_session_from_db()
 
             # Then
             self.db_session.rollback.assert_called_once_with()

--- a/tests/app/authentication/test_session_management.py
+++ b/tests/app/authentication/test_session_management.py
@@ -31,9 +31,13 @@ class BaseSessionManagerTest(unittest.TestCase):
         with self.application.test_request_context():
             self.session_manager.store_user_id("test")
             self.assertIsNotNone(self.session_manager.get_user_id())
-            self.session_manager.clear()
+            self.session_manager.delete_session_from_db()
             self.assertIsNone(self.session_manager.get_user_id())
 
+    def test_remove_user_ik(self):
+        with self.application.test_request_context():
+            self.session_manager.remove_user_ik()
+            self.assertIsNone(self.session_manager.get_user_ik())
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/integration/questionnaire/test_questionnaire_endpoint_redirects.py
+++ b/tests/integration/questionnaire/test_questionnaire_endpoint_redirects.py
@@ -72,3 +72,39 @@ class TestQuestionnaireEndpointRedirects(IntegrationTestCase):
         self.get('/dump/answers')
         answers = json.loads(self.getResponseData())
         self.assertEqual(0, len(answers['answers']))
+
+    def test_when_on_thank_you_get_summary_returns_unauthorised(self):
+        # Given we complete the test_percentage survey and are on the thank you page
+        self.launchSurvey('test', 'percentage', roles=['dumper'])
+        self.post({'answer': '99'})
+        self.post(action=None)
+
+        # When we try to get the summary
+        self.get('questionnaire/test/percentage/789/summary-group/0/summary')
+
+        # Then we get the unauthorised page
+        self.assertStatusUnauthorised()
+
+    def test_when_on_thank_you_get_thank_you_returns_thank_you(self):
+        # Given we complete the test_percentage survey and are on the thank you page
+        self.launchSurvey('test', 'percentage', roles=['dumper'])
+        self.post({'answer': '99'})
+        self.post(action=None)
+
+        # When we try to get the thank-you page
+        self.get('questionnaire/test/percentage/789/thank-you')
+
+        # Then we get the thank-you page
+        self.assertInUrl('questionnaire/test/percentage/789/thank-you')
+
+    def test_when_survey_submitted_re_submitting_returns_unauthorised(self):
+        # Given we have submitted the test_percentage survey
+        self.launchSurvey('test', 'percentage', roles=['dumper'])
+        self.post({'answer': '99'})
+        self.post(action=None)
+
+        # When we try to submit the survey again
+        self.post(url='/questionnaire/test/percentage/789/summary-group/0/summary')
+
+        # Then we get the unauthorised page
+        self.assertStatusUnauthorised()

--- a/tests/integration/questionnaire/test_questionnaire_previous_link.py
+++ b/tests/integration/questionnaire/test_questionnaire_previous_link.py
@@ -61,4 +61,3 @@ class TestQuestionnairePreviousLink(IntegrationTestCase):
 
         self.get('questionnaire/census/household/789/who-lives-here-relationship/1/household-relationships')
         self.assertInPage('Previous')
-

--- a/tests/integration/questionnaire/test_questionnaire_session_expired.py
+++ b/tests/integration/questionnaire/test_questionnaire_session_expired.py
@@ -5,7 +5,7 @@ class TestSessionExpired(IntegrationTestCase):
 
     def test_session_expired_should_log_user_out(self):
         self.launchSurvey('1', '0205')
-        self.get('/questionnaire/1/0205/789/session-expired')
+        self.post(url='/questionnaire/1/0205/789/expire-session')
         self.assertStatusOK()
-        self.get('/questionnaire/1/0205/789/session-expired')
+        self.post(url='/questionnaire/1/0205/789/expire-session')
         self.assertStatusUnauthorised()

--- a/tests/integration/session/test_timeout.py
+++ b/tests/integration/session/test_timeout.py
@@ -16,13 +16,6 @@ class TestTimeout(IntegrationTestCase):
         self.get('/questionnaire/test/timeout/789/timeout-continue')
         self.assertStatusOK()
 
-    def test_session_expired_clears_session(self):
-        self.launchSurvey('test', 'timeout')
-        self.get('/questionnaire/test/timeout/789/session-expired')
-        self.assertStatusOK()
-        self.get('/questionnaire/test/timeout/789/session-expired')
-        self.assertStatusUnauthorised()
-
     def test_when_session_times_out_server_side_401_is_returned(self):
         self.launchSurvey('test', 'timeout')
         time.sleep(2)

--- a/tests/integration/star_wars/test_backwards_navigation_after_submission.py
+++ b/tests/integration/star_wars/test_backwards_navigation_after_submission.py
@@ -21,9 +21,6 @@ class TestBackwardsNavigationAfterSubmission(StarWarsTestCase):
         self.backwards_navigation()
 
     def backwards_navigation(self):
-        # Introduction
-        self.get(star_wars_test_urls.STAR_WARS_INTRODUCTION)
-        self.assertStatusUnauthorised()
 
         # Block Three
         self.get(star_wars_test_urls.STAR_WARS_TRIVIA_PART_3)


### PR DESCRIPTION
### What is the context of this PR?
Remove all state changes  on end points (thank you, signed out and session expired) and introduces survey_completed_metadata in cookie so submit data can clear the questionnaire store

### How to review 
1. Make sure you can't jump to the thank-you page without completing a survey first
2. Make sure once you are on the survey page and try to go back it stays on thank-you
3. Make sure session time works as expected
4. Make sure sign-out works as before
