### PR TITLE
Added print tracking to GA

### DIFF
--- a/app/assets/js/app/modules/analytics.js
+++ b/app/assets/js/app/modules/analytics.js
@@ -46,6 +46,25 @@ export default function initAnalytics() {
       trackElement(target)
     }
   })
+
+  const afterPrint = () => {
+    return trackEvent('send', {
+      hitType: 'event',
+      eventCategory: 'Print Intent',
+      eventAction: 'Print Intent',
+      eventLabel: window.location.pathname.split('/').slice(-3).join('/')
+    })
+  }
+
+  if (window.matchMedia) {
+    const mediaQueryList = window.matchMedia('print')
+    mediaQueryList.addListener(function(mql) {
+      if (!mql.matches) {
+        afterPrint()
+      }
+    })
+  }
+  window.onafterprint = afterPrint
 }
 
 domready(initAnalytics)


### PR DESCRIPTION
### What is the context of this PR?
- Added the ability to track when a user opens up a print option (file > print || cmd + p) through Google Analytics

### How to review 
- Need access to Google Analytics with 'eq.onsdigital' and run it on localhost with the UA ID
- Try a print option in a survey on dev_mode and check that it comes through on Google Analytics
- Suggest better place for code? (maybe in analytics.js?)