### PR TITLE
Update MCI Survey (0215) with latest patterns

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,4 +2,5 @@ coverage/**
 node_modules/**
 dist/**
 *.spec.js
+**/*.page.js
 src/index.html

--- a/app/templating/template_renderer.py
+++ b/app/templating/template_renderer.py
@@ -5,13 +5,14 @@ import json
 import re
 from jinja2 import Environment
 
-from app.jinja_filters import format_date, format_currency, format_household_member_name, format_household_summary
+from app.jinja_filters import format_date, format_currency, format_household_member_name, format_household_summary, format_str_as_date
 
 
 class TemplateRenderer:
     def __init__(self):
         self.environment = Environment()
         self.environment.filters['format_date'] = format_date
+        self.environment.filters['format_str_as_date'] = format_str_as_date
         self.environment.filters['format_currency'] = format_currency
         self.environment.filters['format_household_name'] = format_household_member_name
         self.environment.filters['format_household_summary'] = format_household_summary

--- a/data/en/mci_refresh.json
+++ b/data/en/mci_refresh.json
@@ -1,0 +1,728 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "survey_id": "023",
+    "title": "Monthly Business Survey - Retail Sales Index",
+    "description": "MCI Description",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "groups": [{
+        "blocks": [{
+                "type": "Introduction",
+                "id": "introduction",
+                "description": "<p>The information supplied is used to produce monthly estimates of the total retail sales in Great Britain where retailing is defined as the sale of goods to the general public for household consumption. The Retail Sales Index is a key indicator of the progress of the economy. It is also used to help estimate consumer spending on retail goods and the output of the retail sector, both of which feed into the compilation of the National Accounts. The results are also used by the Bank of England and HM Treasury to inform decision making by government and in formulating financial policies. The results <a href=\"http://www.ons.gov.uk/businessindustryandtrade/retailindustry\">are published on our website</a>.</p>",
+                "information_to_provide": [
+                    "value of total retail turnover",
+                    "value of internet sales",
+                    "numbers of employees",
+                    "reasons for changes to figures"
+                ]
+            },
+            {
+                "type": "Questionnaire",
+                "id": "reporting-period",
+                "sections": [{
+                    "description": "",
+                    "id": "reporting-period-section",
+                    "questions": [{
+                        "answers": [{
+                                "guidance": "",
+                                "id": "period-from",
+                                "alias": "period_from",
+                                "label": "Period from",
+                                "mandatory": true,
+                                "options": [],
+                                "q_code": "11",
+                                "type": "Date",
+                                "validation": {
+                                    "messages": {
+                                        "INVALID_DATE": "The date entered is not valid.  Please correct your answer.",
+                                        "MANDATORY": "Please provide an answer to continue."
+                                    }
+                                }
+                            },
+                            {
+                                "guidance": "",
+                                "id": "period-to",
+                                "alias": "period_to",
+                                "label": "Period to",
+                                "mandatory": true,
+                                "options": [],
+                                "q_code": "12",
+                                "type": "Date",
+                                "validation": {
+                                    "messages": {
+                                        "INVALID_DATE": "The date entered is not valid.  Please correct your answer.",
+                                        "MANDATORY": "Please provide an answer to continue."
+                                    }
+                                }
+                            }
+                        ],
+                        "description": "If possible, this should be for the period {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}.",
+                        "id": "reporting-period-question",
+                        "title": "What are the dates of the sales period you are reporting for?",
+                        "type": "DateRange"
+                    }],
+                    "title": "Reporting Period"
+                }],
+                "title": "Monthly Business Survey"
+            },
+            {
+                "type": "Questionnaire",
+                "id": "total-retail-turnover-block",
+                "sections": [{
+                    "description": "",
+                    "id": "total-turnover-section",
+                    "questions": [{
+                        "guidance": [{
+                                "title": "Include",
+                                "list": [
+                                    "VAT",
+                                    "internet sales",
+                                    "retail sales from outlets in Great Britain to customers abroad"
+                                ]
+                            },
+                            {
+                                "title": "Exclude",
+                                "list": [
+                                    "revenue from mobile phone network commission and top-up",
+                                    "sales from catering facilities used by customers",
+                                    "lottery sales and commission from lottery sales",
+                                    "sales of car accessories and motor vehicles",
+                                    "NHS receipts"
+                                ]
+                            }
+                        ],
+                        "answers": [{
+                            "guidance": "",
+                            "id": "total-retail-turnover",
+                            "alias": "total_turnover",
+                            "description": "Round to the nearest (\u00a3) pound. Do not  include pence",
+                            "label": "Total retail turnover",
+                            "mandatory": true,
+                            "options": [],
+                            "q_code": "20",
+                            "type": "Currency",
+                            "validation": {
+                                "messages": {
+                                    "INTEGER_TOO_LARGE": "The maximum value allowed is 9999999999. Please correct your answer.",
+                                    "MANDATORY": "Please provide a value, even if your value is 0.",
+                                    "NEGATIVE_INTEGER": "The value cannot be negative. Please correct your answer.",
+                                    "NOT_INTEGER": "Please only enter whole numbers into the field."
+                                }
+                            }
+                        }],
+                        "description": "",
+                        "id": "total-turnover-question",
+                        "title": "For the period {{answers.period_from|format_str_as_date}} to {{answers.period_to|format_str_as_date}}, what was the value of {{respondent.trad_as_or_ru_name}}\u2019s <em>total retail turnover</em>?",
+                        "type": "General"
+                    }],
+                    "title": "Retail Turnover"
+                }],
+                "title": "Monthly Business Survey"
+            },
+            {
+                "type": "Questionnaire",
+                "id": "food-sales",
+                "sections": [{
+                    "description": "",
+                    "id": "total-food-sales-section",
+                    "questions": [{
+                        "guidance": [{
+                                "title": "Include",
+                                "list": [
+                                    "all fresh food",
+                                    "other food for human consumption (except chocolate and sugar confectionery)",
+                                    "soft drinks"
+                                ]
+                            },
+                            {
+                                "title": "Exclude",
+                                "list": [
+                                    "sales from catering facilities used by customers"
+                                ]
+                            }
+                        ],
+                        "answers": [{
+                            "guidance": "",
+                            "description": "Round to the nearest (\u00a3) pound. Do not  include pence",
+                            "id": "total-sales-food",
+                            "label": "Food",
+                            "mandatory": false,
+                            "options": [],
+                            "q_code": "22",
+                            "type": "Currency",
+                            "validation": {
+                                "messages": {
+                                    "INTEGER_TOO_LARGE": "The maximum value allowed is 9999999999. Please correct your answer.",
+                                    "NEGATIVE_INTEGER": "The value cannot be negative. Please correct your answer.",
+                                    "NOT_INTEGER": "Please only enter whole numbers into the field."
+                                }
+                            }
+                        }],
+                        "description": "",
+                        "id": "total-sales-food-question",
+                        "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>food</em> sales?",
+                        "type": "General"
+                    }],
+                    "title": "Retail turnover"
+                }],
+                "title": "Monthly Business Survey"
+            },
+            {
+                "type": "Questionnaire",
+                "id": "alcohol-sales",
+                "sections": [{
+                    "description": "",
+                    "id": "total-alcohol-sales-section",
+                    "questions": [{
+                        "guidance": [{
+                            "title": "Include",
+                            "list": [
+                                "alcoholic drink",
+                                "chocolate and sugar confectionery",
+                                "tobacco and smokers\u2019 requisites"
+                            ]
+                        }],
+                        "answers": [{
+                            "guidance": "",
+                            "description": "Round to the nearest (\u00a3) pound. Do not  include pence",
+                            "id": "total-sales-alcohol",
+                            "label": "Alcohol, confectionery and tobacco",
+                            "mandatory": false,
+                            "options": [],
+                            "q_code": "23",
+                            "type": "Currency",
+                            "validation": {
+                                "messages": {
+                                    "INTEGER_TOO_LARGE": "The maximum value allowed is 9999999999. Please correct your answer.",
+                                    "NEGATIVE_INTEGER": "The value cannot be negative. Please correct your answer.",
+                                    "NOT_INTEGER": "Please only enter whole numbers into the field."
+                                }
+                            }
+                        }],
+                        "description": "",
+                        "id": "total-sales-alcohol-question",
+                        "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>alcohol, confectionery and tobacco</em> sales?",
+                        "type": "General"
+                    }],
+                    "title": "Retail turnover"
+                }],
+                "title": "Monthly Business Survey"
+            },
+            {
+                "type": "Questionnaire",
+                "id": "clothing-sales",
+                "sections": [{
+                    "description": "",
+                    "id": "total-clothing-sales-section",
+                    "questions": [{
+                        "guidance": [{
+                            "title": "Include",
+                            "list": [
+                                "clothing and footwear",
+                                "clothing fabrics",
+                                "haberdashery and furs",
+                                "leather and travel goods",
+                                "handbags and umbrellas"
+                            ]
+                        }],
+                        "answers": [{
+                            "guidance": "",
+                            "description": "Round to the nearest (\u00a3) pound. Do not  include pence",
+                            "id": "total-sales-clothing",
+                            "label": "Clothing and footwear",
+                            "mandatory": false,
+                            "options": [],
+                            "q_code": "24",
+                            "type": "Currency",
+                            "validation": {
+                                "messages": {
+                                    "INTEGER_TOO_LARGE": "The maximum value allowed is 9999999999. Please correct your answer.",
+                                    "NEGATIVE_INTEGER": "The value cannot be negative. Please correct your answer.",
+                                    "NOT_INTEGER": "Please only enter whole numbers into the field."
+                                }
+                            }
+                        }],
+                        "description": "",
+                        "id": "total-sales-clothing-question",
+                        "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>clothing and footwear</em> sales?",
+                        "type": "General"
+                    }],
+                    "title": "Retail turnover"
+                }],
+                "title": "Monthly Business Survey"
+            },
+            {
+                "type": "Questionnaire",
+                "id": "household-goods-sales",
+                "sections": [{
+                    "description": "",
+                    "id": "total-household-goods-sales-section",
+                    "questions": [{
+                        "answers": [{
+                            "guidance": "<div> <h4>Include</h4><ul> <li>carpets, rugs and other floor coverings</li> <li>furniture</li> <li>household textiles and soft furnishings</li> <li>prints and picture frames</li> <li>antiques and works of art</li> <li>domestic electrical and gas appliances, audio/visual equipment and home computers</li> <li>lighting and minor electrical supplies</li> <li>records, compact discs, audio and video tapes</li> <li>musical instruments and goods</li> <li>decorators\u2019 and DIY supplies</li> <li>lawn-mowers</li> <li>hardware</li> <li>china, glassware and cutlery</li> <li>novelties, souvenirs and gifts</li> <li>e-cigarettes</li> </ul></div>",
+                            "description": "Round to the nearest (\u00a3) pound. Do not  include pence",
+                            "id": "total-sales-household-goods",
+                            "label": "Household goods",
+                            "mandatory": false,
+                            "options": [],
+                            "q_code": "25",
+                            "type": "Currency",
+                            "validation": {
+                                "messages": {
+                                    "INTEGER_TOO_LARGE": "The maximum value allowed is 9999999999. Please correct your answer.",
+                                    "NEGATIVE_INTEGER": "The value cannot be negative. Please correct your answer.",
+                                    "NOT_INTEGER": "Please only enter whole numbers into the field."
+                                }
+                            }
+                        }],
+                        "description": "",
+                        "id": "total-sales-household-goods-question",
+                        "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of sales for <em>household goods</em>?",
+                        "type": "General"
+                    }],
+                    "title": "Retail turnover"
+                }],
+                "title": "Monthly Business Survey"
+            },
+            {
+                "type": "Questionnaire",
+                "id": "other-goods-sales",
+                "sections": [{
+                    "description": "",
+                    "id": "total-other-goods-sales-section",
+                    "questions": [{
+                        "answers": [{
+                            "guidance": "<h4>Include</h4> <ul>  <li>toiletries and medications (except NHS receipts)</li> <li>newspapers and periodicals</li> <li>books, stationery and office supplies</li> <li>photographic and optical goods</li> <li>spectacles, contact lenses and sunglasses</li> <li>toys and games</li> <li>cycles and cycle accessories</li> <li>sport and camping equipment</li> <li>jewellery</li> <li>silverware and plate, clocks and watches</li> <li>household cleaning products and kitchen paper products</li> <li>pets, pets\u2019 requisites and pet foods</li> <li>cut flowers, plants, seeds and other garden sundries</li> <li>other new and second hand goods</li> <li>mobile phones</li> </ul><h4>Exclude</h4> <ul> <li>revenue from mobile phone network commission and top up </li> <li>lottery sales and commission from lottery sales</li> <li>sales of car accessories and motor vehicles</li> <li>NHS receipts</li> </ul>",
+                            "description": "Round to the nearest (\u00a3) pound. Do not  include pence",
+                            "id": "total-sales-other-goods",
+                            "label": "Other goods",
+                            "mandatory": false,
+                            "options": [],
+                            "q_code": "26",
+                            "type": "Currency",
+                            "validation": {
+                                "messages": {
+                                    "INTEGER_TOO_LARGE": "The maximum value allowed is 9999999999. Please correct your answer.",
+                                    "NEGATIVE_INTEGER": "The value cannot be negative. Please correct your answer.",
+                                    "NOT_INTEGER": "Please only enter whole numbers into the field."
+                                }
+                            }
+                        }],
+                        "description": "",
+                        "id": "total-sales-other-goods-question",
+                        "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>other</em> sales?",
+                        "type": "General"
+                    }],
+                    "title": "Retail turnover"
+                }],
+                "title": "Monthly Business Survey"
+            },
+            {
+                "type": "Questionnaire",
+                "id": "total-internet-sales",
+                "sections": [{
+                    "description": "",
+                    "id": "total-internet-sales-section",
+                    "questions": [{
+                        "guidance": [{
+                            "title": "Include",
+                            "list": [
+                                "VAT"
+                            ]
+                        }],
+                        "answers": [{
+                            "guidance": "",
+                            "description": "Round to the nearest (\u00a3) pound. Do not  include pence",
+                            "id": "internet-sales",
+                            "label": "Internet sales",
+                            "mandatory": false,
+                            "options": [],
+                            "q_code": "21",
+                            "type": "Currency",
+                            "validation": {
+                                "messages": {
+                                    "INTEGER_TOO_LARGE": "The maximum value allowed is 9999999999. Please correct your answer.",
+                                    "NEGATIVE_INTEGER": "The value cannot be negative. Please correct your answer.",
+                                    "NOT_INTEGER": "Please only enter whole numbers into the field."
+                                }
+                            }
+                        }],
+                        "description": "",
+                        "id": "internet-sales-question",
+                        "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>internet</em> sales?",
+                        "type": "General"
+                    }],
+                    "title": "Retail turnover"
+                }],
+                "title": "Monthly Business Survey"
+            },
+            {
+                "type": "Questionnaire",
+                "id": "automotive-fuel",
+                "sections": [{
+                    "description": "",
+                    "id": "total-automotive-fuel-sales-section",
+                    "questions": [{
+                        "guidance": [{
+                                "title": "Include",
+                                "list": [
+                                    "VAT",
+                                    "sales of fuel owned by you",
+                                    "sales of other items not paid a commission for"
+                                ]
+                            },
+                            {
+                                "title": "Exclude",
+                                "list": [
+                                    "sales of fuel not owned by you",
+                                    "any commissions"
+                                ]
+                            }
+                        ],
+                        "answers": [{
+                            "guidance": "",
+                            "description": "Round to the nearest (\u00a3) pound. Do not  include pence",
+                            "id": "total-sales-automotive-fuel",
+                            "label": "Automotive fuel",
+                            "mandatory": false,
+                            "options": [],
+                            "q_code": "27",
+                            "type": "Currency",
+                            "validation": {
+                                "messages": {
+                                    "INTEGER_TOO_LARGE": "The maximum value allowed is 9999999999. Please correct your answer.",
+                                    "NEGATIVE_INTEGER": "The value cannot be negative. Please correct your answer.",
+                                    "NOT_INTEGER": "Please only enter whole numbers into the field."
+                                }
+                            }
+                        }],
+                        "description": "",
+                        "id": "total-sales-automotive-fuel-question",
+                        "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>automotive fuel</em> sales?",
+                        "type": "General"
+                    }],
+                    "title": "Retail turnover"
+                }],
+                "title": "Monthly Business Survey"
+            },
+            {
+                "id": "significant-change",
+                "routing_rules": [{
+                        "goto": {
+                            "id": "reason-for-change",
+                            "when": [{
+                                "id": "significant-change-established-answer",
+                                "condition": "equals",
+                                "value": "Yes"
+                            }]
+                        }
+                    },
+                    {
+                        "goto": {
+                            "id": "total-employees"
+                        }
+                    }
+                ],
+                "sections": [{
+                    "description": "",
+                    "id": "significant-change-section",
+                    "questions": [{
+                        "guidance": [{
+                            "title": "Include",
+                            "list": [
+                                "in-store / online promotions",
+                                "special events (e.g. sporting events)",
+                                "calendar events (e.g. Christmas, Easter, Bank Holiday)",
+                                "weather",
+                                "store closures/openings"
+                            ]
+                        }],
+                        "answers": [{
+                            "description": "",
+                            "id": "significant-change-established-answer",
+                            "label": "",
+                            "mandatory": true,
+                            "options": [{
+                                    "label": "Yes",
+                                    "value": "Yes"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "No"
+                                }
+                            ],
+                            "validation": {
+                                "messages": {
+                                    "MANDATORY": "Please select an answer to continue."
+                                }
+                            },
+                            "q_code": "146a",
+                            "type": "Radio"
+                        }],
+                        "description": "Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                        "id": "significant-change-question",
+                        "title": "Did any significant changes occur to the total retail turnover for {{respondent.trad_as_or_ru_name}}?",
+                        "type": "General"
+                    }],
+                    "title": "Changes in total retail turnover"
+                }],
+                "type": "Questionnaire"
+            },
+            {
+                "type": "Questionnaire",
+                "id": "reason-for-change",
+                "sections": [{
+                    "description": "",
+                    "id": "reason-for-change-section",
+                    "questions": [{
+                        "answers": [{
+                            "description": "",
+                            "id": "reason-for-change-answer",
+                            "label": "",
+                            "mandatory": true,
+                            "options": [{
+                                    "label": "In-store / online promotions",
+                                    "q_code": "146b",
+                                    "value": "In-store / online promotions"
+                                },
+                                {
+                                    "label": "Special events (e.g. sporting events)",
+                                    "q_code": "146c",
+                                    "value": "Special events (e.g. sporting events)"
+                                },
+                                {
+                                    "label": "Calendar events (e.g. Christmas, Easter, Bank Holiday)",
+                                    "q_code": "146d",
+                                    "value": "Calendar events (e.g. Christmas, Easter, Bank Holiday)"
+                                },
+                                {
+                                    "label": "Weather",
+                                    "q_code": "146e",
+                                    "value": "Weather"
+                                },
+                                {
+                                    "label": "Store closures",
+                                    "q_code": "146f",
+                                    "value": "Store closures"
+                                },
+                                {
+                                    "label": "Store openings",
+                                    "q_code": "146g",
+                                    "value": "Store openings"
+                                },
+                                {
+                                    "label": "Other",
+                                    "q_code": "146h",
+                                    "value": "Other"
+                                }
+                            ],
+                            "validation": {
+                                "messages": {
+                                    "MANDATORY": "Please select all that apply to continue."
+                                }
+                            },
+                            "type": "Checkbox"
+                        }],
+
+                        "description": "Select all that apply",
+                        "id": "reason-for-change-question",
+                        "title": "Please indicate the reasons for any changes in the total retail turnover for {{respondent.trad_as_or_ru_name}}",
+                        "type": "General"
+                    }],
+                    "title": "Changes in total retail turnover"
+                }],
+                "title": "Monthly Business Survey"
+            },
+            {
+                "type": "Questionnaire",
+                "id": "change-comment-block",
+                "sections": [{
+                    "description": "",
+                    "id": "change-comment-section",
+                    "questions": [{
+                        "answers": [{
+                            "guidance": "<h4>\u2018In-store promotion\u2019</h4><ul>\u201COffer on wine for the whole month. The promotion was available in-store and online, contributing to an increase in both total turnover and internet sales.\u201D</ul><h4>\u2018Special events (e.g. sporting events)\u2019</h4> <ul>\u201CThis was the month before the start of  Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (e.g., televisions and audio equipment). This led to an increase in sales both in-store and online.\u201D</ul><h4>\u2018Weather\u2019</h4> <ul>\u201CThe bad weather has decreased our sales of summer clothing. This has led to a reduction in total turnover and internet sales this month.\u201D</ul>",
+                            "id": "change-comment",
+                            "label": "Comments",
+                            "mandatory": true,
+                            "options": [],
+                            "q_code": "146",
+                            "type": "TextArea",
+                            "validation": {
+                                "messages": {
+                                    "MANDATORY": "Please enter a comment to continue."
+                                }
+                            }
+                        }],
+                        "description": "We rely on your commentary to \u2018tell the story\u2019 behind changes in figures. By commenting here it will reduce the need for us to call you.",
+                        "id": "change-comment-question",
+                        "title": "Please describe the changes in total retail turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+                        "type": "General"
+                    }],
+                    "title": "Changes in total retail turnover"
+                }],
+                "title": "Monthly Business Survey"
+            },
+            {
+                "type": "Questionnaire",
+                "id": "total-employees",
+                "sections": [{
+                    "description": "",
+                    "id": "total-employees-section",
+                    "questions": [{
+                        "guidance": [{
+                                "title": "Include",
+                                "list": [
+                                    "all workers paid directly from this business\u2019s payroll(s)",
+                                    "those temporarily absent but still being paid, for example on maternity leave"
+                                ]
+                            },
+                            {
+                                "title": "Exclude",
+                                "list": [
+                                    "agency workers paid directly from the agency payroll",
+                                    "voluntary workers",
+                                    "former employees only receiving pension",
+                                    "self-employed workers",
+                                    "working owners who are not paid via PAYE"
+                                ]
+                            }
+                        ],
+                        "answers": [{
+                            "guidance": "",
+                            "id": "total-number-employees",
+                            "alias": "employee_count",
+                            "label": "Total number of employees",
+                            "mandatory": true,
+                            "options": [],
+                            "q_code": "50",
+                            "type": "PositiveInteger",
+                            "validation": {
+                                "messages": {
+                                    "INTEGER_TOO_LARGE": "The maximum value allowed is 9999999999. Please correct your answer.",
+                                    "MANDATORY": "Please provide a value, even if your value is 0.",
+                                    "NEGATIVE_INTEGER": "The value cannot be negative. Please correct your answer.",
+                                    "NOT_INTEGER": "Please only enter whole numbers into the field."
+                                }
+                            }
+                        }],
+                        "description": "<p>An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.</p>",
+                        "id": "total-number-employees-question",
+                        "title": "On {{exercise.employment_date|format_date}} what was the number of employees for {{respondent.trad_as_or_ru_name}}?",
+                        "type": "General"
+                    }],
+                    "title": "Employees"
+                }],
+                "title": "Monthly Business Survey"
+            },
+            {
+                "type": "Questionnaire",
+                "id": "employees-breakdown",
+                "sections": [{
+                    "description": "",
+                    "id": "employee-breakdown-section",
+                    "questions": [{
+                        "guidance": [{
+                                "title": "Include",
+                                "list": [
+                                    "all workers paid directly from this business\u2019s payroll(s)",
+                                    "those temporarily absent but still being paid, for example on maternity leave"
+                                ]
+                            },
+                            {
+                                "title": "Exclude",
+                                "list": [
+                                    "agency workers paid directly from the agency payroll",
+                                    "voluntary workers",
+                                    "former employees only receiving pension",
+                                    "self-employed workers",
+                                    "working owners who are not paid via PAYE"
+                                ]
+                            }
+                        ],
+                        "answers": [{
+                                "guidance": "",
+                                "id": "number-male-employees-over-30-hours",
+                                "label": "Number of male employees working more than 30 hours per week",
+                                "mandatory": false,
+                                "options": [],
+                                "q_code": "51",
+                                "type": "PositiveInteger",
+                                "validation": {
+                                    "messages": {
+                                        "INTEGER_TOO_LARGE": "The maximum value allowed is 9999999999. Please correct your answer.",
+                                        "NEGATIVE_INTEGER": "The value cannot be negative. Please correct your answer.",
+                                        "NOT_INTEGER": "Please only enter whole numbers into the field."
+                                    }
+                                }
+                            },
+                            {
+                                "guidance": "",
+                                "id": "number-male-employees-under-30-hours",
+                                "label": "Number of male employees working 30 hours or less per week",
+                                "mandatory": false,
+                                "options": [],
+                                "q_code": "52",
+                                "type": "PositiveInteger",
+                                "validation": {
+                                    "messages": {
+                                        "INTEGER_TOO_LARGE": "The maximum value allowed is 9999999999. Please correct your answer.",
+                                        "NEGATIVE_INTEGER": "The value cannot be negative. Please correct your answer.",
+                                        "NOT_INTEGER": "Please only enter whole numbers into the field."
+                                    }
+                                }
+                            },
+                            {
+                                "guidance": "",
+                                "id": "number-female-employees-over-30-hours",
+                                "label": "Number of female employees working more than 30 hours per week",
+                                "mandatory": false,
+                                "options": [],
+                                "q_code": "53",
+                                "type": "PositiveInteger",
+                                "validation": {
+                                    "messages": {
+                                        "INTEGER_TOO_LARGE": "The maximum value allowed is 9999999999. Please correct your answer.",
+                                        "NEGATIVE_INTEGER": "The value cannot be negative. Please correct your answer.",
+                                        "NOT_INTEGER": "Please only enter whole numbers into the field."
+                                    }
+                                }
+                            },
+                            {
+                                "guidance": "",
+                                "id": "number-female-employees-under-30-hours",
+                                "label": "Number of female employees working 30 hours or less per week",
+                                "mandatory": false,
+                                "options": [],
+                                "q_code": "54",
+                                "type": "PositiveInteger",
+                                "validation": {
+                                    "messages": {
+                                        "INTEGER_TOO_LARGE": "The maximum value allowed is 9999999999. Please correct your answer.",
+                                        "NEGATIVE_INTEGER": "The value cannot be negative. Please correct your answer.",
+                                        "NOT_INTEGER": "Please only enter whole numbers into the field."
+                                    }
+                                }
+                            }
+                        ],
+                        "description": "",
+                        "id": "employee-breakdown-questions",
+                        "title": "Of the <em>{{answers.employee_count}}</em> total employees employed on {{exercise.employment_date|format_date}}, please specify the number of:",
+                        "type": "General"
+                    }],
+                    "title": "Employees"
+                }],
+                "title": "Monthly Business Survey"
+            },
+            {
+                "type": "Summary",
+                "id": "summary"
+            }
+        ],
+        "id": "mci",
+        "title": ""
+    }]
+}

