### PR TITLE
Update LICENSE Year and Org name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,13 @@
-Copyright (C) 2015 Crown Copyright (Office of National Statistics)
+MIT License
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
+Copyright (c) 2017 Crown Copyright (Office for National Statistics)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.


### PR DESCRIPTION
Updated to GitHub MIT template licence and removed .txt extension

### What is the context of this PR?
Updated year and name of ONS to be correct. Re-applied GitHub MIT License template.

### How to review 
Check against GDS e.g. https://github.com/alphagov/digitalmarketplace-api/blob/master/LICENCE