### PR TITLE
Stage one of moving app settings to app.config

### DIFF
--- a/app/authentication/authenticator.py
+++ b/app/authentication/authenticator.py
@@ -1,4 +1,5 @@
 from flask import session
+from flask import current_app
 from flask_login import LoginManager
 from structlog import get_logger
 
@@ -78,8 +79,17 @@ def decrypt_token(encrypted_token):
     logger.debug("decrypting token")
     if encrypted_token is None:
         raise NoTokenException("Please provide a token")
-    decoder = JWTDecryptor()
-    decrypted_token = decoder.decrypt_jwt_token(encrypted_token)
+
+    decoder = JWTDecryptor(
+        current_app.config['EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY'],
+        current_app.config['EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY_PASSWORD'],
+        current_app.config['EQ_USER_AUTHENTICATION_RRM_PUBLIC_KEY'],
+    )
+
+    decrypted_token = decoder.decrypt_jwt_token(
+        encrypted_token,
+        current_app.config['EQ_JWT_LEEWAY_IN_SECONDS'],
+    )
 
     valid, field = is_valid_metadata(decrypted_token)
     if not valid:

--- a/app/new_relic.py
+++ b/app/new_relic.py
@@ -1,7 +1,3 @@
-from app import settings
-
-
 def setup_newrelic():
-    if settings.EQ_NEW_RELIC_ENABLED:
-        import newrelic.agent
-        newrelic.agent.initialize()
+    import newrelic.agent
+    newrelic.agent.initialize()

--- a/app/settings.py
+++ b/app/settings.py
@@ -28,7 +28,7 @@ def read_file(file_name):
 
 EQ_MINIMIZE_ASSETS = parse_mode(os.getenv('EQ_MINIMIZE_ASSETS', 'False'))
 # max request payload size in bytes
-EQ_MAX_HTTP_POST_CONTENT_LENGTH = os.getenv('EQ_MAX_HTTP_POST_CONTENT_LENGTH', 65536)
+MAX_CONTENT_LENGTH = os.getenv('EQ_MAX_HTTP_POST_CONTENT_LENGTH', 65536)
 
 # max number of repeats from a rule
 EQ_MAX_NUM_REPEATS = os.getenv('EQ_MAX_NUM_REPEATS', 25)

--- a/app/views/flush.py
+++ b/app/views/flush.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, Response, request, session
+from flask import Blueprint, Response, request, session, current_app
 
 from app.authentication.jwt_decoder import JWTDecryptor
 from app.authentication.user import User
@@ -23,8 +23,16 @@ def flush_data():
     if encrypted_token is None:
         return Response(status=403)
 
-    decoder = JWTDecryptor()
-    decrypted_token = decoder.decrypt_jwt_token(encrypted_token)
+    decoder = JWTDecryptor(
+        current_app.config['EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY'],
+        current_app.config['EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY_PASSWORD'],
+        current_app.config['EQ_USER_AUTHENTICATION_RRM_PUBLIC_KEY'],
+    )
+
+    decrypted_token = decoder.decrypt_jwt_token(
+        encrypted_token,
+        current_app.config['EQ_JWT_LEEWAY_IN_SECONDS'],
+    )
 
     roles = decrypted_token.get('roles')
 

--- a/tests/app/authentication/__init__.py
+++ b/tests/app/authentication/__init__.py
@@ -100,3 +100,5 @@ VALID_JWE = "eyJjdHkiOiJKV1QiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiUlNBLU9BRVAifQ.YfYd
             "BslOcCLtAlGdRsptS6-L4YHxaGEAvwXD1heQADoAabjGCA-BZGPdc6h8A6y1QR7m2P33KEz83h141X4Ftyd9kTGxgjQ8-UrIGvu9b1wbm" \
             "cjTWK3hiiyC3o0guBbzBq0SflX-RG9_zyK4sAIksiXj9mNRah1IUjUT5zr9cs1c5i4WwJdpJ28IzKvczgQ63B_t1xEpGsb6A35EhxzRkG" \
             "7BQ.I9WExvUvZVXdwjxz8EPtCg"
+
+TEST_DO_NOT_USE_SR_PRIVATE_PEM_PASSWORD = 'digitaleq'

--- a/tests/app/authentication/test_jwe.py
+++ b/tests/app/authentication/test_jwe.py
@@ -1,52 +1,50 @@
 import os
 import unittest
 
-from app import settings
 from app.authentication.invalid_token_exception import InvalidTokenException
 from app.authentication.jwt_decoder import JWTDecryptor
 from app.cryptography.jwt_encoder import Encoder
-from tests.app.authentication import TEST_DO_NOT_USE_RRM_PUBLIC_PEM, TEST_DO_NOT_USE_SR_PRIVATE_PEM, VALID_SIGNED_JWT, VALID_JWE
+from tests.app.authentication import (
+    TEST_DO_NOT_USE_RRM_PUBLIC_PEM,
+    TEST_DO_NOT_USE_SR_PRIVATE_PEM,
+    TEST_DO_NOT_USE_SR_PRIVATE_PEM_PASSWORD,
+    VALID_SIGNED_JWT,
+    VALID_JWE)
 
 
 class JWETest(unittest.TestCase):
     def setUp(self):
