### PR TITLE
Fix developer page key overriding

### DIFF
--- a/app/views/dev_mode.py
+++ b/app/views/dev_mode.py
@@ -3,7 +3,7 @@ import re
 import time
 from uuid import uuid4
 
-from flask import Blueprint, redirect, render_template, request
+from flask import Blueprint, redirect, render_template, request, current_app
 from structlog import get_logger
 
 from app.cryptography.jwt_encoder import Encoder
@@ -12,10 +12,6 @@ from app.utilities.schema import available_json_schemas
 # pylint: disable=too-many-locals
 logger = get_logger()
 dev_mode_blueprint = Blueprint('dev_mode', __name__, template_folder='templates')
-
-RRM_PRIVATE_KEY = open("./jwt-test-keys/sdc-user-authentication-signing-rrm-private-key.pem").read()
-RRM_PRIVATE_KEY_PASSWORD = "digitaleq"
-SR_PUBLIC_KEY = open("./jwt-test-keys/sdc-user-authentication-encryption-sr-public-key.pem").read()
 
 
 @dev_mode_blueprint.route('/dev', methods=['GET', 'POST'])
@@ -134,7 +130,10 @@ def create_payload(**metadata):
 
 
 def generate_token(payload):
-    encoder = Encoder(RRM_PRIVATE_KEY, RRM_PRIVATE_KEY_PASSWORD, SR_PUBLIC_KEY)
+    rrm_private_key = current_app.config['EQ_USER_AUTHENTICATION_RRM_PRIVATE_KEY']
+    rrm_private_key_password = current_app.config['EQ_USER_AUTHENTICATION_RRM_PRIVATE_KEY_PASSWORD']
+    sr_public_key = current_app.config['EQ_USER_AUTHENTICATION_SR_PUBLIC_KEY']
+    encoder = Encoder(rrm_private_key, rrm_private_key_password, sr_public_key)
     token = encoder.encode(payload)
     encrypted_token = encoder.encrypt_token(token)
     return encrypted_token

--- a/tests/integration/create_token.py
+++ b/tests/integration/create_token.py
@@ -1,7 +1,8 @@
 import time
 from uuid import uuid4
+from app import settings
 
-from app.views.dev_mode import generate_token
+from app.cryptography.jwt_encoder import Encoder
 
 PAYLOAD = {
     'user_id': 'integration-test',
@@ -33,3 +34,13 @@ def create_token(form_type_id, eq_id, **extra_payload):
         payload_vars[key] = value
 
     return generate_token(payload_vars)
+
+
+def generate_token(payload):
+    rrm_private_key = vars(settings)['EQ_USER_AUTHENTICATION_RRM_PRIVATE_KEY']
+    rrm_private_key_password = vars(settings)['EQ_USER_AUTHENTICATION_RRM_PRIVATE_KEY_PASSWORD']
+    sr_public_key = vars(settings)['EQ_USER_AUTHENTICATION_SR_PUBLIC_KEY']
+    encoder = Encoder(rrm_private_key, rrm_private_key_password, sr_public_key)
+    token = encoder.encode(payload)
+    encrypted_token = encoder.encrypt_token(token)
+    return encrypted_token

--- a/tests/integration/test_flush_data.py
+++ b/tests/integration/test_flush_data.py
@@ -1,7 +1,7 @@
 import time
 from mock import patch
 from tests.integration.integration_test_case import IntegrationTestCase
-from app.views.dev_mode import generate_token
+from tests.integration.create_token import generate_token
 
 
 class TestFlushData(IntegrationTestCase):


### PR DESCRIPTION
### What is the context of this PR?
Allows overriding of developer page keys and password. 
Fixes https://github.com/ONSdigital/eq-survey-runner/issues/1115

### How to review 
* Move `sdc-user-authentication-signing-rrm-private-key.pem` to a new location e.g. `mv ./jwt-test-keys/sdc-user-authentication-signing-rrm-private-key.pem ./jwt-test-keys/sdc-user-authentication-signing-rrm-private-key2.pem`
* Start the application
* Logs should contain `Did not load file because filename supplied was None or not a file` 
* Try to start a survey, you should get a 500 error
* Export the environment variable EQ_USER_AUTHENTICATION_RRM_PRIVATE_KEY to point to the new location e.g. `export EQ_USER_AUTHENTICATION_RRM_PRIVATE_KEY=./jwt-test-keys/sdc-user-authentication-signing-rrm-private-key2.pem`
* Logs should **not** contain `Did not load file because filename supplied was None or not a file` 
* You should be able to start a survey
* Try similar changes to `EQ_USER_AUTHENTICATION_RRM_PRIVATE_KEY_PASSWORD` and `EQ_USER_AUTHENTICATION_SR_PUBLIC_KEY`