### PR TITLE
Show/Hide guidance

### DIFF
--- a/app/templates/partials/answer-guidance.html
+++ b/app/templates/partials/answer-guidance.html
@@ -1,8 +1,8 @@
 {% import 'macros/helpers.html' as helpers %}
 
 {% set guidance = {
-  "data-show-label": _("Show further guidance"),
-  "data-hide-label": _("Hide further guidance")
+  "data-show-label": _(answer_guidance.schema_item.show_guidance),
+  "data-hide-label": _(answer_guidance.schema_item.hide_guidance)
 } %}
 
 {% set guidance_link = {
@@ -20,10 +20,10 @@
 
 <div class="guidance js-details" {{guidance|xmlattr}}>
   <a class="guidance__link js-details-trigger js-details-label mars"
-    {{guidance_link|xmlattr}} {{helpers.track('click', 'Help', 'Guidance click', answer_guidance.id)}}>{{_("Show further guidance")}}</a>
+    {{guidance_link|xmlattr}} {{helpers.track('click', 'Help', 'Guidance click', answer_guidance.id)}}>{{_(answer_guidance.schema_item.show_guidance)}}</a>
   <div class="guidance__main js-details-body" {{guidance_body|xmlattr}}>
     <div class="guidance__content mars">
-      {{answer_guidance.content|safe}}
+      {{answer_guidance.schema_item.content|safe}}
     </div>
   </div>
 </div>

--- a/app/templates/partials/answer-guidance.html
+++ b/app/templates/partials/answer-guidance.html
@@ -23,7 +23,21 @@
     {{guidance_link|xmlattr}} {{helpers.track('click', 'Help', 'Guidance click', answer_guidance.id)}}>{{_(answer_guidance.schema_item.show_guidance)}}</a>
   <div class="guidance__main js-details-body" {{guidance_body|xmlattr}}>
     <div class="guidance__content mars">
-      {{answer_guidance.schema_item.content|safe}}
+      {% for guide in answer_guidance.schema_item.content %}
+          {%- if guide.title -%}
+            <h3 class="venus">{{guide.title}}</h3>
+          {% endif %}
+          {%- if guide.description -%}
+            <h2 class="mars">{{guide.description|safe}}</h2>
+          {% endif %}
+          {%- if guide.list -%}
+            <ul class="mars">
+              {%- for item in guide.list -%}
+                <li>{{item|safe}}</li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+      {% endfor %}
     </div>
   </div>
 </div>

--- a/app/templates/partials/answer.html
+++ b/app/templates/partials/answer.html
@@ -11,7 +11,7 @@
       {% with answer_guidance = {
         'id': answer.id,
         'label': answer.label,
-        'content': answer.guidance
+        'schema_item': answer.guidance
       } %}
         {% include 'partials/answer-guidance.html' %}
       {% endwith %}

--- a/app/templates/partials/questions/relationship.html
+++ b/app/templates/partials/questions/relationship.html
@@ -22,27 +22,19 @@
   </fieldset>
 </div>
 
-{% if (question.guidance) %}
-
-  {% set question_guidance %}
-    {%- for guidance in question.guidance -%}
-      <ul class="u-m-no">
-        {%- for item in guidance.list -%}
-          <li>{{item|safe}}</li>
-        {% endfor %}
-      </ul>
-    {% endfor %}
-  {% endset %}
-
-  {% with answer_guidance = {
-    'id': question.id,
-    'label': question.label,
-    'schema_item': {
-        'content': question_guidance,
-        'show_guidance': "Show further guidance",
-        'hide_guidance': "Hide further guidance"
-    }
-  } %}
-    {% include 'partials/answer-guidance.html' %}
-  {% endwith %}
-{% endif %}
+<aside class="question__guidance  question__guidance--bottom">
+    {% set schema_item = question.answers[-1] %}
+    {% if schema_item.guidance %}
+      {% with answer_guidance = {
+        'id': schema_item.id,
+        'label': schema_item.label,
+        'schema_item': {
+            'content': schema_item.guidance.content,
+            'show_guidance': "Show relationship guidance",
+            'hide_guidance': "Hide relationship guidance"
+        }
+      } %}
+        {% include 'partials/answer-guidance.html' %}
+      {% endwith %}
+    {% endif %}
+</aside>

--- a/app/templates/partials/questions/relationship.html
+++ b/app/templates/partials/questions/relationship.html
@@ -37,7 +37,7 @@
   {% with answer_guidance = {
     'id': question.id,
     'label': question.label,
-    'content': question_guidance
+    'schema_item': question.guidance
   } %}
     {% include 'partials/answer-guidance.html' %}
   {% endwith %}

--- a/app/templates/partials/questions/relationship.html
+++ b/app/templates/partials/questions/relationship.html
@@ -37,7 +37,11 @@
   {% with answer_guidance = {
     'id': question.id,
     'label': question.label,
-    'schema_item': question.guidance
+    'schema_item': {
+        'content': question_guidance,
+        'show_guidance': "Show further guidance",
+        'hide_guidance': "Hide further guidance"
+    }
   } %}
     {% include 'partials/answer-guidance.html' %}
   {% endwith %}

--- a/app/templates/partials/questions/repeatinganswer.html
+++ b/app/templates/partials/questions/repeatinganswer.html
@@ -57,7 +57,7 @@
       {% with answer_guidance = {
         'id': schema_item.id,
         'label': schema_item.label,
-        'content': schema_item.guidance
+        'schema_item': schema_item.guidance
         } %}
         {% include 'partials/answer-guidance.html' %}
       {% endwith %}

--- a/app/templates/partials/questions/repeatinganswer.html
+++ b/app/templates/partials/questions/repeatinganswer.html
@@ -57,11 +57,14 @@
       {% with answer_guidance = {
         'id': schema_item.id,
         'label': schema_item.label,
-        'schema_item': schema_item.guidance
-        } %}
+        'schema_item': {
+            'content': schema_item.guidance.content,
+            'show_guidance': "Show naming guidance",
+            'hide_guidance': "Hide naming guidance"
+        }
+      } %}
         {% include 'partials/answer-guidance.html' %}
       {% endwith %}
     {% endif %}
   </aside>
-
 </div>

--- a/data/en/1_0112.json
+++ b/data/en/1_0112.json
@@ -167,7 +167,28 @@
                             "guidance": {
                                 "show_guidance": "Show changes in total retail turnover guidance",
                                 "hide_guidance": "Hide changes in total retail turnover guidance",
-                                "content": "<div><p>Examples of commentary:</p><p><strong>'In-store promotion'</strong></p> <p>Offer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales.</p><strong> 'Special events (for example, sporting events)'</strong></p><p>This was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online.</p><p><strong>‘Weather'</strong></p><p>The bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month.</div>"
+                                "content": [{
+                                        "description": "Examples of commentary:"
+                                    },
+                                    {
+                                        "title": "'In-store promotion'"
+                                    },
+                                    {
+                                        "description": "Offer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales."
+                                    },
+                                    {
+                                        "title": "'Special events (for example, sporting events)'"
+                                    },
+                                    {
+                                        "description": "This was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online."
+                                    },
+                                    {
+                                        "title": "'Weather'"
+                                    },
+                                    {
+                                        "description": "The bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month."
+                                    }
+                                ]
                             },
                             "id": "changes-in-retail-turnover-answer",
                             "label": "Comments",