-        settings.EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY = TEST_DO_NOT_USE_SR_PRIVATE_PEM
-        settings.EQ_USER_AUTHENTICATION_RRM_PUBLIC_KEY = TEST_DO_NOT_USE_RRM_PUBLIC_PEM
-        settings.EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY_PASSWORD = "digitaleq"
+        self.decryptor_args = (
+            TEST_DO_NOT_USE_SR_PRIVATE_PEM,
+            TEST_DO_NOT_USE_SR_PRIVATE_PEM_PASSWORD,
+            TEST_DO_NOT_USE_RRM_PUBLIC_PEM
+        )
+
+        self.leeway = 120
 
     def test_valid_jwe(self):
-        decoder = JWTDecryptor()
-        token = decoder.decrypt_jwt_token(VALID_JWE)
+        decoder = JWTDecryptor(*self.decryptor_args)
+        token = decoder.decrypt_jwt_token(VALID_JWE, self.leeway)
         self.assertEqual("jimmy", token.get("user"))
 
     def test_does_not_contain_four_instances_of_full_stop(self):
         jwe = VALID_JWE.replace('.', '', 1)
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decrypt_jwt_token(jwe)
-        self.assertIn("Incorrect size", ite.exception.value)
+
+        self.assertInDecryptException(jwe, "Incorrect size")
 
     def test_missing_algorithm(self):
         jwe_protected_header = b'{"enc":"A256GCM"}'
         encoder = Encoder()
-        jwe = encoder.encrypt_token(VALID_SIGNED_JWT.encode(),
-                                    jwe_protected_header=encoder._base_64_encode(jwe_protected_header))  # pylint: disable=protected-access
+        jwe = encoder.encrypt_token(VALID_SIGNED_JWT.encode(), jwe_protected_header=encoder._base_64_encode(jwe_protected_header))  # pylint: disable=protected-access
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decrypt_jwt_token(jwe.decode())
-        self.assertIn("Missing Algorithm", ite.exception.value)
+        self.assertInDecryptException(jwe.decode(), "Missing Algorithm")
 
     def test_invalid_algorithm(self):
         jwe_protected_header = b'{"alg":"PBES2_HS256_A128KW","enc":"A256GCM"}'
         encoder = Encoder()
-        jwe = encoder.encrypt_token(VALID_SIGNED_JWT.encode(),
-                                    jwe_protected_header=encoder._base_64_encode(jwe_protected_header))  # pylint: disable=protected-access
+        jwe = encoder.encrypt_token(VALID_SIGNED_JWT.encode(), jwe_protected_header=encoder._base_64_encode(jwe_protected_header))  # pylint: disable=protected-access
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decrypt_jwt_token(jwe.decode())
-        self.assertIn("Invalid Algorithm", ite.exception.value)
+        self.assertInDecryptException(jwe.decode(), "Invalid Algorithm")
 
     def test_enc_missing(self):
         jwe_protected_header = b'{"alg":"RSA-OAEP"}'
@@ -55,10 +53,7 @@ class JWETest(unittest.TestCase):
         jwe = encoder.encrypt_token(VALID_SIGNED_JWT.encode(),
                                     jwe_protected_header=encoder._base_64_encode(jwe_protected_header))  # pylint: disable=protected-access
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decrypt_jwt_token(jwe.decode())
-        self.assertIn("Missing Encoding", ite.exception.value)
+        self.assertInDecryptException(jwe.decode(), "Missing Encoding")
 
     def test_invalid_enc(self):
         jwe_protected_header = b'{"alg":"RSA-OAEP","enc":"A128GCM"}'
@@ -66,10 +61,7 @@ class JWETest(unittest.TestCase):
         jwe = encoder.encrypt_token(VALID_SIGNED_JWT.encode(),
                                     jwe_protected_header=encoder._base_64_encode(jwe_protected_header))  # pylint: disable=protected-access
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decrypt_jwt_token(jwe.decode())
-        self.assertIn("Invalid Encoding", ite.exception.value)
+        self.assertInDecryptException(jwe.decode(), "Invalid Encoding")
 
     def test_jwe_header_contains_alg_twice(self):
         jwe_protected_header = b'{"alg":"RSA-OAEP","alg":"RSA-OAEP","enc":"A256GCM"}'
@@ -77,10 +69,7 @@ class JWETest(unittest.TestCase):
         jwe = encoder.encrypt_token(VALID_SIGNED_JWT.encode(),
                                     jwe_protected_header=encoder._base_64_encode(jwe_protected_header))  # pylint: disable=protected-access
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decrypt_jwt_token(jwe.decode())
-        self.assertIn("InvalidTag", ite.exception.value)
+        self.assertInDecryptException(jwe.decode(), "InvalidTag")
 
     def test_jwe_header_only_contains_alg_and_enc(self):
         jwe_protected_header = b'{"alg":"RSA-OAEP","enc":"A256GCM", "test":"test"}'
