### PR TITLE
Eq 744 cleanse input into survey runner

### DIFF
--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 import re
 import string
 

--- a/app/questionnaire/navigation.py
+++ b/app/questionnaire/navigation.py
@@ -2,6 +2,7 @@ import copy
 from collections import defaultdict
 
 from structlog import get_logger
+from jinja2 import escape
 
 from app.helpers.schema_helper import SchemaHelper
 from app.questionnaire.location import Location
@@ -188,7 +189,7 @@ class Navigation(object):
             answers = self.answer_store.filter(answer_id=answer_id)
             for answer in answers:
                 if answer['value']:
-                    link_names[answer['answer_instance']].append(answer['value'])
+                    link_names[answer['answer_instance']].append(escape(answer['value']))
 
         for link_name in link_names:
             link_names[link_name] = " ".join(link_names[link_name])

--- a/app/setup.py
+++ b/app/setup.py
@@ -114,6 +114,10 @@ def create_app():  # noqa: C901  pylint: disable=too-complex
     else:
         cache.init_app(application)  # Doesnt cache
 
+    # Switch off flask default autoescaping as content is html encoded
+    # during schema/metadata/summary context (and navigition) generation
+    application.jinja_env.autoescape = False
+
     # Add theme manager
     application.config['THEME_PATHS'] = os.path.dirname(os.path.abspath(__file__))
     Themes(application, app_identifier="surveyrunner")

--- a/app/templates/introduction.html
+++ b/app/templates/introduction.html
@@ -58,7 +58,7 @@
   {% block description %}
     {% if content.block.description %}
       <div class="u-mb-l qa-intro-description">
-        {{ content.block.description | safe}}
+        {{ content.block.description}}
       </div>
     {% endif %}
   {% endblock description %}
@@ -69,7 +69,7 @@
         <h2 class="saturn">Basis for completion</h2>
         <ul>
          {% for basis_item in content.block.basis_for_completion %}
-           <li>{{ basis_item|safe }}</li>
+           <li>{{ basis_item }}</li>
          {% endfor %}
         </ul>
       </div>

--- a/app/templates/layouts/_error.html
+++ b/app/templates/layouts/_error.html
@@ -17,7 +17,7 @@
     <p class="u-mb-no">If the problem persists please call the number above.</p>
   </div>
 
-  {{answer_guidance|safe}}
+  {{answer_guidance}}
 
   <div class="u-mt-m u-mb-s">
     <div class="u-fw-b">Your system information</div>

--- a/app/templates/partials/answer-guidance.html
+++ b/app/templates/partials/answer-guidance.html
@@ -23,7 +23,7 @@
     {{guidance_link|xmlattr}} {{helpers.track('click', 'Help', 'Guidance click', answer_guidance.id)}}>{{_("Show further guidance")}}</a>
   <div class="guidance__main js-details-body" {{guidance_body|xmlattr}}>
     <div class="guidance__content mars">
-      {{answer_guidance.content|safe}}
+      {{answer_guidance.content}}
     </div>
   </div>
 </div>

--- a/app/templates/partials/answer.html
+++ b/app/templates/partials/answer.html
@@ -40,14 +40,14 @@
         </ul>
       </div>
       <div class="panel__body" data-qa="error-body">
-        {{answer_fields|safe}}
+        {{answer_fields}}
       </div>
     </aside>
 
-    {{answer_guidance|safe}}
+    {{answer_guidance}}
 
   {% else %}
-    {{answer_fields|safe}}
-    {{answer_guidance|safe}}
+    {{answer_fields}}
+    {{answer_guidance}}
   {% endif %}
 </div>

--- a/app/templates/partials/answers/date.html
+++ b/app/templates/partials/answers/date.html
@@ -30,10 +30,10 @@
 {% if answer.label %}
   <fieldset class="fieldgroup fieldgroup--date" data-qa="widget-date">
     <legend class="fieldgroup__title venus">{{answer.label}}</legend>
-    {{subfields|safe}}
+    {{subfields}}
   </fieldset>
 {% else %}
   <div class="fieldgroup fieldgroup--date">
-    {{subfields|safe}}
+    {{subfields}}
   </div>
 {% endif %}

--- a/app/templates/partials/forms/label.html
+++ b/app/templates/partials/forms/label.html
@@ -7,10 +7,10 @@
 {% if label.text %}
 <label {{attr|xmlattr}}>
   <div class="label__inner">