--- a/tests/functional/pages/surveys/mci-refresh/alcohol-sales.page.js
+++ b/tests/functional/pages/surveys/mci-refresh/alcohol-sales.page.js
@@ -1,0 +1,24 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class AlcoholSalesPage extends QuestionPage {
+  constructor() {
+    super('alcohol-sales')
+  }
+  setTotalSalesAlcohol(value) {
+    browser.setValue('[name="total-sales-alcohol"]', value)
+    return this
+  }
+  getTotalSalesAlcohol(value) {
+    return browser.element('[name="total-sales-alcohol"]').getValue()
+  }
+  getTotalSalesAlcoholLabel() {
+    return browser.element('#label-total-sales-alcohol')
+  }
+  getTotalSalesAlcoholElement() {
+    return browser.element('[name="total-sales-alcohol"]')
+  }
+}
+
+export default new AlcoholSalesPage()

--- a/tests/functional/pages/surveys/mci-refresh/automotive-fuel.page.js
+++ b/tests/functional/pages/surveys/mci-refresh/automotive-fuel.page.js
@@ -1,0 +1,24 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class AutomotiveFuelPage extends QuestionPage {
+  constructor() {
+    super('automotive-fuel')
+  }
+  setTotalSalesAutomotiveFuel(value) {
+    browser.setValue('[name="total-sales-automotive-fuel"]', value)
+    return this
+  }
+  getTotalSalesAutomotiveFuel(value) {
+    return browser.element('[name="total-sales-automotive-fuel"]').getValue()
+  }
+  getTotalSalesAutomotiveFuelLabel() {
+    return browser.element('#label-total-sales-automotive-fuel')
+  }
+  getTotalSalesAutomotiveFuelElement() {
+    return browser.element('[name="total-sales-automotive-fuel"]')
+  }
+}
+
+export default new AutomotiveFuelPage()

