### PR TITLE
Prevent profiling running for all tests

### DIFF
--- a/tests/integration/test_appliation_profiling.py
+++ b/tests/integration/test_appliation_profiling.py
@@ -8,5 +8,9 @@ class TestApplicationProfiling(IntegrationTestCase):
         settings.EQ_PROFILING = True
         super().setUp()
 
+    def tearDown(self):
+        settings.EQ_PROFILING = False
+        super().tearDown()
+
     def test_profiling_is_enabled(self):
         self.assertEqual(True, self._application.config['PROFILE'])


### PR DESCRIPTION
### What is the context of this PR?
Profiling is currently running for all tests. This is causing tests to run slower and a lot of profiling files to be created

### How to review 
Check that the profiling file isn't being filled up with hundreds of files when running the unit tests.