### PR TITLE
Check that a file name is provided before attempting to load it.

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -18,12 +18,13 @@ def parse_mode(string):
 
 
 def read_file(file_name):
-    if os.path.isfile(file_name):
+    if file_name and os.path.isfile(file_name):
         logger.debug("reading from file", filename=file_name)
         f = open(file_name, "r")
         contents = f.read()
         return contents
     else:
+        logger.info("Did not load file because filename supplied was None or not a file", file_name=file_name)
         return None
 
 EQ_MINIMIZE_ASSETS = parse_mode(os.getenv('EQ_MINIMIZE_ASSETS', 'False'))

--- a/tests/app/test_settings.py
+++ b/tests/app/test_settings.py
@@ -21,5 +21,8 @@ class TestSettings(unittest.TestCase):
     def test_missing_get_application_version_from_file(self):
         self.assertEqual(None, settings.read_file('.missing-application-version'))
 
+    def test_none_filename_does_not_attempt_to_load_file(self):
+        self.assertEqual(None, settings.read_file(None))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### What is the context of this PR?
Currently on a non EQ_DEV_MODE deployment the Dev keys have a filename of None which the app attempts to load. This causes the App not to start

### How to review 
Test that the code does not attempt to load the file if the name is None