### PR TITLE
Reference config from Flask application factory (Part 3)

### DIFF
--- a/app/data_model/answer_store.py
+++ b/app/data_model/answer_store.py
@@ -63,6 +63,8 @@ class AnswerStore(object):
     via the Questionnaire Store.
     """
 
+    EQ_MAX_NUM_REPEATS = 25
+
     def __init__(self, existing_answers=None):
         self.answers = existing_answers or []
 
@@ -170,7 +172,7 @@ class AnswerStore(object):
         :param answer_instance: The answer instance to filter results by
         :param group_instance: The group instance to filter results by
         :param location: The location to filter results by (takes precedence over group_id, group_instance and block_id)
-        :param limit: Limit the number of answers returned
+        :param limit: True | False Limit the number of answers returned
         :return: Return a list of answers which satisfy the filter criteria
         """
         filtered = []
@@ -196,7 +198,7 @@ class AnswerStore(object):
                     matches = matches and answer[k] == v
             if matches:
                 filtered.append(answer)
-                if limit and len(filtered) == limit:
+                if limit and len(filtered) == self.EQ_MAX_NUM_REPEATS:
                     break
         return filtered
 

--- a/app/forms/household_relationship_form.py
+++ b/app/forms/household_relationship_form.py
@@ -1,7 +1,6 @@
 from flask_wtf import FlaskForm
 from wtforms import FieldList, SelectField
 
-from app import settings
 from app.forms.fields import build_choices, get_mandatory_validator
 from app.data_model.answer_store import Answer
 from app.helpers.schema_helper import SchemaHelper
@@ -10,7 +9,7 @@ from app.jinja_filters import format_household_member_name
 from werkzeug.datastructures import MultiDict
 
 
-def build_relationship_choices(answer_store, group_instance):
+def build_relationship_choices(answer_store, group_instance):  # pylint: disable=too-many-locals
     """
     A function to build a list of tuples of as yet undefined person relationships
 
@@ -18,8 +17,10 @@ def build_relationship_choices(answer_store, group_instance):
     :param group_instance: The instance of the group being iterated over
     :return:
     """
-    household_first_name_answers = answer_store.filter(block_id='household-composition', answer_id='first-name', limit=settings.EQ_MAX_NUM_REPEATS)
-    household_last_name_answers = answer_store.filter(block_id='household-composition', answer_id='last-name', limit=settings.EQ_MAX_NUM_REPEATS)
+    household_first_name_answers = answer_store.filter(block_id='household-composition', answer_id='first-name',
+                                                       limit=True)
+    household_last_name_answers = answer_store.filter(block_id='household-composition', answer_id='last-name',
+                                                      limit=True)
 
     first_names = []
     last_names = []