--- a/tests/functional/pages/surveys/mci-refresh/change-comment-block.page.js
+++ b/tests/functional/pages/surveys/mci-refresh/change-comment-block.page.js
@@ -1,0 +1,24 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class ChangeCommentBlockPage extends QuestionPage {
+  constructor() {
+    super('change-comment-block')
+  }
+  setChangeComment(value) {
+    browser.setValue('[name="change-comment"]', value)
+    return this
+  }
+  getChangeComment(value) {
+    return browser.element('[name="change-comment"]').getValue()
+  }
+  getChangeCommentLabel() {
+    return browser.element('#label-change-comment')
+  }
+  getChangeCommentElement() {
+    return browser.element('[name="change-comment"]')
+  }
+}
+
+export default new ChangeCommentBlockPage()

--- a/tests/functional/pages/surveys/mci-refresh/clothing-sales.page.js
+++ b/tests/functional/pages/surveys/mci-refresh/clothing-sales.page.js
@@ -1,0 +1,24 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class ClothingSalesPage extends QuestionPage {
+  constructor() {
+    super('clothing-sales')
+  }
+  setTotalSalesClothing(value) {
+    browser.setValue('[name="total-sales-clothing"]', value)
+    return this
+  }
+  getTotalSalesClothing(value) {
+    return browser.element('[name="total-sales-clothing"]').getValue()
+  }
+  getTotalSalesClothingLabel() {
+    return browser.element('#label-total-sales-clothing')
+  }
+  getTotalSalesClothingElement() {
+    return browser.element('[name="total-sales-clothing"]')
+  }
+}
+
+export default new ClothingSalesPage()