--- a/data/en/1_0112.json
+++ b/data/en/1_0112.json
@@ -164,7 +164,11 @@
                     "id": "changes-in-retail-turnover-section",
                     "questions": [{
                         "answers": [{
-                            "guidance": "<div><p>Examples of commentary:</p><p><strong>'In-store promotion'</strong></p> <p>Offer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales.</p><strong> 'Special events (for example, sporting events)'</strong></p><p>This was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online.</p><p><strong>‘Weather'</strong></p><p>The bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month.</div>",
+                            "guidance": {
+                                "show_guidance": "Show changes in total retail turnover guidance",
+                                "hide_guidance": "Hide changes in total retail turnover guidance",
+                                "content": "<div><p>Examples of commentary:</p><p><strong>'In-store promotion'</strong></p> <p>Offer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales.</p><strong> 'Special events (for example, sporting events)'</strong></p><p>This was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online.</p><p><strong>‘Weather'</strong></p><p>The bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month.</div>"
+                            },
                             "id": "changes-in-retail-turnover-answer",
                             "label": "Comments",
                             "mandatory": false,

--- a/data/en/census_household.json
+++ b/data/en/census_household.json
@@ -200,7 +200,22 @@
                                     "guidance": {
                                         "show_guidance": "Show naming guidance",
                                         "hide_guidance": "Hide naming guidance",
-                                        "content":"<p>Enter the current first, middle and last names of all the people who usually live here.</p><p>If you have not yet named your newborn, please enter ‘Baby’ for their first name and then enter their last name (surname).</p><p>Please also include household members who have requested a personal form.</p><p>Please also include the names of people staying with you temporarily who don’t have a usual address in the UK. This is so that we make sure we count everyone.</p><p><strong>Include:</strong></p><ul><li>People who usually live outside the UK who are staying in the UK for <strong>three months or more</strong></li><li>People who work away from home within the UK  if this is their permanent or family home</li><li>Members of the Armed Forces if this is their permanent or family home</li><li>People who are temporarily outside the UK for <strong>less than 12 months</strong></li><li>People staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends</li></ul>"
+                                        "content": [
+                                            { "description": "Enter the current first, middle and last names of all the people who usually live here." },
+                                            { "description": "If you have not yet named your newborn, please enter ‘Baby’ for their first name and then enter their last name (surname)." },
+                                            { "description": "Please also include household members who have requested a personal form." },
+                                            { "description": "Please also include the names of people staying with you temporarily who don’t have a usual address in the UK. This is so that we make sure we count everyone." },
+                                            {
+                                                "title": "Include",
+                                                "list": [
+                                                    "People who usually live outside the UK who are staying in the UK for <strong>three months or more</strong>",
+                                                    "People who work away from home within the UK  if this is their permanent or family home",
+                                                    "Members of the Armed Forces if this is their permanent or family home",
+                                                    "People who are temporarily outside the UK for <strong>less than 12 months</strong>",
+                                                    "People staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends"
+                                                ]
+                                            }
+                                        ]
                                     },
                                     "type": "TextField"
                                 }
@@ -327,8 +342,6 @@
                         "number": "5",
                         "description": "If members are not related, select the ‘unrelated’ option",
                         "guidance": [{
-                            "show_guidance": "Show relationship guidance",
-                            "hide_guidance": "Hide relationship guidance",
                             "list": [
                                 "Select the relationships between members of your household",
                                 "If you are the parents of adopted children, select the ‘Mother or father’ option to show your relationship to them.",
@@ -1741,7 +1754,9 @@
                                 "guidance": {
                                     "show_guidance": "Show intent to stay guidance",
                                     "hide_guidance": "Hide intent to stay guidance",
-                                    "content": "If you arrived in the United Kingdom before May 2016, please select ‘12 months or more’"
+                                    "content": [
+                                        { "description": "If you arrived in the United Kingdom before May 2016, please select ‘12 months or more’" }
+                                    ]
                                 },
                                 "options": [{
                                         "label": "Less than 6 months",

--- a/data/en/census_household.json
+++ b/data/en/census_household.json
@@ -40,7 +40,11 @@
                             "answers": [{
                                 "id": "permanent-or-family-home-answer",
                                 "mandatory": true,
-                                "guidance": "<p>For most people, their permanent home will be the address where they spend the most time.</p>",
+                                "guidance": {
+                                    "show_guidance": "Show permanent home guidance",
+                                    "hide_guidance": "Hide permanent home guidance",
+                                    "content": "<p>For most people, their permanent home will be the address where they spend the most time.</p>"
+                                },
                                 "options": [{
                                         "label": "Yes",
                                         "value": "Yes"
@@ -193,7 +197,11 @@
                                     "id": "last-name",
                                     "label": "Last name",
                                     "mandatory": false,
-                                    "guidance": "<p>Enter the current first, middle and last names of all the people who usually live here.</p><p>If you have not yet named your newborn, please enter ‘Baby’ for their first name and then enter their last name (surname).</p><p>Please also include household members who have requested a personal form.</p><p>Please also include the names of people staying with you temporarily who don’t have a usual address in the UK. This is so that we make sure we count everyone.</p><p><strong>Include:</strong></p><ul><li>People who usually live outside the UK who are staying in the UK for <strong>three months or more</strong></li><li>People who work away from home within the UK  if this is their permanent or family home</li><li>Members of the Armed Forces if this is their permanent or family home</li><li>People who are temporarily outside the UK for <strong>less than 12 months</strong></li><li>People staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends</li></ul>",
+                                    "guidance": {
+                                        "show_guidance": "Show naming guidance",
+                                        "hide_guidance": "Hide naming guidance",
+                                        "content":"<p>Enter the current first, middle and last names of all the people who usually live here.</p><p>If you have not yet named your newborn, please enter ‘Baby’ for their first name and then enter their last name (surname).</p><p>Please also include household members who have requested a personal form.</p><p>Please also include the names of people staying with you temporarily who don’t have a usual address in the UK. This is so that we make sure we count everyone.</p><p><strong>Include:</strong></p><ul><li>People who usually live outside the UK who are staying in the UK for <strong>three months or more</strong></li><li>People who work away from home within the UK  if this is their permanent or family home</li><li>Members of the Armed Forces if this is their permanent or family home</li><li>People who are temporarily outside the UK for <strong>less than 12 months</strong></li><li>People staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends</li></ul>"
+                                    },
                                     "type": "TextField"
                                 }
                             ]
@@ -319,6 +327,8 @@
                         "number": "5",
                         "description": "If members are not related, select the ‘unrelated’ option",
                         "guidance": [{
+                            "show_guidance": "Show relationship guidance",
+                            "hide_guidance": "Hide relationship guidance",
                             "list": [
                                 "Select the relationships between members of your household",
                                 "If you are the parents of adopted children, select the ‘Mother or father’ option to show your relationship to them.",
@@ -695,7 +705,11 @@
                             "answers": [{
                                 "id": "own-or-rent-answer",
                                 "mandatory": false,
-                                "guidance": "<p>‘Owns outright’ means you own without a mortgage or loan, even if you pay a small amount of money to the lender for them to look after the deeds.</p><p>‘Part owns and part rents’ means you own part of your accommodation and also pay rent for part of it. You can part own with or without a mortgage or loan.</p><p>If your rent is paid by housing benefit, select ‘Rents (with or without housing benefit)’.</p><p>If you do not pay rent, but contribute to household expenses, you live rent free.</p>",
+                                "guidance": {
+                                    "show_guidance": "Show owning or renting guidance",
+                                    "hide_guidance": "Hide owning or renting guidance",
+                                    "content": "<p>‘Owns outright’ means you own without a mortgage or loan, even if you pay a small amount of money to the lender for them to look after the deeds.</p><p>‘Part owns and part rents’ means you own part of your accommodation and also pay rent for part of it. You can part own with or without a mortgage or loan.</p><p>If your rent is paid by housing benefit, select ‘Rents (with or without housing benefit)’.</p><p>If you do not pay rent, but contribute to household expenses, you live rent free.</p>"
+                                },
                                 "options": [{
                                         "label": "Owns outright",
                                         "value": "Owns outright"
@@ -1007,7 +1021,11 @@
                             "answers": [{
                                 "id": "private-response-answer",
                                 "mandatory": false,
-                                "guidance": "If you request a personal or confidential form we will send you a unique access code that will allow you to complete the individual questions for yourself. No-one else will be able to see the answers you provide.",
+                                "guidance": {
+                                    "show_guidance": "Show personal form guidance",
+                                    "hide_guidance": "Hide personal form guidance",
+                                    "content": "If you request a personal or confidential form we will send you a unique access code that will allow you to complete the individual questions for yourself. No-one else will be able to see the answers you provide."
+                                },
                                 "options": [{
                                         "label": "No, I do not want to request a personal form",
                                         "value": "No, I do not want to request a personal form"
@@ -1129,7 +1147,11 @@
                             "answers": [{
                                 "id": "marital-status-answer",
                                 "mandatory": false,
-                                "guidance": "<p>Please answer according to your status on 9 April 2017.</p><p>Please answer this question for children, even though they may not be old enough to marry or form a same-sex civil partnership.</p><p>If you were married (or formed a registered same-sex partnership) abroad, and this enables you to be recognised as married or civil partnered in the UK, complete the question reflecting that legal partnership.</p>",
+                                "guidance": {
+                                    "show_guidance": "Show marital status guidance",
+                                    "hide_guidance": "Hide marital status guidance",
+                                    "content": "<p>Please answer according to your status on 9 April 2017.</p><p>Please answer this question for children, even though they may not be old enough to marry or form a same-sex civil partnership.</p><p>If you were married (or formed a registered same-sex partnership) abroad, and this enables you to be recognised as married or civil partnered in the UK, complete the question reflecting that legal partnership.</p>"
+                                },
                                 "options": [{
                                         "label": "Never married and never registered a same-sex civil partnership",
                                         "value": "Never married and never registered a same-sex civil partnership"
@@ -1187,7 +1209,11 @@
                             "answers": [{
                                     "id": "another-address-answer",
                                     "mandatory": false,
-                                    "guidance": "<p>Examples might include another parent’s address, an armed forces base, a holiday home, or term-time address.</p><p>The days you stay at the address do not have to be in a row. They can be at any time during the year.</p>",
+                                    "guidance": {
+                                        "show_guidance": "Show other address guidance",
+                                        "hide_guidance": "Hide other address guidance",
+                                        "content": "<p>Examples might include another parent’s address, an armed forces base, a holiday home, or term-time address.</p><p>The days you stay at the address do not have to be in a row. They can be at any time during the year.</p>"
+                                    },
                                     "options": [{
                                             "label": "No",
                                             "value": "No"
@@ -1389,7 +1415,11 @@
                             "answers": [{
                                 "id": "in-education-answer",
                                 "mandatory": false,
-                                "guidance": "<p>The following are considered to be in full-time education:</p><p>Under 16s</p><p>16-18s if they attend more than 12 hours a week of study on a course up to and including A level standard</p><p>Anyone on a course at a higher standard than A level if they are studying at a UK institution, on a course which:</p><ul><li>lasts for at least 1 academic year</li><li>involves at least 24 weeks per year, and</li><li>involves at least 21 hours of term-time study, classes or work experience per week (including unstructured study)</li></ul>",
+                                "guidance": {
+                                    "show_guidance": "Show education guidance",
+                                    "hide_guidance": "Hide education guidance",
+                                    "content": "<p>The following are considered to be in full-time education:</p><p>Under 16s</p><p>16-18s if they attend more than 12 hours a week of study on a course up to and including A level standard</p><p>Anyone on a course at a higher standard than A level if they are studying at a UK institution, on a course which:</p><ul><li>lasts for at least 1 academic year</li><li>involves at least 24 weeks per year, and</li><li>involves at least 21 hours of term-time study, classes or work experience per week (including unstructured study)</li></ul>"
+                                },
                                 "options": [{
                                         "label": "Yes",
                                         "value": "Yes"
@@ -1708,7 +1738,11 @@
                             "answers": [{
                                 "id": "length-of-stay-answer",
                                 "mandatory": false,
-                                "guidance": "If you arrived in the United Kingdom before May 2016, please select ‘12 months or more’",
+                                "guidance": {
+                                    "show_guidance": "Show intent to stay guidance",
+                                    "hide_guidance": "Hide intent to stay guidance",
+                                    "content": "If you arrived in the United Kingdom before May 2016, please select ‘12 months or more’"
+                                },
                                 "options": [{
                                         "label": "Less than 6 months",
                                         "value": "Less than 6 months"
@@ -1784,7 +1818,11 @@
                                         "id": "national-identity-england-answer",
                                         "label": "Select all that apply",
                                         "mandatory": false,
-                                        "guidance": "<p>You can choose more than one national identity.</p><p>It is for you to choose your national identity or identities. For example this could be about the country or countries where you feel you belong, or think of as home.</p><p>It is not dependent on your ethnic group or legal nationality (citizenship).</p><p>Select all that apply. If your national identity isn’t listed, select ‘Other’ and enter the national identity.</p>",
+                                        "guidance": {
+                                            "show_guidance": "Show national identity guidance",
+                                            "hide_guidance": "Hide national identity guidance",
+                                            "content": "<p>You can choose more than one national identity.</p><p>It is for you to choose your national identity or identities. For example this could be about the country or countries where you feel you belong, or think of as home.</p><p>It is not dependent on your ethnic group or legal nationality (citizenship).</p><p>Select all that apply. If your national identity isn’t listed, select ‘Other’ and enter the national identity.</p>"
+                                        },
                                         "options": [{
                                                 "label": "English",
                                                 "value": "English"
@@ -1838,7 +1876,11 @@
                                         "id": "national-identity-wales-answer",
                                         "label": "Select all that apply",
                                         "mandatory": false,
-                                        "guidance": "<p>You can choose more than one national identity.</p><p>It is for you to choose your national identity or identities. For example this could be about the country or countries where you feel you belong, or think of as home.</p><p>It is not dependent on your ethnic group or legal nationality (citizenship).</p><p>Select all that apply. If your national identity isn’t listed, select ‘Other’ and enter the national identity.</p>",
+                                        "guidance": {
+                                            "show_guidance": "Show national identity guidance",
+                                            "hide_guidance": "Hide national identity guidance",
+                                            "content": "<p>You can choose more than one national identity.</p><p>It is for you to choose your national identity or identities. For example this could be about the country or countries where you feel you belong, or think of as home.</p><p>It is not dependent on your ethnic group or legal nationality (citizenship).</p><p>Select all that apply. If your national identity isn’t listed, select ‘Other’ and enter the national identity.</p>"
+                                        },
                                         "options": [{
                                                 "label": "Welsh",
                                                 "value": "Welsh"
@@ -1901,7 +1943,11 @@
                                 "answers": [{
                                     "id": "ethnic-group-england-answer",
                                     "mandatory": false,
-                                    "guidance": "<p>It is for you to choose your ethnic group. For example this could be your family or cultural background, or it could be how you would describe yourself.</p><p>Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Other ethnic group’. You will then be able to write in the ethnic group you prefer to identify as at the next question.</p>",
+                                    "guidance": {
+                                        "show_guidance": "Show ethnic group guidance",
+                                        "hide_guidance": "Hide ethnic group guidance",
+                                        "content": "<p>It is for you to choose your ethnic group. For example this could be your family or cultural background, or it could be how you would describe yourself.</p><p>Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Other ethnic group’. You will then be able to write in the ethnic group you prefer to identify as at the next question.</p>"
+                                    },
                                     "options": [{
                                             "label": "White",
                                             "value": "White",
@@ -1946,7 +1992,11 @@
                                 "answers": [{
                                     "id": "ethnic-group-wales-answer",
                                     "mandatory": false,
-                                    "guidance": "<p>It is for you to choose your ethnic group. For example this could be your family or cultural background, or it could be how you would describe yourself.</p><p>Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Other ethnic group’.  You will then able to write in the ethnic group you prefer to identify as at the next question.</p>",
+                                    "guidance": {
+                                        "show_guidance": "Show ethnic group guidance",
+                                        "hide_guidance": "Hide ethnic group guidance",
+                                        "content": "<p>It is for you to choose your ethnic group. For example this could be your family or cultural background, or it could be how you would describe yourself.</p><p>Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Other ethnic group’.  You will then able to write in the ethnic group you prefer to identify as at the next question.</p>"
+                                    },
                                     "options": [{
                                             "label": "White",
                                             "value": "White",
@@ -2132,7 +2182,11 @@
                                 "type": "General",
                                 "answers": [{
                                         "id": "white-ethnic-group-england-answer",
-                                        "guidance": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>",
+                                        "guidance": {
+                                            "show_guidance": "Show ethnic group guidance",
+                                            "hide_guidance": "Hide ethnic group guidance",
+                                            "content": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>"
+                                        },
                                         "mandatory": false,
                                         "options": [{
                                                 "label": "English / Welsh / Scottish / Northern Irish / British",
@@ -2177,7 +2231,11 @@
                                 "type": "General",
                                 "answers": [{
                                         "id": "white-ethnic-group-wales-answer",
-                                        "guidance": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>",
+                                        "guidance": {
+                                            "show_guidance": "Show ethnic group guidance",
+                                            "hide_guidance": "Hide ethnic group guidance",
+                                            "content": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>"
+                                        },
                                         "mandatory": false,
                                         "options": [{
                                                 "label": "Welsh / English / Scottish / Northern Irish / British",
@@ -2264,7 +2322,11 @@
                             "type": "General",
                             "answers": [{
                                     "id": "mixed-ethnic-group-answer",
-                                    "guidance": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>",
+                                    "guidance": {
+                                        "show_guidance": "Show ethnic group guidance",
+                                        "hide_guidance": "Hide ethnic group guidance",
+                                        "content": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>"
+                                    },
                                     "mandatory": false,
                                     "options": [{
                                             "label": "White and Black Caribbean",
@@ -2344,7 +2406,11 @@
                             "answers": [{
                                     "id": "asian-ethnic-group-answer",
                                     "mandatory": false,
-                                    "guidance": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>",
+                                    "guidance": {
+                                        "show_guidance": "Show ethnic group guidance",
+                                        "hide_guidance": "Hide ethnic group guidance",
+                                        "content": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>"
+                                    },
                                     "options": [{
                                             "label": "Indian",
                                             "value": "Indian"
@@ -2427,7 +2493,11 @@
                             "answers": [{
                                     "id": "black-ethnic-group-answer",
                                     "mandatory": false,
-                                    "guidance": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>",
+                                    "guidance": {
+                                        "show_guidance": "Show ethnic group guidance",
+                                        "hide_guidance": "Hide ethnic group guidance",
+                                        "content": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>"
+                                    },
                                     "options": [{
                                             "label": "African",
                                             "value": "African"
@@ -2502,7 +2572,11 @@
                             "answers": [{
                                     "id": "other-ethnic-group-answer",
                                     "mandatory": false,
-                                    "guidance": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>",
+                                    "guidance": {
+                                        "show_guidance": "Show ethnic group guidance",
+                                        "hide_guidance": "Hide ethnic group guidance",
+                                        "content": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>"
+                                    },
                                     "options": [{
                                             "label": "Arab",
                                             "value": "Arab"
@@ -2574,7 +2648,11 @@
                             "answers": [{
                                     "id": "sexual-identity-answer",
                                     "mandatory": false,
-                                    "guidance": "<p>It is for you to decide how to choose your answer.</p><p>If you are unsure of the meaning of any words used, the following might help:</p><ul><li>‘Heterosexual or Straight’ means that a person is, for example, attracted to people of the opposite sex/gender</li><li>‘Gay or Lesbian’ means that a person is, for example, attracted to people of the same sex/gender</li><li>‘Bisexual’ means that a person is, for example, attracted to people of both sexes/any gender</li></ul><p><strong>Identity not listed</strong></p><p>If none of the first three answer options apply to you, please select ‘Other’ and enter your preferred answer.</p><p>This question is voluntary; you can leave it blank if you prefer.</p>",
+                                    "guidance": {
+                                        "show_guidance": "Show sexual identity guidance",
+                                        "hide_guidance": "Hide sexual identity guidance",
+                                        "content": "<p>It is for you to decide how to choose your answer.</p><p>If you are unsure of the meaning of any words used, the following might help:</p><ul><li>‘Heterosexual or Straight’ means that a person is, for example, attracted to people of the opposite sex/gender</li><li>‘Gay or Lesbian’ means that a person is, for example, attracted to people of the same sex/gender</li><li>‘Bisexual’ means that a person is, for example, attracted to people of both sexes/any gender</li></ul><p><strong>Identity not listed</strong></p><p>If none of the first three answer options apply to you, please select ‘Other’ and enter your preferred answer.</p><p>This question is voluntary; you can leave it blank if you prefer.</p>"
+                                    },
                                     "options": [{
                                             "label": "Heterosexual or Straight",
                                             "value": "Heterosexual or Straight"
@@ -2959,7 +3037,11 @@
                             "answers": [{
                                     "id": "past-usual-address-answer",
                                     "mandatory": false,
-                                    "guidance": "In most cases your usual address will be the permanent or family home that you were living in.",
+                                    "guidance": {
+                                        "show_guidance": "Show usual address guidance",
+                                        "hide_guidance": "Hide usual address guidance",
+                                        "content": "In most cases your usual address will be the permanent or family home that you were living in."
+                                    },
                                     "options": [{
                                             "label": "This address",
                                             "value": "This address"
@@ -3671,7 +3753,11 @@
                             "answers": [{
                                 "id": "ever-worked-answer",
                                 "mandatory": false,
-                                "guidance": "<p>If you had a full-time or part-time job in the past select ‘Yes’</p><p>This includes work outside of the United Kingdom.</p><p>Please provide an answer even if you are retired.</p><p>If you have never worked, or only ever worked in voluntary/unpaid jobs, select ‘No’.</p>",
+                                "guidance": {
+                                    "show_guidance": "Show working guidance",
+                                    "hide_guidance": "Hide working guidance",
+                                    "content": "<p>If you had a full-time or part-time job in the past select ‘Yes’</p><p>This includes work outside of the United Kingdom.</p><p>Please provide an answer even if you are retired.</p><p>If you have never worked, or only ever worked in voluntary/unpaid jobs, select ‘No’.</p>"
+                                },
                                 "options": [{
                                         "label": "Yes",
                                         "value": "Yes"
@@ -3766,7 +3852,11 @@
                                 "id": "job-title-answer",
                                 "label": "Job title",
                                 "mandatory": false,
-                                "guidance": "<p>Please enter your job title in the space provided.</p><p>Do not state your grade or pay band.</p><p>If you are not sure of your job title please give the best information you can.</p>",
+                                "guidance": {
+                                    "show_guidance": "Show job title guidance",
+                                    "hide_guidance": "Hide job title guidance",
+                                    "content": "<p>Please enter your job title in the space provided.</p><p>Do not state your grade or pay band.</p><p>If you are not sure of your job title please give the best information you can.</p>"
+                                },
                                 "type": "TextField"
                             }]
                         }]
@@ -3788,7 +3878,11 @@
                                 "id": "job-description-answer",
                                 "label": "Description",
                                 "mandatory": false,
-                                "guidance": "<p>Please enter a brief description of what you do or did in your main job. Your main job is the job in which you usually work (or worked) the most hours.</p><p>Please give the best information you can even if you’re not sure or can’t remember all the details.</p>",
+                                "guidance": {
+                                    "show_guidance": "Show job description guidance",
+                                    "hide_guidance": "Hide job description guidance",
+                                    "content": "<p>Please enter a brief description of what you do or did in your main job. Your main job is the job in which you usually work (or worked) the most hours.</p><p>Please give the best information you can even if you’re not sure or can’t remember all the details.</p>"
+                                },
                                 "type": "TextArea"
                             }]
                         }]
@@ -3817,7 +3911,11 @@
                                 "id": "employers-business-answer",
                                 "label": "Description",
                                 "mandatory": false,
-                                "guidance": "<p>Enter the main activity of your employer or business.</p><p>Another way of describing main activity is the industry that your employer or business works in.</p><p>If you are not sure of the main activity of your employer or business please give the best information you can.</p><p>If you are employed through an agency please enter the main activity of the business you are working for, not the agency.</p>",
+                                "guidance": {
+                                    "show_guidance": "Show employers business guidance",
+                                    "hide_guidance": "Hide employers business guidance",
+                                    "content":"<p>Enter the main activity of your employer or business.</p><p>Another way of describing main activity is the industry that your employer or business works in.</p><p>If you are not sure of the main activity of your employer or business please give the best information you can.</p><p>If you are employed through an agency please enter the main activity of the business you are working for, not the agency.</p>"
+                                },
                                 "type": "TextArea"
                             }]
                         }]
@@ -3892,7 +3990,11 @@
                                 "id": "business-name-answer",
                                 "label": "Organisation or business name",
                                 "mandatory": false,
-                                "guidance": "<p>This question is asking for the name of the organisation or business that you work (or worked) for in your main job.</p><p>If you can’t remember the name of the organisation, please give the best information you can.</p><p>If you are employed through an agency please enter the name of the business you are working for, not the agency.</p>",
+                                "guidance": {
+                                    "show_guidance": "Show main job guidance",
+                                    "hide_guidance": "Hide main job guidance",
+                                    "content": "<p>This question is asking for the name of the organisation or business that you work (or worked) for in your main job.</p><p>If you can’t remember the name of the organisation, please give the best information you can.</p><p>If you are employed through an agency please enter the name of the business you are working for, not the agency.</p>"
+                                },
                                 "type": "TextField"
                             }]
                         }]

--- a/data/en/census_household.json
+++ b/data/en/census_household.json
@@ -43,7 +43,9 @@
                                 "guidance": {
                                     "show_guidance": "Show permanent home guidance",
                                     "hide_guidance": "Hide permanent home guidance",
-                                    "content": "<p>For most people, their permanent home will be the address where they spend the most time.</p>"
+                                    "content": [{
+                                        "description": "For most people, their permanent home will be the address where they spend the most time."
+                                    }]
                                 },
                                 "options": [{
                                         "label": "Yes",
@@ -200,11 +202,18 @@
                                     "guidance": {
                                         "show_guidance": "Show naming guidance",
                                         "hide_guidance": "Hide naming guidance",
-                                        "content": [
-                                            { "description": "Enter the current first, middle and last names of all the people who usually live here." },
-                                            { "description": "If you have not yet named your newborn, please enter ‘Baby’ for their first name and then enter their last name (surname)." },
-                                            { "description": "Please also include household members who have requested a personal form." },
-                                            { "description": "Please also include the names of people staying with you temporarily who don’t have a usual address in the UK. This is so that we make sure we count everyone." },
+                                        "content": [{
+                                                "description": "Enter the current first, middle and last names of all the people who usually live here."
+                                            },
+                                            {
+                                                "description": "If you have not yet named your newborn, please enter ‘Baby’ for their first name and then enter their last name (surname)."
+                                            },
+                                            {
+                                                "description": "Please also include household members who have requested a personal form."
+                                            },
+                                            {
+                                                "description": "Please also include the names of people staying with you temporarily who don’t have a usual address in the UK. This is so that we make sure we count everyone."
+                                            },
                                             {
                                                 "title": "Include",
                                                 "list": [
@@ -341,21 +350,24 @@
                         "title": "How is {{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }} related to the people below?",
                         "number": "5",
                         "description": "If members are not related, select the ‘unrelated’ option",
-                        "guidance": [{
-                            "list": [
-                                "Select the relationships between members of your household",
-                                "If you are the parents of adopted children, select the ‘Mother or father’ option to show your relationship to them.",
-                                "If you have foster children living with you, select the ‘Unrelated’ option.",
-                                "Include half-brothers and half-sisters in the ‘Step-brother or step-sister’ category.",
-                                "Same-sex civil partner is used to describe the relationship between two people who have legally registered a civil partnership.",
-                                "If none of the options fully reflects your relationship, please select the one which you feel best describes your situation."
-                            ]
-                        }],
+                        "guidance": "",
                         "type": "Relationship",
                         "answers": [{
                             "id": "household-relationships-answer",
                             "label": "%(current_person)s is %(other_person)s",
                             "mandatory": false,
+                            "guidance": {
+                                "content": [{
+                                    "list": [
+                                        "Select the relationships between members of your household",
+                                        "If you are the parents of adopted children, select the ‘Mother or father’ option to show your relationship to them.",
+                                        "If you have foster children living with you, select the ‘Unrelated’ option.",
+                                        "Include half-brothers and half-sisters in the ‘Step-brother or step-sister’ category.",
+                                        "Same-sex civil partner is used to describe the relationship between two people who have legally registered a civil partnership.",
+                                        "If none of the options fully reflects your relationship, please select the one which you feel best describes your situation."
+                                    ]
+                                }]
+                            },
                             "options": [{
                                     "label": "Husband or wife",
                                     "value": "Husband or wife"
@@ -1754,9 +1766,7 @@
                                 "guidance": {
                                     "show_guidance": "Show intent to stay guidance",
                                     "hide_guidance": "Hide intent to stay guidance",
-                                    "content": [
-                                        { "description": "If you arrived in the United Kingdom before May 2016, please select ‘12 months or more’" }
-                                    ]
+                                    "content": "If you arrived in the United Kingdom before May 2016, please select ‘12 months or more’"
                                 },
                                 "options": [{
                                         "label": "Less than 6 months",
@@ -3929,7 +3939,7 @@
                                 "guidance": {
                                     "show_guidance": "Show employers business guidance",
                                     "hide_guidance": "Hide employers business guidance",
-                                    "content":"<p>Enter the main activity of your employer or business.</p><p>Another way of describing main activity is the industry that your employer or business works in.</p><p>If you are not sure of the main activity of your employer or business please give the best information you can.</p><p>If you are employed through an agency please enter the main activity of the business you are working for, not the agency.</p>"
+                                    "content": "<p>Enter the main activity of your employer or business.</p><p>Another way of describing main activity is the industry that your employer or business works in.</p><p>If you are not sure of the main activity of your employer or business please give the best information you can.</p><p>If you are employed through an agency please enter the main activity of the business you are working for, not the agency.</p>"
                                 },
                                 "type": "TextArea"
                             }]

--- a/data/en/census_household.json
+++ b/data/en/census_household.json
@@ -733,7 +733,18 @@
                                 "guidance": {
                                     "show_guidance": "Show owning or renting guidance",
                                     "hide_guidance": "Hide owning or renting guidance",
-                                    "content": "<p>‘Owns outright’ means you own without a mortgage or loan, even if you pay a small amount of money to the lender for them to look after the deeds.</p><p>‘Part owns and part rents’ means you own part of your accommodation and also pay rent for part of it. You can part own with or without a mortgage or loan.</p><p>If your rent is paid by housing benefit, select ‘Rents (with or without housing benefit)’.</p><p>If you do not pay rent, but contribute to household expenses, you live rent free.</p>"
+                                    "content": [{
+                                        "description": "‘Owns outright’ means you own without a mortgage or loan, even if you pay a small amount of money to the lender for them to look after the deeds."
+                                    },
+                                    {
+                                        "description": "‘Part owns and part rents’ means you own part of your accommodation and also pay rent for part of it. You can part own with or without a mortgage or loan."
+                                    },
+                                    {
+                                        "description": "If your rent is paid by housing benefit, select ‘Rents (with or without housing benefit)’."
+                                    },
+                                    {
+                                        "description": "If you do not pay rent, but contribute to household expenses, you live rent free."
+                                    }]
                                 },
                                 "options": [{
                                         "label": "Owns outright",
@@ -1049,7 +1060,9 @@
                                 "guidance": {
                                     "show_guidance": "Show personal form guidance",
                                     "hide_guidance": "Hide personal form guidance",
-                                    "content": "If you request a personal or confidential form we will send you a unique access code that will allow you to complete the individual questions for yourself. No-one else will be able to see the answers you provide."
+                                    "content": [{
+                                        "description": "If you request a personal or confidential form we will send you a unique access code that will allow you to complete the individual questions for yourself. No-one else will be able to see the answers you provide."
+                                    }]
                                 },
                                 "options": [{
                                         "label": "No, I do not want to request a personal form",
@@ -1175,7 +1188,15 @@
                                 "guidance": {
                                     "show_guidance": "Show marital status guidance",
                                     "hide_guidance": "Hide marital status guidance",
-                                    "content": "<p>Please answer according to your status on 9 April 2017.</p><p>Please answer this question for children, even though they may not be old enough to marry or form a same-sex civil partnership.</p><p>If you were married (or formed a registered same-sex partnership) abroad, and this enables you to be recognised as married or civil partnered in the UK, complete the question reflecting that legal partnership.</p>"
+                                    "content": [{
+                                        "description": "Please answer according to your status on 9 April 2017."
+                                    },
+                                    {
+                                        "description": "Please answer this question for children, even though they may not be old enough to marry or form a same-sex civil partnership."
+                                    },
+                                    {
+                                        "description": "If you were married (or formed a registered same-sex partnership) abroad, and this enables you to be recognised as married or civil partnered in the UK, complete the question reflecting that legal partnership."
+                                    }]
                                 },
                                 "options": [{
                                         "label": "Never married and never registered a same-sex civil partnership",
@@ -1237,7 +1258,12 @@
                                     "guidance": {
                                         "show_guidance": "Show other address guidance",
                                         "hide_guidance": "Hide other address guidance",
-                                        "content": "<p>Examples might include another parent’s address, an armed forces base, a holiday home, or term-time address.</p><p>The days you stay at the address do not have to be in a row. They can be at any time during the year.</p>"
+                                        "content": [{
+                                            "description": "Examples might include another parent’s address, an armed forces base, a holiday home, or term-time address."
+                                        },
+                                        {
+                                            "description": "The days you stay at the address do not have to be in a row. They can be at any time during the year."
+                                        }]
                                     },
                                     "options": [{
                                             "label": "No",
@@ -1443,7 +1469,25 @@
                                 "guidance": {
                                     "show_guidance": "Show education guidance",
                                     "hide_guidance": "Hide education guidance",
-                                    "content": "<p>The following are considered to be in full-time education:</p><p>Under 16s</p><p>16-18s if they attend more than 12 hours a week of study on a course up to and including A level standard</p><p>Anyone on a course at a higher standard than A level if they are studying at a UK institution, on a course which:</p><ul><li>lasts for at least 1 academic year</li><li>involves at least 24 weeks per year, and</li><li>involves at least 21 hours of term-time study, classes or work experience per week (including unstructured study)</li></ul>"
+                                    "content": [{
+                                        "description": "The following are considered to be in full-time education:"
+                                    },
+                                    {
+                                        "description": "Under 16s"
+                                    },
+                                    {
+                                        "description": "16-18s if they attend more than 12 hours a week of study on a course up to and including A level standard"
+                                    },
+                                    {
+                                        "description": "Anyone on a course at a higher standard than A level if they are studying at a UK institution, on a course which:"
+                                    },
+                                    {
+                                        "list": [
+                                            "lasts for at least 1 academic year",
+                                            "involves at least 24 weeks per year, and",
+                                            "involves at least 21 hours of term-time study, classes or work experience per week (including unstructured study)"
+                                        ]
+                                    }]
                                 },
                                 "options": [{
                                         "label": "Yes",
@@ -1766,7 +1810,9 @@
                                 "guidance": {
                                     "show_guidance": "Show intent to stay guidance",
                                     "hide_guidance": "Hide intent to stay guidance",
-                                    "content": "If you arrived in the United Kingdom before May 2016, please select ‘12 months or more’"
+                                    "content": [{
+                                        "description": "If you arrived in the United Kingdom before May 2016, please select ‘12 months or more’"
+                                    }]
                                 },
                                 "options": [{
                                         "label": "Less than 6 months",
@@ -1846,7 +1892,18 @@
                                         "guidance": {
                                             "show_guidance": "Show national identity guidance",
                                             "hide_guidance": "Hide national identity guidance",
-                                            "content": "<p>You can choose more than one national identity.</p><p>It is for you to choose your national identity or identities. For example this could be about the country or countries where you feel you belong, or think of as home.</p><p>It is not dependent on your ethnic group or legal nationality (citizenship).</p><p>Select all that apply. If your national identity isn’t listed, select ‘Other’ and enter the national identity.</p>"
+                                            "content": [{
+                                                "description": "You can choose more than one national identity."
+                                            },
+                                            {
+                                               "description": "It is for you to choose your national identity or identities. For example this could be about the country or countries where you feel you belong, or think of as home."
+                                            },
+                                            {
+                                                "description": "It is not dependent on your ethnic group or legal nationality (citizenship)."
+                                            },
+                                            {
+                                                "description": "Select all that apply. If your national identity isn’t listed, select ‘Other’ and enter the national identity."
+                                            }]
                                         },
                                         "options": [{
                                                 "label": "English",
@@ -1904,7 +1961,18 @@
                                         "guidance": {
                                             "show_guidance": "Show national identity guidance",
                                             "hide_guidance": "Hide national identity guidance",
-                                            "content": "<p>You can choose more than one national identity.</p><p>It is for you to choose your national identity or identities. For example this could be about the country or countries where you feel you belong, or think of as home.</p><p>It is not dependent on your ethnic group or legal nationality (citizenship).</p><p>Select all that apply. If your national identity isn’t listed, select ‘Other’ and enter the national identity.</p>"
+                                            "content": [{
+                                                "description": "You can choose more than one national identity."
+                                            },
+                                            {
+                                                "description": "It is for you to choose your national identity or identities. For example this could be about the country or countries where you feel you belong, or think of as home."
+                                            },
+                                            {
+                                                "description": "It is not dependent on your ethnic group or legal nationality (citizenship)."
+                                            },
+                                            {
+                                                "description": "Select all that apply. If your national identity isn’t listed, select ‘Other’ and enter the national identity."
+                                            }]
                                         },
                                         "options": [{
                                                 "label": "Welsh",
@@ -1971,7 +2039,15 @@
                                     "guidance": {
                                         "show_guidance": "Show ethnic group guidance",
                                         "hide_guidance": "Hide ethnic group guidance",
-                                        "content": "<p>It is for you to choose your ethnic group. For example this could be your family or cultural background, or it could be how you would describe yourself.</p><p>Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Other ethnic group’. You will then be able to write in the ethnic group you prefer to identify as at the next question.</p>"
+                                        "content": [{
+                                            "description": "It is for you to choose your ethnic group. For example this could be your family or cultural background, or it could be how you would describe yourself."
+                                        },
+                                        {
+                                            "description": "Please select the answer you think is most appropriate."
+                                        },
+                                        {
+                                            "description": "If you don’t feel the options apply to you, select ‘Other ethnic group’. You will then be able to write in the ethnic group you prefer to identify as at the next question."
+                                        }]
                                     },
                                     "options": [{
                                             "label": "White",
@@ -2020,7 +2096,15 @@
                                     "guidance": {
                                         "show_guidance": "Show ethnic group guidance",
                                         "hide_guidance": "Hide ethnic group guidance",
-                                        "content": "<p>It is for you to choose your ethnic group. For example this could be your family or cultural background, or it could be how you would describe yourself.</p><p>Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Other ethnic group’.  You will then able to write in the ethnic group you prefer to identify as at the next question.</p>"
+                                        "content": [{
+                                            "description": "It is for you to choose your ethnic group. For example this could be your family or cultural background, or it could be how you would describe yourself."
+                                        },
+                                        {
+                                            "description": "Please select the answer you think is most appropriate."
+                                        },
+                                        {
+                                            "description": "If you don’t feel the options apply to you, select ‘Other ethnic group’. You will then be able to write in the ethnic group you prefer to identify as at the next question."
+                                        }]
                                     },
                                     "options": [{
                                             "label": "White",
@@ -2210,7 +2294,12 @@
                                         "guidance": {
                                             "show_guidance": "Show ethnic group guidance",
                                             "hide_guidance": "Hide ethnic group guidance",
-                                            "content": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>"
+                                            "content": [{
+                                                "description": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p>"
+                                            },
+                                            {
+                                                "description": "If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>"
+                                            }]
                                         },
                                         "mandatory": false,
                                         "options": [{
@@ -2259,7 +2348,12 @@
                                         "guidance": {
                                             "show_guidance": "Show ethnic group guidance",
                                             "hide_guidance": "Hide ethnic group guidance",
-                                            "content": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>"
+                                            "content": [{
+                                                "description": "The options are based on the answer to the previous question. Please select the answer you think is most appropriate."
+                                            },
+                                            {
+                                                "description": "If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group."
+                                            }]
                                         },
                                         "mandatory": false,
                                         "options": [{
@@ -2350,7 +2444,12 @@
                                     "guidance": {
                                         "show_guidance": "Show ethnic group guidance",
                                         "hide_guidance": "Hide ethnic group guidance",
-                                        "content": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>"
+                                        "content": [{
+                                            "description": "The options are based on the answer to the previous question. Please select the answer you think is most appropriate."
+                                        },
+                                        {
+                                            "description": "If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group."
+                                        }]
                                     },
                                     "mandatory": false,
                                     "options": [{
@@ -2434,7 +2533,12 @@
                                     "guidance": {
                                         "show_guidance": "Show ethnic group guidance",
                                         "hide_guidance": "Hide ethnic group guidance",
-                                        "content": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>"
+                                        "content": [{
+                                            "description": "The options are based on the answer to the previous question. Please select the answer you think is most appropriate."
+                                        },
+                                        {
+                                            "description": "If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group."
+                                        }]
                                     },
                                     "options": [{
                                             "label": "Indian",
@@ -2521,7 +2625,12 @@
                                     "guidance": {
                                         "show_guidance": "Show ethnic group guidance",
                                         "hide_guidance": "Hide ethnic group guidance",
-                                        "content": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>"
+                                        "content": [{
+                                            "description": "The options are based on the answer to the previous question. Please select the answer you think is most appropriate."
+                                        },
+                                        {
+                                            "description": "If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group."
+                                        }]
                                     },
                                     "options": [{
                                             "label": "African",
@@ -2600,7 +2709,12 @@
                                     "guidance": {
                                         "show_guidance": "Show ethnic group guidance",
                                         "hide_guidance": "Hide ethnic group guidance",
-                                        "content": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>"
+                                        "content": [{
+                                            "description": "The options are based on the answer to the previous question. Please select the answer you think is most appropriate."
+                                        },
+                                        {
+                                            "description": "If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group."
+                                        }]
                                     },
                                     "options": [{
                                             "label": "Arab",
@@ -2676,7 +2790,30 @@
                                     "guidance": {
                                         "show_guidance": "Show sexual identity guidance",
                                         "hide_guidance": "Hide sexual identity guidance",
-                                        "content": "<p>It is for you to decide how to choose your answer.</p><p>If you are unsure of the meaning of any words used, the following might help:</p><ul><li>‘Heterosexual or Straight’ means that a person is, for example, attracted to people of the opposite sex/gender</li><li>‘Gay or Lesbian’ means that a person is, for example, attracted to people of the same sex/gender</li><li>‘Bisexual’ means that a person is, for example, attracted to people of both sexes/any gender</li></ul><p><strong>Identity not listed</strong></p><p>If none of the first three answer options apply to you, please select ‘Other’ and enter your preferred answer.</p><p>This question is voluntary; you can leave it blank if you prefer.</p>"
+                                        "content": [{
+                                            "description": "It is for you to decide how to choose your answer."
+                                        },
+                                        {
+                                            "description": "If you are unsure of the meaning of any words used, the following might help:"
+                                        },
+                                        {
+                                            "list": "‘Heterosexual or Straight’ means that a person is, for example, attracted to people of the opposite sex/gender"
+                                        },
+                                        {
+                                            "list": "‘Gay or Lesbian’ means that a person is, for example, attracted to people of the same sex/gender"
+                                        },
+                                        {
+                                            "list": "‘Bisexual’ means that a person is, for example, attracted to people of both sexes/any gender"
+                                        },
+                                        {
+                                            "title": "Identity not listed"
+                                        },
+                                        {
+                                            "description": "If none of the first three answer options apply to you, please select ‘Other’ and enter your preferred answer."
+                                        },
+                                        {
+                                            "description": "This question is voluntary; you can leave it blank if you prefer."
+                                        }]
                                     },
                                     "options": [{
                                             "label": "Heterosexual or Straight",
@@ -3065,7 +3202,9 @@
                                     "guidance": {
                                         "show_guidance": "Show usual address guidance",
                                         "hide_guidance": "Hide usual address guidance",
-                                        "content": "In most cases your usual address will be the permanent or family home that you were living in."
+                                        "content": [{
+                                            "description": "In most cases your usual address will be the permanent or family home that you were living in."
+                                        }]
                                     },
                                     "options": [{
                                             "label": "This address",
@@ -3781,7 +3920,18 @@
                                 "guidance": {
                                     "show_guidance": "Show working guidance",
                                     "hide_guidance": "Hide working guidance",
-                                    "content": "<p>If you had a full-time or part-time job in the past select ‘Yes’</p><p>This includes work outside of the United Kingdom.</p><p>Please provide an answer even if you are retired.</p><p>If you have never worked, or only ever worked in voluntary/unpaid jobs, select ‘No’.</p>"
+                                    "content": [{
+                                        "description": "If you had a full-time or part-time job in the past select ‘Yes’"
+                                    },
+                                    {
+                                        "description": "This includes work outside of the United Kingdom."
+                                    },
+                                    {
+                                        "description": "Please provide an answer even if you are retired."
+                                    },
+                                    {
+                                        "description": "If you have never worked, or only ever worked in voluntary/unpaid jobs, select ‘No’."
+                                    }]
                                 },
                                 "options": [{
                                         "label": "Yes",
@@ -3880,7 +4030,15 @@
                                 "guidance": {
                                     "show_guidance": "Show job title guidance",
                                     "hide_guidance": "Hide job title guidance",
-                                    "content": "<p>Please enter your job title in the space provided.</p><p>Do not state your grade or pay band.</p><p>If you are not sure of your job title please give the best information you can.</p>"
+                                    "content": [{
+                                        "description": "Please enter your job title in the space provided."
+                                    },
+                                    {
+                                        "description": "Do not state your grade or pay band."
+                                    },
+                                    {
+                                        "description": "If you are not sure of your job title please give the best information you can."
+                                    }]
                                 },
                                 "type": "TextField"
                             }]
@@ -3906,7 +4064,12 @@
                                 "guidance": {
                                     "show_guidance": "Show job description guidance",
                                     "hide_guidance": "Hide job description guidance",
-                                    "content": "<p>Please enter a brief description of what you do or did in your main job. Your main job is the job in which you usually work (or worked) the most hours.</p><p>Please give the best information you can even if you’re not sure or can’t remember all the details.</p>"
+                                    "content": [{
+                                        "description": "Please enter a brief description of what you do or did in your main job. Your main job is the job in which you usually work (or worked) the most hours."
+                                    },
+                                    {
+                                        "description": "Please give the best information you can even if you’re not sure or can’t remember all the details."
+                                    }]
                                 },
                                 "type": "TextArea"
                             }]
@@ -3939,7 +4102,18 @@
                                 "guidance": {
                                     "show_guidance": "Show employers business guidance",
                                     "hide_guidance": "Hide employers business guidance",
-                                    "content": "<p>Enter the main activity of your employer or business.</p><p>Another way of describing main activity is the industry that your employer or business works in.</p><p>If you are not sure of the main activity of your employer or business please give the best information you can.</p><p>If you are employed through an agency please enter the main activity of the business you are working for, not the agency.</p>"
+                                    "content": [{
+                                        "description": "Enter the main activity of your employer or business."
+                                    },
+                                    {
+                                        "description": "Another way of describing main activity is the industry that your employer or business works in."
+                                    },
+                                    {
+                                        "description": "If you are not sure of the main activity of your employer or business please give the best information you can."
+                                    },
+                                    {
+                                        "description": "If you are employed through an agency please enter the main activity of the business you are working for, not the agency."
+                                    }]
                                 },
                                 "type": "TextArea"
                             }]
@@ -4018,7 +4192,15 @@
                                 "guidance": {
                                     "show_guidance": "Show main job guidance",
                                     "hide_guidance": "Hide main job guidance",
-                                    "content": "<p>This question is asking for the name of the organisation or business that you work (or worked) for in your main job.</p><p>If you can’t remember the name of the organisation, please give the best information you can.</p><p>If you are employed through an agency please enter the name of the business you are working for, not the agency.</p>"
+                                    "content": [{
+                                        "description": "This question is asking for the name of the organisation or business that you work (or worked) for in your main job."
+                                    },
+                                    {
+                                        "description": "If you can’t remember the name of the organisation, please give the best information you can."
+                                    },
+                                    {
+                                        "description": "If you are employed through an agency please enter the name of the business you are working for, not the agency."
+                                    }]
                                 },
                                 "type": "TextField"
                             }]

--- a/data/en/test_question_guidance.json
+++ b/data/en/test_question_guidance.json
@@ -18,62 +18,6 @@
             },
             {
                 "type": "Questionnaire",
-                "id": "block-test-guidance-all",
-                "title": "",
-                "sections": [{
-                    "id": "section-test-guidance-all",
-                    "title": "Section: Test guidance all",
-                    "description": "",
-                    "questions": [{
-                        "id": "question-test-guidance-all",
-                        "title": "Question: Test guidance all",
-                        "description": "<p>Testing all features of the guidance block enabled together</p>",
-                        "guidance": [{
-                                "title": "Include",
-                                "description": "<p>Guidance <b>include</b> description text</p>",
-                                "list": [
-                                    "Item Include 1",
-                                    "Item Include 2",
-                                    "Item Include 3",
-                                    "Item Include 4"
-                                ]
-                            },
-                            {
-                                "title": "Exclude",
-                                "description": "<p>Guidance <b>exclude</b> description text</p>",
-                                "list": [
-                                    "Item Exclude 1",
-                                    "Item Exclude 2",
-                                    "Item Exclude 3",
-                                    "Item Exclude 4"
-                                ]
-                            },
-                            {
-                                "title": "Other",
-                                "description": "<p>Guidance <b>other</b> description text</p>",
-                                "list": [
-                                    "Item Other 1",
-                                    "Item Other 2",
-                                    "Item Other 3",
-                                    "Item Other 4"
-                                ]
-                            }
-                        ],
-                        "type": "General",
-                        "answers": [{
-                            "guidance": "",
-                            "id": "answer-test-guidance-all",
-                            "label": "Text question",
-                            "mandatory": false,
-                            "options": [],
-                            "q_code": "0",
-                            "type": "TextField"
-                        }]
-                    }]
-                }]
-            },
-            {
-                "type": "Questionnaire",
                 "id": "block-test-guidance-title",
                 "title": "",
                 "sections": [{
@@ -83,10 +27,10 @@
                     "questions": [{
                         "id": "question-test-guidance-title",
                         "title": "Question: Test guidance title",
-                        "description": "<p>Testing combinations of the title within guidance</p>",
+                        "description": "Testing combinations of the title within guidance",
                         "guidance": [{
                                 "title": "This one has a description but no list",
-                                "description": "<p>No list items below this text</p>"
+                                "description": "No list items below this text"
                             },
                             {
                                 "title": "This one has no list or description"
@@ -116,9 +60,9 @@
                     "questions": [{
                         "id": "question-test-guidance-description",
                         "title": "Question: Test guidance descriptions",
-                        "description": "<p>Tests the descriptions within guidance</p>",
+                        "description": "Tests the descriptions within guidance",
                         "guidance": [{
-                                "description": "<p>No title above this text, list below</p>",
+                                "description": "No title above this text, list below",
                                 "list": [
                                     "Item Include 1",
                                     "Item Include 2",
@@ -127,7 +71,7 @@
                                 ]
                             },
                             {
-                                "description": "<p>Just description, no title above this text, no list below</p>"
+                                "description": "Just description, no title above this text, no list below"
                             }
                         ],
                         "type": "General",
@@ -176,6 +120,185 @@
                         "answers": [{
                             "guidance": "",
                             "id": "answer-test-guidance-lists",
+                            "label": "Text question",
+                            "mandatory": false,
+                            "options": [],
+                            "q_code": "0",
+                            "type": "TextField"
+                        }]
+                    }]
+                }]
+            },
+            {
+                "type": "Questionnaire",
+                "id": "block-test-guidance-content-description",
+                "title": "",
+                "sections": [{
+                    "id": "section-test-guidance-content-description",
+                    "title": "Section: Test show custom guidance content description",
+                    "description": "",
+                    "questions": [{
+                        "id": "question-test-guidance-content-description",
+                        "title": "Question: Test show custom guidance content description",
+                        "guidance": [{
+                            "title": "Custom guidance with content description"
+                        }],
+                        "type": "General",
+                        "answers": [{
+                            "guidance": {
+                                "show_guidance": "Show test guidance.",
+                                "hide_guidance": "Hide test guidance.",
+                                "content": [{
+                                    "description": "The text here is for description"
+                                }]
+                            },
+                            "id": "answer-test-guidance-content-description",
+                            "label": "Text question",
+                            "mandatory": false,
+                            "options": [],
+                            "q_code": "0",
+                            "type": "TextField"
+                        }]
+                    }]
+                }]
+            },
+            {
+                "type": "Questionnaire",
+                "id": "block-test-guidance-content-title",
+                "title": "",
+                "sections": [{
+                    "id": "section-test-guidance-content-title",
+                    "title": "Section: Test show custom guidance content title",
+                    "description": "",
+                    "questions": [{
+                        "id": "question-test-guidance-content-title",
+                        "title": "Question: Test show custom guidance content title",
+                        "guidance": [{
+                            "title": "Custom guidance with content title"
+                        }],
+                        "type": "General",
+                        "answers": [{
+                            "guidance": {
+                                "show_guidance": "Show test guidance.",
+                                "hide_guidance": "Hide test guidance.",
+                                "content": [{
+                                    "title": "The text here is for a title"
+                                }]
+                            },
+                            "id": "answer-test-guidance-content-title",
+                            "label": "Text question",
+                            "mandatory": false,
+                            "options": [],
+                            "q_code": "0",
+                            "type": "TextField"
+                        }]
+                    }]
+                }]
+            },
+            {
+                "type": "Questionnaire",
+                "id": "block-test-guidance-content-list",
+                "title": "",
+                "sections": [{
+                    "id": "section-test-guidance-content-list",
+                    "title": "Section: Test show custom guidance content list",
+                    "description": "",
+                    "questions": [{
+                        "id": "question-test-guidance-content-list",
+                        "title": "Question: Test show custom guidance content list",
+                        "guidance": [{
+                            "title": "Custom guidance with content list"
+                        }],
+                        "type": "General",
+                        "answers": [{
+                            "guidance": {
+                                "show_guidance": "Show test guidance.",
+                                "hide_guidance": "Hide test guidance.",
+                                "content": [{
+                                    "list": [
+                                        "The text here is for a list",
+                                        "Another list item",
+                                        "One more"
+                                    ]
+                                }]
+                            },
+                            "id": "answer-test-guidance-content-list",
+                            "label": "Text question",
+                            "mandatory": false,
+                            "options": [],
+                            "q_code": "0",
+                            "type": "TextField"
+                        }]
+                    }]
+                }]
+            },
+            {
+                "type": "Questionnaire",
+                "id": "block-test-guidance-all",
+                "title": "",
+                "sections": [{
+                    "id": "section-test-guidance-all",
+                    "title": "Section: Test guidance all",
+                    "description": "",
+                    "questions": [{
+                        "id": "question-test-guidance-all",
+                        "title": "Question: Test guidance all",
+                        "description": "<p>Testing all features of the guidance block enabled together</p>",
+                        "guidance": [{
+                                "title": "Include",
+                                "description": "<p>Guidance <b>include</b> description text</p>",
+                                "list": [
+                                    "Item Include 1",
+                                    "Item Include 2",
+                                    "Item Include 3",
+                                    "Item Include 4"
+                                ]
+                            },
+                            {
+                                "title": "Exclude",
+                                "description": "<p>Guidance <b>exclude</b> description text</p>",
+                                "list": [
+                                    "Item Exclude 1",
+                                    "Item Exclude 2",
+                                    "Item Exclude 3",
+                                    "Item Exclude 4"
+                                ]
+                            },
+                            {
+                                "title": "Other",
+                                "description": "<p>Guidance <b>other</b> description text</p>",
+                                "list": [
+                                    "Item Other 1",
+                                    "Item Other 2",
+                                    "Item Other 3",
+                                    "Item Other 4"
+                                ]
+                            }
+                        ],
+                        "type": "General",
+                        "answers": [{
+                            "guidance": {
+                                "show_guidance": "Show test guidance.",
+                                "hide_guidance": "Hide test guidance.",
+                                "content": [{
+                                        "description": "The text here is for a description"
+                                    },
+                                    {
+                                        "description": "Here's some more description text"
+                                    },
+                                    {
+                                        "title": "This text here is the title"
+                                    },
+                                    {
+                                        "list": [
+                                            "The text here is for a list",
+                                            "Another list item",
+                                            "One more"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "id": "answer-test-guidance-all",
                             "label": "Text question",
                             "mandatory": false,
                             "options": [],

--- a/data/schema/schema_v1.json
+++ b/data/schema/schema_v1.json
@@ -393,7 +393,24 @@
                                                                         "type": "string"
                                                                     },
                                                                     "guidance": {
-                                                                        "type": "string"
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "title": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "description": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "list": {
+                                                                                    "type": "array",
+                                                                                    "items": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
                                                                     },
                                                                     "description": {
                                                                         "type": "string"

--- a/data/schema/schema_v1.json
+++ b/data/schema/schema_v1.json
@@ -12,6 +12,18 @@
             "description": "A question code used by downstream systems to identify answers",
             "pattern": "^[0-9a-z]+$"
         },
+        "show_guidance": {
+            "description": "Allows customisation of guidance text",
+            "type": "string"
+        },
+        "hide_guidance": {
+            "description": "Allows customisation of guidance text",
+            "type": "string"
+        },
+        "content": {
+            "description": "Allows customisation of guidance text",
+            "type": "string"
+        },
         "skip_condition": {
             "description": "Allows an element to be skipped when a condition has been met. By adding more than one `when` element it will evaluate as an or rule.",
             "type": "array",


### PR DESCRIPTION
### What is the context of this PR?
- Having the ability to customise Show/Hide further guidance to match the questions.
- Changed the html templates to be able to use the repeating answer, relationship, question_guidance(hacky) & answer_guidance.
- Census_household & 1_0112 have been changed to work with the new style.
- Tests fail as only part completed.

### How to review 
- Test Census_household & 1_0112 to see if 'custom' show/hide is available.
- The other surveys in theory shouldn't show the further guidance.
- Discussion on : 
Schema structure.
Naming.
Next steps.


