### PR TITLE
Revert change to turn asset minification on by default

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -38,7 +38,7 @@ def get_env_or_fail(key):
     return value
 
 
-EQ_MINIMIZE_ASSETS = parse_mode(os.getenv('EQ_MINIMIZE_ASSETS', 'True'))
+EQ_MINIMIZE_ASSETS = parse_mode(os.getenv('EQ_MINIMIZE_ASSETS', 'False'))
 # max request payload size in bytes
 MAX_CONTENT_LENGTH = os.getenv('EQ_MAX_HTTP_POST_CONTENT_LENGTH', 65536)
 


### PR DESCRIPTION
### What is the context of this PR?
Turns asset minification off by default. Asset minification has never been enabled and tested in
pre-production.

### How to review 
Remove setting of `EQ_MINIMIZE_ASSETS` from `scripts/dev_settings.py` and run the app, un-minified versions of assets should be referenced.