@@ -88,10 +77,7 @@ class JWETest(unittest.TestCase):
         jwe = encoder.encrypt_token(VALID_SIGNED_JWT.encode(),
                                     jwe_protected_header=encoder._base_64_encode(jwe_protected_header))  # pylint: disable=protected-access
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decrypt_jwt_token(jwe.decode())
-        self.assertIn("InvalidTag", ite.exception.value)
+        self.assertInDecryptException(jwe.decode(), "InvalidTag")
 
     def test_jwe_key_not_2048_bits(self):
         cek = os.urandom(32)
@@ -102,10 +88,7 @@ class JWETest(unittest.TestCase):
         encrypted_key = encrypted_key[0:len(encrypted_key) - 2]
         jwe = encoder.encrypt_token(VALID_SIGNED_JWT.encode(), encrypted_key=encrypted_key)
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decrypt_jwt_token(jwe.decode())
-        self.assertIn("ValueError", ite.exception.value)
+        self.assertInDecryptException(jwe.decode(), "ValueError")
 
     def test_cek_not_256_bits(self):
         cek = os.urandom(24)
@@ -114,10 +97,7 @@ class JWETest(unittest.TestCase):
         encoder.cek = cek
         jwe = encoder.encrypt_token(VALID_SIGNED_JWT.encode())
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decrypt_jwt_token(jwe.decode())
-        self.assertIn("CEK incorrect length", ite.exception.value)
+        self.assertInDecryptException(jwe.decode(), "CEK incorrect length")
 
     def test_iv_not_96_bits(self):
         iv = os.urandom(45)
@@ -126,27 +106,21 @@ class JWETest(unittest.TestCase):
         encoder.iv = iv
         jwe = encoder.encrypt_token(VALID_SIGNED_JWT.encode())
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decrypt_jwt_token(jwe.decode())
-            self.assertIn("IV incorrect length", ite.exception.value)
+        self.assertInDecryptException(jwe.decode(), "IV incorrect length")
 
     def test_authentication_tag_not_128_bits(self):
         encoder = Encoder()
         jwe = encoder.encrypt_token(VALID_SIGNED_JWT.encode(), tag=os.urandom(10))
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decrypt_jwt_token(jwe.decode())
-        self.assertIn("'Authentication tag must be 16 bytes or longer", ite.exception.value)
+        self.assertInDecryptException(jwe.decode(), "'Authentication tag must be 16 bytes or longer")
 
     def test_authentication_tag_corrupted(self):
         encoder = Encoder()
         jwe = encoder.encrypt_token(VALID_SIGNED_JWT.encode(), tag=b'adssadsadsadsadasdasdasads')
 
-        decoder = JWTDecryptor()
+        decoder = JWTDecryptor(*self.decryptor_args)
         with self.assertRaises(InvalidTokenException):
-            decoder.decrypt_jwt_token(jwe.decode())
+            decoder.decrypt_jwt_token(jwe.decode(), self.leeway)
 
     def test_cipher_text_corrupted(self):
         encoder = Encoder()
@@ -162,9 +136,17 @@ class JWETest(unittest.TestCase):
         corrupted_cipher = encoded_cipher_text[0:len(encoded_cipher_text) - 1]
         reassembled = jwe_protected_header + "." + encrypted_key + "." + encoded_iv + "." + corrupted_cipher + "." + encoded_tag
 
-        decoder = JWTDecryptor()
+        decoder = JWTDecryptor(*self.decryptor_args)
         with self.assertRaises(InvalidTokenException):
-            decoder.decrypt_jwt_token(reassembled)
+            decoder.decrypt_jwt_token(reassembled, self.leeway)
+
+    def assertInDecryptException(self, jwe, error):
+        decoder = JWTDecryptor(*self.decryptor_args)
+        with self.assertRaises(InvalidTokenException) as ite:
+            decoder.decrypt_jwt_token(jwe, self.leeway)
+
+        if error not in ite.exception.value:
+            raise AssertionError('"{}" not found in decrypt exception'.format(error))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/app/authentication/test_jwt.py
+++ b/tests/app/authentication/test_jwt.py
@@ -2,10 +2,9 @@ import base64
 import os
 import unittest
 
-from app import settings
 from app.authentication.invalid_token_exception import InvalidTokenException
 from app.authentication.jwt_decoder import JWTDecryptor
-from tests.app.authentication import TEST_DO_NOT_USE_SR_PRIVATE_PEM
+from tests.app.authentication import TEST_DO_NOT_USE_SR_PRIVATE_PEM, TEST_DO_NOT_USE_SR_PRIVATE_PEM_PASSWORD
 
 # public key from jwt.io
 
@@ -29,207 +28,147 @@ jwtio_signed = jwtio_header + "." + jwtio_payload + "." + jwtio_signature
 
 class JWTTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
     def setUp(self):