--- a/app/helpers/form_helper.py
+++ b/app/helpers/form_helper.py
@@ -10,11 +10,11 @@ def get_form_for_location(block_json, location, answer_store, error_messages, di
     """
     Returns the form necessary for the location given a get request, plus any template arguments
 
-    :param disable_mandatory: Make mandatory answers optional
-    :param error_messages: The default error messages to use within the form
     :param block_json: The block json
     :param location: The location which this form is for
     :param answer_store: The current answer store
+    :param error_messages: The default error messages to use within the form
+    :param disable_mandatory: Make mandatory answers optional
     :return: form, template_args A tuple containing the form for this location and any additional template arguments
     """
     if disable_mandatory:
@@ -61,12 +61,12 @@ def post_form_for_location(block_json, location, answer_store, request_form, err
     """
     Returns the form necessary for the location given a post request, plus any template arguments
 
-    :param disable_mandatory: Make mandatory answers optional
-    :param error_messages: The default error messages to use within the form
     :param block_json: The block json
     :param location: The location which this form is for
     :param answer_store: The current answer store
     :param request_form: form, template_args A tuple containing the form for this location and any additional template arguments
+    :param error_messages: The default error messages to use within the form
+    :param disable_mandatory: Make mandatory answers optional
     """
     if disable_mandatory:
         block_json = disable_mandatory_answers(block_json)

--- a/app/settings.py
+++ b/app/settings.py
@@ -42,9 +42,6 @@ EQ_MINIMIZE_ASSETS = parse_mode(os.getenv('EQ_MINIMIZE_ASSETS', 'False'))
 # max request payload size in bytes
 MAX_CONTENT_LENGTH = os.getenv('EQ_MAX_HTTP_POST_CONTENT_LENGTH', 65536)
 
-# max number of repeats from a rule
-EQ_MAX_NUM_REPEATS = os.getenv('EQ_MAX_NUM_REPEATS', 25)
-
 EQ_PROFILING = parse_mode(os.getenv('EQ_PROFILING', 'False'))
 
 EQ_RABBITMQ_URL = get_env_or_fail('EQ_RABBITMQ_URL')
@@ -52,7 +49,6 @@ EQ_RABBITMQ_URL_SECONDARY = get_env_or_fail('EQ_RABBITMQ_URL_SECONDARY')
 EQ_RABBITMQ_QUEUE_NAME = os.getenv('EQ_RABBITMQ_QUEUE_NAME', 'submit_q')
 EQ_RABBITMQ_ENABLED = parse_mode(os.getenv('EQ_RABBITMQ_ENABLED', 'True'))
 EQ_NEW_RELIC_CONFIG_FILE = os.getenv('EQ_NEW_RELIC_CONFIG_FILE', './newrelic.ini')
-EQ_SCHEMA_DIRECTORY = os.getenv('EQ_SCHEMA_DIRECTORY', 'data')
 EQ_SESSION_TIMEOUT_SECONDS = int(os.getenv('EQ_SESSION_TIMEOUT_SECONDS', 45 * 60))
 EQ_SESSION_TIMEOUT_GRACE_PERIOD_SECONDS = int(os.getenv('EQ_SESSION_TIMEOUT_GRACE_PERIOD_SECONDS', '30'))
 EQ_SESSION_TIMEOUT_PROMPT_SECONDS = int(os.getenv('EQ_SESSION_TIMEOUT_PROMPT_SECONDS', 120))
@@ -102,6 +98,3 @@ for key_name, dev_location in _KEYS.items():
 for password_name, dev_default in _PASSWORDS.items():
     password = os.getenv(password_name, dev_default if EQ_DEV_MODE else None)
     vars()[password_name] = password  # assigns attribute to this module
-
-# Date Format expected by SDX
-SDX_DATE_FORMAT = "%d/%m/%Y"

--- a/app/submitter/converter.py
+++ b/app/submitter/converter.py
@@ -3,7 +3,6 @@ from datetime import datetime, timezone
 
 from structlog import get_logger
 
-from app import settings
 from app.helpers.schema_helper import SchemaHelper
 
 logger = get_logger()
@@ -124,11 +123,13 @@ def _get_checkbox_answer_data(answer_store, checkboxes_with_qcode, value):
 
         if option:
             if 'child_answer_id' in option:
-                filtered = answer_store.filter(answer_id=option['child_answer_id'], limit=1)
+                filtered = answer_store.filter(answer_id=option['child_answer_id'])
+
+                assert len(filtered) <= 1, 'Multiple answers found for "{0}"'.format(option['child_answer_id'])
 
                 # if the user has selected 'other' we need to find the value it refers to.
                 # when non-mandatory, the other box value can be empty, in this case we just use its value
-                checkbox_answer_data[option['q_code']] = filtered[0]['value'] if len(filtered) == 1 else option['value']
+                checkbox_answer_data[option['q_code']] = filtered[0]['value'] if len(filtered) >= 1 else option['value']
             else:
                 checkbox_answer_data[option['q_code']] = user_answer
 
@@ -193,8 +194,6 @@ def _build_metadata(metadata):
 def _encode_value(value):
     if isinstance(value, int):
         return str(value)
-    elif isinstance(value, datetime):
-        return value.strftime(settings.SDX_DATE_FORMAT)
     elif isinstance(value, str) and value == '':
         return None
     else:

--- a/app/templating/schema_context.py
+++ b/app/templating/schema_context.py
@@ -1,4 +1,3 @@
-from app import settings
 from app.utilities.date_utils import to_date
 
 
@@ -24,7 +23,7 @@ def _map_alias_to_answers(aliases, answer_store):
     for alias, answer_info in aliases.items():
         matching_answers = []
 
-        answers = answer_store.filter(answer_id=answer_info['answer_id'], limit=settings.EQ_MAX_NUM_REPEATS)
+        answers = answer_store.filter(answer_id=answer_info['answer_id'], limit=True)
 
         for answer in answers:
             safe_answer = json_safe(answer['value'])

--- a/app/utilities/schema.py
+++ b/app/utilities/schema.py
@@ -4,10 +4,10 @@ import os
 from structlog import get_logger
 
 from app import cache
-from app import settings
 
 logger = get_logger()
 
+DEFAULT_SCHEMA_DIR = 'data'
 DEFAULT_LANGUAGE_CODE = 'en'
 
 
@@ -46,12 +46,16 @@ def load_schema_file(schema_file, language_code=None):
         raise e
 
 
-def get_schema_path(language_code=DEFAULT_LANGUAGE_CODE):
-    return os.path.join(settings.EQ_SCHEMA_DIRECTORY, language_code)
+def get_schema_definition_path(schema_dir=DEFAULT_SCHEMA_DIR):
+    return os.path.join(schema_dir, "schema/schema_v1.json")
+
+
+def get_schema_path(schema_dir=DEFAULT_SCHEMA_DIR, language_code=DEFAULT_LANGUAGE_CODE):
+    return os.path.join(schema_dir, language_code)
 
 
 def get_schema_file_path(schema_file, language_code=DEFAULT_LANGUAGE_CODE):
-    schema_dir = get_schema_path(language_code)
+    schema_dir = get_schema_path(language_code=language_code)
     return os.path.join(schema_dir, schema_file)
 
 

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -104,7 +104,7 @@ def post_block(eq_id, form_type, collection_id, group_id, group_instance, block_
     error_messages = SchemaHelper.get_messages(g.schema_json)
     block = _render_schema(current_location)
     disable_mandatory = 'action[save_sign_out]' in request.form
-    form, _ = post_form_for_location(block, current_location, answer_store, request.form, error_messages, disable_mandatory=disable_mandatory)
+    form, _ = post_form_for_location(block, current_location, answer_store, request.form, error_messages, disable_mandatory)
 
     if 'action[save_sign_out]' in request.form:
         return _save_sign_out(collection_id, eq_id, form_type, current_location, form)

--- a/tests/app/data/test_schema_id_regex.py
+++ b/tests/app/data/test_schema_id_regex.py
@@ -1,12 +1,10 @@
-import os
 import unittest
 
 from json import load
 
 from jsonschema import ValidationError, validate
 
-from app import settings
-from app.utilities.schema import get_schema_file_path
+from app.utilities.schema import get_schema_file_path, get_schema_definition_path
 
 
 def create_schema_with_id(schema_id='answer'):
@@ -33,7 +31,7 @@ def validate_json_against_schema(json_to_validate, schema):
 class TestSchemaIdRegEx(unittest.TestCase):
 
     def setUp(self):
-        schema_file = open(os.path.join(settings.EQ_SCHEMA_DIRECTORY, "schema/schema_v1.json"), encoding="utf8")
+        schema_file = open(get_schema_definition_path(), encoding="utf8")
         self.errors = []
         self.schema = load(schema_file)
 

--- a/tests/app/data/test_schema_validation.py
+++ b/tests/app/data/test_schema_validation.py
@@ -8,9 +8,8 @@ from structlog import getLogger
 from structlog.dev import ConsoleRenderer
 from structlog.stdlib import LoggerFactory
 
-from app import settings
 from app.helpers.schema_helper import SchemaHelper
-from app.utilities.schema import get_schema_path
+from app.utilities.schema import get_schema_path, get_schema_definition_path
 
 logger = getLogger()
 
@@ -20,7 +19,7 @@ configure(logger_factory=LoggerFactory(), processors=[ConsoleRenderer()])
 class TestSchemaValidation(unittest.TestCase):
 
     def test_invalid_schema(self):
-        schema_file = open(os.path.join(settings.EQ_SCHEMA_DIRECTORY, "schema/schema_v1.json"), encoding="utf8")
+        schema_file = open(get_schema_definition_path(), encoding="utf8")
         schema = load(schema_file)
 
         file = "test_invalid_routing.json"
@@ -38,7 +37,7 @@ class TestSchemaValidation(unittest.TestCase):
 
         files = self.all_schema_files()
 
-        schema_file = open(os.path.join(settings.EQ_SCHEMA_DIRECTORY, "schema/schema_v1.json"), encoding="utf8")
+        schema_file = open(get_schema_definition_path(), encoding="utf8")
         schema = load(schema_file)
 
         for file in files:

--- a/tests/app/data_model/test_answer_store.py
+++ b/tests/app/data_model/test_answer_store.py
@@ -300,7 +300,7 @@ class TestAnswerStore(unittest.TestCase):  # pylint: disable=too-many-public-met
                 value=25,
             ))
 
-        filtered = self.store.filter(limit=25)
+        filtered = self.store.filter(limit=True)
 
         self.assertEqual(len(filtered), 25)
 

--- a/tests/app/forms/test_household_relationship_form.py
+++ b/tests/app/forms/test_household_relationship_form.py
@@ -215,5 +215,4 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
 
         choices = build_relationship_choices(answer_store, 0)
 
-        self.assertEqual(settings.EQ_MAX_NUM_REPEATS - 1, len(choices))
-
+        self.assertEqual(len(choices), answer_store.EQ_MAX_NUM_REPEATS - 1)


### PR DESCRIPTION
### What is the context of this PR?
This PR aims to refactor some of the code to remove a dependency on settings and opt for using Flask config instead.
This particular PR is concerned with refactoring the following modules:
- `converter.py`
- `schema_context.py`, and
- `schema.py`

### How to review 
All existing tests and functionality should continue to pass/behave as expected.
