### PR TITLE
Timeout Javascript to cancel interval

### DIFF
--- a/app/assets/js/app/modules/timeout.js
+++ b/app/assets/js/app/modules/timeout.js
@@ -121,10 +121,10 @@ domready(() => {
   // must be initialised after the keydown listener
   dialog.init()
 
-  window.setInterval((a) => {
+  let timeoutInterval = window.setInterval((a) => {
     let countDown = timeoutUI.onTick()
     if (countDown < 1) {
-      window.clearInterval(this)
+      window.clearInterval(timeoutInterval)
       fetch(expireSessionUrl, { method: 'POST' })
         .then(() => {
           window.location = sessionExpiredUrl


### PR DESCRIPTION
### What is the context of this PR?
The timeout Javascript was causing requests to be made over 1 second if the browser did not load the expired page within 1 second

### How to review 
Test the timeout on a slow network connection (simulate in chrome) when the page expires then only 1 network request should be make to the expired page.