-        settings.EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY = TEST_DO_NOT_USE_SR_PRIVATE_PEM
-        settings.EQ_USER_AUTHENTICATION_RRM_PUBLIC_KEY = TEST_DO_NOT_USE_PUBLIC_KEY
-        settings.EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY_PASSWORD = "digitaleq"
+        self.decryptor_args = (
+            TEST_DO_NOT_USE_SR_PRIVATE_PEM,
+            TEST_DO_NOT_USE_SR_PRIVATE_PEM_PASSWORD,
+            TEST_DO_NOT_USE_PUBLIC_KEY
+        )
+
+        self.leeway = 120
 
     def test_jwt_io(self):
-        decoder = JWTDecryptor()
-        token = decoder.decode_signed_jwt_token(jwtio_signed)
+        decoder = JWTDecryptor(*self.decryptor_args)
+        token = decoder.decode_signed_jwt_token(jwtio_signed, self.leeway)
         self.assertEqual("John Doe", token.get("name"))
 
     def test_does_not_contain_two_instances_of_full_stop(self):
         jwe = jwtio_signed.replace('.', '', 1)
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(jwe)
-        self.assertIn("Invalid Token", ite.exception.value)
+        self.assertInDecodeSignedJWTException(jwe, "Invalid Token")
 
     def test_jwt_contains_empty_header(self):
         token_without_header = "e30." + jwtio_payload + "." + jwtio_signature
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(token_without_header)
-        self.assertIn("Missing Headers", ite.exception.value)
+        self.assertInDecodeSignedJWTException(token_without_header, "Missing Headers")
 
     def test_jwt_does_not_contain_header_at_all(self):
         token_without_header = "." + jwtio_payload + "." + jwtio_signature
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(token_without_header)
-        self.assertIn("Missing Headers", ite.exception.value)
+        self.assertInDecodeSignedJWTException(token_without_header, "Missing Headers")
 
     def test_jwt_contains_empty_payload(self):
         token_without_payload = jwtio_header + ".e30." + jwtio_signature
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(token_without_payload)
-        self.assertIn("Missing Payload", ite.exception.value)
+
+        self.assertInDecodeSignedJWTException(token_without_payload, "Missing Payload")
 
     def test_jwt_does_not_contain_payload(self):
         token_without_payload = jwtio_header + ".." + jwtio_signature
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(token_without_payload)
-        self.assertIn("Missing Payload", ite.exception.value)
+
+        self.assertInDecodeSignedJWTException(token_without_payload, "Missing Payload")
 
     def test_jwt_does_not_contain_signature(self):
         jwt = jwtio_header + "." + jwtio_payload + ".e30"
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(jwt)
-        self.assertIn("Signature verification failed", ite.exception.value)
+        self.assertInDecodeSignedJWTException(jwt, "Signature verification failed")
 
     def test_jose_header_missing_type(self):
         header = base64.urlsafe_b64encode(b'{"alg":"RS256", "kid":"EDCRRM"}')
         jwt = header.decode() + "." + jwtio_payload + "." + jwtio_signature
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(jwt)
-        self.assertIn("Missing Type", ite.exception.value)
+        self.assertInDecodeSignedJWTException(jwt, "Missing Type")
 
     def test_jose_header_invalid_type(self):
         header = base64.urlsafe_b64encode(b'{"alg":"RS256", "kid":"EDCRRM", "typ":"TEST"}')
         jwt = header.decode() + "." + jwtio_payload + "." + jwtio_signature
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(jwt)
-        self.assertIn("Invalid Type", ite.exception.value)
+        self.assertInDecodeSignedJWTException(jwt, "Invalid Type")
 
     def test_jose_header_contains_multiple_type(self):
         header = base64.urlsafe_b64encode(b'{"alg":"RS256", "kid":"EDCRRM","typ":"JWT","typ":"TEST"}')
         jwt = header.decode() + "." + jwtio_payload + "." + jwtio_signature
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(jwt)
-        self.assertIn("Multiple typ Headers", ite.exception.value)
+        self.assertInDecodeSignedJWTException(jwt, "Multiple 'typ' Headers")
 
     def test_jose_header_missing_alg(self):
         header = base64.urlsafe_b64encode(b'{"kid":"EDCRRM","typ":"JWT"}')
         jwt = header.decode() + "." + jwtio_payload + "." + jwtio_signature
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(jwt)
-        self.assertIn("Missing Algorithm", ite.exception.value)
+        self.assertInDecodeSignedJWTException(jwt, "Missing Algorithm")
 
     def test_jose_header_invalid_alg(self):
         header = base64.urlsafe_b64encode(b'{"alg":"invalid","kid":"EDCRRM","typ":"JWT"}')
         jwt = header.decode() + "." + jwtio_payload + "." + jwtio_signature
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(jwt)
-        self.assertIn("Invalid Algorithm", ite.exception.value)
+        self.assertInDecodeSignedJWTException(jwt, "Invalid Algorithm")
 
     def test_jose_header_none_alg(self):
         header = base64.urlsafe_b64encode(b'{"alg":"None","kid":"EDCRRM","typ":"JWT"}')
         jwt = header.decode() + "." + jwtio_payload + "." + jwtio_signature
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(jwt)
-        self.assertIn("Invalid Algorithm", ite.exception.value)
+        self.assertInDecodeSignedJWTException(jwt, "Invalid Algorithm")
 
     def test_jose_header_contains_multiple_alg(self):
         header = base64.urlsafe_b64encode(b'{"alg":"RS256", "alg":"HS256","kid":"EDCRRM", "typ":"JWT"}')
         jwt = header.decode() + "." + jwtio_payload + "." + jwtio_signature
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(jwt)
-        self.assertIn("Multiple alg Headers", ite.exception.value)
+        self.assertInDecodeSignedJWTException(jwt, "Multiple 'alg' Headers")
 
     def test_jose_header_missing_kid(self):
         header = base64.urlsafe_b64encode(b'{"alg":"RS256", "typ":"JWT"}')
         jwt = header.decode() + "." + jwtio_payload + "." + jwtio_signature
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(jwt)
-        self.assertIn("Missing kid", ite.exception.value)
+        self.assertInDecodeSignedJWTException(jwt, "Missing kid")
 
     def test_jose_header_contains_multiple_kid(self):
         header = base64.urlsafe_b64encode(b'{"alg":"RS256", "kid":"EDCRRM", "kid":"test", "typ":"JWT"}')
         jwt = header.decode() + "." + jwtio_payload + "." + jwtio_signature
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(jwt)
-        self.assertIn("Multiple kid Headers", ite.exception.value)
+        self.assertInDecodeSignedJWTException(jwt, "Multiple 'kid' Headers")
 
     def test_jose_header_contains_invalid_kid(self):
         header = base64.urlsafe_b64encode(b'{"alg":"RS256", "kid":"UNKNOWN", "typ":"JWT"}')
         jwt = header.decode() + "." + jwtio_payload + "." + jwtio_signature
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(jwt)
-        self.assertIn("Invalid Key Identifier", ite.exception.value)
+        self.assertInDecodeSignedJWTException(jwt, "Invalid Key Identifier")
 
     def test_signature_not_2048_bits(self):
         jwt = jwtio_header + "." + jwtio_payload + "." + base64.urlsafe_b64encode(os.urandom(255)).decode()
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(jwt)
-        self.assertIn("Signature verification", ite.exception.value)
+        self.assertInDecodeSignedJWTException(jwt, "Signature verification")
 
     def test_payload_corrupt(self):
         jwt = jwtio_header + ".asdasd." + jwtio_signature
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(jwt)
-        self.assertIn("Corrupted Payload", ite.exception.value)
+        self.assertInDecodeSignedJWTException(jwt, "Corrupted Payload")
 
     def test_header_corrupt(self):
         jwt = "asdsadsa" + "." + jwtio_payload + "." + jwtio_signature
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(jwt)
-        self.assertIn("Corrupted Header", ite.exception.value)
+        self.assertInDecodeSignedJWTException(jwt, "Corrupted Header")
 
     def test_signature_corrupt(self):
         jwt = jwtio_header + "." + jwtio_payload + ".asdasddas"
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(jwt)
-        self.assertIn("DecodeError", ite.exception.value)
+        self.assertInDecodeSignedJWTException(jwt, "DecodeError")
 
     def test_payload_contains_malformed_json(self):
         payload = base64.urlsafe_b64encode(b'{"user":"jimmy,"iat": "1454935765","exp": "2075297148"')
         jwt = jwtio_header + "." + payload.decode() + "." + jwtio_signature
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(jwt)
-        self.assertIn("DecodeError", ite.exception.value)
+
+        self.assertInDecodeSignedJWTException(jwt, "DecodeError")
 
     def test_payload_contains_corrupted_json(self):
         payload = base64.urlsafe_b64encode(b'{"user":"jimmy","iat": "1454935765","exp": "2075297148"}ABDCE')
         jwt = jwtio_header + "." + payload.decode() + "." + jwtio_signature
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(jwt)
-        self.assertIn("DecodeError", ite.exception.value)
+
+        self.assertInDecodeSignedJWTException(jwt, "DecodeError")
 
     def test_payload_does_not_contain_exp(self):
         valid_token_no_exp = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IkVEQ1JSTSJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibm" \
                              "FtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6IjE0NTQ5MzU3NjcifQ.VupTBEOEzeDjxd37PQ34xv" \
                              "BlLzeGTA0xFdGnLZDcnxAS1AjNcJ66edRmr4tmPIXnD6Mgen3HSB36xuXSnfzPld2msFHUXmB18CoaJQK19BXEY" \
                              "vosrBPzc1ohSvam_DgXCzdSMAcWSE63e6LTWNCT93-npD3p9tjdY_TWpEOOg14"
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(valid_token_no_exp)
-        self.assertIn("Missing exp claim", ite.exception.value)
+
+        self.assertInDecodeSignedJWTException(valid_token_no_exp, "Missing exp claim")
 
     def test_payload_does_not_contain_iat(self):
         valid_token_no_iat = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IkVEQ1JSTSJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibm" \
@@ -237,10 +176,7 @@ class JWTTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
                              "gdKQuNJ6o5oXA8rwEFiIE9UYo0yALhsQf5BbYs7RmVq760jde2FqwbwHze_XHFlOcg9nODfevEbRAUxjt_jpDaI" \
                              "LWmzreVw8jYTie9qn-F-7Tb6R1fgvvi5Fd7h0Py_LTLTZ72H1NOXCMtL_bbv6Y"
 
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(valid_token_no_iat)
-        self.assertIn("Missing iat claim", ite.exception.value)
+        self.assertInDecodeSignedJWTException(valid_token_no_iat, "Missing iat claim")
 
     def test_payload_invalid_exp(self):
         valid_token_with_invalid_exp = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IkVEQ1JSTSJ9.eyJzdWIiOiIxMjM0NTY3" \
@@ -248,10 +184,8 @@ class JWTTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
                                        "HAiOiI_In0.0ApxEXw1rzo21XQo8WgcPvnz0e8QnT0GaoXVbCj-OdJtB7GArPzaiQ1cU53WaJsvGE" \
                                        "zHTczc6Y0xN7WzcTdcXN8Yjenf4VqoiYc6_FXGJ1s9Brd0JOFPyVipTFxPoWvYTWLXE-CAEpXrEb3" \
                                        "0kB3nRjHFV_yVhLiiZUU-gpUHqNQ"
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(valid_token_with_invalid_exp)
-        self.assertIn("Expiration Time claim (exp) must be an integer", ite.exception.value)
+
+        self.assertInDecodeSignedJWTException(valid_token_with_invalid_exp, "Expiration Time claim (exp) must be an integer")
 
     def test_payload_invalid_iat(self):
         valid_token_with_invalid_iat = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IkVEQ1JSTSJ9.eyJzdWIiOiIxMjM0NTY3" \
@@ -259,10 +193,8 @@ class JWTTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
                                        "jk3MTQ4In0.1NIuxcD1FsZlU17NxK4UHdCfzl7qTV03qEaTRcqTC6A1Fs2Alc7mSQgkF_SpUw4Ylt" \
                                        "n-7DhO2InfcwDA0VhxBOHDL6ZzcEvzw-49iD-AaSd4aINIkDK-Iim5uzbKzgQCuZqSXFqxsZlezA4" \
                                        "BtwV7Lv2puqdPrXT8k3SvM2rOwRw"
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(valid_token_with_invalid_iat)
-        self.assertIn("Issued At claim (iat) must be an integer", ite.exception.value)
+
+        self.assertInDecodeSignedJWTException(valid_token_with_invalid_iat, "Issued At claim (iat) must be an integer")
 
     def test_payload_expired_exp(self):
         valid_token_with_exp_in_the_past = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IkVEQ1JSTSJ9.eyJzdWIiOiIxMjM" \
@@ -270,10 +202,8 @@ class JWTTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
                                            "3NjUiLCJleHAiOiIxNDU0OTM1NzY2In0.PLIaSBh3jiPCsYgx7l1m8enorE7FzYUxVHgarlm" \
                                            "ZiMzpNjNmEzBYBq0yCk7wzkbrJhe5slliaMDY6C4hrAGo8oIUwYp_bQxxDCzyfeXiqdewdPe" \
                                            "L2X8D47Yw-KRt2XF03LXnMEyAaHD9CPhtnSWYUijka5h5yJIG62JTOGWvKGU"
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(valid_token_with_exp_in_the_past)
-        self.assertIn("Signature has expired", ite.exception.value)
+
+        self.assertInDecodeSignedJWTException(valid_token_with_exp_in_the_past, "Signature has expired")
 
     def test_payload_exp_less_than_iat(self):
         valid_token_with_exp_less_than_iat = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IkVEQ1JSTSJ9.eyJzdWIiOiIxM" \
@@ -281,10 +211,8 @@ class JWTTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
                                              "5MzU3NjUiLCJleHAiOiIxNDU0OTM1NzY0In0.p2T1go1DblkgYiYHj_cLV1Jd169sG4bqv" \
                                              "qncTSpYPYawMIkjeb7s0IWFaswi348YLvcaAuQxaq3H5sw6RG3338TmFWYMJhvJTOYCZBC" \
                                              "pvkuu2PTKBAxYlQt9dHuWnFODYtjFgdsJigMrePdY9FIqyifyUAJsUHhA7WagOxUwW_I"
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(valid_token_with_exp_less_than_iat)
-        self.assertIn("Signature has expired", ite.exception.value)
+
+        self.assertInDecodeSignedJWTException(valid_token_with_exp_less_than_iat, "Signature has expired")
 
     def test_payload_iat_in_future(self):
         # set iat to Oct 2035