--- a/tests/functional/pages/surveys/mci-refresh/employees-breakdown.page.js
+++ b/tests/functional/pages/surveys/mci-refresh/employees-breakdown.page.js
@@ -1,0 +1,63 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class EmployeesBreakdownPage extends QuestionPage {
+  constructor() {
+    super('employees-breakdown')
+  }
+  setNumberMaleEmployeesOver30Hours(value) {
+    browser.setValue('[name="number-male-employees-over-30-hours"]', value)
+    return this
+  }
+  getNumberMaleEmployeesOver30Hours(value) {
+    return browser.element('[name="number-male-employees-over-30-hours"]').getValue()
+  }
+  getNumberMaleEmployeesOver30HoursLabel() {
+    return browser.element('#label-number-male-employees-over-30-hours')
+  }
+  getNumberMaleEmployeesOver30HoursElement() {
+    return browser.element('[name="number-male-employees-over-30-hours"]')
+  }
+  setNumberMaleEmployeesUnder30Hours(value) {
+    browser.setValue('[name="number-male-employees-under-30-hours"]', value)
+    return this
+  }
+  getNumberMaleEmployeesUnder30Hours(value) {
+    return browser.element('[name="number-male-employees-under-30-hours"]').getValue()
+  }
+  getNumberMaleEmployeesUnder30HoursLabel() {
+    return browser.element('#label-number-male-employees-under-30-hours')
+  }
+  getNumberMaleEmployeesUnder30HoursElement() {
+    return browser.element('[name="number-male-employees-under-30-hours"]')
+  }
+  setNumberFemaleEmployeesOver30Hours(value) {
+    browser.setValue('[name="number-female-employees-over-30-hours"]', value)
+    return this
+  }
+  getNumberFemaleEmployeesOver30Hours(value) {
+    return browser.element('[name="number-female-employees-over-30-hours"]').getValue()
+  }
+  getNumberFemaleEmployeesOver30HoursLabel() {
+    return browser.element('#label-number-female-employees-over-30-hours')
+  }
+  getNumberFemaleEmployeesOver30HoursElement() {
+    return browser.element('[name="number-female-employees-over-30-hours"]')
+  }
+  setNumberFemaleEmployeesUnder30Hours(value) {
+    browser.setValue('[name="number-female-employees-under-30-hours"]', value)
+    return this
+  }
+  getNumberFemaleEmployeesUnder30Hours(value) {
+    return browser.element('[name="number-female-employees-under-30-hours"]').getValue()
+  }
+  getNumberFemaleEmployeesUnder30HoursLabel() {
+    return browser.element('#label-number-female-employees-under-30-hours')
+  }
+  getNumberFemaleEmployeesUnder30HoursElement() {
+    return browser.element('[name="number-female-employees-under-30-hours"]')
+  }
+}
+
+export default new EmployeesBreakdownPage()

