### PR TITLE
Added the flushed flag to message schema

### DIFF
--- a/app/submitter/converter.py
+++ b/app/submitter/converter.py
@@ -18,7 +18,7 @@ class DataVersionError(Exception):
         return 'Data version {} not supported'.format(self.version)
 
 
-def convert_answers(metadata, questionnaire_json, answer_store, routing_path):
+def convert_answers(metadata, questionnaire_json, answer_store, routing_path, flushed=False):
     """
     Create the JSON answer format for down stream processing
     :param metadata: metadata for the questionnaire
@@ -32,6 +32,7 @@ def convert_answers(metadata, questionnaire_json, answer_store, routing_path):
         "version" : "0.0.1",
         "origin" : "uk.gov.ons.edc.eq",
         "survey_id": "021",
+        "flushed": true|false
         "collection":{
           "exercise_sid": "hfjdskf",
           "instrument_id": "yui789",
@@ -53,6 +54,7 @@ def convert_answers(metadata, questionnaire_json, answer_store, routing_path):
         'version': questionnaire_json['data_version'],
         'origin': 'uk.gov.ons.edc.eq',
         'survey_id': survey_id,
+        'flushed': flushed,
         'submitted_at': submitted_at.isoformat(),
         'collection': _build_collection(metadata),
         'metadata': _build_metadata(metadata),

--- a/app/views/flush.py
+++ b/app/views/flush.py
@@ -55,7 +55,7 @@ def _submit_data(user):
         schema = load_schema_from_metadata(metadata)
         routing_path = PathFinder(schema, answer_store, metadata).get_routing_path()
 
-        message = convert_answers(metadata, schema, answer_store, routing_path)
+        message = convert_answers(metadata, schema, answer_store, routing_path, flushed=True)
         message = current_app.eq['encrypter'].encrypt(message)
 
         sent = current_app.eq['submitter'].send_message(message, current_app.config['EQ_RABBITMQ_QUEUE_NAME'], metadata["tx_id"])

--- a/tests/app/submitter/test_converter.py
+++ b/tests/app/submitter/test_converter.py
@@ -24,6 +24,32 @@ metadata = parse_metadata({
 
 
 class TestConverter(SurveyRunnerTestCase):
+    def test_convert_answers_flushed_flag_default_is_false(self):
+        with self.application.test_request_context():
+            user_answer = [create_answer('GHI', 0)]
+
+            questionnaire = {
+                "survey_id": "021",
+                "data_version": "0.0.2"
+            }
+
+            answer_object = convert_answers(metadata, questionnaire, AnswerStore(user_answer), {})
+
+            self.assertFalse(answer_object['flushed'])
+
+    def test_convert_answers_flushed_flag_overriden_to_true(self):
+        with self.application.test_request_context():
+            user_answer = [create_answer('GHI', 0)]
+
+            questionnaire = {
+                "survey_id": "021",
+                "data_version": "0.0.2"
+            }
+
+            answer_object = convert_answers(metadata, questionnaire, AnswerStore(user_answer), {}, flushed=True)
+
+            self.assertTrue(answer_object['flushed'])
+
     def test_convert_answers(self):
         with self.application.test_request_context():
             user_answer = [create_answer('ABC', '2016-01-01', group_id='group-1', block_id='block-1'),

--- a/tests/integration/mci/test_mci_submission_data.py
+++ b/tests/integration/mci/test_mci_submission_data.py
@@ -1,4 +1,3 @@
-
 from tests.integration.integration_test_case import IntegrationTestCase
 
 
@@ -65,6 +64,7 @@ class TestMciSubmissionData(IntegrationTestCase):
                 },
                 "version": "0.0.1",
                 "survey_id": "023",
+                "flushed": False,
                 "tx_id": actual['submission']['tx_id'],
                 "submitted_at": actual['submission']['submitted_at'],
                 "collection": {

--- a/tests/integration/mwss/test_mwss_submission_data.py
+++ b/tests/integration/mwss/test_mwss_submission_data.py
@@ -1,4 +1,3 @@
-
 from tests.integration.integration_test_case import IntegrationTestCase
 
 
@@ -122,7 +121,8 @@ class TestMwssSubmissionData(IntegrationTestCase):
                     "60f": "1",
                     "91f": "Yes"
                 },
-                "survey_id": "134"
+                "survey_id": "134",
+                "flushed": False
             }
         }
         return expected_downstream_data

--- a/tests/integration/qbs/test_qbs_submission_data.py
+++ b/tests/integration/qbs/test_qbs_submission_data.py
@@ -1,4 +1,3 @@
-
 from tests.integration.integration_test_case import IntegrationTestCase
 
 
@@ -49,6 +48,7 @@ class TestQbsSubmissionData(IntegrationTestCase):
                     'instrument_id': '0001'
                     },
                 'survey_id': '139',
+                'flushed': False,
                 'tx_id': actual['submission']['tx_id'],
                 'data': {
                     '50': '5',

--- a/tests/integration/rsi/test_rsi_submission_data.py
+++ b/tests/integration/rsi/test_rsi_submission_data.py
@@ -57,6 +57,7 @@ class TestRsiSubmissionData(IntegrationTestCase):
                     "exercise_sid": "789"
                 },
                 "survey_id": "023",
+                "flushed": False,
                 "origin": "uk.gov.ons.edc.eq",
                 "metadata": {
                     "user_id": "integration-test",
@@ -136,6 +137,7 @@ class TestRsiSubmissionData(IntegrationTestCase):
                 "submitted_at": actual['submission']['submitted_at'],
                 "version": "0.0.1",
                 "survey_id": "023",
+                "flushed": False,
                 "data": {
                     "11": "01/04/2016",
                     "12": "30/04/2016",

--- a/tests/integration/ukis/test_ukis_submission_data.py
+++ b/tests/integration/ukis/test_ukis_submission_data.py
@@ -1,4 +1,3 @@
-
 from tests.integration.integration_test_case import IntegrationTestCase
 
 
@@ -155,6 +154,7 @@ class TestUkisSubmissionData(IntegrationTestCase):
                 "submitted_at": submitted_at,
                 "version": "0.0.1",
                 "survey_id": "144",
+                "flushed": False,
                 "collection": {
                     "instrument_id": "0001",
                     "period": "201604",

--- a/tests/integration/views/test_dump.py
+++ b/tests/integration/views/test_dump.py
@@ -133,6 +133,7 @@ class TestDumpSubmission(IntegrationTestCase):
             'submission': {
                 'version': '0.0.1',
                 'survey_id': '0',
+                'flushed': False,
                 'origin': 'uk.gov.ons.edc.eq',
                 'type': 'uk.gov.ons.edc.eq:surveyresponse',
                 'tx_id': actual['submission']['tx_id'],
@@ -176,6 +177,7 @@ class TestDumpSubmission(IntegrationTestCase):
             'submission': {
                 'version': '0.0.1',
                 'survey_id': '0',
+                'flushed': False,
                 'origin': 'uk.gov.ons.edc.eq',
                 'type': 'uk.gov.ons.edc.eq:surveyresponse',
                 'tx_id': actual['submission']['tx_id'],


### PR DESCRIPTION
The flag defaults to false with an optional override that the flush
blueprint/view uses to set it to true.

### What is the context of this PR?
Added the flushed flag to the message payload that is sent downstream, see card for more details.

[Trello Card](https://trello.com/c/Mj2GCWGv/1014-flushing-flag-flushed)

### How to review 
-New functionality has unit and integration tests around it