@@ -293,10 +221,8 @@ class JWTTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
                                          "iLCJleHAiOiIyMDc1Mjk3MTQ4In0.2MQNPXUAiT3AFhbQWoNZ3bs14WeQDloiJfP-3s9ddprzY" \
                                          "tj4omGaym32WvD-f4kBjuEwe479QzpJQoV_oTYCwB8VmFnKd4lKWKMUnNHQYcG0GWVB1Y9qWuW" \
                                          "nPG32kfS2Z7YuMkCgar8qttajB_YRcwhes4rIVaObFFXywnSinCQ"
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(valid_token_with_iat_in_future)
-        self.assertIn("Issued At claim (iat) cannot be in the future", ite.exception.value)
+
+        self.assertInDecodeSignedJWTException(valid_token_with_iat_in_future, "Issued At claim (iat) cannot be in the future")
 
     def test_payload_contains_more_than_one_iat(self):
         payload = base64.urlsafe_b64encode(b'{"user":"jimmy",'
@@ -304,10 +230,8 @@ class JWTTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
                                            b'"iat": "1454935765",'
                                            b'"exp": "2075297148"}')
         jwt = jwtio_header + "." + payload.decode() + "." + jwtio_signature
-        decoder = JWTDecryptor()
-        with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(jwt)
-        self.assertIn("Multiple iat claims", ite.exception.value)
+
+        self.assertInDecodeSignedJWTException(jwt, "Multiple iat claims")
 
     def test_payload_contains_more_than_one_exp(self):
         payload = base64.urlsafe_b64encode(b'{"user":"jimmy",'
@@ -315,10 +239,16 @@ class JWTTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
                                            b'"exp": "1454935765",'
                                            b'"exp": "2075297148"}')
         jwt = jwtio_header + "." + payload.decode() + "." + jwtio_signature