-    {{label.text|safe}}
+    {{label.text}}
     {% if label.description %}
       <br />
-      <span class="label__description pluto">{{label.description|safe}}</span>
+      <span class="label__description pluto">{{label.description}}</span>
     {% endif %}
   </div>
 </label>

--- a/app/templates/partials/question.html
+++ b/app/templates/partials/question.html
@@ -13,18 +13,18 @@
       {%- if question_number -%}
         <span class="question__number">{{question_number}}. </span>
       {% endif %}
-      {{question_title|safe}}
+      {{question_title}}
     </h2>
   {%- endif %}
   {%- if question_subtitle -%}
-    <h3 class="question__subtitle mars">{{question_subtitle|safe}}</h3>
+    <h3 class="question__subtitle mars">{{question_subtitle}}</h3>
   {%- endif -%}
 {% endset %}
 
 {% set question_description %}
   {%- if question.description -%}
     <div class="question__description mars" id="description-{{question.id}}">
-      {{question.description|safe}}
+      {{question.description}}
     </div>
   {% endif %}
 {% endset %}
@@ -38,12 +38,12 @@
             <h3 class="venus">{{guidance.title}}</h3>
           {% endif %}
           {%- if guidance.description -%}
-            <div class="mars">{{guidance.description|safe}}</div>
+            <div class="mars">{{guidance.description}}</div>
           {% endif %}
           {%- if guidance.list -%}
             <ul class="mars">
               {%- for item in guidance.list -%}
-                <li>{{item|safe}}</li>
+                <li>{{item}}</li>
               {% endfor %}
             </ul>
           {% endif %}

--- a/app/templates/partials/questions/errors.html
+++ b/app/templates/partials/questions/errors.html
@@ -8,6 +8,6 @@
     {% endif %}
   </div>
   <div class="panel__body" data-qa="error-body">
-    {{question_markup|safe}}
+    {{question_markup}}
   </div>
 </div>

--- a/app/templates/partials/questions/general.html
+++ b/app/templates/partials/questions/general.html
@@ -16,24 +16,24 @@
 
     {% if question.answers|length > 1 %}
 
-      {{question_titles|safe}}
+      {{question_titles}}
 
       <fieldset class="question__fieldset js-question-fieldset">
 
         <legend class="u-vh">{{question_title|striptags}}</legend>
 
-        {{question_description|safe}}
-        {{question_guidance|safe}}
-        {{question_answers|safe}}
+        {{question_description}}
+        {{question_guidance}}
+        {{question_answers}}
 
       </fieldset>
 
     {% else %}
 
-      {{question_titles|safe}}
-      {{question_description|safe}}
-      {{question_guidance|safe}}
-      {{question_answers|safe}}
+      {{question_titles}}
+      {{question_description}}
+      {{question_guidance}}
+      {{question_answers}}
 
     {% endif %}
 
@@ -45,8 +45,8 @@
 
   {% else %}
 
-    {{question_markup|safe}}
-    {{question_actions|safe}}
+    {{question_markup}}
+    {{question_actions}}
 
   {% endif %}
 

--- a/app/templates/partials/questions/relationship.html
+++ b/app/templates/partials/questions/relationship.html
@@ -4,13 +4,13 @@
     {%- if question_number -%}
       <span class="question__number">{{question_number}}{{current_location.group_instance|format_number_to_alphabetic_letter}}. </span>
     {% endif %}
-    {{question_title|safe}}
+    {{question_title}}
   </h2>
 
-  {{question_description|safe}}
+  {{question_description}}
   <fieldset>
     <legend class="field__legend u-vh">
-      {{question_title|safe}}
+      {{question_title}}
     </legend>
     <div class="question__answers">
         {% for current_person, other_person in content.relation_instances %}
@@ -28,7 +28,7 @@
     {%- for guidance in question.guidance -%}
       <ul class="u-m-no">
         {%- for item in guidance.list -%}
-          <li>{{item|safe}}</li>
+          <li>{{item}}</li>
         {% endfor %}
       </ul>
     {% endfor %}

--- a/app/templates/partials/questions/repeatinganswer.html
+++ b/app/templates/partials/questions/repeatinganswer.html
@@ -4,11 +4,11 @@
     {%- if question_number -%}
       <span class="question__number">{{question_number}}. </span>
     {% endif %}
-    {{question_title|safe}}
+    {{question_title}}
   </h2>
 