--- a/tests/functional/pages/surveys/mci-refresh/food-sales.page.js
+++ b/tests/functional/pages/surveys/mci-refresh/food-sales.page.js
@@ -1,0 +1,24 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class FoodSalesPage extends QuestionPage {
+  constructor() {
+    super('food-sales')
+  }
+  setTotalSalesFood(value) {
+    browser.setValue('[name="total-sales-food"]', value)
+    return this
+  }
+  getTotalSalesFood(value) {
+    return browser.element('[name="total-sales-food"]').getValue()
+  }
+  getTotalSalesFoodLabel() {
+    return browser.element('#label-total-sales-food')
+  }
+  getTotalSalesFoodElement() {
+    return browser.element('[name="total-sales-food"]')
+  }
+}
+
+export default new FoodSalesPage()

--- a/tests/functional/pages/surveys/mci-refresh/household-goods-sales.page.js
+++ b/tests/functional/pages/surveys/mci-refresh/household-goods-sales.page.js
@@ -1,0 +1,24 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class HouseholdGoodsSalesPage extends QuestionPage {
+  constructor() {
+    super('household-goods-sales')
+  }
+  setTotalSalesHouseholdGoods(value) {
+    browser.setValue('[name="total-sales-household-goods"]', value)
+    return this
+  }
+  getTotalSalesHouseholdGoods(value) {
+    return browser.element('[name="total-sales-household-goods"]').getValue()
+  }
+  getTotalSalesHouseholdGoodsLabel() {
+    return browser.element('#label-total-sales-household-goods')
+  }
+  getTotalSalesHouseholdGoodsElement() {
+    return browser.element('[name="total-sales-household-goods"]')
+  }
+}
+
+export default new HouseholdGoodsSalesPage()