-        decoder = JWTDecryptor()
+
+        self.assertInDecodeSignedJWTException(jwt, "Multiple exp claims")
+
+    def assertInDecodeSignedJWTException(self, jwe, error):
+        decoder = JWTDecryptor(*self.decryptor_args)
         with self.assertRaises(InvalidTokenException) as ite:
-            decoder.decode_signed_jwt_token(jwt)
-        self.assertIn("Multiple exp claims", ite.exception.value)
+            decoder.decode_signed_jwt_token(jwe, self.leeway)
+
+        if error not in ite.exception.value:
+            raise AssertionError('"{}" not found in decode exception'.format(error))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/app/authentication/test_jwt_decoder.py
+++ b/tests/app/authentication/test_jwt_decoder.py
@@ -1,64 +1,62 @@
 import unittest
 
-from app import settings
 from app.authentication.invalid_token_exception import InvalidTokenException
 from app.authentication.jwt_decoder import JWTDecryptor
 from app.authentication.no_token_exception import NoTokenException
-from tests.app.authentication import TEST_DO_NOT_USE_RRM_PUBLIC_PEM, TEST_DO_NOT_USE_SR_PRIVATE_PEM
+from tests.app.authentication import TEST_DO_NOT_USE_RRM_PUBLIC_PEM, TEST_DO_NOT_USE_SR_PRIVATE_PEM, TEST_DO_NOT_USE_SR_PRIVATE_PEM_PASSWORD
 from tests.app.authentication import VALID_SIGNED_JWT, VALID_JWE
 
 
 class JWTDecodeTest(unittest.TestCase):
     def setUp(self):