-  {{question_description|safe}}
-  {{question_guidance|safe}}
+  {{question_description}}
+  {{question_guidance}}
 
   <div class="question__answers">
     {% for name_form in form.household %}

--- a/app/templates/partials/section.html
+++ b/app/templates/partials/section.html
@@ -7,7 +7,7 @@
       {{section['title']}}</h1>
   {% endif %}
   {% if section['description'] %}
-    <div class="section__description mars">{{section['description']|safe}}</div>
+    <div class="section__description mars">{{section['description']}}</div>
   {% endif %}
 
   {% for question in section['questions'] %}

--- a/app/templates/partials/widgets/date_widget.html
+++ b/app/templates/partials/widgets/date_widget.html
@@ -30,10 +30,10 @@
 {% if legend %}
   <fieldset class="fieldgroup fieldgroup--date" data-qa="widget-date">
     <legend class="fieldgroup__title venus">{{legend}}</legend>
-    {{subfields|safe}}
+    {{subfields}}
   </fieldset>
 {% else %}
   <div class="fieldgroup fieldgroup--date">
-    {{subfields|safe}}
+    {{subfields}}
   </div>
 {% endif %}

--- a/app/templates/partials/widgets/multiple_choice_widget.html
+++ b/app/templates/partials/widgets/multiple_choice_widget.html
@@ -1,12 +1,12 @@
 <fieldset>
   {% set answer_label = answer.label or question.title %}
   <legend class="field__legend mars {{'u-vh' if answer.label|length == 0}}">
-    {{answer_label|safe}}
+    {{answer_label}}
     {%- if answer_label and answer.description -%}
       <br />
     {%- endif -%}
     {%- if answer.description -%}
-      <span class="label__description pluto">{{answer.description|safe}}</span>
+      <span class="label__description pluto">{{answer.description}}</span>
     {%- endif -%}
   </legend>
 
@@ -33,7 +33,7 @@
         {{option.label.text}}
         {% if option.description %}
           <br />
-          <span class="label__description label__inner pluto">{{option.description|safe}}</span>
+          <span class="label__description label__inner pluto">{{option.description}}</span>
         {% endif %}
       </label>
 

--- a/app/templates/summary.html
+++ b/app/templates/summary.html
@@ -30,7 +30,7 @@
 
   {% for group in content.summary %}
 
-      <h2 class="summary__title saturn" id="{{group.id}}">{{group.title|safe}}</h2>
+      <h2 class="summary__title saturn" id="{{group.id}}">{{group.title}}</h2>
 
       <div class="summary__block">
 
@@ -43,14 +43,14 @@
             {% for question in section.questions %}
 
                 <div class="summary__question" id="{{question.id}}">
-                  {{question.number or ''}} {{question.title|striptags|safe}}
+                  {{question.number or ''}} {{question.title|striptags}}
                 </div>
 
                 {% for answer in question.answers %}
 
                   {% if question.answers|length > 1 %}
                     <div class="summary__question summary__question--sub">
-                      {{answer.label|striptags|safe}}
+                      {{answer.label|striptags}}
                     </div>
                   {% endif %}
 

--- a/app/templates/thank-you.html
+++ b/app/templates/thank-you.html
@@ -19,7 +19,7 @@
     <p class="u-mb-no mars">You may wish to save or print this page for your records.</p>
   </div>
 
-  {{answer_guidance|safe}}
+  {{answer_guidance}}
 
   <div class="u-mt-s">
     <div class="mars">For more information on how we use this data.</div>

--- a/app/templating/metadata_context.py
+++ b/app/templating/metadata_context.py
@@ -1,5 +1,6 @@
 from app.libs.utils import convert_tx_id
 from app.utilities.date_utils import to_date
+from app.templating.schema_context import json_and_html_safe
 
 
 def build_metadata_context(metadata):
@@ -26,10 +27,10 @@ def _build_respondent_meta(metadata):
 
     respondent_meta = {
         "tx_id": convert_tx_id(metadata["tx_id"]),
-        "respondent_id": respondent_id,
+        "respondent_id": json_and_html_safe(respondent_id),
         "address": {
-            "name": name,
-            "trading_as": trading_as,
+            "name": json_and_html_safe(name),
+            "trading_as": json_and_html_safe(trading_as),
         },
     }
     return respondent_meta
@@ -41,11 +42,11 @@ def _build_survey_meta(metadata):
         "start_date":  to_date(metadata["ref_p_start_date"]),
         "end_date": to_date(metadata["ref_p_end_date"]),
         "employment_date": to_date(metadata["employment_date"]),