--- a/tests/functional/pages/surveys/mci-refresh/introduction.page.js
+++ b/tests/functional/pages/surveys/mci-refresh/introduction.page.js
@@ -1,0 +1,11 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class IntroductionPage extends QuestionPage {
+  constructor() {
+    super('introduction')
+  }
+}
+
+export default new IntroductionPage()

--- a/tests/functional/pages/surveys/mci-refresh/other-goods-sales.page.js
+++ b/tests/functional/pages/surveys/mci-refresh/other-goods-sales.page.js
@@ -1,0 +1,24 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class OtherGoodsSalesPage extends QuestionPage {
+  constructor() {
+    super('other-goods-sales')
+  }
+  setTotalSalesOtherGoods(value) {
+    browser.setValue('[name="total-sales-other-goods"]', value)
+    return this
+  }
+  getTotalSalesOtherGoods(value) {
+    return browser.element('[name="total-sales-other-goods"]').getValue()
+  }
+  getTotalSalesOtherGoodsLabel() {
+    return browser.element('#label-total-sales-other-goods')
+  }
+  getTotalSalesOtherGoodsElement() {
+    return browser.element('[name="total-sales-other-goods"]')
+  }
+}
+
+export default new OtherGoodsSalesPage()

--- a/tests/functional/pages/surveys/mci-refresh/reason-for-change.page.js
+++ b/tests/functional/pages/surveys/mci-refresh/reason-for-change.page.js
@@ -1,0 +1,60 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class ReasonForChangePage extends MultipleChoiceWithOtherPage {
+  constructor() {
+    super('reason-for-change')
+  }
+  clickReasonForChangeAnswerInStoreOnlinePromotions() {
+    browser.element('[id="reason-for-change-answer-0"]').click()
+    return this
+  }
+  ReasonForChangeAnswerInStoreOnlinePromotionsIsSelected() {
+    return browser.element('[id="reason-for-change-answer-0"]').isSelected()
+  }
+  clickReasonForChangeAnswerSpecialEventsEGSportingEvents() {
+    browser.element('[id="reason-for-change-answer-1"]').click()
+    return this
+  }
+  ReasonForChangeAnswerSpecialEventsEGSportingEventsIsSelected() {
+    return browser.element('[id="reason-for-change-answer-1"]').isSelected()
+  }
+  clickReasonForChangeAnswerCalendarEventsEGChristmasEasterBankHoliday() {
+    browser.element('[id="reason-for-change-answer-2"]').click()
+    return this
+  }
+  ReasonForChangeAnswerCalendarEventsEGChristmasEasterBankHolidayIsSelected() {
+    return browser.element('[id="reason-for-change-answer-2"]').isSelected()
+  }
+  clickReasonForChangeAnswerWeather() {
+    browser.element('[id="reason-for-change-answer-3"]').click()
+    return this
+  }
+  ReasonForChangeAnswerWeatherIsSelected() {
+    return browser.element('[id="reason-for-change-answer-3"]').isSelected()
+  }
+  clickReasonForChangeAnswerStoreClosures() {
+    browser.element('[id="reason-for-change-answer-4"]').click()
+    return this
+  }
+  ReasonForChangeAnswerStoreClosuresIsSelected() {
+    return browser.element('[id="reason-for-change-answer-4"]').isSelected()
+  }
+  clickReasonForChangeAnswerStoreOpenings() {
+    browser.element('[id="reason-for-change-answer-5"]').click()
+    return this
+  }
+  ReasonForChangeAnswerStoreOpeningsIsSelected() {
+    return browser.element('[id="reason-for-change-answer-5"]').isSelected()
+  }
+  clickReasonForChangeAnswerOther() {
+    browser.element('[id="reason-for-change-answer-6"]').click()
+    return this
+  }
+  ReasonForChangeAnswerOtherIsSelected() {
+    return browser.element('[id="reason-for-change-answer-6"]').isSelected()
+  }
+}
+
+export default new ReasonForChangePage()