-        settings.EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY = TEST_DO_NOT_USE_SR_PRIVATE_PEM
-        settings.EQ_USER_AUTHENTICATION_RRM_PUBLIC_KEY = TEST_DO_NOT_USE_RRM_PUBLIC_PEM
-        settings.EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY_PASSWORD = "digitaleq"
+        self.SR_PRIVATE_KEY = TEST_DO_NOT_USE_SR_PRIVATE_PEM
+        self.RRM_PUBLIC_KEY = TEST_DO_NOT_USE_RRM_PUBLIC_PEM
+        self.SR_PRIVATE_KEY_PASSWORD = TEST_DO_NOT_USE_SR_PRIVATE_PEM_PASSWORD
+
+        self.good_args = (self.SR_PRIVATE_KEY, self.SR_PRIVATE_KEY_PASSWORD, self.RRM_PUBLIC_KEY)
 
     def test_invalid_keymat_sr_private_key(self):
-        settings.EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY = None
         with self.assertRaises(OSError) as ose:
-            JWTDecryptor()
+            JWTDecryptor(None, self.SR_PRIVATE_KEY_PASSWORD, self.RRM_PUBLIC_KEY)
         self.assertIn("keymat not configured correctly", ose.exception.args)
 
     def test_invalid_keymat_sr_private_key_password(self):
-        settings.EQ_USER_AUTHENTICATION_RRM_PUBLIC_KEY = None
         with self.assertRaises(OSError) as ose:
-            JWTDecryptor()
+            JWTDecryptor(self.SR_PRIVATE_KEY, None, self.RRM_PUBLIC_KEY)
         self.assertIn("keymat not configured correctly", ose.exception.args)
 
     def test_invalid_keymat_rrm_public_key(self):
-        settings.EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY_PASSWORD = None
         with self.assertRaises(OSError) as ose:
-            JWTDecryptor()
+            JWTDecryptor(self.SR_PRIVATE_KEY, self.SR_PRIVATE_KEY_PASSWORD, None)
         self.assertIn("keymat not configured correctly", ose.exception.args)
 
     def test_decode_signed_jwt_token(self):