-        "region_code": metadata["region_code"] if 'region_code' in metadata else None,
-        "period_str": metadata["period_str"],
-        "eq_id": metadata["eq_id"],
-        "collection_id": metadata["collection_exercise_sid"],
-        "form_type": metadata["form_type"],
+        "region_code": json_and_html_safe(metadata["region_code"]) if 'region_code' in metadata else None,
+        "period_str": json_and_html_safe(metadata["period_str"]),
+        "eq_id": json_and_html_safe(metadata["eq_id"]),
+        "collection_id": json_and_html_safe(metadata["collection_exercise_sid"]),
+        "form_type": json_and_html_safe(metadata["form_type"]),
     }
 
 

--- a/app/templating/schema_context.py
+++ b/app/templating/schema_context.py
@@ -1,3 +1,4 @@
+from jinja2 import escape
 from app.utilities.date_utils import to_date
 
 
@@ -26,7 +27,7 @@ def _map_alias_to_answers(aliases, answer_store):
         answers = answer_store.filter(answer_id=answer_info['answer_id'], limit=True)
 
         for answer in answers:
-            safe_answer = json_safe(answer['value'])
+            safe_answer = json_and_html_safe(answer['value'])
             matching_answers.append(safe_answer)
 
         number_of_matches = len(matching_answers)
@@ -45,23 +46,23 @@ def _build_exercise(metadata):
     return {
         "start_date": to_date(metadata["ref_p_start_date"]),
         "end_date": to_date(metadata["ref_p_end_date"]),
-        "period_str": metadata["period_str"],
+        "period_str": json_and_html_safe(metadata["period_str"]),
         "employment_date": to_date(metadata["employment_date"]),
         "return_by": to_date(metadata["return_by"]),
-        "region_code": metadata["region_code"],
+        "region_code": json_and_html_safe(metadata["region_code"]),
     }
 
 
 def _build_respondent(metadata):
     return {
-        "ru_name": json_safe(metadata["ru_name"]),
-        "trad_as": json_safe(metadata["trad_as"]),
-        "trad_as_or_ru_name": json_safe(metadata["trad_as"] or metadata["ru_name"]),
+        "ru_name": json_and_html_safe(metadata["ru_name"]),
+        "trad_as": json_and_html_safe(metadata["trad_as"]),
+        "trad_as_or_ru_name": json_and_html_safe(metadata["trad_as"] or metadata["ru_name"]),
     }
 
 
-def json_safe(data):
+def json_and_html_safe(data):
     if isinstance(data, str):
-        return data.replace('\\', r'\\').replace('"', r'\"')
+        return escape(data.replace('\\', r'\\'))
     else:
         return data

--- a/app/templating/summary/question.py
+++ b/app/templating/summary/question.py
@@ -1,6 +1,7 @@
 from app.questionnaire.rules import evaluate_rule
 from app.data_model.answer_store import iterate_over_instance_ids
 from app.templating.summary.answer import Answer
+from jinja2 import Markup
 
 
 class Question:
@@ -18,6 +19,9 @@ class Question:
         if self.skip_condition is not None:
             for when_rule in self.skip_condition['when']:
                 answer = all_answers.get(when_rule['id'])
+                if isinstance(answer, Markup):
+                    answer = answer.unescape()
+
                 if not evaluate_rule(when_rule, answer):
                     return False
             return True

--- a/app/templating/summary_context.py
+++ b/app/templating/summary_context.py
@@ -1,5 +1,5 @@
 from flask import url_for
-
+from jinja2 import escape
 from app.helpers.schema_helper import SchemaHelper
 from app.questionnaire.path_finder import PathFinder
 from app.templating.summary.group import Group
@@ -20,6 +20,13 @@ def build_summary_rendering_context(schema_json, answer_store, metadata):
     for group in schema_json['groups']:
         if SchemaHelper.group_has_questions(group) \
                 and group['id'] in [location.group_id for location in path]:
-            groups.extend([Group(group, answer_store.map(), path, metadata, url_for)])
+
+            answers = answer_store.map()
+
+            for answer_id, value in answers.items():
+                if isinstance(value, str):
+                    answers[answer_id] = escape(value)
+
+            groups.extend([Group(group, answers, path, metadata, url_for)])
 
     return groups