--- a/tests/functional/pages/surveys/mci-refresh/reporting-period.page.js
+++ b/tests/functional/pages/surveys/mci-refresh/reporting-period.page.js
@@ -1,0 +1,53 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class ReportingPeriodPage extends QuestionPage {
+  constructor() {
+    super('reporting-period')
+  }
+  setPeriodFromDay(value) {
+    browser.setValue('[name="period-from-day"]', value)
+    return this
+  }
+  getPeriodFromDay(value) {
+    return browser.element('[name="period-from-day"]').getValue()
+  }
+  setPeriodFromMonth(value) {
+    browser.selectByValue('[name="period-from-month"]', value)
+    return this
+  }
+  getPeriodFromMonth(value) {
+    return browser.element('[name="period-from-month"]').getValue()
+  }
+  setPeriodFromYear(value) {
+    browser.setValue('[name="period-from-year"]', value)
+    return this
+  }
+  getPeriodFromYear(value) {
+    return browser.element('[name="period-from-year"]').getValue()
+  }
+  setPeriodToDay(value) {
+    browser.setValue('[name="period-to-day"]', value)
+    return this
+  }
+  getPeriodToDay(value) {
+    return browser.element('[name="period-to-day"]').getValue()
+  }
+  setPeriodToMonth(value) {
+    browser.selectByValue('[name="period-to-month"]', value)
+    return this
+  }
+  getPeriodToMonth(value) {
+    return browser.element('[name="period-to-month"]').getValue()
+  }
+  setPeriodToYear(value) {
+    browser.setValue('[name="period-to-year"]', value)
+    return this
+  }
+  getPeriodToYear(value) {
+    return browser.element('[name="period-to-year"]').getValue()
+  }
+}
+
+export default new ReportingPeriodPage()

--- a/tests/functional/pages/surveys/mci-refresh/significant-change.page.js
+++ b/tests/functional/pages/surveys/mci-refresh/significant-change.page.js
@@ -1,0 +1,25 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import MultipleChoiceWithOtherPage from '../multiple-choice.page'
+
+class SignificantChangePage extends MultipleChoiceWithOtherPage {
+  constructor() {
+    super('significant-change')
+  }
+  clickSignificantChangeEstablishedAnswerYes() {
+    browser.element('[id="significant-change-established-answer-0"]').click()
+    return this
+  }
+  SignificantChangeEstablishedAnswerYesIsSelected() {
+    return browser.element('[id="significant-change-established-answer-0"]').isSelected()
+  }
+  clickSignificantChangeEstablishedAnswerNo() {
+    browser.element('[id="significant-change-established-answer-1"]').click()
+    return this
+  }
+  SignificantChangeEstablishedAnswerNoIsSelected() {
+    return browser.element('[id="significant-change-established-answer-1"]').isSelected()
+  }
+}
+
+export default new SignificantChangePage()

--- a/tests/functional/pages/surveys/mci-refresh/summary.page.js
+++ b/tests/functional/pages/surveys/mci-refresh/summary.page.js
@@ -1,0 +1,11 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class SummaryPage extends QuestionPage {
+  constructor() {
+    super('summary')
+  }
+}
+
+export default new SummaryPage()

--- a/tests/functional/pages/surveys/mci-refresh/total-employees.page.js
+++ b/tests/functional/pages/surveys/mci-refresh/total-employees.page.js
@@ -1,0 +1,24 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class TotalEmployeesPage extends QuestionPage {
+  constructor() {
+    super('total-employees')
+  }
+  setTotalNumberEmployees(value) {
+    browser.setValue('[name="total-number-employees"]', value)
+    return this
+  }
+  getTotalNumberEmployees(value) {
+    return browser.element('[name="total-number-employees"]').getValue()
+  }
+  getTotalNumberEmployeesLabel() {
+    return browser.element('#label-total-number-employees')
+  }
+  getTotalNumberEmployeesElement() {
+    return browser.element('[name="total-number-employees"]')
+  }
+}
+
+export default new TotalEmployeesPage()

--- a/tests/functional/pages/surveys/mci-refresh/total-internet-sales.page.js
+++ b/tests/functional/pages/surveys/mci-refresh/total-internet-sales.page.js
@@ -1,0 +1,24 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class TotalInternetSalesPage extends QuestionPage {
+  constructor() {
+    super('total-internet-sales')
+  }
+  setInternetSales(value) {
+    browser.setValue('[name="internet-sales"]', value)
+    return this
+  }
+  getInternetSales(value) {
+    return browser.element('[name="internet-sales"]').getValue()
+  }
+  getInternetSalesLabel() {
+    return browser.element('#label-internet-sales')
+  }
+  getInternetSalesElement() {
+    return browser.element('[name="internet-sales"]')
+  }
+}
+
+export default new TotalInternetSalesPage()

--- a/tests/functional/pages/surveys/mci-refresh/total-retail-turnover-block.page.js
+++ b/tests/functional/pages/surveys/mci-refresh/total-retail-turnover-block.page.js
@@ -1,0 +1,24 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+
+import QuestionPage from '../question.page'
+
+class TotalRetailTurnoverBlockPage extends QuestionPage {
+  constructor() {
+    super('total-retail-turnover-block')
+  }
+  setTotalRetailTurnover(value) {
+    browser.setValue('[name="total-retail-turnover"]', value)
+    return this
+  }
+  getTotalRetailTurnover(value) {
+    return browser.element('[name="total-retail-turnover"]').getValue()
+  }
+  getTotalRetailTurnoverLabel() {
+    return browser.element('#label-total-retail-turnover')
+  }
+  getTotalRetailTurnoverElement() {
+    return browser.element('[name="total-retail-turnover"]')
+  }
+}
+
+export default new TotalRetailTurnoverBlockPage()