-        decoder = JWTDecryptor()
-        token = decoder.decode_signed_jwt_token(VALID_SIGNED_JWT)
+        decoder = JWTDecryptor(*self.good_args)
+        token = decoder.decode_signed_jwt_token(VALID_SIGNED_JWT, 120)
         self.assertEqual("jimmy", token.get("user"))
 
     def test_decode_signed_jwt_token_with_no_token(self):
-        decoder = JWTDecryptor()
-        self.assertRaises(NoTokenException, decoder.decode_signed_jwt_token, None)
+        decoder = JWTDecryptor(*self.good_args)
+        self.assertRaises(NoTokenException, decoder.decode_signed_jwt_token, *(None, 120))
 
     def test_decode_signed_jwt_token_with_invalid_token(self):
-        decoder = JWTDecryptor()
+        decoder = JWTDecryptor(*self.good_args)
         token = "asdasdasdasd"
-        self.assertRaises(InvalidTokenException, decoder.decode_signed_jwt_token, token)
+        self.assertRaises(InvalidTokenException, decoder.decode_signed_jwt_token, *(token, 120))
 
     def test_decrypt_jwt_token(self):
-        decoder = JWTDecryptor()
-        token = decoder.decrypt_jwt_token(VALID_JWE)
+        decoder = JWTDecryptor(*self.good_args)
+        token = decoder.decrypt_jwt_token(VALID_JWE, 120)
         self.assertEqual("jimmy", token.get("user"))
 
     def test_decrypt_jwt_token_with_no_token(self):
-        decoder = JWTDecryptor()
-        self.assertRaises(NoTokenException, decoder.decrypt_jwt_token, None)
+        decoder = JWTDecryptor(*self.good_args)
+        self.assertRaises(NoTokenException, decoder.decrypt_jwt_token, *(None, 120))
 
     def test_decrypt_jwt_token_with_invalid_token(self):
-        decoder = JWTDecryptor()
+        decoder = JWTDecryptor(*self.good_args)
         token = "asdasdasdasd"
-        self.assertRaises(InvalidTokenException, decoder.decrypt_jwt_token, token)
+        self.assertRaises(InvalidTokenException, decoder.decrypt_jwt_token, *(token, 120))
 
 
 if __name__ == '__main__':

--- a/tests/app/authentication/test_jwt_decoder_using_rfc_example.py
+++ b/tests/app/authentication/test_jwt_decoder_using_rfc_example.py
@@ -1,6 +1,6 @@
 import unittest
 
-from app import settings
+from tests.app.authentication import TEST_DO_NOT_USE_SR_PRIVATE_PEM_PASSWORD
 from app.authentication.jwt_decoder import JWTDecryptor
 
 # Not used in this test, but needed for the Decoder constructor
@@ -74,15 +74,19 @@ encrypted_jwt = "eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkEyNTZHQ00ifQ.OKOawDo13gRp2oja
 # Unit test based of Example A.1 in RFC 7516 (https://tools.ietf.org/html/rfc7516#appendix-A.1)
 class JWTDecoderRFCTest(unittest.TestCase):
     def setUp(self):
-        settings.EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY = private_pem
-        settings.EQ_USER_AUTHENTICATION_RRM_PUBLIC_KEY = public_pem
-        settings.EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY_PASSWORD = "digitaleq"
+        self.decryptor_args = (
+            private_pem,
+            TEST_DO_NOT_USE_SR_PRIVATE_PEM_PASSWORD,
+            public_pem
+        )
+
+        self.leeway = 120
 
     def test_plaintext_conversion(self):
         self.assertEqual(plaintext, ''.join(chr(i) for i in plaintext_in_ascii))
 
     def test_decrypt(self):
-        decoder = JWTDecryptor()
+        decoder = JWTDecryptor(*self.decryptor_args)
 
         tokens = encrypted_jwt.split('.')
 

--- a/tests/app/test_new_relic.py
+++ b/tests/app/test_new_relic.py
@@ -1,30 +1,16 @@
 import unittest
-
 from mock import patch
 
 from app.new_relic import setup_newrelic
-from app import settings
-
 
 class TestSettings(unittest.TestCase):
 
     def test_new_relic_is_enabled(self):
         with patch('newrelic.agent.initialize') as new_relic:
 
-            settings.EQ_NEW_RELIC_ENABLED = True
-
             setup_newrelic()
 
             self.assertEqual(new_relic.call_count, 1)
-
-    def test_new_relic_is_disabled(self):
-        with patch('newrelic.agent.initialize') as new_relic:
-
-            settings.EQ_NEW_RELIC_ENABLED = False
-
-            setup_newrelic()
-
-            self.assertEqual(new_relic.call_count, 0)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### What is the context of this PR?

[Trello Card](https://trello.com/c/4kjDSdfM/1049-move-app-config-from-settings-py-to-flask-application-factory)

Removed settings from new_relic and jwt_decoder, plus associated
changes for their dependents.

### How to review 
Functionality should be unchanged, imports of settings.py should be reduced, config should be being accessed via the Flask applications config dictionary.