--- a/app/templating/template_renderer.py
+++ b/app/templating/template_renderer.py
@@ -27,6 +27,7 @@ class TemplateRenderer:
         template = self.environment.from_string(json_string)
         rendered = template.render(**context)
         result = rendered if isinstance(renderable, dict) else json.dumps(rendered)
+
         return json.loads(result)
 
     @staticmethod

--- a/tests/app/templating/test_schema_context.py
+++ b/tests/app/templating/test_schema_context.py
@@ -234,7 +234,7 @@ class TestSchemaContext(SurveyRunnerTestCase):  # pylint: disable=too-many-publi
 
         self.assertEqual(schema_context['respondent']['trad_as_or_ru_name'], metadata['ru_name'])
 
-    def test_given_quotes_in_trading_name_when_create_context_then_quotes_are_escaped(self):
+    def test_given_quotes_in_trading_name_when_create_context_then_quotes_are_html_encoded(self):
         # Given
         metadata = self.metadata.copy()
         metadata['trad_as'] = "\"trading name\""
@@ -243,7 +243,7 @@ class TestSchemaContext(SurveyRunnerTestCase):  # pylint: disable=too-many-publi
         schema_context = build_schema_context(metadata, {}, self.answer_store)
 
         # Then
-        self.assertEqual(schema_context['respondent']['trad_as'], r'\"trading name\"')
+        self.assertEqual(schema_context['respondent']['trad_as'], r'&#34;trading name&#34;')
 
     def test_given_backslash_in_trading_name_when_create_context_then_backslash_are_escaped(self):
         # Given
@@ -256,7 +256,7 @@ class TestSchemaContext(SurveyRunnerTestCase):  # pylint: disable=too-many-publi
         # Then
         self.assertEqual(schema_context['respondent']['trad_as'], r'\\trading name\\')
 
-    def test_given_quotes_in_ru_name_when_create_context_then_quotes_are_escaped(self):
+    def test_given_quotes_in_ru_name_when_create_context_then_quotes_are_html_encoded(self):
         # Given
         metadata = self.metadata.copy()
         metadata['ru_name'] = "\"ru name\""
@@ -265,7 +265,7 @@ class TestSchemaContext(SurveyRunnerTestCase):  # pylint: disable=too-many-publi
         schema_context = build_schema_context(metadata, {}, self.answer_store)
 
         # Then
-        self.assertEqual(schema_context['respondent']['ru_name'], r'\"ru name\"')
+        self.assertEqual(schema_context['respondent']['ru_name'], r'&#34;ru name&#34;')
 
     def test_given_backslash_in_ru_name_when_create_context_then_backslash_are_escaped(self):
         # Given
@@ -278,7 +278,7 @@ class TestSchemaContext(SurveyRunnerTestCase):  # pylint: disable=too-many-publi
         # Then
         self.assertEqual(schema_context['respondent']['ru_name'], r'\\ru name\\')
 
-    def test_given_quotes_in_ru_name_or_trading_name_when_create_context_then_quotes_are_escaped(self):
+    def test_given_quotes_in_ru_name_or_trading_name_when_create_context_then_quotes_are_html_encoded(self):
         # Given
         metadata = self.metadata.copy()
         metadata['ru_name'] = '"ru_name"'
@@ -288,7 +288,7 @@ class TestSchemaContext(SurveyRunnerTestCase):  # pylint: disable=too-many-publi
         schema_context = build_schema_context(metadata, {}, self.answer_store)
 
         # Then
-        self.assertEqual(schema_context['respondent']['trad_as_or_ru_name'], r'\"ru_name\"')
+        self.assertEqual(schema_context['respondent']['trad_as_or_ru_name'], r'&#34;ru_name&#34;')
 
     def test_given_backslash_in_ru_name_or_trading_name_when_create_context_then_backslash_are_escaped(self):
         # Given
@@ -301,7 +301,7 @@ class TestSchemaContext(SurveyRunnerTestCase):  # pylint: disable=too-many-publi
         # Then
         self.assertEqual(schema_context['respondent']['trad_as_or_ru_name'], r'\\trading name\\')
 