--- a/tests/functional/spec/mci-refresh.spec.js
+++ b/tests/functional/spec/mci-refresh.spec.js
@@ -1,0 +1,127 @@
+import {startQuestionnaire} from '../helpers'
+import {openQuestionnaire} from '../helpers'
+
+import landingPage from '../pages/landing.page'
+import Introduction from '../pages/surveys/mci-refresh/introduction.page.js'
+import ReportingPeriod from '../pages/surveys/mci-refresh/reporting-period.page.js'
+import TotalRetailTurnoverBlock from '../pages/surveys/mci-refresh/total-retail-turnover-block.page.js'
+import FoodSales from '../pages/surveys/mci-refresh/food-sales.page.js'
+import AlcoholSales from '../pages/surveys/mci-refresh/alcohol-sales.page.js'
+import ClothingSales from '../pages/surveys/mci-refresh/clothing-sales.page.js'
+import HouseholdGoodsSales from '../pages/surveys/mci-refresh/household-goods-sales.page.js'
+import OtherGoodsSales from '../pages/surveys/mci-refresh/other-goods-sales.page.js'
+import TotalInternetSales from '../pages/surveys/mci-refresh/total-internet-sales.page.js'
+import AutomotiveFuel from '../pages/surveys/mci-refresh/automotive-fuel.page.js'
+import SignificantChange from '../pages/surveys/mci-refresh/significant-change.page.js'
+import ReasonForChange from '../pages/surveys/mci-refresh/reason-for-change.page.js'
+import ChangeCommentBlock from '../pages/surveys/mci-refresh/change-comment-block.page.js'
+import TotalEmployees from '../pages/surveys/mci-refresh/total-employees.page.js'
+import EmployeesBreakdown from '../pages/surveys/mci-refresh/employees-breakdown.page.js'
+import Summary from '../pages/surveys/mci-refresh/summary.page.js'
+import thankYou from '../pages/thank-you.page'
+
+
+describe('MCI 0215 Test', function() {
+
+  it('Given the mci business survey 0215 is selected when I start the survey then the landing page is displayed', function() {
+    // Given
+    // When
+    openQuestionnaire('mci_refresh.json')
+
+    // Then
+    expect(landingPage.isOpen(), 'Landing page should be open').to.be.true
+  })
+
+  it('Given the mci business survey 0215 has been started when I complete the survey then I reach the thank you page', function() {
+    // Given
+    startQuestionnaire('mci_refresh.json')
+
+    // When
+    ReportingPeriod.setPeriodFromDay('01')
+        .setPeriodFromMonth(5)
+        .setPeriodFromYear('2016')
+        .setPeriodToDay('31')
+        .setPeriodToMonth(5)
+        .setPeriodToYear('2016')
+        .submit()
+
+    TotalRetailTurnoverBlock.setTotalRetailTurnover('1234567')
+        .submit()
+
+    FoodSales.setTotalSalesFood('7')
+        .submit()
+
+    AlcoholSales.setTotalSalesAlcohol('60')
+        .submit()
+
+    ClothingSales.setTotalSalesClothing('500')
+        .submit()
+
+    HouseholdGoodsSales.setTotalSalesHouseholdGoods('4000')
+        .submit()
+
+    OtherGoodsSales.setTotalSalesOtherGoods('30000')
+        .submit()
+
+    TotalInternetSales.setInternetSales('200000')
+        .submit()
+
+    AutomotiveFuel.setTotalSalesAutomotiveFuel('1000000')
+        .submit()
+
+    SignificantChange.clickSignificantChangeEstablishedAnswerYes()
+        .submit()
+
+    ReasonForChange.clickReasonForChangeAnswerWeather()
+        .submit()
+
+    ChangeCommentBlock.setChangeComment('Bad weather reduced shop footfall')
+        .submit()
+
+    TotalEmployees.setTotalNumberEmployees('100')
+        .submit()
+
+    EmployeesBreakdown.setNumberMaleEmployeesOver30Hours('10')
+        .setNumberMaleEmployeesUnder30Hours('20')
+        .setNumberFemaleEmployeesOver30Hours('30')
+        .setNumberFemaleEmployeesUnder30Hours('40')
+        .submit()
+
+    Summary.submit()
+
+    // Then
+    expect(thankYou.isOpen(), 'Thank you page should be open').to.be.true
+  })
+
+  it('Given the mci business survey 0215 has been started and sales questions completed when I select No for significant changes I skip to total employees question', function() {
+    // Given
+    startQuestionnaire('mci_refresh.json')
+
+    ReportingPeriod.setPeriodFromDay('01')
+        .setPeriodFromMonth(5)
+        .setPeriodFromYear('2016')
+        .setPeriodToDay('31')
+        .setPeriodToMonth(5)
+        .setPeriodToYear('2016')
+        .submit()
+
+    TotalRetailTurnoverBlock.setTotalRetailTurnover('0')
+        .submit()
+    FoodSales.submit()
+    AlcoholSales.submit()
+    ClothingSales.submit()
+    HouseholdGoodsSales.submit()
+    OtherGoodsSales.submit()
+    TotalInternetSales.submit()
+    AutomotiveFuel.submit()
+
+    // When
+    SignificantChange.clickSignificantChangeEstablishedAnswerNo()
+        .submit()
+
+    // Then
+    expect(TotalEmployees.isOpen(), 'Total Employees page should be open').to.be.true
+  })
+
+})
+


### PR DESCRIPTION
### What is the context of this PR?
For the respondent to have a more up to date pattern and functionality on the MCI survey (0215).

### How to review 
From the trello card https://trello.com/c/y4lXGGQi/1052-mci-refresh
Spec: https://docs.google.com/presentation/d/1VYmB1jJsxbJFRFvuOUh1zUZB_Rk2eIbjfX1d5hhF6u8/edit#slide=id.g1ba6eee5f3_0_82

On the refreshed MCI you will see:

Comments question broken into 3 questions as per the spec
Piping (trad_as or Ru, dates, values)
Highlighting (to be confirmed with DCM if any required)
Single question per page (except for totals with breakdowns)
Include 'Round to the nearest pound. Do not include pence.' This goes immediately above entry field
It will match the finalised, agreed specification
MCI will not use navigation
Summary screen will not be negatively impacted