-    def test_given_quotes_in_answers_when_create_context_quotes_then_are_escaped(self):
+    def test_given_quotes_in_answers_when_create_context_quotes_then_are_html_encoded(self):
         aliases = {
             'first_name': {
                 'answer_id': 'answer_id',
@@ -320,7 +320,7 @@ class TestSchemaContext(SurveyRunnerTestCase):  # pylint: disable=too-many-publi
 
         context_answers = schema_context['answers']
         self.assertEqual(len(context_answers), 1)
-        self.assertEqual(context_answers['first_name'], r'\"')
+        self.assertEqual(context_answers['first_name'], r'&#34;')
 
     def test_given_backslash_in_answers_when_create_context_then_backslash_are_escaped(self):
         aliases = {

--- a/tests/app/templating/test_template_renderer.py
+++ b/tests/app/templating/test_template_renderer.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 import unittest
 from datetime import datetime
 
@@ -33,7 +35,7 @@ class TestTemplateRenderer(unittest.TestCase):
 
         self.assertEqual(rendered, '\\')
 
-    def test_strings_containing_quotes_are_escaped(self):
+    def test_strings_containing_quotes_not_changed(self):
         title = '{{ [answers.person_name] | format_household_name }}'
         context = {
             'answers': {
@@ -45,7 +47,7 @@ class TestTemplateRenderer(unittest.TestCase):
 
         self.assertEqual(rendered, '"')
 
-    def test_household_summary_values_are_escaped(self):
+    def test_household_summary_values_are_escaped_and_not_encoded(self):
         description = "<h2 class='neptune'>Your household includes:</h2> " \
                       "{{ [answers.first_name, answers.middle_names, answers.last_name]|format_household_summary }}"
         context = {

--- a/tests/integration/mci/test_clear_error.py
+++ b/tests/integration/mci/test_clear_error.py
@@ -41,7 +41,7 @@ class TestClearError(IntegrationTestCase):
 
         # We submit the form
         self.post(form_data)
-        self.assertInPage("The &#39;period to&#39; date cannot be before the &#39;period from&#39; date.")
+        self.assertInPage("The 'period to' date cannot be before the 'period from' date.")
 
         # Fill the dates in correctly, but this time miss out the required value
         form_data = {
@@ -62,4 +62,4 @@ class TestClearError(IntegrationTestCase):
 
         # Check the page content again
         self.assertInPage('Please provide a value, even if your value is 0.')
-        self.assertNotInPage('The &#39;period to&#39; date cannot be before the &#39;period from&#39; date.')
+        self.assertNotInPage("The 'period to' date cannot be before the 'period from' date.")

--- a/tests/integration/mci/test_clear_value.py
+++ b/tests/integration/mci/test_clear_value.py
@@ -43,7 +43,7 @@ class TestClearValue(IntegrationTestCase):
 
         # We submit the form
         self.post(form_data)
-        self.assertInPage('The &#39;period to&#39; date cannot be before the &#39;period from&#39; date.')
+        self.assertInPage("The 'period to' date cannot be before the 'period from' date.")
 
         # Fill the dates incorrectly again, but this time supply an invalid value for retail total
         form_data = {
@@ -63,7 +63,7 @@ class TestClearValue(IntegrationTestCase):
         self.post(form_data)
 
         # Get the page content again
-        self.assertInPage('The &#39;period to&#39; date cannot be before the &#39;period from&#39; date.')
+        self.assertInPage("The 'period to' date cannot be before the 'period from' date.")
         self.assertInPage('Please only enter whole numbers into the field.')
         self.assertNotInPage('100000')  # We have cleared the valid value
         self.assertInPage('Invalid Retail Total')  # Our invalid value is redisplayed
@@ -85,7 +85,7 @@ class TestClearValue(IntegrationTestCase):
         # We submit the form
         self.post(form_data)
 
-        self.assertInPage('The &#39;period to&#39; date cannot be before the &#39;period from&#39; date.')
+        self.assertInPage("The 'period to' date cannot be before the 'period from' date.")
         self.assertNotInPage('Please only enter whole numbers into the field.')  # Our message has gone
         self.assertNotInPage('Invalid Retail Total')  # Our invalid value has gone
         self.assertInPage('1000')  # Our new valid value is redisplayed

--- a/tests/integration/mci/test_invalid_dates_numbers.py
+++ b/tests/integration/mci/test_invalid_dates_numbers.py
@@ -29,7 +29,7 @@ class TestInvalidDateNumber(IntegrationTestCase):
 
         # We submit the form with the dates the same
         self.post(form_data)
-        self.assertInPage("The &#39;period to&#39; date must be different to the &#39;period from&#39; date.")
+        self.assertInPage("The 'period to' date must be different to the 'period from' date.")
 
         form_data = {
             # Start Date
@@ -80,7 +80,7 @@ class TestInvalidDateNumber(IntegrationTestCase):
 
         # We submit the form with the dates the same
         self.post(form_data)
-        self.assertInPage("The &#39;period to&#39; date must be different to the &#39;period from&#39; date.")
+        self.assertInPage("The 'period to' date must be different to the 'period from' date.")
 
     def test_invalid_date_range(self):
         self.launchSurvey('1', '0205')
@@ -101,7 +101,7 @@ class TestInvalidDateNumber(IntegrationTestCase):
 
         # We submit the form with the front date later then the to date
         self.post(form_data)
-        self.assertInPage("The &#39;period to&#39; date cannot be before the &#39;period from&#39; date.")
+        self.assertInPage("The 'period to' date cannot be before the 'period from' date.")
 
     def test_invalid_year(self):
         self.launchSurvey('1', '0205')

--- a/tests/integration/questionnaire/test_questionnaire_piping.py
+++ b/tests/integration/questionnaire/test_questionnaire_piping.py
@@ -3,7 +3,7 @@ from tests.integration.integration_test_case import IntegrationTestCase
 
 class TestQuestionnairePiping(IntegrationTestCase):
 
-    def test_given_quotes_in_answer_when_piped_into_page_then_quotes_on_page(self):
+    def test_given_quotes_in_answer_when_piped_into_page_then_html_escaped_quotes_on_page(self):
         # Given
         self.launchSurvey('census', 'household')
         self.post({'permanent-or-family-home-answer': 'Yes'})
@@ -14,7 +14,7 @@ class TestQuestionnairePiping(IntegrationTestCase):
         # Then
         self.get(self.last_url)
         self.assertStatusOK()
-        self.assertInPage('Joe Bloggs "Junior"')
+        self.assertInPage('Joe Bloggs &#34;Junior&#34;')
 
     def test_given_backslash_in_answer_when_piped_into_page_then_backslash_on_page(self):
         # Given

--- a/tests/integration/star_wars/test_dark_side_path.py
+++ b/tests/integration/star_wars/test_dark_side_path.py
@@ -48,7 +48,7 @@ class TestDarkSidePath(StarWarsTestCase):
         # Submit the form
         self.post(form_data)
         # Test error messages
-        self.assertInPage('The &#39;period to&#39; date cannot be before the &#39;period from&#39; date.')
+        self.assertInPage("The 'period to' date cannot be before the 'period from' date.")
 
     def test_negative_currency(self):
         self.launchSurvey()
@@ -90,7 +90,7 @@ class TestDarkSidePath(StarWarsTestCase):
         self.assertInPage('This field is mandatory')
         self.assertInPage('How much, idiot you must be')
         self.assertInPage('How can it be negative?')
-        self.assertInPage('The &#39;period to&#39; date must be different to the &#39;period from&#39; date.')
+        self.assertInPage("The 'period to' date must be different to the 'period from' date.")
 
     def test_more_validation_combinations(self):
         """

--- a/tests/integration/star_wars/test_star_wars_introduction.py
+++ b/tests/integration/star_wars/test_star_wars_introduction.py
@@ -23,4 +23,4 @@ class TestStarWarsIntroduction(StarWarsTestCase):
 
         # Information to provide
         self.assertInPage('Total Yearly cost of Rebel Alliance')
-        self.assertInPage('Yoda&#39;s siblings')
+        self.assertInPage("Yoda's siblings")

--- a/tests/integration/ukis/test_ukis_submission_data.py
+++ b/tests/integration/ukis/test_ukis_submission_data.py
@@ -498,7 +498,7 @@ class TestUkisSubmissionData(IntegrationTestCase):
 
         # We have completed Business Strategy and Practices section
 
-        self.assertInPage('>Business Strategy &amp; Practices</')
+        self.assertInPage('>Business Strategy & Practices</')
         self.assertInPage('You have successfully completed this section')
         self.post(action='save_continue')
 


### PR DESCRIPTION
### What is the context of this PR?

Reworked the way user input is sanitised so that is clearer and cleaner. Moved all HTML encoding to the point where schema context generation happens and turned off autoescaping for theme templates, see card for more details.

[Trello Card](https://trello.com/c/FsZ1ute6/744-cleanse-input-into-survey-runner)

### How to review 

- All Existing functionality should be intact
- There should be no vectors for XSS via user input
