### PR TITLE
Show/Hide further guidance

### DIFF
--- a/app/assets/styles/partials/components/_guidance.scss
+++ b/app/assets/styles/partials/components/_guidance.scss
@@ -74,25 +74,5 @@
   border-left: 2px solid $color-borders;
   padding-left: 1rem;
   margin-left: 1px;
-  div {
-    @include mq(s) {
-      display: table-cell;
-      &:first-of-type {
-        padding-left: 0.25rem;
-        padding-right: 0.5rem;
-      }
-      &:last-of-type {
-        padding-left: 1rem;
-      }
-    }
-    ul {
-      padding-left: 1rem;
-      @include mq(s) {
-        margin-bottom: 0;
-      }
-      @include lt-ie8 {
-        margin-bottom: 1rem;
-      }
-    }
-  }
+
 }

--- a/app/assets/styles/partials/utilities/_display.scss
+++ b/app/assets/styles/partials/utilities/_display.scss
@@ -1,3 +1,7 @@
 .u-d-no {
   display: none;
 }
+
+.u-d-b {
+  display: block;
+}

--- a/app/templates/partials/answer-guidance.html
+++ b/app/templates/partials/answer-guidance.html
@@ -1,8 +1,8 @@
 {% import 'macros/helpers.html' as helpers %}
 
 {% set guidance = {
-  "data-show-label": _("Show further guidance"),
-  "data-hide-label": _("Hide further guidance")
+  "data-show-label": _(answer_guidance.schema_item.show_guidance),
+  "data-hide-label": _(answer_guidance.schema_item.hide_guidance)
 } %}
 
 {% set guidance_link = {
@@ -18,12 +18,16 @@
   "aria-hidden": "true"
 } %}
 
+{% set guidance_content = {
+  "content": answer_guidance.schema_item.content
+} %}
+
 <div class="guidance js-details" {{guidance|xmlattr}}>
   <a class="guidance__link js-details-trigger js-details-label mars"
-    {{guidance_link|xmlattr}} {{helpers.track('click', 'Help', 'Guidance click', answer_guidance.id)}}>{{_("Show further guidance")}}</a>
+    {{guidance_link|xmlattr}} {{helpers.track('click', 'Help', 'Guidance click', answer_guidance.id)}}>{{_(answer_guidance.schema_item.show_guidance)}}</a>
   <div class="guidance__main js-details-body" {{guidance_body|xmlattr}}>
     <div class="guidance__content mars">
-      {{answer_guidance.content}}
+      {% include 'partials/guidance.html' %}
     </div>
   </div>
 </div>

--- a/app/templates/partials/answer.html
+++ b/app/templates/partials/answer.html
@@ -11,7 +11,7 @@
       {% with answer_guidance = {
         'id': answer.id,
         'label': answer.label,
-        'content': answer.guidance
+        'schema_item': answer.guidance
       } %}
         {% include 'partials/answer-guidance.html' %}
       {% endwith %}

--- a/app/templates/partials/guidance.html
+++ b/app/templates/partials/guidance.html
@@ -1,0 +1,17 @@
+{% import 'macros/helpers.html' as helpers %}
+
+{% for item in guidance_content.content %}
+  {%- if item.title -%}
+    <strong class="u-mb-s u-d-b">{{item.title}}</strong>
+  {% endif %}
+  {%- if item.description -%}
+    <p>{{item.description}}</p>
+  {% endif %}
+  {%- if item.list -%}
+    <ul class="mars">
+      {%- for list_item in item.list -%}
+        <li>{{list_item}}</li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+{% endfor %}

--- a/app/templates/partials/question.html
+++ b/app/templates/partials/question.html
@@ -31,23 +31,12 @@
 
 {% set question_guidance %}
   {%- if question.guidance -%}
+    {% set guidance_content = {
+      "content": question.guidance.content
+    } %}
     <aside class="question__guidance">
       <div class="panel panel--simple panel--info" id="question-guidance-{{question.id}}">
-        {%- for guidance in question.guidance -%}
-          {%- if guidance.title -%}
-            <h3 class="venus">{{guidance.title}}</h3>
-          {% endif %}
-          {%- if guidance.description -%}
-            <div class="mars">{{guidance.description}}</div>
-          {% endif %}
-          {%- if guidance.list -%}
-            <ul class="mars">
-              {%- for item in guidance.list -%}
-                <li>{{item}}</li>
-              {% endfor %}
-            </ul>
-          {% endif %}
-        {% endfor %}
+        {% include 'partials/guidance.html' %}
       </div>
     </aside>
   {% endif %}

--- a/app/templates/partials/questions/relationship.html
+++ b/app/templates/partials/questions/relationship.html
@@ -22,23 +22,20 @@
   </fieldset>
 </div>
 
-{% if (question.guidance) %}
+<aside class="question__guidance  question__guidance--bottom">
+    {% set schema_item = question.answers[-1] %}
+    {% if schema_item.guidance %}
+      {% with answer_guidance = {
+        'id': schema_item.id,
+        'label': schema_item.label,
+        'schema_item': {
+            'content': schema_item.guidance.content,
+            'show_guidance': schema_item.guidance.show_guidance,
+            'hide_guidance': schema_item.guidance.hide_guidance
+        }
+      } %}
+        {% include 'partials/answer-guidance.html' %}
+      {% endwith %}
+    {% endif %}
+</aside>
 
-  {% set question_guidance %}
-    {%- for guidance in question.guidance -%}
-      <ul class="u-m-no">
-        {%- for item in guidance.list -%}
-          <li>{{item}}</li>
-        {% endfor %}
-      </ul>
-    {% endfor %}
-  {% endset %}
-
-  {% with answer_guidance = {
-    'id': question.id,
-    'label': question.label,
-    'content': question_guidance
-  } %}
-    {% include 'partials/answer-guidance.html' %}
-  {% endwith %}
-{% endif %}

--- a/app/templates/partials/questions/repeatinganswer.html
+++ b/app/templates/partials/questions/repeatinganswer.html
@@ -57,11 +57,14 @@
       {% with answer_guidance = {
         'id': schema_item.id,
         'label': schema_item.label,
-        'content': schema_item.guidance
-        } %}
+        'schema_item': {
+            'content': schema_item.guidance.content,
+            'show_guidance': schema_item.guidance.show_guidance,
+            'hide_guidance': schema_item.guidance.hide_guidance
+        }
+      } %}
         {% include 'partials/answer-guidance.html' %}
       {% endwith %}
     {% endif %}
   </aside>
-
 </div>

--- a/data/en/0_rogue_one.json
+++ b/data/en/0_rogue_one.json
@@ -21,7 +21,6 @@
                         "questions": [{
                             "answers": [{
                                 "alias": "character",
-                                "guidance": "",
                                 "id": "character-answer",
                                 "label": "Who do you want to know more about?",
                                 "mandatory": true,
@@ -106,7 +105,6 @@
                         "id": "jyn-erso-like-this-page-section",
                         "questions": [{
                             "answers": [{
-                                "guidance": "",
                                 "id": "jyn-erso-like-this-page-answer",
                                 "label": "",
                                 "mandatory": true,
@@ -148,7 +146,6 @@
                         "id": "cassian-andor-like-this-page-section",
                         "questions": [{
                             "answers": [{
-                                "guidance": "",
                                 "id": "cassian-andor-like-this-page-answer",
                                 "label": "",
                                 "mandatory": true,
@@ -190,7 +187,6 @@
                         "id": "bodhi-rook-like-this-page-section",
                         "questions": [{
                             "answers": [{
-                                "guidance": "",
                                 "id": "bodhi-rook-like-this-page-answer",
                                 "label": "",
                                 "mandatory": true,
@@ -232,7 +228,6 @@
                         "id": "orson-krennic-like-this-page-section",
                         "questions": [{
                             "answers": [{
-                                "guidance": "",
                                 "id": "orson-krennic-like-this-page-answer",
                                 "label": "",
                                 "mandatory": true,
@@ -274,7 +269,6 @@
                         "id": "film-takings-section",
                         "questions": [{
                             "answers": [{
-                                "guidance": "",
                                 "id": "film-takings-answer",
                                 "label": "",
                                 "mandatory": true,

--- a/data/en/0_star_wars.json
+++ b/data/en/0_star_wars.json
@@ -29,7 +29,6 @@
                     "id": "choose-your-side-section",
                     "questions": [{
                         "answers": [{
-                            "guidance": "",
                             "id": "choose-your-side-answer",
                             "label": "Choose a side",
                             "mandatory": true,
@@ -114,7 +113,6 @@
                     "id": "light-side-pick-character-ship-section",
                     "questions": [{
                             "answers": [{
-                                "guidance": "",
                                 "id": "light-side-pick-character-answer",
                                 "label": "",
                                 "mandatory": true,
@@ -148,7 +146,6 @@
                         },
                         {
                             "answers": [{
-                                "guidance": "",
                                 "id": "light-side-pick-ship-answer",
                                 "label": "",
                                 "mandatory": true,
@@ -206,7 +203,6 @@
                     "id": "dark-side-pick-character-ship-section",
                     "questions": [{
                             "answers": [{
-                                "guidance": "",
                                 "id": "dark-side-pick-character-answer",
                                 "label": "",
                                 "mandatory": true,
@@ -240,7 +236,6 @@
                         },
                         {
                             "answers": [{
-                                "guidance": "",
                                 "id": "dark-side-pick-ship-answer",
                                 "label": "",
                                 "mandatory": true,
@@ -312,7 +307,6 @@
                     "id": "light-side-ship-type-section",
                     "questions": [{
                         "answers": [{
-                            "guidance": "",
                             "id": "light-side-ship-type-answer",
                             "label": "",
                             "mandatory": true,
@@ -353,7 +347,6 @@
                     "id": "dark-side-ship-type-section",
                     "questions": [{
                         "answers": [{
-                            "guidance": "",
                             "id": "dark-side-ship-type-answer",
                             "label": "",
                             "mandatory": true,
@@ -394,7 +387,6 @@
                     "id": "star-wars-trivia-section",
                     "questions": [{
                             "answers": [{
-                                "guidance": "",
                                 "id": "death-star-plans-answer",
                                 "label": "Which species stole the plans to the second Death Star?",
                                 "mandatory": false,
@@ -410,7 +402,6 @@
                         {
                             "answers": [{
                                 "alias": "chewies_age",
-                                "guidance": "",
                                 "id": "chewies-age-answer",
                                 "label": "How old is Chewy?",
                                 "mandatory": true,
@@ -432,7 +423,6 @@
                         },
                         {
                             "answers": [{
-                                "guidance": "",
                                 "id": "death-star-cost-answer",
                                 "label": "How many Octillions do Nasa reckon it would cost to build a death star?",
                                 "mandatory": true,
@@ -454,7 +444,6 @@
                         },
                         {
                             "answers": [{
-                                "guidance": "",
                                 "id": "lightsaber-cost-answer",
                                 "label": "How hot is a lightsaber in degrees C?",
                                 "mandatory": false,
@@ -476,7 +465,6 @@
                         },
                         {
                             "answers": [{
-                                "guidance": "",
                                 "id": "tie-fighter-sound-answer",
                                 "label": "",
                                 "mandatory": true,
@@ -507,7 +495,6 @@
                         },
                         {
                             "answers": [{
-                                "guidance": "",
                                 "id": "darth-vader-quotes-answer",
                                 "label": "",
                                 "mandatory": false,
@@ -538,7 +525,6 @@
                         },
                         {
                             "answers": [{
-                                "guidance": "",
                                 "id": "green-lightsaber-answer",
                                 "label": "",
                                 "mandatory": true,
@@ -578,7 +564,6 @@
                         },
                         {
                             "answers": [{
-                                "guidance": "",
                                 "id": "opening-crawler-answer",
                                 "label": "",
                                 "mandatory": false,
@@ -617,7 +602,6 @@
                         },
                         {
                             "answers": [{
-                                    "guidance": "",
                                     "id": "empire-strikes-back-from-answer",
                                     "label": "Period from",
                                     "mandatory": true,
@@ -632,7 +616,6 @@
                                     }
                                 },
                                 {
-                                    "guidance": "",
                                     "id": "empire-strikes-back-to-answer",
                                     "label": "Period to",
                                     "mandatory": true,
@@ -665,7 +648,6 @@
                         "id": "star-wars-trivia-part-2-section-1",
                         "questions": [{
                             "answers": [{
-                                "guidance": "",
                                 "id": "jar-jar-binks-answer",
                                 "label": "What was the total number of Ewoks?",
                                 "mandatory": false,
@@ -692,7 +674,6 @@
                         "id": "star-wars-trivia-part-2-section-2",
                         "questions": [{
                                 "answers": [{
-                                    "guidance": "",
                                     "id": "rebel-alliance-answer",
                                     "label": "What else did the Bothan spies steal for the Rebel Alliance?",
                                     "mandatory": false,
@@ -714,7 +695,6 @@
                             },
                             {
                                 "answers": [{
-                                    "guidance": "",
                                     "id": "chewbacca-medal-answer",
                                     "label": "Why doesn't Chewbacca receive a medal at the end of A New Hope?",
                                     "mandatory": true,
@@ -729,7 +709,6 @@
                             },
                             {
                                 "answers": [{
-                                    "guidance": "",
                                     "id": "confirm-chewbacca-age-answer",
                                     "label": "",
                                     "mandatory": true,
@@ -752,7 +731,6 @@
                             },
                             {
                                 "answers": [{
-                                    "guidance": "",
                                     "id": "star-wars-prequel-answer",
                                     "label": "",
                                     "mandatory": false,
@@ -787,7 +765,6 @@
                     "id": "star-wars-trivia-part-3-section",
                     "questions": [{
                             "answers": [{
-                                "guidance": "",
                                 "id": "jar-jar-binks-planet-answer",
                                 "label": "What is the name of Jar Jar Binks' home planet?",
                                 "mandatory": true,
@@ -809,7 +786,6 @@
                         },
                         {
                             "answers": [{
-                                "guidance": "",
                                 "id": "favourite-film-answer",
                                 "label": "",
                                 "mandatory": false,

--- a/data/en/1_0001.json
+++ b/data/en/1_0001.json
@@ -233,22 +233,22 @@
                                 }
                             ],
                             "description": "",
-                            "guidance": [{
-                                    "description": "",
-                                    "list": [
-                                        "all <em>new</em> and <em>significantly improved</em> forms of organisation, business structures or practices aimed at raising internal efficiency or the effectiveness of approaching markets and customers.",
-                                        "changes that have been implemented during the 3 year period"
-                                    ],
-                                    "title": "Include:"
-                                },
-                                {
-                                    "description": "",
-                                    "list": [
-                                        "ongoing changes"
-                                    ],
-                                    "title": "Exclude:"
-                                }
-                            ],
+                            "guidance": {
+                                "content": [{
+                                        "title": "Include:",
+                                        "list": [
+                                            "all <em>new</em> and <em>significantly improved</em> forms of organisation, business structures or practices aimed at raising internal efficiency or the effectiveness of approaching markets and customers.",
+                                            "changes that have been implemented during the 3 year period"
+                                        ]
+                                    },
+                                    {
+                                        "title": "Exclude:",
+                                        "list": [
+                                            "ongoing changes"
+                                        ]
+                                    }
+                                ]
+                            },
                             "id": "business-changes-question",
                             "number": "2.1",
                             "title": "Did {{respondent.ru_name}} make changes in the following areas?",
@@ -321,13 +321,14 @@
                                 "type": "Radio"
                             }],
                             "description": "",
-                            "guidance": [{
-                                "description": "",
-                                "list": [
-                                    "Creative work undertaken within your business that increases knowledge for developing new and improved goods or services and processes."
-                                ],
-                                "title": "Definition of ‘internal Research and Development’:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Definition of ‘internal Research and Development’:",
+                                    "list": [
+                                        "Creative work undertaken within your business that increases knowledge for developing new and improved goods or services and processes."
+                                    ]
+                                }]
+                            },
                             "id": "internal-investment-r-d-question",
                             "number": "3.1",
                             "title": "Did {{respondent.ru_name}} invest in <em>internal Research and Development</em> for the purposes of current or future innovation?",
@@ -410,13 +411,14 @@
                                 "type": "Currency"
                             }],
                             "description": "",
-                            "guidance": [{
-                                "description": "",
-                                "list": [
-                                    "Internal costs and purchases from outside the business"
-                                ],
-                                "title": "Include:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "Internal costs and purchases from outside the business"
+                                    ]
+                                }]
+                            },
                             "id": "expenditure-internal-investment-r-d-question",
                             "number": "3.3",
                             "title": "Please estimate the amount of expenditure on internal Research & Development  the <em>calendar  year 2016 only</em>?",
@@ -467,13 +469,14 @@
                                 "type": "Radio"
                             }],
                             "description": "",
-                            "guidance": [{
-                                "description": "",
-                                "list": [
-                                    "Creative work undertaken  by companies, including other businesses within your group, or by public or private research organisations and purchased by your business"
-                                ],
-                                "title": "Include:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "Creative work undertaken  by companies, including other businesses within your group, or by public or private research organisations and purchased by your business"
+                                    ]
+                                }]
+                            },
                             "id": "acquisition-internal-investment-r-d-question",
                             "number": "3.4",
                             "title": "Did {{respondent.ru_name}} invest in the <em>acquisition of</em><em> Research and Development</em> for the purposes of current or future innovation?",
@@ -500,13 +503,14 @@
                                 "type": "Currency"
                             }],
                             "description": "",
-                            "guidance": [{
-                                "description": "",
-                                "list": [
-                                    "Internal costs and purchases from outside the business"
-                                ],
-                                "title": "Include:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "Internal costs and purchases from outside the business"
+                                    ]
+                                }]
+                            },
                             "id": "amount-acquisition-internal-investment-r-d-question",
                             "number": "3.5",
                             "title": "Please estimate the amount of expenditure on acquisition of Research & Development in  the <em>calendar  year 2016 only</em>?",
@@ -623,13 +627,14 @@
                                 "type": "Currency"
                             }],
                             "description": "",
-                            "guidance": [{
-                                "description": "",
-                                "list": [
-                                    "Internal costs and purchase from outside the business"
-                                ],
-                                "title": "Include:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "Internal costs and purchase from outside the business"
+                                    ]
+                                }]
+                            },
                             "id": "amount-acquisition-advanced-machinery-question",
                             "number": "3.8",
                             "title": "Please estimate the amount of expenditure for the total acquisition of advanced machinery, equipment and software for  the <em>calendar year 2016 only</em>?",
@@ -680,13 +685,14 @@
                                 "type": "Radio"
                             }],
                             "description": "",
-                            "guidance": [{
-                                "description": "",
-                                "list": [
-                                    "Purchase or licensing of patents and non-patented inventions, know-how and other types of knowledge from other businesses or organisations"
-                                ],
-                                "title": "Include:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "Purchase or licensing of patents and non-patented inventions, know-how and other types of knowledge from other businesses or organisations"
+                                    ]
+                                }]
+                            },
                             "id": "investment-existing-knowledge-innovation-question",
                             "number": "3.9",
                             "title": "Did {{respondent.ru_name}} invest in the <em>acquisition of existing knowledge</em> for the purposes of current or future innovation?",
@@ -713,13 +719,14 @@
                                 "type": "Currency"
                             }],
                             "description": "",
-                            "guidance": [{
-                                "description": "",
-                                "list": [
-                                    "Internal costs and purchase from outside {{respondent.ru_name}}"
-                                ],
-                                "title": "Include:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "Internal costs and purchase from outside {{respondent.ru_name}}"
+                                    ]
+                                }]
+                            },
                             "id": "expenditure-existing-2016-question",
                             "number": "3.10",
                             "title": "Please estimate the amount of expenditure for acquisition of existing knowledge for the <em>calendar year 2016 only</em>?",
@@ -770,13 +777,14 @@
                                 "type": "Radio"
                             }],
                             "description": "",
-                            "guidance": [{
-                                "description": "",
-                                "list": [
-                                    "Internal or external training for your personnel, specifically for the development or implementation of new or improved goods, services and processes."
-                                ],
-                                "title": "Include:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "Internal or external training for your personnel, specifically for the development or implementation of new or improved goods, services and processes."
+                                    ]
+                                }]
+                            },
                             "id": "investment-training-innovative-question",
                             "number": "3.11",
                             "title": "Did {{respondent.ru_name}} invest in <em>training for innovative activities</em> for the purposes of current or future innovation?",
@@ -803,13 +811,14 @@
                                 "type": "Currency"
                             }],
                             "description": "",
-                            "guidance": [{
-                                "description": "",
-                                "list": [
-                                    "Internal costs and purchase from outside the business"
-                                ],
-                                "title": "Include:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "Internal costs and purchase from outside the business"
+                                    ]
+                                }]
+                            },
                             "id": "expenditure-training-innovative-2016-question",
                             "number": "3.12",
                             "title": "Please estimate the amount of expenditure for training for innovative activities for the <em>calendar year 2016 only</em>?",
@@ -860,13 +869,14 @@
                                 "type": "Radio"
                             }],
                             "description": "",
-                            "guidance": [{
-                                "description": "",
-                                "list": [
-                                    "Engagement in all design activities, including strategic, for the development or implementation of new or improved goods, services and processes."
-                                ],
-                                "title": "Include:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "Engagement in all design activities, including strategic, for the development or implementation of new or improved goods, services and processes."
+                                    ]
+                                }]
+                            },
                             "id": "investment-design-future-innovation-question",
                             "number": "3.13",
                             "title": "Did {{respondent.ru_name}} invest in <em>all forms of design</em> for the purposes of current or future innovation?",
@@ -893,13 +903,14 @@
                                 "type": "Currency"
                             }],
                             "description": "",
-                            "guidance": [{
-                                "description": "",
-                                "list": [
-                                    "Internal costs and purchase from outside the business"
-                                ],
-                                "title": "Include:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "Internal costs and purchase from outside the business"
+                                    ]
+                                }]
+                            },
                             "id": "expenditure-design-2016-question",
                             "number": "3.14",
                             "title": "Please estimate the amount of expenditure for all forms of design for the <em>calendar year 2016 only</em>?",
@@ -1021,13 +1032,14 @@
                                 "type": "Currency"
                             }],
                             "description": "",
-                            "guidance": [{
-                                "description": "",
-                                "list": [
-                                    "Internal costs and purchase from outside the business"
-                                ],
-                                "title": "Include:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "Internal costs and purchase from outside the business"
+                                    ]
+                                }]
+                            },
                             "id": "expenditure-introduction-innovations-2016-question",
                             "number": "3.17",
                             "title": "Please estimate the amount of expenditure for market introduction of innovations for the <em>calendar year 2016 only</em>?",
@@ -1100,23 +1112,23 @@
                                 "type": "Radio"
                             }],
                             "description": "",
-                            "guidance": [{
-                                    "description": "",
-                                    "list": [
-                                        "all <em>new</em> or <em>significantly improved</em> goods (for example, improvement in quality or distinct user benefits)",
-                                        "goods innovations that are new to the business, even if they are not new to the market",
-                                        "all product innovations, regardless of their origin"
-                                    ],
-                                    "title": "Include:"
-                                },
-                                {
-                                    "description": "",
-                                    "list": [
-                                        "the simple resale of goods purchased from other businesses and changes of a solely aesthetic nature"
-                                    ],
-                                    "title": "Exclude:"
-                                }
-                            ],
+                            "guidance": {
+                                "content": [{
+                                        "title": "Include:",
+                                        "list": [
+                                            "all <em>new</em> or <em>significantly improved</em> goods (for example, improvement in quality or distinct user benefits)",
+                                            "goods innovations that are new to the business, even if they are not new to the market",
+                                            "all product innovations, regardless of their origin"
+                                        ]
+                                    },
+                                    {
+                                        "title": "Exclude:",
+                                        "list": [
+                                            "the simple resale of goods purchased from other businesses and changes of a solely aesthetic nature"
+                                        ]
+                                    }
+                                ]
+                            },
                             "id": "introducing-significantly-improved-goods-question",
                             "number": "4.1",
                             "title": "Did {{respondent.ru_name}} introduce new or significantly improved <em>goods</em>?",
@@ -1217,14 +1229,15 @@
                                 "type": "Radio"
                             }],
                             "description": "",
-                            "guidance": [{
-                                "description": "",
-                                "list": [
-                                    "all <em>new</em> or <em>significantly improved</em> services (for example, improvement in quality or distinct user benefits)",
-                                    "services innovations that are new to the business, even if they are not new to the market"
-                                ],
-                                "title": "Include:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "all <em>new</em> or <em>significantly improved</em> services (for example, improvement in quality or distinct user benefits)",
+                                        "services innovations that are new to the business, even if they are not new to the market"
+                                    ]
+                                }]
+                            },
                             "id": "introduce-significantly-improvement-question",
                             "number": "4.3",
                             "title": "Did {{respondent.ru_name}} introduce new or significantly improved <em>services</em>?",
@@ -1299,13 +1312,14 @@
                                 "type": "Radio"
                             }],
                             "description": "",
-                            "guidance": [{
-                                "description": "",
-                                "list": [
-                                    "Goods or services this business introduced to the market before competitors"
-                                ],
-                                "title": "Include:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "Goods or services this business introduced to the market before competitors"
+                                    ]
+                                }]
+                            },
                             "id": "new-goods-services-innovations-question",
                             "number": "4.5",
                             "title": "Were any of your <em>goods and services innovations</em> new to the <em>market</em>?",
@@ -1340,13 +1354,14 @@
                                 "type": "Radio"
                             }],
                             "description": "",
-                            "guidance": [{
-                                "description": "",
-                                "list": [
-                                    "New goods or services that were essentially the same as a good or service already available from competitors"
-                                ],
-                                "title": "Include:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "New goods or services that were essentially the same as a good or service already available from competitors"
+                                    ]
+                                }]
+                            },
                             "id": "goods-services-innovations-new-question",
                             "number": "4.6",
                             "title": "Were any of your <em>goods and services innovations</em> only new to  <em>{{respondent.ru_name}}</em>?",
@@ -1436,13 +1451,14 @@
                                 }
                             ],
                             "description": "",
-                            "guidance": [{
-                                "description": "",
-                                "list": [
-                                    "The market sales of goods and services (including all taxes except VAT)"
-                                ],
-                                "title": "Definition of ‘turnover’:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Definition of ‘turnover’:",
+                                    "list": [
+                                        "The market sales of goods and services (including all taxes except VAT)"
+                                    ]
+                                }]
+                            },
                             "id": "percentage-turnover-2016-question",
                             "number": "4.7",
                             "title": "Please <em>estimate</em> the percentage of {{respondent.ru_name}}’s <em>total</em> turnover in <em>calendar year 2016 only</em> from goods and services that were:",
@@ -1515,15 +1531,16 @@
                                 "type": "Radio"
                             }],
                             "description": "",
-                            "guidance": [{
-                                "description": "",
-                                "list": [
-                                    "all new or significantly improved methods for the production or supply of goods or services",
-                                    "process innovations that are new to {{respondent.ru_name}}, even if they are not new to your industry",
-                                    "all process innovations, regardless of their origin"
-                                ],
-                                "title": "Include:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "all new or significantly improved methods for the production or supply of goods or services",
+                                        "process innovations that are new to {{respondent.ru_name}}, even if they are not new to your industry",
+                                        "all process innovations, regardless of their origin"
+                                    ]
+                                }]
+                            },
                             "id": "process-improved-question",
                             "number": "5.1",
                             "title": "Did {{respondent.ru_name}} introduce any new or significantly improved <em>processes</em> for producing or supplying goods or services?",
@@ -1731,11 +1748,15 @@
                                 "type": "Radio"
                             }],
                             "description": "",
-                            "guidance": [{
-                                "description": "what constitutes an answer of 'high', 'medium', 'low', or ‘not important’ is dependent on your own interpretation in relation to {{respondent.ru_name}}",
-                                "list": [],
-                                "title": "Please note:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                        "title": "Please note:"
+                                    },
+                                    {
+                                        "description": "what constitutes an answer of 'high', 'medium', 'low', or ‘not important’ is dependent on your own interpretation in relation to {{respondent.ru_name}}"
+                                    }
+                                ]
+                            },
                             "id": "constraining-innovation-economic-question",
                             "number": "6.2",
                             "title": "How important were the following factors in constraining innovation activities?",
@@ -3142,7 +3163,17 @@
                                 ],
                                 "q_code": "1632",
                                 "type": "Radio",
-                                "guidance": "<p><strong>Definition of ‘public sector’</strong></p><p>The public sector includes government owned organisations such as local, regional and national administrations and agencies, schools, hospitals and government providers of services such as security, transport, housing and energy etc.</p>"
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                            "title": "Definition of ‘public sector’"
+                                        },
+                                        {
+                                            "description": "The public sector includes government owned organisations such as local, regional and national administrations and agencies, schools, hospitals and government providers of services such as security, transport, housing and energy etc."
+                                        }
+                                    ]
+                                }
                             }],
                             "description": "",
                             "id": "importances-information-public-sector-question",
@@ -3769,7 +3800,17 @@
                                     }
                                 ],
                                 "type": "Checkbox",
-                                "guidance": "<p><strong>Definition of ‘public sector’</strong></p><p>The public sector includes government owned organisations such as local, regional and national administrations and agencies, schools, hospitals and government providers of services such as security, transport, housing and energy etc.</p>"
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                            "title": "Definition of ‘public sector’"
+                                        },
+                                        {
+                                            "description": "The public sector includes government owned organisations such as local, regional and national administrations and agencies, schools, hospitals and government providers of services such as security, transport, housing and energy etc."
+                                        }
+                                    ]
+                                }
                             }],
                             "description": "",
                             "id": "co-operation-public-sector-question",
@@ -4441,22 +4482,24 @@
                                 }
                             ],
                             "description": "",
-                            "guidance": [{
-                                    "list": [
-                                        "financial support via tax credits or deductions, grants, subsidised loans and loan guarantees"
-                                    ],
-                                    "title": "Include:"
-                                },
-                                {
-                                    "list": [
-                                        "Research and Development and other innovations activities conducted entirely for the <em>public sector</em> under contract."
-                                    ],
-                                    "title": "Exclude:"
-                                },
-                                {
-                                    "description": "The public sector includes government owned organisations such as local, regional and national administrations and agencies, schools, hospitals and government providers of services such as security, transport, housing and energy"
-                                }
-                            ],
+                            "guidance": {
+                                "content": [{
+                                        "title": "Include:",
+                                        "list": [
+                                            "financial support via tax credits or deductions, grants, subsidised loans and loan guarantees"
+                                        ]
+                                    },
+                                    {
+                                        "title": "Exclude:",
+                                        "list": [
+                                            "Research and Development and other innovations activities conducted entirely for the <em>public sector</em> under contract."
+                                        ]
+                                    },
+                                    {
+                                        "description": "The public sector includes government owned organisations such as local, regional and national administrations and agencies, schools, hospitals and government providers of services such as security, transport, housing and energy"
+                                    }
+                                ]
+                            },
                             "id": "public-financial-support-question",
                             "number": "10.1",
                             "title": "Did {{respondent.ru_name}} receive public financial support for innovation activities from the following levels of government?",
@@ -4737,13 +4780,14 @@
                                 }
                             ],
                             "description": "",
-                            "guidance": [{
-                                "description": "",
-                                "list": [
-                                    "BA, BSc, MA, PhD, PGCE"
-                                ],
-                                "title": "For example:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "For example:",
+                                    "list": [
+                                        "BA, BSc, MA, PhD, PGCE"
+                                    ]
+                                }]
+                            },
                             "id": "employees-qualifications-2016-question",
                             "number": "12.3",
                             "title": "Please <em>estimate</em> the proportion of employees that hold a degree or higher qualification in the following areas for the <em>calendar year 2016 only</em>:",
@@ -4883,13 +4927,14 @@
                                 }
                             ],
                             "description": "",
-                            "guidance": [{
-                                "description": "",
-                                "list": [
-                                    "Any time spent extracting information from your accounting systems and collating data over and above normal accounting operations"
-                                ],
-                                "title": "Include:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "Any time spent extracting information from your accounting systems and collating data over and above normal accounting operations"
+                                    ]
+                                }]
+                            },
                             "id": "how-long-question",
                             "number": "13.2",
                             "title": "How long has it taken you to complete this questionnaire?",
@@ -4948,13 +4993,14 @@
                         "id": "ready-to-submit-completed-question",
                         "title": "Submission",
                         "type": "General",
-                        "guidance": [{
-                            "title": "",
-                            "list": [
-                                "You will not be able to access or change your answers on submitting the questionnaire",
-                                "If you wish to review your answers please select the relevant completed sections"
-                            ]
-                        }]
+                        "guidance": {
+                            "content": [{
+                                "list": [
+                                    "You will not be able to access or change your answers on submitting the questionnaire",
+                                    "If you wish to review your answers please select the relevant completed sections"
+                                ]
+                            }]
+                        }
                     }],
                     "title": "You are now ready to submit this survey"
                 }],

--- a/data/en/1_0005.json
+++ b/data/en/1_0005.json
@@ -111,21 +111,23 @@
                                 }
                             }],
                             "description": "<p>If the last week of the month is affected by holidays please use a more representative week.</p>",
-                            "guidance": [{
-                                    "list": [
-                                        "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received pay in the relevant period"
-                                    ],
-                                    "title": "Include:"
-                                },
-                                {
-                                    "list": [
-                                        "trainees on government schemes",
-                                        "employees working abroad unless paid directly from this business\u2019s GB payroll",
-                                        "employees in Northern Ireland"
-                                    ],
-                                    "title": "Exclude:"
-                                }
-                            ],
+                            "guidance": {
+                                "content": [{
+                                        "title": "Include:",
+                                        "list": [
+                                            "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received pay in the relevant period"
+                                        ]
+                                    },
+                                    {
+                                        "title": "Include:",
+                                        "list": [
+                                            "trainees on government schemes",
+                                            "employees working abroad unless paid directly from this business\u2019s GB payroll",
+                                            "employees in Northern Ireland"
+                                        ]
+                                    }
+                                ]
+                            },
                             "id": "weekly-pay-paid-employees-question",
                             "number": "2.1",
                             "title": "What was the number of <em>weekly paid</em> employees paid in the last week of {{exercise.period_str}}?",
@@ -143,7 +145,26 @@
                         "questions": [{
                             "answers": [{
                                 "description": "Please round to the nearest pound. Do not include pence.",
-                                "guidance": "<p>Exclude:</p><p><ul><li>trainees on government schemes</li><li>director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable)</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                        "title": "Exclude:",
+                                        "list": [
+                                            "trainees on government schemes",
+                                            "director\u2019s fees",
+                                            "employer\u2019s NI and contribution to pension schemes",
+                                            "employees working abroad unless paid directly from this business\u2019s GB payroll",
+                                            "signing on fees (sporting professionals)",
+                                            "payment in lieu of notice",
+                                            "redundancy pay (taxable and non-taxable)",
+                                            "accrued holiday pay",
+                                            "employees in Northern Ireland",
+                                            "benefits employees receive through pay, for example, family working tax credit",
+                                            "expenses payments for attending meetings, for example, councillors"
+                                        ]
+                                    }]
+                                },
                                 "id": "weekly-pay-gross-pay-answer",
                                 "label": "Total gross weekly pay",
                                 "mandatory": true,
@@ -156,23 +177,25 @@
                                     }
                                 }
                             }],
-                            "guidance": [{
-                                    "list": [
-                                        "overtime and shift allowance payments",
-                                        "advanced holiday pay",
-                                        "pay award arrears",
-                                        "bonuses or commissions",
-                                        "voluntary employee contributions to, and annual profit from, profit related pay schemes"
-                                    ],
-                                    "title": "Include:"
-                                },
-                                {
-                                    "list": [
-                                        "any redundancy pay and pay in lieu of notice payments"
-                                    ],
-                                    "title": "Exclude:"
-                                }
-                            ],
+                            "guidance": {
+                                "content": [{
+                                        "title": "Include:",
+                                        "list": [
+                                            "overtime and shift allowance payments",
+                                            "advanced holiday pay",
+                                            "pay award arrears",
+                                            "bonuses or commissions",
+                                            "voluntary employee contributions to, and annual profit from, profit related pay schemes"
+                                        ]
+                                    },
+                                    {
+                                        "title": "Exclude:",
+                                        "list": [
+                                            "any redundancy pay and pay in lieu of notice payments"
+                                        ]
+                                    }
+                                ]
+                            },
                             "id": "weekly-pay-gross-pay-question",
                             "number": "2.2",
                             "title": "What was the <em>total gross weekly pay</em> paid to employees in the last week of {{exercise.period_str}}?",
@@ -216,7 +239,35 @@
                                 },
                                 {
                                     "description": "Please round to the nearest pound. Do not include pence.",
-                                    "guidance": "<p>Include:</p><p><ul><li>performance pay (for example productivity bonuses)</li><li>long service awards</li><li>appearance money (sporting professionals)</li></ul>Exclude:</p><p><ul><li>trainees on government schemes</li><li>director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable)</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "title": "Include:",
+                                                "list": [
+                                                    "performance pay (for example productivity bonuses)",
+                                                    "long service awards",
+                                                    "appearance money (sporting professionals)"
+                                                ]
+                                            },
+                                            {
+                                                "title": "Exclude:",
+                                                "list": [
+                                                    "trainees on government schemes",
+                                                    "director\u2019s fees",
+                                                    "employer\u2019s NI and contribution to pension schemes",
+                                                    "employees working abroad unless paid directly from this business\u2019s GB payroll",
+                                                    "signing on fees (sporting professionals)",
+                                                    "payment in lieu of notice",
+                                                    "redundancy pay (taxable and non-taxable)",
+                                                    "accrued holiday pay",
+                                                    "employees in Northern Ireland",
+                                                    "benefits employees receive through pay, for example, family working tax credit",
+                                                    "expenses payments for attending meetings, for example, councillors"
+                                                ]
+                                            }
+                                        ]
+                                    },
                                     "id": "weekly-pay-breakdown-prp-answer",
                                     "label": "Bonuses, commissions or annual profit from profit related pay schemes",
                                     "mandatory": true,
@@ -261,13 +312,15 @@
                                 "type": "Radio"
                             }],
                             "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
-                            "guidance": [{
-                                "list": [
-                                    "redundancies",
-                                    "changes in the number of temporary staff"
-                                ],
-                                "title": "Include:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "redundancies",
+                                        "changes in the number of temporary staff"
+                                    ]
+                                }]
+                            },
                             "id": "weekly-pay-significant-changes-paid-employees-question",
                             "number": "2.4",
                             "title": "Did any significant changes occur to the <em>number of weekly paid employees</em>?",
@@ -387,14 +440,16 @@
                                 "type": "Radio"
                             }],
                             "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
-                            "guidance": [{
-                                "list": [
-                                    "more or less overtime",
-                                    "new pay rates",
-                                    "industrial action"
-                                ],
-                                "title": "Include:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "more or less overtime",
+                                        "new pay rates",
+                                        "industrial action"
+                                    ]
+                                }]
+                            },
                             "id": "weekly-pay-significant-changes-gross-pay-question",
                             "number": "2.7",
                             "title": "Did any significant changes occur to the <em>total gross pay</em> paid to <em>weekly paid employees</em>?",
@@ -712,21 +767,23 @@
                                 }
                             }],
                             "description": "<p>If the last week of the month is affected by holidays please use a more representative week.</p>",
-                            "guidance": [{
-                                    "list": [
-                                        "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received pay in the relevant period"
-                                    ],
-                                    "title": "Include:"
-                                },
-                                {
-                                    "list": [
-                                        "trainees on government schemes",
-                                        "employees working abroad unless paid directly from this business\u2019s GB payroll",
-                                        "employees in Northern Ireland"
-                                    ],
-                                    "title": "Exclude:"
-                                }
-                            ],
+                            "guidance": {
+                                "content": [{
+                                        "title": "Include:",
+                                        "list": [
+                                            "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received pay in the relevant period"
+                                        ]
+                                    },
+                                    {
+                                        "title": "Exclude:",
+                                        "list": [
+                                            "trainees on government schemes",
+                                            "employees working abroad unless paid directly from this business\u2019s GB payroll",
+                                            "employees in Northern Ireland"
+                                        ]
+                                    }
+                                ]
+                            },
                             "id": "fortnightly-pay-paid-employees-question",
                             "number": "3.1",
                             "title": "What was the number of <em>fortnightly paid employees</em> paid in the last week of {{exercise.period_str}}?",
@@ -744,7 +801,26 @@
                         "questions": [{
                             "answers": [{
                                 "description": "Please round to the nearest pound. Do not include pence.",
-                                "guidance": "<p>Exclude:</p><p><ul><li>trainees on government schemes</li><li>director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable)</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings (councillors)</li></ul></p>",
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                        "title": "Exclude:",
+                                        "list": [
+                                            "trainees on government schemes",
+                                            "director\u2019s fees",
+                                            "employer\u2019s NI and contribution to pension schemes",
+                                            "employees working abroad unless paid directly from this business\u2019s GB payroll",
+                                            "signing on fees (sporting professionals)",
+                                            "payment in lieu of notice",
+                                            "redundancy pay (taxable and non-taxable)",
+                                            "accrued holiday pay",
+                                            "employees in Northern Ireland",
+                                            "benefits employees receive through pay, for example, family working tax credit",
+                                            "expenses payments for attending meetings (councillors)"
+                                        ]
+                                    }]
+                                },
                                 "id": "fortnightly-pay-gross-pay-answer",
                                 "label": "Total gross fortnightly pay including advanced holiday pay, pay award arrears, and bonuses or commissions",
                                 "mandatory": true,
@@ -757,23 +833,25 @@
                                     }
                                 }
                             }],
-                            "guidance": [{
-                                    "list": [
-                                        "overtime and shift allowance payments",
-                                        "advanced holiday pay",
-                                        "pay award arrears",
-                                        "bonuses or commissions",
-                                        "voluntary employee contributions to, and annual profit from, profit related pay schemes"
-                                    ],
-                                    "title": "Include:"
-                                },
-                                {
-                                    "list": [
-                                        "any redundancy pay and pay in lieu of notice payments"
-                                    ],
-                                    "title": "Exclude:"
-                                }
-                            ],
+                            "guidance": {
+                                "content": [{
+                                        "title": "Include",
+                                        "list": [
+                                            "overtime and shift allowance payments",
+                                            "advanced holiday pay",
+                                            "pay award arrears",
+                                            "bonuses or commissions",
+                                            "voluntary employee contributions to, and annual profit from, profit related pay schemes"
+                                        ]
+                                    },
+                                    {
+                                        "title": "Exclude:",
+                                        "list": [
+                                            "any redundancy pay and pay in lieu of notice payments"
+                                        ]
+                                    }
+                                ]
+                            },
                             "id": "fortnightly-pay-gross-pay-question",
                             "number": "3.2",
                             "title": "What was the <em>total gross fortnightly pay</em> paid to employees in the last week of {{exercise.period_str}}?",
@@ -817,7 +895,18 @@
                                 },
                                 {
                                     "description": "Please round to the nearest pound. Do not include pence.",
-                                    "guidance": "<p>Include:</p><p><ul><li>performance pay (for example, productivity bonuses)</li><li>long service awards</li><li>appearance money (sporting professionals)</li></ul></p>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                            "title": "Include:",
+                                            "list": [
+                                                "performance pay (for example, productivity bonuses)",
+                                                "long service awards",
+                                                "appearance money (sporting professionals)"
+                                            ]
+                                        }]
+                                    },
                                     "id": "fortnightly-pay-breakdown-prp-answer",
                                     "label": "Bonuses, commissions or annual profit from profit related pay schemes",
                                     "mandatory": true,
@@ -862,13 +951,15 @@
                                 "type": "Radio"
                             }],
                             "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
-                            "guidance": [{
-                                "list": [
-                                    "redundancies",
-                                    "changes in the number of temporary staff"
-                                ],
-                                "title": "Include:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "redundancies",
+                                        "changes in the number of temporary staff"
+                                    ]
+                                }]
+                            },
                             "id": "fortnightly-pay-significant-changes-paid-employees-question",
                             "number": "3.4",
                             "title": "Did any significant changes occur to the <em>number of fortnightly paid employees</em>?",
@@ -988,14 +1079,16 @@
                                 "type": "Radio"
                             }],
                             "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
-                            "guidance": [{
-                                "list": [
-                                    "more or less overtime",
-                                    "new pay rates",
-                                    "industrial action"
-                                ],
-                                "title": "Include:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "more or less overtime",
+                                        "new pay rates",
+                                        "industrial action"
+                                    ]
+                                }]
+                            },
                             "id": "fortnightly-pay-significant-changes-gross-pay-question",
                             "number": "3.7",
                             "title": "Did any significant changes occur to the <em>total gross pay</em> paid to <em>fortnightly paid employees</em>?",
@@ -1314,21 +1407,23 @@
                                 }
                             }],
                             "description": "<p>If there are two pay days in the same month only give details for one.</p>",
-                            "guidance": [{
-                                    "list": [
-                                        "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received monthly pay in the relevant period"
-                                    ],
-                                    "title": "Include:"
-                                },
-                                {
-                                    "list": [
-                                        "trainees on government schemes",
-                                        "employees working abroad unless paid directly from this business\u2019s GB payroll",
-                                        "employees in Northern Ireland"
-                                    ],
-                                    "title": "Exclude:"
-                                }
-                            ],
+                            "guidance": {
+                                "content": [{
+                                        "title": "Include:",
+                                        "list": [
+                                            "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received monthly pay in the relevant period"
+                                        ]
+                                    },
+                                    {
+                                        "title": "Exclude:",
+                                        "list": [
+                                            "trainees on government schemes",
+                                            "employees working abroad unless paid directly from this business\u2019s GB payroll",
+                                            "employees in Northern Ireland"
+                                        ]
+                                    }
+                                ]
+                            },
                             "id": "calendar-monthly-pay-paid-employees-question",
                             "number": "4.1",
                             "title": "What was the number of <em>calendar monthly paid employees</em> paid in {{exercise.period_str}}?",
@@ -1347,7 +1442,26 @@
                         "questions": [{
                             "answers": [{
                                 "description": "Please round to the nearest pound. Do not include pence.",
-                                "guidance": "<p>Exclude:</p><p><ul><li>trainees on government schemes</li><li>director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable)</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                        "title": "Exclude:",
+                                        "list": [
+                                            "trainees on government schemes",
+                                            "director\u2019s fees",
+                                            "employer\u2019s NI and contribution to pension schemes",
+                                            "employees working abroad unless paid directly from this business\u2019s GB payroll",
+                                            "signing on fees (sporting professionals)",
+                                            "payment in lieu of notice",
+                                            "redundancy pay (taxable and non-taxable)",
+                                            "accrued holiday pay",
+                                            "employees in Northern Ireland",
+                                            "benefits employees receive through pay, for example, family working tax credit",
+                                            "expenses payments for attending meetings, for example, councillors"
+                                        ]
+                                    }]
+                                },
                                 "id": "calendar-monthly-pay-gross-pay-answer",
                                 "label": "Total gross calendar monthly pay including advanced holiday pay, pay award arrears, and bonuses or commissions",
                                 "mandatory": true,
@@ -1360,22 +1474,24 @@
                                     }
                                 }
                             }],
-                            "guidance": [{
-                                    "list": [
-                                        "overtime and shift allowance payments",
-                                        "pay awards",
-                                        "bonuses or commissions",
-                                        "voluntary employee contributions to, and annual profit from, profit related pay schemes"
-                                    ],
-                                    "title": "Include:"
-                                },
-                                {
-                                    "list": [
-                                        "any redundancy pay and pay in lieu of notice payments"
-                                    ],
-                                    "title": "Exclude:"
-                                }
-                            ],
+                            "guidance": {
+                                "content": [{
+                                        "title": "Include:",
+                                        "list": [
+                                            "overtime and shift allowance payments",
+                                            "pay awards",
+                                            "bonuses or commissions",
+                                            "voluntary employee contributions to, and annual profit from, profit related pay schemes"
+                                        ]
+                                    },
+                                    {
+                                        "title": "Exclude:",
+                                        "list": [
+                                            "any redundancy pay and pay in lieu of notice payments"
+                                        ]
+                                    }
+                                ]
+                            },
                             "id": "calendar-monthly-pay-gross-pay-question",
                             "number": "4.2",
                             "title": "What was the <em>total gross calendar monthly pay</em> paid to employees in {{exercise.period_str}}?",
@@ -1407,7 +1523,18 @@
                                 },
                                 {
                                     "description": "Please round to the nearest pound. Do not include pence.",
-                                    "guidance": "<p>Include:</p><p><ul><li>performance pay (for example productivity bonuses)</li><li>long service awards</li><li>appearance money (sporting professionals)</li></ul></p>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                            "title": "Include:",
+                                            "list": [
+                                                "performance pay (for example productivity bonuses)",
+                                                "long service awards",
+                                                "appearance money (sporting professionals)"
+                                            ]
+                                        }]
+                                    },
                                     "id": "calendar-monthly-pay-breakdown-prp-answer",
                                     "label": "Bonuses, commissions or annual profit from profit related pay schemes",
                                     "mandatory": true,
@@ -1452,13 +1579,15 @@
                                 "type": "Radio"
                             }],
                             "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
-                            "guidance": [{
-                                "list": [
-                                    "redundancies",
-                                    "changes in the number of temporary staff"
-                                ],
-                                "title": "Include:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "redundancies",
+                                        "changes in the number of temporary staff"
+                                    ]
+                                }]
+                            },
                             "id": "calendar-monthly-pay-significant-changes-paid-employees-question",
                             "number": "4.4",
                             "title": "Did any significant changes occur to the <em>number of calendar monthly paid employees</em>?",
@@ -1578,14 +1707,16 @@
                                 "type": "Radio"
                             }],
                             "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
-                            "guidance": [{
-                                "list": [
-                                    "more or less overtime",
-                                    "new pay rates",
-                                    "industrial action"
-                                ],
-                                "title": "Include:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "more or less overtime",
+                                        "new pay rates",
+                                        "industrial action"
+                                    ]
+                                }]
+                            },
                             "id": "calendar-monthly-pay-significant-changes-gross-pay-question",
                             "number": "4.7",
                             "title": "Did any significant changes occur to the <em>total gross pay</em> paid to <em>calendar monthly paid employees</em>?",
@@ -1904,21 +2035,23 @@
                                 }
                             }],
                             "description": "<p>If there are two pay days in the same month only give details for one.</p>",
-                            "guidance": [{
-                                    "list": [
-                                        "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received monthly pay in the relevant period"
-                                    ],
-                                    "title": "Include:"
-                                },
-                                {
-                                    "list": [
-                                        "trainees on government schemes",
-                                        "employees working abroad unless paid directly from this business\u2019s GB payroll",
-                                        "employees in Northern Ireland"
-                                    ],
-                                    "title": "Exclude:"
-                                }
-                            ],
+                            "guidance": {
+                                "content": [{
+                                        "title": "Include:",
+                                        "list": [
+                                            "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received monthly pay in the relevant period"
+                                        ]
+                                    },
+                                    {
+                                        "title": "Exclude:",
+                                        "list": [
+                                            "trainees on government schemes",
+                                            "employees working abroad unless paid directly from this business\u2019s GB payroll",
+                                            "employees in Northern Ireland"
+                                        ]
+                                    }
+                                ]
+                            },
                             "id": "four-weekly-pay-paid-employees-question",
                             "number": "5.1",
                             "title": "What was the number of <em>four weekly paid employees</em> paid in {{exercise.period_str}}?",
@@ -1937,7 +2070,25 @@
                         "questions": [{
                             "answers": [{
                                 "description": "Please round to the nearest pound. Do not include pence.",
-                                "guidance": "<p>Exclude:</p><p><ul><li>trainees on government schemes director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable)</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                        "title": "Exclude:",
+                                        "list": [
+                                            "trainees on government schemes director\u2019s fees",
+                                            "employer\u2019s NI and contribution to pension schemes",
+                                            "employees working abroad unless paid directly from this business\u2019s GB payroll",
+                                            "signing on fees (sporting professionals)",
+                                            "payment in lieu of notice",
+                                            "redundancy pay (taxable and non-taxable)",
+                                            "accrued holiday pay",
+                                            "employees in Northern Ireland",
+                                            "benefits employees receive through pay, for example, family working tax credit",
+                                            "expenses payments for attending meetings, for example, councillors"
+                                        ]
+                                    }]
+                                },
                                 "id": "four-weekly-pay-gross-pay-answer",
                                 "label": "Total gross four weekly pay including advanced holiday pay, pay award arrears, and bonuses or commissions",
                                 "mandatory": true,
@@ -1950,22 +2101,24 @@
                                     }
                                 }
                             }],
-                            "guidance": [{
-                                    "list": [
-                                        "overtime and shift allowance payments",
-                                        "pay awards",
-                                        "bonuses or commissions",
-                                        "voluntary employee contributions to, and annual profit from, profit related pay schemes"
-                                    ],
-                                    "title": "Include:"
-                                },
-                                {
-                                    "list": [
-                                        "any redundancy pay and pay in lieu of notice payments"
-                                    ],
-                                    "title": "Exclude:"
-                                }
-                            ],
+                            "guidance": {
+                                "content": [{
+                                        "title": "Include:",
+                                        "list": [
+                                            "overtime and shift allowance payments",
+                                            "pay awards",
+                                            "bonuses or commissions",
+                                            "voluntary employee contributions to, and annual profit from, profit related pay schemes"
+                                        ]
+                                    },
+                                    {
+                                        "title": "Exclude:",
+                                        "list": [
+                                            "any redundancy pay and pay in lieu of notice payments"
+                                        ]
+                                    }
+                                ]
+                            },
                             "id": "four-weekly-pay-gross-pay-question",
                             "number": "5.2",
                             "title": "What was the <em>total gross four weekly pay</em> paid to employees in {{exercise.period_str}}?",
@@ -1997,7 +2150,18 @@
                                 },
                                 {
                                     "description": "Please round to the nearest pound. Do not include pence.",
-                                    "guidance": "<p>Include:</p><p><ul><li>performance pay (for example productivity bonuses)</li><li>long service awards</li><li>appearance money (sporting professionals)</li></ul></p>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                            "title": "Include:",
+                                            "list": [
+                                                "performance pay (for example productivity bonuses)",
+                                                "long service awards",
+                                                "appearance money (sporting professionals)"
+                                            ]
+                                        }]
+                                    },
                                     "id": "four-weekly-pay-breakdown-prp-answer",
                                     "label": "Bonuses, commissions or annual profit from profit related pay schemes",
                                     "mandatory": true,
@@ -2042,13 +2206,15 @@
                                 "type": "Radio"
                             }],
                             "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
-                            "guidance": [{
-                                "list": [
-                                    "redundancies",
-                                    "changes in the number of temporary staff"
-                                ],
-                                "title": "Include:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "redundancies",
+                                        "changes in the number of temporary staff"
+                                    ]
+                                }]
+                            },
                             "id": "four-weekly-pay-significant-changes-paid-employees-question",
                             "number": "5.4",
                             "title": "Did any significant changes occur to the <em>number of four weekly paid employees</em>?",
@@ -2168,14 +2334,16 @@
                                 "type": "Radio"
                             }],
                             "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
-                            "guidance": [{
-                                "list": [
-                                    "more or less overtime",
-                                    "new pay rates",
-                                    "industrial action"
-                                ],
-                                "title": "Include:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "more or less overtime",
+                                        "new pay rates",
+                                        "industrial action"
+                                    ]
+                                }]
+                            },
                             "id": "four-weekly-pay-significant-changes-gross-pay-question",
                             "number": "5.7",
                             "title": "Did any significant changes occur to the <em>total gross pay</em> paid to <em>four weekly paid employees</em>?",
@@ -2494,21 +2662,23 @@
                                 }
                             }],
                             "description": "<p>If there are two pay dates in the same month only give details for one.</p>",
-                            "guidance": [{
-                                    "list": [
-                                        "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received monthly pay in the relevant period"
-                                    ],
-                                    "title": "Include:"
-                                },
-                                {
-                                    "list": [
-                                        "trainees on government schemes",
-                                        "employees working abroad unless paid directly from this business\u2019s GB payroll",
-                                        "employees in Northern Ireland"
-                                    ],
-                                    "title": "Exclude:"
-                                }
-                            ],
+                            "guidance": {
+                                "content": [{
+                                        "title": "Include:",
+                                        "list": [
+                                            "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received monthly pay in the relevant period"
+                                        ]
+                                    },
+                                    {
+                                        "title": "Exclude:",
+                                        "list": [
+                                            "trainees on government schemes",
+                                            "employees working abroad unless paid directly from this business\u2019s GB payroll",
+                                            "employees in Northern Ireland"
+                                        ]
+                                    }
+                                ]
+                            },
                             "id": "five-weekly-pay-paid-employees-question",
                             "number": "6.1",
                             "title": "What was the number of <em>five weekly paid employees</em> paid in {{exercise.period_str}}?",
@@ -2527,7 +2697,26 @@
                         "questions": [{
                             "answers": [{
                                 "description": "Please round to the nearest pound. Do not include pence.",
-                                "guidance": "<p>Exclude:</p><p><ul><li>trainees on government schemes</li><li>director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                        "title": "Exclude:",
+                                        "list": [
+                                            "trainees on government schemes",
+                                            "director\u2019s fees",
+                                            "employer\u2019s NI and contribution to pension schemes",
+                                            "employees working abroad unless paid directly from this business\u2019s GB payroll",
+                                            "signing on fees (sporting professionals)",
+                                            "payment in lieu of notice",
+                                            "redundancy pay (taxable and non-taxable)",
+                                            "accrued holiday pay",
+                                            "employees in Northern Ireland",
+                                            "benefits employees receive through pay, for example, family working tax credit",
+                                            "expenses payments for attending meetings, for example, councillors"
+                                        ]
+                                    }]
+                                },
                                 "id": "five-weekly-pay-gross-pay-answer",
                                 "label": "Total gross five weekly pay",
                                 "mandatory": true,
@@ -2540,23 +2729,25 @@
                                     }
                                 }
                             }],
-                            "guidance": [{
-                                    "list": [
-                                        "overtime and shift allowance payments",
-                                        "advanced holiday pay",
-                                        "pay award arrears",
-                                        "bonuses or commissions",
-                                        "voluntary employee contributions to, and annual profit from, profit related pay schemes"
-                                    ],
-                                    "title": "Include:"
-                                },
-                                {
-                                    "list": [
-                                        "any redundancy pay and pay in lieu of notice payments"
-                                    ],
-                                    "title": "Exclude:"
-                                }
-                            ],
+                            "guidance": {
+                                "content": [{
+                                        "title": "Include:",
+                                        "list": [
+                                            "overtime and shift allowance payments",
+                                            "advanced holiday pay",
+                                            "pay award arrears",
+                                            "bonuses or commissions",
+                                            "voluntary employee contributions to, and annual profit from, profit related pay schemes"
+                                        ]
+                                    },
+                                    {
+                                        "title": "Exclude:",
+                                        "list": [
+                                            "any redundancy pay and pay in lieu of notice payments"
+                                        ]
+                                    }
+                                ]
+                            },
                             "id": "five-weekly-pay-gross-pay-question",
                             "number": "6.2",
                             "title": "What was the total gross <em>five weekly pay</em> paid to employees in {{exercise.period_str}}?",
@@ -2588,7 +2779,18 @@
                                 },
                                 {
                                     "description": "Please round to the nearest pound. Do not include pence.",
-                                    "guidance": "<p>Include:</p><p><ul><li>performance pay (for example productivity bonuses)</li><li>long service awards</li><li>appearance money (sporting professionals)</li></ul></p>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                            "title": "Include:",
+                                            "list": [
+                                                "performance pay (for example productivity bonuses)",
+                                                "long service awards",
+                                                "appearance money (sporting professionals)"
+                                            ]
+                                        }]
+                                    },
                                     "id": "five-weekly-pay-breakdown-prp-answer",
                                     "label": "Bonuses, commissions or annual profit from profit related pay schemes",
                                     "mandatory": true,
@@ -2633,13 +2835,15 @@
                                 "type": "Radio"
                             }],
                             "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
-                            "guidance": [{
-                                "list": [
-                                    "redundancies",
-                                    "changes in the number of temporary staff"
-                                ],
-                                "title": "Include:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "redundancies",
+                                        "changes in the number of temporary staff"
+                                    ]
+                                }]
+                            },
                             "id": "five-weekly-pay-significant-changes-paid-employees-question",
                             "number": "6.4",
                             "title": "Did any significant changes occur to the <em>number of five weekly paid employees</em>?",
@@ -2759,14 +2963,16 @@
                                 "type": "Radio"
                             }],
                             "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
-                            "guidance": [{
-                                "list": [
-                                    "more or less overtime",
-                                    "new pay rates",
-                                    "industrial action"
-                                ],
-                                "title": "Include:"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "more or less overtime",
+                                        "new pay rates",
+                                        "industrial action"
+                                    ]
+                                }]
+                            },
                             "id": "five-weekly-pay-significant-changes-gross-pay-question",
                             "number": "6.7",
                             "title": "Did any significant changes occur to the <em>total gross pay</em> paid to <em>five weekly paid employees</em>?",

--- a/data/en/1_0102.json
+++ b/data/en/1_0102.json
@@ -26,7 +26,6 @@
                     "id": "reporting-period-section",
                     "questions": [{
                         "answers": [{
-                                "guidance": "",
                                 "id": "period-from",
                                 "label": "Period from",
                                 "mandatory": true,
@@ -41,7 +40,6 @@
                                 }
                             },
                             {
-                                "guidance": "",
                                 "id": "period-to",
                                 "label": "Period to",
                                 "mandatory": true,
@@ -73,7 +71,6 @@
                     "id": "total-retail-turnover-section",
                     "questions": [{
                         "answers": [{
-                            "guidance": "",
                             "id": "total-retail-turnover-answer",
                             "label": "Total retail turnover",
                             "mandatory": true,
@@ -90,24 +87,26 @@
                             }
                         }],
                         "description": "<p>Round your figures to the nearest whole pound (£). Even if your figures are zero, please still complete.</p>",
-                        "guidance": [{
-                                "title": "Include",
-                                "list": [
-                                    "VAT",
-                                    "internet sales"
-                                ]
-                            },
-                            {
-                                "title": "Exclude",
-                                "list": [
-                                    "revenue from mobile phone network commission and top up ",
-                                    "sales from catering facilities used by customers",
-                                    "lottery sales and commission from lottery sales",
-                                    "sales of car accessories and motor vehicles",
-                                    "NHS receipts"
-                                ]
-                            }
-                        ],
+                        "guidance": {
+                            "content": [{
+                                    "title": "Include",
+                                    "list": [
+                                        "VAT",
+                                        "internet sales"
+                                    ]
+                                },
+                                {
+                                    "title": "Exclude",
+                                    "list": [
+                                        "revenue from mobile phone network commission and top up ",
+                                        "sales from catering facilities used by customers",
+                                        "lottery sales and commission from lottery sales",
+                                        "sales of car accessories and motor vehicles",
+                                        "NHS receipts"
+                                    ]
+                                }
+                            ]
+                        },
                         "id": "total-retail-turnover-question",
                         "title": "For the reporting period, what was the value of the business’s total retail turnover?",
                         "type": "General"
@@ -124,7 +123,6 @@
                     "id": "internet-sales-section",
                     "questions": [{
                         "answers": [{
-                            "guidance": "",
                             "id": "internet-sales-answer",
                             "label": "Internet sales",
                             "mandatory": true,
@@ -141,12 +139,14 @@
                             }
                         }],
                         "description": "<p>Round your figures to the nearest whole pound (£). Even if your figures are zero, please still complete.</p>",
-                        "guidance": [{
-                            "title": "Include",
-                            "list": [
-                                "VAT"
-                            ]
-                        }],
+                        "guidance": {
+                            "content": [{
+                                "title": "Include",
+                                "list": [
+                                    "VAT"
+                                ]
+                            }]
+                        },
                         "id": "internet-sales-question",
                         "title": "Of the business's total retail turnover, what was the value of internet sales?",
                         "type": "General"
@@ -163,7 +163,32 @@
                     "id": "changes-in-retail-turnover-section",
                     "questions": [{
                         "answers": [{
-                            "guidance": "<div><p>Examples of commentary:</p><p><strong>'In-store promotion'</strong></p> <p>Offer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales.</p><strong> 'Special events (for example, sporting events)'</strong></p><p>This was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online.</p><p><strong>‘Weather'</strong></p><p>The bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month.</div>",
+                            "guidance": {
+                                "show_guidance": "Show further guidance",
+                                "hide_guidance": "Hide further guidance",
+                                "content": [{
+                                        "description": "Examples of commentary:"
+                                    },
+                                    {
+                                        "title": "'In-store promotion'"
+                                    },
+                                    {
+                                        "description": "Offer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales."
+                                    },
+                                    {
+                                        "title": "'Special events (for example, sporting events)'"
+                                    },
+                                    {
+                                        "description": "This was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online."
+                                    },
+                                    {
+                                        "title": "‘Weather'"
+                                    },
+                                    {
+                                        "description": "The bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month."
+                                    }
+                                ]
+                            },
                             "id": "changes-in-retail-turnover-answer",
                             "label": "Comments",
                             "mandatory": false,
@@ -175,13 +200,18 @@
                             }
                         }],
                         "description": "<p>We rely on your commentary to 'tell the story' behind changes to the business's figures.</p><p>By commenting here it will reduce the need for us to call you.</p>",
-                        "guidance": [{
-                            "description": "<p>Comment on significant changes to the business's total retail turnover figures from:</p>",
-                            "list": [
-                                "the previous reporting period",
-                                "the same reporting period last year"
+                        "guidance": {
+                            "content": [{
+                                    "description": "<p>Comment on significant changes to the business's total retail turnover figures from:</p>"
+                                },
+                                {
+                                    "list": [
+                                        "the previous reporting period",
+                                        "the same reporting period last year"
+                                    ]
+                                }
                             ]
-                        }],
+                        },
                         "id": "changes-in-retail-turnover-question",
                         "title": "Indicate the reasons for any changes in the business's total retail turnover",
                         "type": "General"

--- a/data/en/1_0112.json
+++ b/data/en/1_0112.json
@@ -27,7 +27,6 @@
                     "id": "reporting-period-section",
                     "questions": [{
                         "answers": [{
-                                "guidance": "",
                                 "id": "period-from",
                                 "label": "Period from",
                                 "mandatory": true,
@@ -42,7 +41,6 @@
                                 }
                             },
                             {
-                                "guidance": "",
                                 "id": "period-to",
                                 "label": "Period to",
                                 "mandatory": true,
@@ -74,7 +72,6 @@
                     "id": "total-retail-turnover-section",
                     "questions": [{
                         "answers": [{
-                            "guidance": "",
                             "id": "total-retail-turnover-answer",
                             "label": "Total retail turnover",
                             "mandatory": true,
@@ -91,24 +88,26 @@
                             }
                         }],
                         "description": "<p>Round your figures to the nearest whole pound (£). Even if your figures are zero, please still complete.</p>",
-                        "guidance": [{
-                                "title": "Include",
-                                "list": [
-                                    "VAT",
-                                    "internet sales"
-                                ]
-                            },
-                            {
-                                "title": "Exclude",
-                                "list": [
-                                    "revenue from mobile phone network commission and top up",
-                                    "sales from catering facilities used by customers",
-                                    "lottery sales and commission from lottery sales",
-                                    "sales of car accessories and motor vehicles",
-                                    "NHS receipts"
-                                ]
-                            }
-                        ],
+                        "guidance": {
+                            "content": [{
+                                    "title": "Include",
+                                    "list": [
+                                        "VAT",
+                                        "internet sales"
+                                    ]
+                                },
+                                {
+                                    "title": "Exclude",
+                                    "list": [
+                                        "revenue from mobile phone network commission and top up",
+                                        "sales from catering facilities used by customers",
+                                        "lottery sales and commission from lottery sales",
+                                        "sales of car accessories and motor vehicles",
+                                        "NHS receipts"
+                                    ]
+                                }
+                            ]
+                        },
                         "id": "total-retail-turnover-question",
                         "title": "For the reporting period, what was the value of the business’s total retail turnover?",
                         "type": "General"
@@ -125,7 +124,6 @@
                     "id": "internet-sales-section",
                     "questions": [{
                         "answers": [{
-                            "guidance": "",
                             "id": "internet-sales-answer",
                             "label": "Internet sales",
                             "mandatory": true,
@@ -142,12 +140,14 @@
                             }
                         }],
                         "description": "<p>Round your figures to the nearest whole pound (£). Even if your figures are zero, please still complete.</p>",
-                        "guidance": [{
-                            "title": "Include",
-                            "list": [
-                                "VAT"
-                            ]
-                        }],
+                        "guidance": {
+                            "content": [{
+                                "title": "Include",
+                                "list": [
+                                    "VAT"
+                                ]
+                            }]
+                        },
                         "id": "internet-sales-question",
                         "title": "Of the business's total retail turnover, what was the value of internet sales?",
                         "type": "General"
@@ -164,7 +164,32 @@
                     "id": "changes-in-retail-turnover-section",
                     "questions": [{
                         "answers": [{
-                            "guidance": "<div><p>Examples of commentary:</p><p><strong>'In-store promotion'</strong></p> <p>Offer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales.</p><strong> 'Special events (for example, sporting events)'</strong></p><p>This was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online.</p><p><strong>‘Weather'</strong></p><p>The bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month.</div>",
+                            "guidance": {
+                                "show_guidance": "Show further guidance",
+                                "hide_guidance": "Hide further guidance",
+                                "content": [{
+                                        "description": "Examples of commentary:"
+                                    },
+                                    {
+                                        "title": "'In-store promotion'"
+                                    },
+                                    {
+                                        "description": "Offer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales."
+                                    },
+                                    {
+                                        "title": "'Special events (for example, sporting events)'"
+                                    },
+                                    {
+                                        "description": "This was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online."
+                                    },
+                                    {
+                                        "title": "'Weather'"
+                                    },
+                                    {
+                                        "description": "The bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month."
+                                    }
+                                ]
+                            },
                             "id": "changes-in-retail-turnover-answer",
                             "label": "Comments",
                             "mandatory": false,
@@ -176,13 +201,18 @@
                             }
                         }],
                         "description": "<p>We rely on your commentary to 'tell the story' behind changes to the business's figures.</p><p>By commenting here it will reduce the need for us to call you.</p>",
-                        "guidance": [{
-                            "description": "<p>Comment on significant changes to the business's total retail turnover figures from:</p>",
-                            "list": [
-                                "the previous reporting period",
-                                "the same reporting period last year"
+                        "guidance": {
+                            "content": [{
+                                    "description": "<p>Comment on significant changes to the business's total retail turnover figures from:</p>"
+                                },
+                                {
+                                    "list": [
+                                        "the previous reporting period",
+                                        "the same reporting period last year"
+                                    ]
+                                }
                             ]
-                        }],
+                        },
                         "id": "changes-in-retail-turnover-question",
                         "title": "Indicate the reasons for any changes in the business's total retail turnover",
                         "type": "General"
@@ -198,7 +228,6 @@
                     "id": "number-of-employees-section",
                     "questions": [{
                         "answers": [{
-                                "guidance": "",
                                 "id": "male-employees-over-30-hours",
                                 "label": "Male employees working more than 30 hours per week",
                                 "mandatory": false,
@@ -214,7 +243,6 @@
                                 }
                             },
                             {
-                                "guidance": "",
                                 "id": "male-employees-under-30-hours",
                                 "label": "Male employees working 30 hours or less per week",
                                 "mandatory": false,
@@ -230,7 +258,6 @@
                                 }
                             },
                             {
-                                "guidance": "",
                                 "id": "female-employees-over-30-hours",
                                 "label": "Female employees working more than 30 hours per week",
                                 "mandatory": false,
@@ -246,7 +273,6 @@
                                 }
                             },
                             {
-                                "guidance": "",
                                 "id": "female-employees-under-30-hours",
                                 "label": "Female employees working 30 hours or less per week",
                                 "mandatory": false,
@@ -262,7 +288,6 @@
                                 }
                             },
                             {
-                                "guidance": "",
                                 "id": "total-number-employees",
                                 "label": "Total number of employees",
                                 "mandatory": true,
@@ -282,24 +307,26 @@
                         "id": "number-of-employees-question",
                         "title": "On {{exercise.employment_date|format_date}} what was the number of employees?",
                         "description": "<p>An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.</p>",
-                        "guidance": [{
-                                "title": "Include",
-                                "list": [
-                                    "all workers paid directly from this business's payroll(s)",
-                                    "those temporarily absent but still being paid, for example on maternity leave"
-                                ]
-                            },
-                            {
-                                "title": "Exclude",
-                                "list": [
-                                    "agency workers paid directly from the agency payroll",
-                                    "voluntary workers",
-                                    "former employees only receiving pension",
-                                    "self-employed workers",
-                                    "working owners who are not paid via PAYE"
-                                ]
-                            }
-                        ],
+                        "guidance": {
+                            "content": [{
+                                    "title": "Include",
+                                    "list": [
+                                        "all workers paid directly from this business's payroll(s)",
+                                        "those temporarily absent but still being paid, for example on maternity leave"
+                                    ]
+                                },
+                                {
+                                    "title": "Exclude",
+                                    "list": [
+                                        "agency workers paid directly from the agency payroll",
+                                        "voluntary workers",
+                                        "former employees only receiving pension",
+                                        "self-employed workers",
+                                        "working owners who are not paid via PAYE"
+                                    ]
+                                }
+                            ]
+                        },
                         "type": "General"
                     }],
                     "title": "Employees"
@@ -325,13 +352,18 @@
                             }
                         }],
                         "description": "",
-                        "guidance": [{
-                            "description": "<p>Comment on significant changes in the number of employees from:</p>",
-                            "list": [
-                                "the previous reporting period",
-                                "the same reporting period last year"
+                        "guidance": {
+                            "content": [{
+                                    "description": "<p>Comment on significant changes in the number of employees from:</p>"
+                                },
+                                {
+                                    "list": [
+                                        "the previous reporting period",
+                                        "the same reporting period last year"
+                                    ]
+                                }
                             ]
-                        }],
+                        },
                         "id": "changes-in-employees-question",
                         "title": "Explain any significant changes in the number of employees",
                         "type": "General"

--- a/data/en/1_0203.json
+++ b/data/en/1_0203.json
@@ -26,7 +26,6 @@
                         "id": "reporting-period-section",
                         "questions": [{
                             "answers": [{
-                                    "guidance": "",
                                     "id": "period-from",
                                     "label": "Period from",
                                     "mandatory": true,
@@ -41,7 +40,6 @@
                                     }
                                 },
                                 {
-                                    "guidance": "",
                                     "id": "period-to",
                                     "label": "Period to",
                                     "mandatory": true,
@@ -67,15 +65,35 @@
                         "description": "<p>- You should enter figures for the reporting period stated above<br>- You should round your figures to the nearest (\u00a3) pound</p>",
                         "id": "total-sales-section",
                         "questions": [{
-                                "guidance": [{
-                                    "title": "Include",
-                                    "list": [
-                                        "VAT",
-                                        "Internet Sales"
-                                    ]
-                                }],
+                                "guidance": {
+                                    "content": [{
+                                        "title": "Include",
+                                        "list": [
+                                            "VAT",
+                                            "Internet Sales"
+                                        ]
+                                    }]
+                                },
                                 "answers": [{
-                                    "guidance": "<div> <h4>Include</h4> <ul> <li>all fresh food</li> <li>other food for human consumption (except chocolate and sugar confectionery)</li> <li>soft drinks</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>sales from catering facilities used by customers</li> </ul> </div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "title": "Include",
+                                                "list": [
+                                                    "all fresh food",
+                                                    "other food for human consumption (except chocolate and sugar confectionery)",
+                                                    "soft drinks"
+                                                ]
+                                            },
+                                            {
+                                                "title": "Exclude",
+                                                "list": [
+                                                    "sales from catering facilities used by customers"
+                                                ]
+                                            }
+                                        ]
+                                    },
                                     "id": "total-sales-food",
                                     "label": "What was the value of the business's total sales of food?",
                                     "mandatory": false,
@@ -97,7 +115,18 @@
                             },
                             {
                                 "answers": [{
-                                    "guidance": "<div> <h4>Include</h4> <ul> <li>alcoholic drink</li> <li>chocolate and sugar confectionery</li> <li>tobacco and smokers\u2019 requisites</li></ul> </div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                            "title": "Include",
+                                            "list": [
+                                                "alcoholic drink",
+                                                "chocolate and sugar confectionery",
+                                                "tobacco and smokers requisites"
+                                            ]
+                                        }]
+                                    },
                                     "id": "total-sales-alcohol",
                                     "label": "What was the value of the business's total sales of alcohol, confectionery and tobacco?",
                                     "mandatory": false,
@@ -119,7 +148,21 @@
                             },
                             {
                                 "answers": [{
-                                    "guidance": "<div> <h4>Include</h4><ul> <li>clothing and footwear</li> <li>clothing fabrics</li> <li>haberdashery and furs</li> <li>leather and travel goods</li> <li>handbags</li> <li>umbrellas</li></ul></div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                            "title": "Include",
+                                            "list": [
+                                                "clothing and footwear",
+                                                "clothing fabrics",
+                                                "haberdashery and furs",
+                                                "leather and travel goods",
+                                                "handbags",
+                                                "umbrellas"
+                                            ]
+                                        }]
+                                    },
                                     "id": "total-sales-clothing",
                                     "label": "What was the value of the business's total sales of clothing and footwear?",
                                     "mandatory": false,
@@ -141,7 +184,30 @@
                             },
                             {
                                 "answers": [{
-                                    "guidance": "<div> <h4>Include</h4><ul> <li>carpets, rugs and other floor coverings</li> <li>furniture</li> <li>household textiles and soft furnishings</li> <li>prints and picture frames</li> <li>antiques and works of art</li> <li>domestic electrical and gas appliances, audio/visual equipment and home computers</li> <li>lighting and minor electrical supplies</li> <li>records, compact discs, audio and video tapes</li> <li>musical instruments and goods</li> <li>decorators\u2019 and DIY supplies</li> <li>lawn-mowers</li> <li>hardware</li> <li>china, glassware and cutlery</li> <li>novelties, souvenirs and gifts</li> <li>e-cigarettes</li> </ul></div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                            "title": "Include",
+                                            "list": [
+                                                "carpets, rugs and other floor coverings",
+                                                "furniture",
+                                                "household textiles and soft furnishings",
+                                                "prints and picture frames",
+                                                "antiques and works of art",
+                                                "domestic electrical and gas appliances, audio/visual equipment and home computers",
+                                                "lighting and minor electrical supplies",
+                                                "records, compact discs, audio and video tapes",
+                                                "musical instruments and goods",
+                                                "decorators\u2019 and DIY supplies",
+                                                "lawn-mowers",
+                                                "hardware",
+                                                "china, glassware and cutlery",
+                                                "novelties, souvenirs and gifts",
+                                                "e-cigarettes"
+                                            ]
+                                        }]
+                                    },
                                     "id": "total-sales-household-goods",
                                     "label": "What was the value of the business's total sales of household goods?",
                                     "mandatory": false,
@@ -163,7 +229,40 @@
                             },
                             {
                                 "answers": [{
-                                    "guidance": "<div> <h4>Include</h4> <ul>  <li>toiletries and medications (except NHS receipts)</li> <li>newspapers and periodicals</li> <li>books, stationery and office supplies</li> <li>photographic and optical goods</li> <li>spectacles, contact lenses and sunglasses</li> <li>toys and games</li> <li>cycles and cycle accessories</li> <li>sport and camping equipment</li> <li>jewellery</li> <li>silverware and plate, clocks and watches</li> <li>household cleaning products and kitchen paper products</li> <li>pets, pets\u2019 requisites and pet foods</li> <li>cut flowers, plants, seeds and other garden sundries</li> <li>other new and second hand goods</li> <li>Mobile phones</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>revenue from mobile phone network commission and top up </li> <li>lottery sales and commission from lottery sales</li> <li>sales of car accessories and motor vehicles</li> <li>NHS receipts</li> </ul> </div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "title": "Include",
+                                                "list": [
+                                                    "toiletries and medications (except NHS receipts)",
+                                                    "newspapers and periodicals",
+                                                    "books, stationery and office supplies",
+                                                    "photographic and optical goods",
+                                                    "spectacles, contact lenses and sunglasses",
+                                                    "toys and games",
+                                                    "cycles and cycle accessories",
+                                                    "sport and camping equipment",
+                                                    "jewellery",
+                                                    "silverware and plate, clocks and watches",
+                                                    "household cleaning products and kitchen paper products",
+                                                    "pets, pets\u2019 requisites and pet foods",
+                                                    "cut flowers, plants, seeds and other garden sundries",
+                                                    "other new and second hand goods",
+                                                    "Mobile phones"
+                                                ]
+                                            },
+                                            {
+                                                "title": "Exclude",
+                                                "list": [
+                                                    "revenue from mobile phone network commission and top up",
+                                                    "lottery sales and commission from lottery sales",
+                                                    "sales of car accessories and motor vehicles",
+                                                    "NHS receipts"
+                                                ]
+                                            }
+                                        ]
+                                    },
                                     "id": "total-sales-other-goods",
                                     "label": "What was the value of the business\u2019s total sales of other goods?",
                                     "mandatory": false,
@@ -185,7 +284,29 @@
                             },
                             {
                                 "answers": [{
-                                    "guidance": "<div> <h4>Include</h4> <ul> <li>VAT</li> <li>internet sales</li> <li>retail sale from outlets in Great Britain to customers abroad</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>revenue from mobile phone network commission and top up </li> <li>sales from catering facilities used by customers</li>  <li>lottery sales and commission from lottery sales</li> <li>sales of car accessories and motor vehicles</li> <li>NHS receipts</li> </ul> </div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "title": "Include",
+                                                "list": [
+                                                    "VAT",
+                                                    "internet sales",
+                                                    "retail sale from outlets in Great Britain to customers abroad"
+                                                ]
+                                            },
+                                            {
+                                                "title": "Exclude",
+                                                "list": [
+                                                    "revenue from mobile phone network commission and top up",
+                                                    "sales from catering facilities used by customers",
+                                                    "lottery sales and commission from lottery sales",
+                                                    "sales of car accessories and motor vehicles",
+                                                    "NHS receipts"
+                                                ]
+                                            }
+                                        ]
+                                    },
                                     "id": "total-retail-turnover",
                                     "label": "What was the value of the business\u2019s total retail turnover?",
                                     "mandatory": true,
@@ -208,7 +329,18 @@
                             },
                             {
                                 "answers": [{
-                                    "guidance": "<div> <h4>Include</h4><ul> <li>VAT</li> <li>sales from orders received over the internet, irrespective of the payment or delivery method</li> </ul></div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                            "title": "Include",
+                                            "list": [
+                                                "VAT",
+                                                "sales from orders received over the internet, irrespective of the payment or delivery method",
+                                                "soft drinks"
+                                            ]
+                                        }]
+                                    },
                                     "id": "internet-sales",
                                     "label": "Of your total retail turnover, how much were from internet sales?",
                                     "mandatory": false,
@@ -236,7 +368,6 @@
                         "id": "reason-for-change-section",
                         "questions": [{
                             "answers": [{
-                                "guidance": "",
                                 "id": "reason-for-change",
                                 "label": "Comments",
                                 "mandatory": false,

--- a/data/en/1_0205.json
+++ b/data/en/1_0205.json
@@ -45,7 +45,6 @@
                                     "id": "period-from",
                                     "q_code": "11",
                                     "label": "Period from",
-                                    "guidance": "",
                                     "type": "Date",
                                     "options": [],
                                     "mandatory": true
@@ -54,7 +53,6 @@
                                     "id": "period-to",
                                     "q_code": "12",
                                     "label": "Period to",
-                                    "guidance": "",
                                     "type": "Date",
                                     "options": [],
                                     "mandatory": true
@@ -67,13 +65,15 @@
                         "title": "Commodities - Retail Turnover",
                         "description": "<p>- You should enter figures for the reporting period stated above<br>- You should round your figures to the nearest (£) pound</p>",
                         "questions": [{
-                                "guidance": [{
-                                    "title": "Include",
-                                    "list": [
-                                        "VAT",
-                                        "Internet Sales"
-                                    ]
-                                }],
+                                "guidance": {
+                                    "content": [{
+                                        "title": "Include",
+                                        "list": [
+                                            "VAT",
+                                            "Internet Sales"
+                                        ]
+                                    }]
+                                },
                                 "id": "total-sales-food-question",
                                 "title": "",
                                 "description": "",
@@ -82,7 +82,25 @@
                                     "id": "total-sales-food",
                                     "q_code": "22",
                                     "label": "What was the value of the business's total sales of food?",
-                                    "guidance": "<div> <h4>Include</h4> <ul> <li>all fresh food</li> <li>other food for human consumption (except chocolate and sugar confectionery)</li> <li>soft drinks</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>sales from catering facilities used by customers</li> </ul> </div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "title": "Include",
+                                                "list": [
+                                                    "all fresh food",
+                                                    "other food for human consumption (except chocolate and sugar confectionery)",
+                                                    "soft drinks"
+                                                ]
+                                            },
+                                            {
+                                                "title": "Exclude",
+                                                "list": [
+                                                    "sales from catering facilities used by customers"
+                                                ]
+                                            }
+                                        ]
+                                    },
                                     "type": "Currency",
                                     "options": [],
                                     "mandatory": false
@@ -97,7 +115,18 @@
                                     "id": "total-sales-alcohol",
                                     "q_code": "23",
                                     "label": "What was the value of the business's total sales of alcohol, confectionery and tobacco?",
-                                    "guidance": "<div> <h4>Include</h4> <ul> <li>alcoholic drink</li> <li>chocolate and sugar confectionery</li> <li>tobacco and smokers’ requisites</li></ul> </div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                            "title": "Include",
+                                            "list": [
+                                                "alcoholic drink",
+                                                "chocolate and sugar confectionery",
+                                                "tobacco and smokers requisites"
+                                            ]
+                                        }]
+                                    },
                                     "type": "Currency",
                                     "options": [],
                                     "mandatory": false,
@@ -119,7 +148,21 @@
                                     "id": "total-sales-clothing",
                                     "q_code": "24",
                                     "label": "What was the value of the business's total sales of clothing and footwear?",
-                                    "guidance": "<div> <h4>Include</h4><ul> <li>clothing and footwear</li> <li>clothing fabrics</li> <li>haberdashery and furs</li> <li>leather and travel goods</li> <li>handbags</li> <li>umbrellas</li></ul></div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                            "title": "Include",
+                                            "list": [
+                                                "clothing and footwear",
+                                                "clothing fabrics",
+                                                "haberdashery and furs",
+                                                "leather and travel goods",
+                                                "handbags",
+                                                "umbrellas"
+                                            ]
+                                        }]
+                                    },
                                     "type": "Currency",
                                     "options": [],
                                     "mandatory": false
@@ -134,7 +177,30 @@
                                     "id": "total-sales-household-goods",
                                     "q_code": "25",
                                     "label": "What was the value of the business's total sales of household goods?",
-                                    "guidance": "<div> <h4>Include</h4><ul> <li>carpets, rugs and other floor coverings</li> <li>furniture</li> <li>household textiles and soft furnishings</li> <li>prints and picture frames</li> <li>antiques and works of art</li> <li>domestic electrical and gas appliances, audio/visual equipment and home computers</li> <li>lighting and minor electrical supplies</li> <li>records, compact discs, audio and video tapes</li> <li>musical instruments and goods</li> <li>decorators’ and DIY supplies</li> <li>lawn-mowers</li> <li>hardware</li> <li>china, glassware and cutlery</li> <li>novelties, souvenirs and gifts</li> <li>e-cigarettes</li> </ul></div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                            "title": "Include",
+                                            "list": [
+                                                "carpets, rugs and other floor coverings",
+                                                "furniture",
+                                                "household textiles and soft furnishings",
+                                                "prints and picture frames",
+                                                "antiques and works of art",
+                                                "domestic electrical and gas appliances, audio/visual equipment and home computers",
+                                                "lighting and minor electrical supplies",
+                                                "records, compact discs, audio and video tapes",
+                                                "musical instruments and goods",
+                                                "decorators\u2019 and DIY supplies",
+                                                "lawn-mowers",
+                                                "hardware",
+                                                "china, glassware and cutlery",
+                                                "novelties, souvenirs and gifts",
+                                                "e-cigarettes"
+                                            ]
+                                        }]
+                                    },
                                     "type": "Currency",
                                     "options": [],
                                     "mandatory": false
@@ -149,7 +215,40 @@
                                     "id": "total-sales-other-goods",
                                     "q_code": "26",
                                     "label": "What was the value of the business’s total sales of other goods?",
-                                    "guidance": "<div> <h4>Include</h4> <ul>  <li>toiletries and medications (except NHS receipts)</li> <li>newspapers and periodicals</li> <li>books, stationery and office supplies</li> <li>photographic and optical goods</li> <li>spectacles, contact lenses and sunglasses</li> <li>toys and games</li> <li>cycles and cycle accessories</li> <li>sport and camping equipment</li> <li>jewellery</li> <li>silverware and plate, clocks and watches</li> <li>household cleaning products and kitchen paper products</li> <li>pets, pets’ requisites and pet foods</li> <li>cut flowers, plants, seeds and other garden sundries</li> <li>other new and second hand goods</li> <li>Mobile phones</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>revenue from mobile phone network commission and top up </li> <li>lottery sales and commission from lottery sales</li> <li>sales of car accessories and motor vehicles</li> <li>NHS receipts</li> </ul> </div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "title": "Include",
+                                                "list": [
+                                                    "toiletries and medications (except NHS receipts)",
+                                                    "newspapers and periodicals",
+                                                    "books, stationery and office supplies",
+                                                    "photographic and optical goods",
+                                                    "spectacles, contact lenses and sunglasses",
+                                                    "toys and games",
+                                                    "cycles and cycle accessories",
+                                                    "sport and camping equipment",
+                                                    "jewellery",
+                                                    "silverware and plate, clocks and watches",
+                                                    "household cleaning products and kitchen paper products",
+                                                    "pets, pets\u2019 requisites and pet foods",
+                                                    "cut flowers, plants, seeds and other garden sundries",
+                                                    "other new and second hand goods",
+                                                    "Mobile phones"
+                                                ]
+                                            },
+                                            {
+                                                "title": "Exclude",
+                                                "list": [
+                                                    "revenue from mobile phone network commission and top up",
+                                                    "lottery sales and commission from lottery sales",
+                                                    "sales of car accessories and motor vehicles",
+                                                    "NHS receipts"
+                                                ]
+                                            }
+                                        ]
+                                    },
                                     "type": "Currency",
                                     "options": [],
                                     "mandatory": false
@@ -164,7 +263,29 @@
                                     "id": "total-retail-turnover",
                                     "q_code": "20",
                                     "label": "What was the value of the business’s total retail turnover?",
-                                    "guidance": "<div> <h4>Include</h4> <ul> <li>VAT</li> <li>internet sales</li> <li>retail sale from outlets in Great Britain to customers abroad</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>revenue from mobile phone network commission and top up </li> <li>sales from catering facilities used by customers</li>  <li>lottery sales and commission from lottery sales</li> <li>sales of car accessories and motor vehicles</li> <li>NHS receipts</li> </ul> </div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "title": "Include",
+                                                "list": [
+                                                    "VAT",
+                                                    "internet sales",
+                                                    "retail sale from outlets in Great Britain to customers abroad"
+                                                ]
+                                            },
+                                            {
+                                                "title": "Exclude",
+                                                "list": [
+                                                    "revenue from mobile phone network commission and top up",
+                                                    "sales from catering facilities used by customers",
+                                                    "lottery sales and commission from lottery sales",
+                                                    "sales of car accessories and motor vehicles",
+                                                    "NHS receipts"
+                                                ]
+                                            }
+                                        ]
+                                    },
                                     "type": "Currency",
                                     "options": [],
                                     "mandatory": true,
@@ -184,7 +305,18 @@
                                     "id": "internet-sales",
                                     "q_code": "21",
                                     "label": "Of your total retail turnover, how much were from internet sales?",
-                                    "guidance": "<div> <h4>Include</h4><ul> <li>VAT</li> <li>sales from orders received over the internet, irrespective of the payment or delivery method</li> </ul></div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                            "title": "Include",
+                                            "list": [
+                                                "VAT",
+                                                "sales from orders received over the internet, irrespective of the payment or delivery method",
+                                                "soft drinks"
+                                            ]
+                                        }]
+                                    },
                                     "type": "Currency",
                                     "options": [],
                                     "mandatory": false
@@ -199,7 +331,26 @@
                                     "id": "total-sales-automotive-fuel",
                                     "q_code": "27",
                                     "label": "What was the value of the business’s total sales of automotive fuel?",
-                                    "guidance": "<div><h4>Include</h4><ul> <li>VAT</li> <li>sales of fuel owned by you</li> <li>sales of other items not paid a commission for</li>  </ul></div><div> <h4>Exclude</h4> <ul> <li>sales of fuel not owned by you</li> <li>any commissions</li> </ul></div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "title": "Include",
+                                                "list": [
+                                                    "VAT",
+                                                    "sales of fuel owned by you",
+                                                    "sales of other items not paid a commission for"
+                                                ]
+                                            },
+                                            {
+                                                "title": "Exclude",
+                                                "list": [
+                                                    "sales of fuel not owned by you",
+                                                    "any commissions"
+                                                ]
+                                            }
+                                        ]
+                                    },
                                     "type": "Currency",
                                     "options": [],
                                     "mandatory": false
@@ -220,7 +371,6 @@
                                 "id": "reason-for-change",
                                 "q_code": "146",
                                 "label": "Comments",
-                                "guidance": "",
                                 "type": "TextArea",
                                 "options": [],
                                 "mandatory": false

--- a/data/en/1_0213.json
+++ b/data/en/1_0213.json
@@ -27,7 +27,6 @@
                         "id": "reporting-period-section",
                         "questions": [{
                             "answers": [{
-                                    "guidance": "",
                                     "id": "period-from",
                                     "label": "Period from",
                                     "mandatory": true,
@@ -42,7 +41,6 @@
                                     }
                                 },
                                 {
-                                    "guidance": "",
                                     "id": "period-to",
                                     "label": "Period to",
                                     "mandatory": true,
@@ -68,15 +66,35 @@
                         "description": "<p>- You should enter figures for the reporting period stated above<br>- You should round your figures to the nearest (\u00a3) pound</p>",
                         "id": "total-sales-section",
                         "questions": [{
-                                "guidance": [{
-                                    "title": "Include",
-                                    "list": [
-                                        "VAT",
-                                        "Internet Sales"
-                                    ]
-                                }],
+                                "guidance": {
+                                    "content": [{
+                                        "title": "Include:",
+                                        "list": [
+                                            "VAT",
+                                            "Internet Sales"
+                                        ]
+                                    }]
+                                },
                                 "answers": [{
-                                    "guidance": "<div> <h4>Include</h4> <ul> <li>all fresh food</li> <li>other food for human consumption (except chocolate and sugar confectionery)</li> <li>soft drinks</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>sales from catering facilities used by customers</li> </ul> </div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "title": "Include",
+                                                "list": [
+                                                    "all fresh food",
+                                                    "other food for human consumption (except chocolate and sugar confectionery)",
+                                                    "soft drinks"
+                                                ]
+                                            },
+                                            {
+                                                "title": "Exclude",
+                                                "list": [
+                                                    "sales from catering facilities used by customers"
+                                                ]
+                                            }
+                                        ]
+                                    },
                                     "id": "total-sales-food",
                                     "label": "What was the value of the business's total sales of food?",
                                     "mandatory": false,
@@ -98,7 +116,18 @@
                             },
                             {
                                 "answers": [{
-                                    "guidance": "<div> <h4>Include</h4> <ul> <li>alcoholic drink</li> <li>chocolate and sugar confectionery</li> <li>tobacco and smokers\u2019 requisites</li></ul> </div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                            "title": "Include",
+                                            "list": [
+                                                "alcoholic drink",
+                                                "chocolate and sugar confectionery",
+                                                "tobacco and smokers\u2019 requisites"
+                                            ]
+                                        }]
+                                    },
                                     "id": "total-sales-alcohol",
                                     "label": "What was the value of the business's total sales of alcohol, confectionery and tobacco?",
                                     "mandatory": false,
@@ -120,7 +149,21 @@
                             },
                             {
                                 "answers": [{
-                                    "guidance": "<div> <h4>Include</h4><ul> <li>clothing and footwear</li> <li>clothing fabrics</li> <li>haberdashery and furs</li> <li>leather and travel goods</li> <li>handbags</li> <li>umbrellas</li></ul></div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                            "title": "Include",
+                                            "list": [
+                                                "clothing and footwear",
+                                                "clothing fabrics",
+                                                "haberdashery and furs",
+                                                "leather and travel goods",
+                                                "handbags",
+                                                "umbrellas"
+                                            ]
+                                        }]
+                                    },
                                     "id": "total-sales-clothing",
                                     "label": "What was the value of the business's total sales of clothing and footwear?",
                                     "mandatory": false,
@@ -142,7 +185,30 @@
                             },
                             {
                                 "answers": [{
-                                    "guidance": "<div> <h4>Include</h4><ul> <li>carpets, rugs and other floor coverings</li> <li>furniture</li> <li>household textiles and soft furnishings</li> <li>prints and picture frames</li> <li>antiques and works of art</li> <li>domestic electrical and gas appliances, audio/visual equipment and home computers</li> <li>lighting and minor electrical supplies</li> <li>records, compact discs, audio and video tapes</li> <li>musical instruments and goods</li> <li>decorators\u2019 and DIY supplies</li> <li>lawn-mowers</li> <li>hardware</li> <li>china, glassware and cutlery</li> <li>novelties, souvenirs and gifts</li> <li>e-cigarettes</li> </ul></div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                            "title": "Include",
+                                            "list": [
+                                                "carpets, rugs and other floor coverings",
+                                                "furniture",
+                                                "household textiles and soft furnishings",
+                                                "prints and picture frames",
+                                                "antiques and works of art",
+                                                "domestic electrical and gas appliances, audio/visual equipment and home computers",
+                                                "lighting and minor electrical supplies",
+                                                "records, compact discs, audio and video tapes",
+                                                "musical instruments and goods",
+                                                "decorators\u2019 and DIY supplies",
+                                                "lawn-mowers",
+                                                "hardware",
+                                                "china, glassware and cutlery",
+                                                "novelties, souvenirs and gifts",
+                                                "e-cigarettes"
+                                            ]
+                                        }]
+                                    },
                                     "id": "total-sales-household-goods",
                                     "label": "What was the value of the business's total sales of household goods?",
                                     "mandatory": false,
@@ -164,7 +230,40 @@
                             },
                             {
                                 "answers": [{
-                                    "guidance": "<div> <h4>Include</h4> <ul>  <li>toiletries and medications (except NHS receipts)</li> <li>newspapers and periodicals</li> <li>books, stationery and office supplies</li> <li>photographic and optical goods</li> <li>spectacles, contact lenses and sunglasses</li> <li>toys and games</li> <li>cycles and cycle accessories</li> <li>sport and camping equipment</li> <li>jewellery</li> <li>silverware and plate, clocks and watches</li> <li>household cleaning products and kitchen paper products</li> <li>pets, pets\u2019 requisites and pet foods</li> <li>cut flowers, plants, seeds and other garden sundries</li> <li>other new and second hand goods</li> <li>Mobile phones</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>revenue from mobile phone network commission and top up </li> <li>lottery sales and commission from lottery sales</li> <li>sales of car accessories and motor vehicles</li> <li>NHS receipts</li> </ul> </div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "title": "Include",
+                                                "list": [
+                                                    "toiletries and medications (except NHS receipts)",
+                                                    "newspapers and periodicals",
+                                                    "books, stationery and office supplies",
+                                                    "photographic and optical goods",
+                                                    "spectacles, contact lenses and sunglasses",
+                                                    "toys and games",
+                                                    "cycles and cycle accessories",
+                                                    "sport and camping equipment",
+                                                    "jewellery",
+                                                    "silverware and plate, clocks and watches",
+                                                    "household cleaning products and kitchen paper products",
+                                                    "pets, pets\u2019 requisites and pet foods",
+                                                    "cut flowers, plants, seeds and other garden sundries",
+                                                    "other new and second hand goods",
+                                                    "Mobile phones"
+                                                ]
+                                            },
+                                            {
+                                                "title": "Exclude",
+                                                "list": [
+                                                    "revenue from mobile phone network commission and top up ",
+                                                    "lottery sales and commission from lottery sales",
+                                                    "sales of car accessories and motor vehicles",
+                                                    "NHS receipts"
+                                                ]
+                                            }
+                                        ]
+                                    },
                                     "id": "total-sales-other-goods",
                                     "label": "What was the value of the business\u2019s total sales of other goods?",
                                     "mandatory": false,
@@ -186,7 +285,29 @@
                             },
                             {
                                 "answers": [{
-                                    "guidance": "<div> <h4>Include</h4> <ul> <li>VAT</li> <li>internet sales</li> <li>retail sale from outlets in Great Britain to customers abroad</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>revenue from mobile phone network commission and top up </li> <li>sales from catering facilities used by customers</li>  <li>lottery sales and commission from lottery sales</li> <li>sales of car accessories and motor vehicles</li> <li>NHS receipts</li> </ul> </div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "title": "Include",
+                                                "list": [
+                                                    "VAT",
+                                                    "internet sales",
+                                                    "retail sale from outlets in Great Britain to customers abroad"
+                                                ]
+                                            },
+                                            {
+                                                "title": "Exclude",
+                                                "list": [
+                                                    "revenue from mobile phone network commission and top up",
+                                                    "sales from catering facilities used by customers",
+                                                    "lottery sales and commission from lottery sales",
+                                                    "sales of car accessories and motor vehicles",
+                                                    "NHS receipts"
+                                                ]
+                                            }
+                                        ]
+                                    },
                                     "id": "total-retail-turnover",
                                     "label": "What was the value of the business\u2019s total retail turnover?",
                                     "mandatory": true,
@@ -209,7 +330,17 @@
                             },
                             {
                                 "answers": [{
-                                    "guidance": "<div> <h4>Include</h4><ul> <li>VAT</li> <li>sales from orders received over the internet, irrespective of the payment or delivery method</li> </ul></div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                            "title": "Include",
+                                            "list": [
+                                                "VAT",
+                                                "sales from orders received over the internet, irrespective of the payment or delivery method"
+                                            ]
+                                        }]
+                                    },
                                     "id": "internet-sales",
                                     "label": "Of your total retail turnover, how much were from internet sales?",
                                     "mandatory": false,
@@ -237,7 +368,6 @@
                         "id": "reason-for-change-section",
                         "questions": [{
                             "answers": [{
-                                "guidance": "",
                                 "id": "reason-for-change",
                                 "label": "Comments",
                                 "mandatory": false,
@@ -265,26 +395,27 @@
                     "description": "<p>An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.</p>",
                     "id": "number-employees-section",
                     "questions": [{
-                            "guidance": [{
-                                    "title": "Include",
-                                    "list": [
-                                        "all workers paid directly from this business\u2019s payroll(s)",
-                                        "those temporarily absent but still being paid, for example on maternity leave"
-                                    ]
-                                },
-                                {
-                                    "title": "Exclude",
-                                    "list": [
-                                        "agency workers paid directly from the agency payroll",
-                                        "voluntary workers",
-                                        "former employees only receiving pension",
-                                        "self-employed workers",
-                                        "<b>working</b> owners who are not paid via PAYE"
-                                    ]
-                                }
-                            ],
+                            "guidance": {
+                                "content": [{
+                                        "title": "Include",
+                                        "list": [
+                                            "all workers paid directly from this business\u2019s payroll(s)",
+                                            "those temporarily absent but still being paid, for example on maternity leave"
+                                        ]
+                                    },
+                                    {
+                                        "title": "Exclude",
+                                        "list": [
+                                            "agency workers paid directly from the agency payroll",
+                                            "voluntary workers",
+                                            "former employees only receiving pension",
+                                            "self-employed workers",
+                                            "<b>working</b> owners who are not paid via PAYE"
+                                        ]
+                                    }
+                                ]
+                            },
                             "answers": [{
-                                "guidance": "",
                                 "id": "number-male-employees-over-30-hours",
                                 "label": "What was the number of male employees working more than 30 hours per week?",
                                 "mandatory": false,
@@ -306,7 +437,6 @@
                         },
                         {
                             "answers": [{
-                                "guidance": "",
                                 "id": "number-male-employees-under-30-hours",
                                 "label": "What was the number of male employees working 30 hours or less per week?",
                                 "mandatory": false,
@@ -328,7 +458,6 @@
                         },
                         {
                             "answers": [{
-                                "guidance": "",
                                 "id": "number-female-employees-over-30-hours",
                                 "label": "What was the number of female employees working more than 30 hours per week?",
                                 "mandatory": false,
@@ -350,7 +479,6 @@
                         },
                         {
                             "answers": [{
-                                "guidance": "",
                                 "id": "number-female-employees-under-30-hours",
                                 "label": "What was the number of female employees working 30 hours or less per week?",
                                 "mandatory": false,
@@ -372,7 +500,6 @@
                         },
                         {
                             "answers": [{
-                                "guidance": "",
                                 "id": "total-number-employees",
                                 "label": "What was the total number of employees?",
                                 "mandatory": true,

--- a/data/en/1_0215.json
+++ b/data/en/1_0215.json
@@ -27,7 +27,6 @@
                         "id": "reporting-period-section",
                         "questions": [{
                             "answers": [{
-                                    "guidance": "",
                                     "id": "period-from",
                                     "label": "Period from",
                                     "mandatory": true,
@@ -42,7 +41,6 @@
                                     }
                                 },
                                 {
-                                    "guidance": "",
                                     "id": "period-to",
                                     "label": "Period to",
                                     "mandatory": true,
@@ -68,15 +66,35 @@
                         "description": "<p>- You should enter figures for the reporting period stated above<br>- You should round your figures to the nearest (\u00a3) pound</p>",
                         "id": "total-sales-section",
                         "questions": [{
-                                "guidance": [{
-                                    "title": "Include",
-                                    "list": [
-                                        "VAT",
-                                        "Internet Sales"
-                                    ]
-                                }],
+                                "guidance": {
+                                    "content": [{
+                                        "title": "Include",
+                                        "list": [
+                                            "VAT",
+                                            "Internet Sales"
+                                        ]
+                                    }]
+                                },
                                 "answers": [{
-                                    "guidance": "<div> <h4>Include</h4> <ul> <li>all fresh food</li> <li>other food for human consumption (except chocolate and sugar confectionery)</li> <li>soft drinks</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>sales from catering facilities used by customers</li> </ul> </div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "title": "Include",
+                                                "list": [
+                                                    "all fresh food",
+                                                    "other food for human consumption (except chocolate and sugar confectionery)",
+                                                    "soft drinks"
+                                                ]
+                                            },
+                                            {
+                                                "title": "Exclude",
+                                                "list": [
+                                                    "sales from catering facilities used by customers"
+                                                ]
+                                            }
+                                        ]
+                                    },
                                     "id": "total-sales-food",
                                     "label": "What was the value of the business's total sales of food?",
                                     "mandatory": false,
@@ -98,7 +116,18 @@
                             },
                             {
                                 "answers": [{
-                                    "guidance": "<div> <h4>Include</h4> <ul> <li>alcoholic drink</li> <li>chocolate and sugar confectionery</li> <li>tobacco and smokers\u2019 requisites</li></ul> </div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                            "title": "Include",
+                                            "list": [
+                                                "alcoholic drink",
+                                                "chocolate and sugar confectionery",
+                                                "tobacco and smokers\u2019 requisites"
+                                            ]
+                                        }]
+                                    },
                                     "id": "total-sales-alcohol",
                                     "label": "What was the value of the business's total sales of alcohol, confectionery and tobacco?",
                                     "mandatory": false,
@@ -120,7 +149,21 @@
                             },
                             {
                                 "answers": [{
-                                    "guidance": "<div> <h4>Include</h4><ul> <li>clothing and footwear</li> <li>clothing fabrics</li> <li>haberdashery and furs</li> <li>leather and travel goods</li> <li>handbags</li> <li>umbrellas</li></ul></div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                            "title": "Include",
+                                            "list": [
+                                                "clothing and footwear",
+                                                "clothing fabrics",
+                                                "haberdashery and furs",
+                                                "leather and travel goods",
+                                                "handbags",
+                                                "umbrellas"
+                                            ]
+                                        }]
+                                    },
                                     "id": "total-sales-clothing",
                                     "label": "What was the value of the business's total sales of clothing and footwear?",
                                     "mandatory": false,
@@ -142,7 +185,21 @@
                             },
                             {
                                 "answers": [{
-                                    "guidance": "<div> <h4>Include</h4><ul> <li>carpets, rugs and other floor coverings</li> <li>furniture</li> <li>household textiles and soft furnishings</li> <li>prints and picture frames</li> <li>antiques and works of art</li> <li>domestic electrical and gas appliances, audio/visual equipment and home computers</li> <li>lighting and minor electrical supplies</li> <li>records, compact discs, audio and video tapes</li> <li>musical instruments and goods</li> <li>decorators\u2019 and DIY supplies</li> <li>lawn-mowers</li> <li>hardware</li> <li>china, glassware and cutlery</li> <li>novelties, souvenirs and gifts</li> <li>e-cigarettes</li> </ul></div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                            "title": "Include",
+                                            "list": [
+                                                "clothing and footwear",
+                                                "clothing fabrics",
+                                                "haberdashery and furs",
+                                                "leather and travel goods",
+                                                "handbags",
+                                                "umbrellas"
+                                            ]
+                                        }]
+                                    },
                                     "id": "total-sales-household-goods",
                                     "label": "What was the value of the business's total sales of household goods?",
                                     "mandatory": false,
@@ -164,7 +221,40 @@
                             },
                             {
                                 "answers": [{
-                                    "guidance": "<div> <h4>Include</h4> <ul>  <li>toiletries and medications (except NHS receipts)</li> <li>newspapers and periodicals</li> <li>books, stationery and office supplies</li> <li>photographic and optical goods</li> <li>spectacles, contact lenses and sunglasses</li> <li>toys and games</li> <li>cycles and cycle accessories</li> <li>sport and camping equipment</li> <li>jewellery</li> <li>silverware and plate, clocks and watches</li> <li>household cleaning products and kitchen paper products</li> <li>pets, pets\u2019 requisites and pet foods</li> <li>cut flowers, plants, seeds and other garden sundries</li> <li>other new and second hand goods</li> <li>Mobile phones</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>revenue from mobile phone network commission and top up </li> <li>lottery sales and commission from lottery sales</li> <li>sales of car accessories and motor vehicles</li> <li>NHS receipts</li> </ul> </div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "title": "Include",
+                                                "list": [
+                                                    "toiletries and medications (except NHS receipts)",
+                                                    "newspapers and periodicals",
+                                                    "books, stationery and office supplies",
+                                                    "photographic and optical goods",
+                                                    "spectacles, contact lenses and sunglasses",
+                                                    "toys and games",
+                                                    "cycles and cycle accessories",
+                                                    "sport and camping equipment",
+                                                    "jewellery",
+                                                    "silverware and plate, clocks and watches",
+                                                    "household cleaning products and kitchen paper products",
+                                                    "pets, pets\u2019 requisites and pet foods",
+                                                    "cut flowers, plants, seeds and other garden sundries",
+                                                    "other new and second hand goods",
+                                                    "Mobile phones"
+                                                ]
+                                            },
+                                            {
+                                                "title": "Exclude",
+                                                "list": [
+                                                    "revenue from mobile phone network commission and top up ",
+                                                    "lottery sales and commission from lottery sales",
+                                                    "sales of car accessories and motor vehicles",
+                                                    "NHS receipts"
+                                                ]
+                                            }
+                                        ]
+                                    },
                                     "id": "total-sales-other-goods",
                                     "label": "What was the value of the business\u2019s total sales of other goods?",
                                     "mandatory": false,
@@ -186,7 +276,29 @@
                             },
                             {
                                 "answers": [{
-                                    "guidance": "<div> <h4>Include</h4> <ul> <li>VAT</li> <li>internet sales</li> <li>retail sale from outlets in Great Britain to customers abroad</li> </ul> </div> <div> <h4>Exclude</h4> <ul> <li>revenue from mobile phone network commission and top up </li> <li>sales from catering facilities used by customers</li>  <li>lottery sales and commission from lottery sales</li> <li>sales of car accessories and motor vehicles</li> <li>NHS receipts</li> </ul> </div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "title": "Include",
+                                                "list": [
+                                                    "VAT",
+                                                    "internet sales",
+                                                    "retail sale from outlets in Great Britain to customers abroad"
+                                                ]
+                                            },
+                                            {
+                                                "title": "Exclude",
+                                                "list": [
+                                                    "revenue from mobile phone network commission and top up",
+                                                    "sales from catering facilities used by customers",
+                                                    "lottery sales and commission from lottery sales",
+                                                    "sales of car accessories and motor vehicles",
+                                                    "NHS receipts"
+                                                ]
+                                            }
+                                        ]
+                                    },
                                     "id": "total-retail-turnover",
                                     "label": "What was the value of the business\u2019s total retail turnover?",
                                     "mandatory": true,
@@ -209,7 +321,17 @@
                             },
                             {
                                 "answers": [{
-                                    "guidance": "<div> <h4>Include</h4><ul> <li>VAT</li> <li>sales from orders received over the internet, irrespective of the payment or delivery method</li> </ul></div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                            "title": "Include",
+                                            "list": [
+                                                "VAT",
+                                                "sales from orders received over the internet, irrespective of the payment or delivery method"
+                                            ]
+                                        }]
+                                    },
                                     "id": "internet-sales",
                                     "label": "Of your total retail turnover, how much were from internet sales?",
                                     "mandatory": false,
@@ -231,7 +353,26 @@
                             },
                             {
                                 "answers": [{
-                                    "guidance": "<div><h4>Include</h4><ul> <li>VAT</li> <li>sales of fuel owned by you</li> <li>sales of other items not paid a commission for</li>  </ul></div><div> <h4>Exclude</h4> <ul> <li>sales of fuel not owned by you</li> <li>any commissions</li> </ul></div>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "title": "Include",
+                                                "list": [
+                                                    "VAT",
+                                                    "sales of fuel owned by you",
+                                                    "sales of other items not paid a commission for"
+                                                ]
+                                            },
+                                            {
+                                                "title": "Exclude",
+                                                "list": [
+                                                    "sales of fuel not owned by you",
+                                                    "any commissions"
+                                                ]
+                                            }
+                                        ]
+                                    },
                                     "id": "total-sales-automotive-fuel",
                                     "label": "What was the value of the business\u2019s total sales of automotive fuel?",
                                     "mandatory": false,
@@ -259,7 +400,6 @@
                         "id": "reason-for-change-section",
                         "questions": [{
                             "answers": [{
-                                "guidance": "",
                                 "id": "reason-for-change",
                                 "label": "Comments",
                                 "mandatory": false,
@@ -287,26 +427,27 @@
                     "description": "<p>An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.</p>",
                     "id": "number-employees-section",
                     "questions": [{
-                            "guidance": [{
-                                    "title": "Include",
-                                    "list": [
-                                        "all workers paid directly from this business\u2019s payroll(s)",
-                                        "those temporarily absent but still being paid, for example on maternity leave"
-                                    ]
-                                },
-                                {
-                                    "title": "Exclude",
-                                    "list": [
-                                        "agency workers paid directly from the agency payroll",
-                                        "voluntary workers",
-                                        "former employees only receiving pension",
-                                        "self-employed workers",
-                                        "<b>working</b> owners who are not paid via PAYE"
-                                    ]
-                                }
-                            ],
+                            "guidance": {
+                                "content": [{
+                                        "title": "Include",
+                                        "list": [
+                                            "all workers paid directly from this business\u2019s payroll(s)",
+                                            "those temporarily absent but still being paid, for example on maternity leave"
+                                        ]
+                                    },
+                                    {
+                                        "title": "Exclude",
+                                        "list": [
+                                            "agency workers paid directly from the agency payroll",
+                                            "voluntary workers",
+                                            "former employees only receiving pension",
+                                            "self-employed workers",
+                                            "<b>working</b> owners who are not paid via PAYE"
+                                        ]
+                                    }
+                                ]
+                            },
                             "answers": [{
-                                "guidance": "",
                                 "id": "number-male-employees-over-30-hours",
                                 "label": "What was the number of male employees working more than 30 hours per week?",
                                 "mandatory": false,
@@ -328,7 +469,6 @@
                         },
                         {
                             "answers": [{
-                                "guidance": "",
                                 "id": "number-male-employees-under-30-hours",
                                 "label": "What was the number of male employees working 30 hours or less per week?",
                                 "mandatory": false,
@@ -350,7 +490,6 @@
                         },
                         {
                             "answers": [{
-                                "guidance": "",
                                 "id": "number-female-employees-over-30-hours",
                                 "label": "What was the number of female employees working more than 30 hours per week?",
                                 "mandatory": false,
@@ -372,7 +511,6 @@
                         },
                         {
                             "answers": [{
-                                "guidance": "",
                                 "id": "number-female-employees-under-30-hours",
                                 "label": "What was the number of female employees working 30 hours or less per week?",
                                 "mandatory": false,
@@ -394,7 +532,6 @@
                         },
                         {
                             "answers": [{
-                                "guidance": "",
                                 "id": "total-number-employees",
                                 "label": "What was the total number of employees?",
                                 "mandatory": true,

--- a/data/en/2_0001.json
+++ b/data/en/2_0001.json
@@ -55,24 +55,26 @@
                             }
                         ],
                         "description": "An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.",
-                        "guidance": [{
-                                "list": [
-                                    "all workers paid directly from this business’s payroll(s)",
-                                    "those temporarily absent but still being paid, for example on maternity leave"
-                                ],
-                                "title": "Include:"
-                            },
-                            {
-                                "list": [
-                                    "agency workers paid directly from the agency payroll",
-                                    "voluntary workers",
-                                    "former employees only receiving a pension",
-                                    "self-employed workers",
-                                    "working owners who are not paid via PAYE"
-                                ],
-                                "title": "Exclude:"
-                            }
-                        ],
+                        "guidance": {
+                            "content": [{
+                                    "title": "Include",
+                                    "list": [
+                                        "all workers paid directly from this business’s payroll(s)",
+                                        "those temporarily absent but still being paid, for example on maternity leave"
+                                    ]
+                                },
+                                {
+                                    "title": "Exclude:",
+                                    "list": [
+                                        "agency workers paid directly from the agency payroll",
+                                        "voluntary workers",
+                                        "former employees only receiving a pension",
+                                        "self-employed workers",
+                                        "working owners who are not paid via PAYE"
+                                    ]
+                                }
+                            ]
+                        },
                         "id": "number-of-employees-question",
                         "title": "On {{exercise.start_date|format_date}} what was the number of employees for {{respondent.trad_as_or_ru_name}}?",
                         "type": "General"

--- a/data/en/census_communal.json
+++ b/data/en/census_communal.json
@@ -116,17 +116,19 @@
                         "title": "Are there any usual residents living at this establishment?",
                         "number": "1",
                         "type": "General",
-                        "guidance": [{
-                            "title": "Include",
-                            "list": [
-                                "Yourself, your family and anyone else who lives at this address",
-                                "Students or  school children who live away from your establishment during term time",
-                                "People who usually live outside the UK, who are staying in the UK for 3 months or more",
-                                "People who work away from home within the UK, or are members of the armed forces, if this is their permanent or family home",
-                                "People who are currently outside the UK for less than 12 months, if this is their permanent or family home",
-                                "People staying temporarily who usually live in the UK but do not have another UK address"
-                            ]
-                        }],
+                        "guidance": {
+                            "content": [{
+                                "title": "Include",
+                                "list": [
+                                    "Yourself, your family and anyone else who lives at this address",
+                                    "Students or  school children who live away from your establishment during term time",
+                                    "People who usually live outside the UK, who are staying in the UK for 3 months or more",
+                                    "People who work away from home within the UK, or are members of the armed forces, if this is their permanent or family home",
+                                    "People who are currently outside the UK for less than 12 months, if this is their permanent or family home",
+                                    "People staying temporarily who usually live in the UK but do not have another UK address"
+                                ]
+                            }]
+                        },
                         "answers": [{
                             "id": "usual-residents-answer",
                             "mandatory": true,
@@ -531,14 +533,16 @@
                         "id": "questionnaire-completed-question",
                         "title": "",
                         "type": "General",
-                        "guidance": [{
-                            "title": "Please note:",
-                            "list": [
-                                "By submitting your responses, you are declaring that you have completed to the best of your knowledge and belief.",
-                                "If you do not submit, your responses will be automatically submitted when the Census 2017 Test closes.",
-                                "After submission you will have an opportunity to provide feedback on your experience."
-                            ]
-                        }]
+                        "guidance": {
+                            "content": [{
+                                "title": "Please note:",
+                                "list": [
+                                    "By submitting your responses, you are declaring that you have completed to the best of your knowledge and belief.",
+                                    "If you do not submit, your responses will be automatically submitted when the Census 2017 Test closes.",
+                                    "After submission you will have an opportunity to provide feedback on your experience."
+                                ]
+                            }]
+                        }
                     }]
                 }]
             }

--- a/data/en/census_household.json
+++ b/data/en/census_household.json
@@ -27,20 +27,28 @@
                             "id": "permanent-or-family-home-question",
                             "title": "Does anyone live here as their permanent or family home?",
                             "number": "1",
-                            "guidance": [{
-                                "title": "Include",
-                                "list": [
-                                    "Yourself, if this is your permanent or family home",
-                                    "Family members including partners, children and babies born on or before 9 April 2017",
-                                    "Students and, or school children who live away from home during term time",
-                                    "Housemates tenants or lodgers"
-                                ]
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include",
+                                    "list": [
+                                        "Yourself, if this is your permanent or family home",
+                                        "Family members including partners, children and babies born on or before 9 April 2017",
+                                        "Students and, or school children who live away from home during term time",
+                                        "Housemates tenants or lodgers"
+                                    ]
+                                }]
+                            },
                             "type": "General",
                             "answers": [{
                                 "id": "permanent-or-family-home-answer",
                                 "mandatory": true,
-                                "guidance": "<p>For most people, their permanent home will be the address where they spend the most time.</p>",
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                        "description": "For most people, their permanent home will be the address where they spend the most time."
+                                    }]
+                                },
                                 "options": [{
                                         "label": "Yes",
                                         "value": "Yes"
@@ -93,17 +101,19 @@
                             "id": "else-permanent-or-family-home-question",
                             "title": "Can you confirm no one lives here as their permanent or family home?",
                             "number": "1a",
-                            "guidance": [{
-                                "title": "This could be:",
-                                "list": [
-                                    "People who usually live outside the UK who are staying in the UK for <b>three months or more</b>",
-                                    "People who work away from home within the UK if this is their permanent or family home",
-                                    "Members of the Armed Forces if this is their permanent or family home",
-                                    "People who are temporarily outside the UK for <b>less than 12 months</b>",
-                                    "People staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends",
-                                    "Other people who usually live here, including anyone temporarily away from home "
-                                ]
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "This could be:",
+                                    "list": [
+                                        "People who usually live outside the UK who are staying in the UK for <b>three months or more</b>",
+                                        "People who work away from home within the UK if this is their permanent or family home",
+                                        "Members of the Armed Forces if this is their permanent or family home",
+                                        "People who are temporarily outside the UK for <b>less than 12 months</b>",
+                                        "People staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends",
+                                        "Other people who usually live here, including anyone temporarily away from home "
+                                    ]
+                                }]
+                            },
                             "type": "General",
                             "answers": [{
                                 "id": "else-permanent-or-family-home-answer",
@@ -159,15 +169,17 @@
                             "id": "household-composition-question",
                             "title": "List the names of everyone  who lives here.",
                             "number": "2",
-                            "guidance": [{
-                                "title": "Include",
-                                "list": [
-                                    "Yourself, if this is your permanent or family home",
-                                    "Family members including partners, children and babies born on or before 9 April 2017",
-                                    "Students and, or school children who live away from home during term time",
-                                    "Housemates tenants or lodgers"
-                                ]
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include",
+                                    "list": [
+                                        "Yourself, if this is your permanent or family home",
+                                        "Family members including partners, children and babies born on or before 9 April 2017",
+                                        "Students and, or school children who live away from home during term time",
+                                        "Housemates tenants or lodgers"
+                                    ]
+                                }]
+                            },
                             "type": "RepeatingAnswer",
                             "answers": [{
                                     "alias": "first_name",
@@ -193,7 +205,33 @@
                                     "id": "last-name",
                                     "label": "Last name",
                                     "mandatory": false,
-                                    "guidance": "<p>Enter the current first, middle and last names of all the people who usually live here.</p><p>If you have not yet named your newborn, please enter ‘Baby’ for their first name and then enter their last name (surname).</p><p>Please also include household members who have requested a personal form.</p><p>Please also include the names of people staying with you temporarily who don’t have a usual address in the UK. This is so that we make sure we count everyone.</p><p><strong>Include:</strong></p><ul><li>People who usually live outside the UK who are staying in the UK for <strong>three months or more</strong></li><li>People who work away from home within the UK  if this is their permanent or family home</li><li>Members of the Armed Forces if this is their permanent or family home</li><li>People who are temporarily outside the UK for <strong>less than 12 months</strong></li><li>People staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends</li></ul>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "description": "Enter the current first, middle and last names of all the people who usually live here."
+                                            },
+                                            {
+                                                "description": "If you have not yet named your newborn, please enter ‘Baby’ for their first name and then enter their last name (surname)."
+                                            },
+                                            {
+                                                "description": "Please also include household members who have requested a personal form."
+                                            },
+                                            {
+                                                "description": "Please also include the names of people staying with you temporarily who don’t have a usual address in the UK. This is so that we make sure we count everyone."
+                                            },
+                                            {
+                                                "title": "Include",
+                                                "list": [
+                                                    "People who usually live outside the UK who are staying in the UK for <strong>three months or more</strong>",
+                                                    "People who work away from home within the UK  if this is their permanent or family home",
+                                                    "Members of the Armed Forces if this is their permanent or family home",
+                                                    "People who are temporarily outside the UK for <strong>less than 12 months</strong>",
+                                                    "People staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends"
+                                                ]
+                                            }
+                                        ]
+                                    },
                                     "type": "TextField"
                                 }
                             ]
@@ -213,17 +251,19 @@
                             "title": "Is this everyone for whom this is their permanent or family home?",
                             "number": "3",
                             "description": "Please note that you will need to ensure that everyone is included because you will be unable to make changes later",
-                            "guidance": [{
-                                "title": "Include",
-                                "list": [
-                                    "People who usually live outside the UK who are staying in the UK for <b>three months or more</b>",
-                                    "People who work away from home within the UK  if this is their permanent or family home",
-                                    "Members of the Armed Forces if this is their permanent or family home",
-                                    "People who are temporarily outside the UK for <b>less than 12 months</b>",
-                                    "People staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends",
-                                    "Other people who usually live here, including anyone temporarily away from home"
-                                ]
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include",
+                                    "list": [
+                                        "People who usually live outside the UK who are staying in the UK for <b>three months or more</b>",
+                                        "People who work away from home within the UK  if this is their permanent or family home",
+                                        "Members of the Armed Forces if this is their permanent or family home",
+                                        "People who are temporarily outside the UK for <b>less than 12 months</b>",
+                                        "People staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends",
+                                        "Other people who usually live here, including anyone temporarily away from home"
+                                    ]
+                                }]
+                            },
                             "type": "General",
                             "answers": [{
                                 "id": "everyone-at-address-confirmation-answer",
@@ -269,15 +309,17 @@
                             "id": "overnight-visitors-question",
                             "title": "How many visitors are staying overnight here on 9th April 2017?",
                             "number": "4",
-                            "guidance": [{
-                                "title": "Include",
-                                "list": [
-                                    "People who usually live somewhere else in the UK. For example, boy or girl friends, relatives",
-                                    "People staying here because it is their second address, for example, for work. Their permanent or family home is elsewhere",
-                                    "People who usually live outside the UK who are visiting the UK for less than three months",
-                                    "People here on holiday"
-                                ]
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include",
+                                    "list": [
+                                        "People who usually live somewhere else in the UK. For example, boy or girl friends, relatives",
+                                        "People staying here because it is their second address, for example, for work. Their permanent or family home is elsewhere",
+                                        "People who usually live outside the UK who are visiting the UK for less than three months",
+                                        "People here on holiday"
+                                    ]
+                                }]
+                            },
                             "type": "General",
                             "answers": [{
                                 "id": "overnight-visitors-answer",
@@ -318,21 +360,25 @@
                         "title": "How is {{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }} related to the people below?",
                         "number": "5",
                         "description": "If members are not related, select the ‘unrelated’ option",
-                        "guidance": [{
-                            "list": [
-                                "Select the relationships between members of your household",
-                                "If you are the parents of adopted children, select the ‘Mother or father’ option to show your relationship to them.",
-                                "If you have foster children living with you, select the ‘Unrelated’ option.",
-                                "Include half-brothers and half-sisters in the ‘Step-brother or step-sister’ category.",
-                                "Same-sex civil partner is used to describe the relationship between two people who have legally registered a civil partnership.",
-                                "If none of the options fully reflects your relationship, please select the one which you feel best describes your situation."
-                            ]
-                        }],
                         "type": "Relationship",
                         "answers": [{
                             "id": "household-relationships-answer",
                             "label": "%(current_person)s is %(other_person)s",
                             "mandatory": false,
+                            "guidance": {
+                                "show_guidance": "Show further guidance",
+                                "hide_guidance": "Hide further guidance",
+                                "content": [{
+                                    "list": [
+                                        "Select the relationships between members of your household",
+                                        "If you are the parents of adopted children, select the ‘Mother or father’ option to show your relationship to them.",
+                                        "If you have foster children living with you, select the ‘Unrelated’ option.",
+                                        "Include half-brothers and half-sisters in the ‘Step-brother or step-sister’ category.",
+                                        "Same-sex civil partner is used to describe the relationship between two people who have legally registered a civil partnership.",
+                                        "If none of the options fully reflects your relationship, please select the one which you feel best describes your situation."
+                                    ]
+                                }]
+                            },
                             "options": [{
                                     "label": "Husband or wife",
                                     "value": "Husband or wife"
@@ -558,9 +604,11 @@
                             "id": "self-contained-accommodation-question",
                             "title": "Is this household’s accommodation self-contained?",
                             "number": "2",
-                            "guidance": [{
-                                "description": "This means that all the rooms, including the kitchen, bathroom and toilet, are behind a door that only this household can use"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "description": "This means that all the rooms, including the kitchen, bathroom and toilet, are behind a door that only this household can use"
+                                }]
+                            },
                             "type": "General",
                             "answers": [{
                                 "id": "self-contained-accommodation-answer",
@@ -590,9 +638,11 @@
                             "id": "number-of-bedrooms-question",
                             "title": "How many bedrooms are available for use only by this household?",
                             "number": "3",
-                            "guidance": [{
-                                "description": "Include all rooms built or converted for use as bedrooms, even if they’re not currently used as bedrooms"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "description": "Include all rooms built or converted for use as bedrooms, even if they’re not currently used as bedrooms"
+                                }]
+                            },
                             "type": "General",
                             "answers": [{
                                 "id": "number-of-bedrooms-answer",
@@ -695,7 +745,23 @@
                             "answers": [{
                                 "id": "own-or-rent-answer",
                                 "mandatory": false,
-                                "guidance": "<p>‘Owns outright’ means you own without a mortgage or loan, even if you pay a small amount of money to the lender for them to look after the deeds.</p><p>‘Part owns and part rents’ means you own part of your accommodation and also pay rent for part of it. You can part own with or without a mortgage or loan.</p><p>If your rent is paid by housing benefit, select ‘Rents (with or without housing benefit)’.</p><p>If you do not pay rent, but contribute to household expenses, you live rent free.</p>",
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                            "description": "‘Owns outright’ means you own without a mortgage or loan, even if you pay a small amount of money to the lender for them to look after the deeds."
+                                        },
+                                        {
+                                            "description": "‘Part owns and part rents’ means you own part of your accommodation and also pay rent for part of it. You can part own with or without a mortgage or loan."
+                                        },
+                                        {
+                                            "description": "If your rent is paid by housing benefit, select ‘Rents (with or without housing benefit)’."
+                                        },
+                                        {
+                                            "description": "If you do not pay rent, but contribute to household expenses, you live rent free."
+                                        }
+                                    ]
+                                },
                                 "options": [{
                                         "label": "Owns outright",
                                         "value": "Owns outright"
@@ -804,9 +870,11 @@
                             "id": "number-of-vehicles-question",
                             "title": "In total, how many cars or vans are owned, or available for use, by members of this household?",
                             "number": "7",
-                            "guidance": [{
-                                "description": "Include any company cars or vans available for private use"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "description": "Include any company cars or vans available for private use"
+                                }]
+                            },
                             "type": "General",
                             "answers": [{
                                 "id": "number-of-vehicles-answer",
@@ -1007,7 +1075,13 @@
                             "answers": [{
                                 "id": "private-response-answer",
                                 "mandatory": false,
-                                "guidance": "If you request a personal or confidential form we will send you a unique access code that will allow you to complete the individual questions for yourself. No-one else will be able to see the answers you provide.",
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                        "description": "If you request a personal or confidential form we will send you a unique access code that will allow you to complete the individual questions for yourself. No-one else will be able to see the answers you provide."
+                                    }]
+                                },
                                 "options": [{
                                         "label": "No, I do not want to request a personal form",
                                         "value": "No, I do not want to request a personal form"
@@ -1129,7 +1203,20 @@
                             "answers": [{
                                 "id": "marital-status-answer",
                                 "mandatory": false,
-                                "guidance": "<p>Please answer according to your status on 9 April 2017.</p><p>Please answer this question for children, even though they may not be old enough to marry or form a same-sex civil partnership.</p><p>If you were married (or formed a registered same-sex partnership) abroad, and this enables you to be recognised as married or civil partnered in the UK, complete the question reflecting that legal partnership.</p>",
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                            "description": "Please answer according to your status on 9 April 2017."
+                                        },
+                                        {
+                                            "description": "Please answer this question for children, even though they may not be old enough to marry or form a same-sex civil partnership."
+                                        },
+                                        {
+                                            "description": "If you were married (or formed a registered same-sex partnership) abroad, and this enables you to be recognised as married or civil partnered in the UK, complete the question reflecting that legal partnership."
+                                        }
+                                    ]
+                                },
                                 "options": [{
                                         "label": "Never married and never registered a same-sex civil partnership",
                                         "value": "Never married and never registered a same-sex civil partnership"
@@ -1187,7 +1274,17 @@
                             "answers": [{
                                     "id": "another-address-answer",
                                     "mandatory": false,
-                                    "guidance": "<p>Examples might include another parent’s address, an armed forces base, a holiday home, or term-time address.</p><p>The days you stay at the address do not have to be in a row. They can be at any time during the year.</p>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "description": "Examples might include another parent’s address, an armed forces base, a holiday home, or term-time address."
+                                            },
+                                            {
+                                                "description": "The days you stay at the address do not have to be in a row. They can be at any time during the year."
+                                            }
+                                        ]
+                                    },
                                     "options": [{
                                             "label": "No",
                                             "value": "No"
@@ -1389,7 +1486,30 @@
                             "answers": [{
                                 "id": "in-education-answer",
                                 "mandatory": false,
-                                "guidance": "<p>The following are considered to be in full-time education:</p><p>Under 16s</p><p>16-18s if they attend more than 12 hours a week of study on a course up to and including A level standard</p><p>Anyone on a course at a higher standard than A level if they are studying at a UK institution, on a course which:</p><ul><li>lasts for at least 1 academic year</li><li>involves at least 24 weeks per year, and</li><li>involves at least 21 hours of term-time study, classes or work experience per week (including unstructured study)</li></ul>",
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                            "description": "The following are considered to be in full-time education:"
+                                        },
+                                        {
+                                            "description": "Under 16s"
+                                        },
+                                        {
+                                            "description": "16-18s if they attend more than 12 hours a week of study on a course up to and including A level standard"
+                                        },
+                                        {
+                                            "description": "Anyone on a course at a higher standard than A level if they are studying at a UK institution, on a course which:"
+                                        },
+                                        {
+                                            "list": [
+                                                "lasts for at least 1 academic year",
+                                                "involves at least 24 weeks per year, and",
+                                                "involves at least 21 hours of term-time study, classes or work experience per week (including unstructured study)"
+                                            ]
+                                        }
+                                    ]
+                                },
                                 "options": [{
                                         "label": "Yes",
                                         "value": "Yes"
@@ -1676,9 +1796,11 @@
                             "id": "arrive-in-uk-question",
                             "title": "If you were not born in the United Kingdom, when did you most recently arrive to live here?",
                             "number": "10",
-                            "guidance": [{
-                                "description": "Exclude short visits away from the UK"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "description": "Exclude short visits away from the UK"
+                                }]
+                            },
                             "type": "General",
                             "answers": [{
                                 "id": "arrive-in-uk-answer",
@@ -1708,7 +1830,13 @@
                             "answers": [{
                                 "id": "length-of-stay-answer",
                                 "mandatory": false,
-                                "guidance": "If you arrived in the United Kingdom before May 2016, please select ‘12 months or more’",
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                        "description": "If you arrived in the United Kingdom before May 2016, please select ‘12 months or more’"
+                                    }]
+                                },
                                 "options": [{
                                         "label": "Less than 6 months",
                                         "value": "Less than 6 months"
@@ -1739,9 +1867,11 @@
                             "title": "Do you look after, or give any help or support to family members, friends, neighbours or others because of either:",
                             "number": "13",
                             "description": "<div><ul><li>Long-term physical or mental ill-health/disability?</li><li>Problems related to old age?</li></ul></div>",
-                            "guidance": [{
-                                "description": "<strong>Exclude</strong> anything you do as part of your paid employment"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "description": "<strong>Exclude</strong> anything you do as part of your paid employment"
+                                }]
+                            },
                             "type": "General",
                             "answers": [{
                                 "id": "carer-answer",
@@ -1784,7 +1914,23 @@
                                         "id": "national-identity-england-answer",
                                         "label": "Select all that apply",
                                         "mandatory": false,
-                                        "guidance": "<p>You can choose more than one national identity.</p><p>It is for you to choose your national identity or identities. For example this could be about the country or countries where you feel you belong, or think of as home.</p><p>It is not dependent on your ethnic group or legal nationality (citizenship).</p><p>Select all that apply. If your national identity isn’t listed, select ‘Other’ and enter the national identity.</p>",
+                                        "guidance": {
+                                            "show_guidance": "Show further guidance",
+                                            "hide_guidance": "Hide further guidance",
+                                            "content": [{
+                                                    "description": "You can choose more than one national identity."
+                                                },
+                                                {
+                                                    "description": "It is for you to choose your national identity or identities. For example this could be about the country or countries where you feel you belong, or think of as home."
+                                                },
+                                                {
+                                                    "description": "It is not dependent on your ethnic group or legal nationality (citizenship)."
+                                                },
+                                                {
+                                                    "description": "Select all that apply. If your national identity isn’t listed, select ‘Other’ and enter the national identity."
+                                                }
+                                            ]
+                                        },
                                         "options": [{
                                                 "label": "English",
                                                 "value": "English"
@@ -1838,7 +1984,23 @@
                                         "id": "national-identity-wales-answer",
                                         "label": "Select all that apply",
                                         "mandatory": false,
-                                        "guidance": "<p>You can choose more than one national identity.</p><p>It is for you to choose your national identity or identities. For example this could be about the country or countries where you feel you belong, or think of as home.</p><p>It is not dependent on your ethnic group or legal nationality (citizenship).</p><p>Select all that apply. If your national identity isn’t listed, select ‘Other’ and enter the national identity.</p>",
+                                        "guidance": {
+                                            "show_guidance": "Show further guidance",
+                                            "hide_guidance": "Hide further guidance",
+                                            "content": [{
+                                                    "description": "You can choose more than one national identity."
+                                                },
+                                                {
+                                                    "description": "It is for you to choose your national identity or identities. For example this could be about the country or countries where you feel you belong, or think of as home."
+                                                },
+                                                {
+                                                    "description": "It is not dependent on your ethnic group or legal nationality (citizenship)."
+                                                },
+                                                {
+                                                    "description": "Select all that apply. If your national identity isn’t listed, select ‘Other’ and enter the national identity."
+                                                }
+                                            ]
+                                        },
                                         "options": [{
                                                 "label": "Welsh",
                                                 "value": "Welsh"
@@ -1901,7 +2063,20 @@
                                 "answers": [{
                                     "id": "ethnic-group-england-answer",
                                     "mandatory": false,
-                                    "guidance": "<p>It is for you to choose your ethnic group. For example this could be your family or cultural background, or it could be how you would describe yourself.</p><p>Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Other ethnic group’. You will then be able to write in the ethnic group you prefer to identify as at the next question.</p>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "description": "It is for you to choose your ethnic group. For example this could be your family or cultural background, or it could be how you would describe yourself."
+                                            },
+                                            {
+                                                "description": "Please select the answer you think is most appropriate."
+                                            },
+                                            {
+                                                "description": "If you don’t feel the options apply to you, select ‘Other ethnic group’. You will then be able to write in the ethnic group you prefer to identify as at the next question."
+                                            }
+                                        ]
+                                    },
                                     "options": [{
                                             "label": "White",
                                             "value": "White",
@@ -1946,7 +2121,20 @@
                                 "answers": [{
                                     "id": "ethnic-group-wales-answer",
                                     "mandatory": false,
-                                    "guidance": "<p>It is for you to choose your ethnic group. For example this could be your family or cultural background, or it could be how you would describe yourself.</p><p>Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Other ethnic group’.  You will then able to write in the ethnic group you prefer to identify as at the next question.</p>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "description": "It is for you to choose your ethnic group. For example this could be your family or cultural background, or it could be how you would describe yourself."
+                                            },
+                                            {
+                                                "description": "Please select the answer you think is most appropriate."
+                                            },
+                                            {
+                                                "description": "If you don’t feel the options apply to you, select ‘Other ethnic group’. You will then be able to write in the ethnic group you prefer to identify as at the next question."
+                                            }
+                                        ]
+                                    },
                                     "options": [{
                                             "label": "White",
                                             "value": "White",
@@ -2132,7 +2320,17 @@
                                 "type": "General",
                                 "answers": [{
                                         "id": "white-ethnic-group-england-answer",
-                                        "guidance": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>",
+                                        "guidance": {
+                                            "show_guidance": "Show further guidance",
+                                            "hide_guidance": "Hide further guidance",
+                                            "content": [{
+                                                    "description": "The options are based on the answer to the previous question. Please select the answer you think is most appropriate."
+                                                },
+                                                {
+                                                    "description": "If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group."
+                                                }
+                                            ]
+                                        },
                                         "mandatory": false,
                                         "options": [{
                                                 "label": "English / Welsh / Scottish / Northern Irish / British",
@@ -2177,7 +2375,17 @@
                                 "type": "General",
                                 "answers": [{
                                         "id": "white-ethnic-group-wales-answer",
-                                        "guidance": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>",
+                                        "guidance": {
+                                            "show_guidance": "Show further guidance",
+                                            "hide_guidance": "Hide further guidance",
+                                            "content": [{
+                                                    "description": "The options are based on the answer to the previous question. Please select the answer you think is most appropriate."
+                                                },
+                                                {
+                                                    "description": "If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group."
+                                                }
+                                            ]
+                                        },
                                         "mandatory": false,
                                         "options": [{
                                                 "label": "Welsh / English / Scottish / Northern Irish / British",
@@ -2264,7 +2472,17 @@
                             "type": "General",
                             "answers": [{
                                     "id": "mixed-ethnic-group-answer",
-                                    "guidance": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "description": "The options are based on the answer to the previous question. Please select the answer you think is most appropriate."
+                                            },
+                                            {
+                                                "description": "If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group."
+                                            }
+                                        ]
+                                    },
                                     "mandatory": false,
                                     "options": [{
                                             "label": "White and Black Caribbean",
@@ -2344,7 +2562,17 @@
                             "answers": [{
                                     "id": "asian-ethnic-group-answer",
                                     "mandatory": false,
-                                    "guidance": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "description": "The options are based on the answer to the previous question. Please select the answer you think is most appropriate."
+                                            },
+                                            {
+                                                "description": "If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group."
+                                            }
+                                        ]
+                                    },
                                     "options": [{
                                             "label": "Indian",
                                             "value": "Indian"
@@ -2427,7 +2655,17 @@
                             "answers": [{
                                     "id": "black-ethnic-group-answer",
                                     "mandatory": false,
-                                    "guidance": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "description": "The options are based on the answer to the previous question. Please select the answer you think is most appropriate."
+                                            },
+                                            {
+                                                "description": "If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group."
+                                            }
+                                        ]
+                                    },
                                     "options": [{
                                             "label": "African",
                                             "value": "African"
@@ -2502,7 +2740,17 @@
                             "answers": [{
                                     "id": "other-ethnic-group-answer",
                                     "mandatory": false,
-                                    "guidance": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "description": "The options are based on the answer to the previous question. Please select the answer you think is most appropriate."
+                                            },
+                                            {
+                                                "description": "If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group."
+                                            }
+                                        ]
+                                    },
                                     "options": [{
                                             "label": "Arab",
                                             "value": "Arab"
@@ -2574,7 +2822,33 @@
                             "answers": [{
                                     "id": "sexual-identity-answer",
                                     "mandatory": false,
-                                    "guidance": "<p>It is for you to decide how to choose your answer.</p><p>If you are unsure of the meaning of any words used, the following might help:</p><ul><li>‘Heterosexual or Straight’ means that a person is, for example, attracted to people of the opposite sex/gender</li><li>‘Gay or Lesbian’ means that a person is, for example, attracted to people of the same sex/gender</li><li>‘Bisexual’ means that a person is, for example, attracted to people of both sexes/any gender</li></ul><p><strong>Identity not listed</strong></p><p>If none of the first three answer options apply to you, please select ‘Other’ and enter your preferred answer.</p><p>This question is voluntary; you can leave it blank if you prefer.</p>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "description": "It is for you to decide how to choose your answer."
+                                            },
+                                            {
+                                                "description": "If you are unsure of the meaning of any words used, the following might help:"
+                                            },
+                                            {
+                                                "list": [
+                                                    "‘Heterosexual or Straight’ means that a person is, for example, attracted to people of the opposite sex/gender",
+                                                    "‘Gay or Lesbian’ means that a person is, for example, attracted to people of the same sex/gender",
+                                                    "‘Bisexual’ means that a person is, for example, attracted to people of both sexes/any gender"
+                                                ]
+                                            },
+                                            {
+                                                "title": "Identity not listed"
+                                            },
+                                            {
+                                                "description": "If none of the first three answer options apply to you, please select ‘Other’ and enter your preferred answer."
+                                            },
+                                            {
+                                                "description": "This question is voluntary; you can leave it blank if you prefer."
+                                            }
+                                        ]
+                                    },
                                     "options": [{
                                             "label": "Heterosexual or Straight",
                                             "value": "Heterosexual or Straight"
@@ -2959,7 +3233,13 @@
                             "answers": [{
                                     "id": "past-usual-address-answer",
                                     "mandatory": false,
-                                    "guidance": "In most cases your usual address will be the permanent or family home that you were living in.",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                            "description": "In most cases your usual address will be the permanent or family home that you were living in."
+                                        }]
+                                    },
                                     "options": [{
                                             "label": "This address",
                                             "value": "This address"
@@ -3149,9 +3429,11 @@
                             "id": "disability-question",
                             "title": "Are your day-to-day activities limited because of a health problem or disability which has lasted, or is expected to last, at least 12 months?",
                             "number": "24",
-                            "guidance": [{
-                                "description": "<strong>Include</strong> Problems related to old age"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "description": "<strong>Include</strong> Problems related to old age"
+                                }]
+                            },
                             "type": "General",
                             "answers": [{
                                 "id": "disability-answer",
@@ -3379,9 +3661,11 @@
                             "id": "volunteering-question",
                             "title": "Thinking of the last 12 months, have you taken part in any volunteering for any groups, clubs or organisations?",
                             "number": "27",
-                            "guidance": [{
-                                "description": "<strong>Exclude</strong> any Court ordered activities"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "description": "<strong>Exclude</strong> any Court ordered activities"
+                                }]
+                            },
                             "type": "General",
                             "answers": [{
                                 "id": "volunteering-answer",
@@ -3420,9 +3704,11 @@
                             "title": "Last week were you:",
                             "number": "28",
                             "description": "Select all that apply",
-                            "guidance": [{
-                                "description": "<strong>Include</strong> any paid work, including casual or temporary work, even if only for one hour"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "description": "<strong>Include</strong> any paid work, including casual or temporary work, even if only for one hour"
+                                }]
+                            },
                             "type": "General",
                             "answers": [{
                                 "id": "employment-type-answer",
@@ -3671,7 +3957,23 @@
                             "answers": [{
                                 "id": "ever-worked-answer",
                                 "mandatory": false,
-                                "guidance": "<p>If you had a full-time or part-time job in the past select ‘Yes’</p><p>This includes work outside of the United Kingdom.</p><p>Please provide an answer even if you are retired.</p><p>If you have never worked, or only ever worked in voluntary/unpaid jobs, select ‘No’.</p>",
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                            "description": "If you had a full-time or part-time job in the past select ‘Yes’"
+                                        },
+                                        {
+                                            "description": "This includes work outside of the United Kingdom."
+                                        },
+                                        {
+                                            "description": "Please provide an answer even if you are retired."
+                                        },
+                                        {
+                                            "description": "If you have never worked, or only ever worked in voluntary/unpaid jobs, select ‘No’."
+                                        }
+                                    ]
+                                },
                                 "options": [{
                                         "label": "Yes",
                                         "value": "Yes"
@@ -3722,9 +4024,11 @@
                             "id": "main-job-question",
                             "title": "In your main job, are (were) you:",
                             "number": "35",
-                            "guidance": [{
-                                "description": "<p>If you are not working answer the remaining questions about your last main job.</p><p>Your main job is the job which you usually work (worked) the most hours</p>"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "description": "<p>If you are not working answer the remaining questions about your last main job.</p><p>Your main job is the job which you usually work (worked) the most hours</p>"
+                                }]
+                            },
                             "type": "General",
                             "answers": [{
                                 "id": "main-job-answer",
@@ -3758,15 +4062,30 @@
                             "id": "job-title-question",
                             "title": "What is (was) your full and specific job title?",
                             "number": "36",
-                            "guidance": [{
-                                "description": "<p>For example, <b>primary school teacher, car mechanic, district nurse, structural engineer</b></p><p>Do not state your grade or pay band</p>"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "description": "<p>For example, <b>primary school teacher, car mechanic, district nurse, structural engineer</b></p><p>Do not state your grade or pay band</p>"
+                                }]
+                            },
                             "type": "General",
                             "answers": [{
                                 "id": "job-title-answer",
                                 "label": "Job title",
                                 "mandatory": false,
-                                "guidance": "<p>Please enter your job title in the space provided.</p><p>Do not state your grade or pay band.</p><p>If you are not sure of your job title please give the best information you can.</p>",
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                            "description": "Please enter your job title in the space provided."
+                                        },
+                                        {
+                                            "description": "Do not state your grade or pay band."
+                                        },
+                                        {
+                                            "description": "If you are not sure of your job title please give the best information you can."
+                                        }
+                                    ]
+                                },
                                 "type": "TextField"
                             }]
                         }]
@@ -3788,7 +4107,17 @@
                                 "id": "job-description-answer",
                                 "label": "Description",
                                 "mandatory": false,
-                                "guidance": "<p>Please enter a brief description of what you do or did in your main job. Your main job is the job in which you usually work (or worked) the most hours.</p><p>Please give the best information you can even if you’re not sure or can’t remember all the details.</p>",
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                            "description": "Please enter a brief description of what you do or did in your main job. Your main job is the job in which you usually work (or worked) the most hours."
+                                        },
+                                        {
+                                            "description": "Please give the best information you can even if you’re not sure or can’t remember all the details."
+                                        }
+                                    ]
+                                },
                                 "type": "TextArea"
                             }]
                         }]
@@ -3805,19 +4134,37 @@
                             "id": "employers-business-question",
                             "title": "At your workplace what is (was) the main activity of your employer or business?",
                             "number": "38",
-                            "guidance": [{
-                                "list": [
-                                    "For example, <b>primary education, repairing cars, contract catering, computer servicing</b>",
-                                    "If you are (were) a civil servant, write <b>government</b>",
-                                    "If you are (were) a local government officer, write <b>local government</b> and give the name of the department within the local authority"
-                                ]
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "list": [
+                                        "For example, <b>primary education, repairing cars, contract catering, computer servicing</b>",
+                                        "If you are (were) a civil servant, write <b>government</b>",
+                                        "If you are (were) a local government officer, write <b>local government</b> and give the name of the department within the local authority"
+                                    ]
+                                }]
+                            },
                             "type": "General",
                             "answers": [{
                                 "id": "employers-business-answer",
                                 "label": "Description",
                                 "mandatory": false,
-                                "guidance": "<p>Enter the main activity of your employer or business.</p><p>Another way of describing main activity is the industry that your employer or business works in.</p><p>If you are not sure of the main activity of your employer or business please give the best information you can.</p><p>If you are employed through an agency please enter the main activity of the business you are working for, not the agency.</p>",
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                            "description": "Enter the main activity of your employer or business."
+                                        },
+                                        {
+                                            "description": "Another way of describing main activity is the industry that your employer or business works in."
+                                        },
+                                        {
+                                            "description": "If you are not sure of the main activity of your employer or business please give the best information you can."
+                                        },
+                                        {
+                                            "description": "If you are employed through an agency please enter the main activity of the business you are working for, not the agency."
+                                        }
+                                    ]
+                                },
                                 "type": "TextArea"
                             }]
                         }]
@@ -3884,15 +4231,30 @@
                             "id": "business-name-question",
                             "title": "In your main job, what is (was) the name of the organisation or business you work (worked) for?",
                             "number": "39a",
-                            "guidance": [{
-                                "description": "If you were self-employed in your own organisation or business, enter the name"
-                            }],
+                            "guidance": {
+                                "content": [{
+                                    "description": "If you were self-employed in your own organisation or business, enter the name"
+                                }]
+                            },
                             "type": "General",
                             "answers": [{
                                 "id": "business-name-answer",
                                 "label": "Organisation or business name",
                                 "mandatory": false,
-                                "guidance": "<p>This question is asking for the name of the organisation or business that you work (or worked) for in your main job.</p><p>If you can’t remember the name of the organisation, please give the best information you can.</p><p>If you are employed through an agency please enter the name of the business you are working for, not the agency.</p>",
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                            "description": "This question is asking for the name of the organisation or business that you work (or worked) for in your main job."
+                                        },
+                                        {
+                                            "description": "If you can’t remember the name of the organisation, please give the best information you can."
+                                        },
+                                        {
+                                            "description": "If you are employed through an agency please enter the name of the business you are working for, not the agency."
+                                        }
+                                    ]
+                                },
                                 "type": "TextField"
                             }]
                         }]
@@ -4184,14 +4546,16 @@
                         "id": "questionnaire-completed-question",
                         "title": "",
                         "type": "General",
-                        "guidance": [{
-                            "title": "Please note:",
-                            "list": [
-                                "By submitting your responses, you are declaring that you have completed to the best of your knowledge and belief.",
-                                "If you do not submit, your responses will be automatically submitted when the Census 2017 Test closes.",
-                                "After submission you will have an opportunity to provide feedback on your experience."
-                            ]
-                        }]
+                        "guidance": {
+                            "content": [{
+                                "title": "Please note:",
+                                "list": [
+                                    "By submitting your responses, you are declaring that you have completed to the best of your knowledge and belief.",
+                                    "If you do not submit, your responses will be automatically submitted when the Census 2017 Test closes.",
+                                    "After submission you will have an opportunity to provide feedback on your experience."
+                                ]
+                            }]
+                        }
                     }]
                 }]
             }]

--- a/data/en/census_individual.json
+++ b/data/en/census_individual.json
@@ -122,7 +122,20 @@
                         "answers": [{
                             "id": "marital-status-answer",
                             "mandatory": false,
-                            "guidance": "<p>Please answer according to your status on 9 April 2017.</p><p>Please answer this question for children, even though they may not be old enough to marry or form a same-sex civil partnership.</p><p>If you were married (or formed a registered same-sex partnership) abroad, and this enables you to be recognised as married or civil partnered in the UK, complete the question reflecting that legal partnership.</p>",
+                            "guidance": {
+                                "show_guidance": "Show further guidance",
+                                "hide_guidance": "Hide further guidance",
+                                "content": [{
+                                        "description": "Please answer according to your status on 9 April 2017."
+                                    },
+                                    {
+                                        "description": "Please answer this question for children, even though they may not be old enough to marry or form a same-sex civil partnership."
+                                    },
+                                    {
+                                        "description": "If you were married (or formed a registered same-sex partnership) abroad, and this enables you to be recognised as married or civil partnered in the UK, complete the question reflecting that legal partnership."
+                                    }
+                                ]
+                            },
                             "options": [{
                                     "label": "Never married and never registered a same-sex civil partnership",
                                     "value": "Never married and never registered a same-sex civil partnership"
@@ -180,7 +193,17 @@
                         "answers": [{
                                 "id": "another-address-answer",
                                 "mandatory": false,
-                                "guidance": "<p>Examples might include another parent’s address, an armed forces base, a holiday home, or term-time address.</p><p>The days you stay at the address do not have to be in a row. They can be at any time during the year.</p>",
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                            "description": "Examples might include another parent’s address, an armed forces base, a holiday home, or term-time address."
+                                        },
+                                        {
+                                            "description": "The days you stay at the address do not have to be in a row. They can be at any time during the year."
+                                        }
+                                    ]
+                                },
                                 "options": [{
                                         "label": "No",
                                         "value": "No"
@@ -382,7 +405,30 @@
                         "answers": [{
                             "id": "in-education-answer",
                             "mandatory": false,
-                            "guidance": "<p>The following are considered to be in full-time education:</p><p>Under 16s</p><p>16-18s if they attend more than 12 hours a week of study on a course up to and including A level standard</p><p>Anyone on a course at a higher standard than A level if they are studying at a UK institution, on a course which:</p><ul><li>lasts for at least 1 academic year</li><li>involves at least 24 weeks per year, and</li><li>involves at least 21 hours of term-time study, classes or work experience per week (including unstructured study)</li></ul>",
+                            "guidance": {
+                                "show_guidance": "Show further guidance",
+                                "hide_guidance": "Hide further guidance",
+                                "content": [{
+                                        "description": "The following are considered to be in full-time education:"
+                                    },
+                                    {
+                                        "description": "Under 16s"
+                                    },
+                                    {
+                                        "description": "16-18s if they attend more than 12 hours a week of study on a course up to and including A level standard"
+                                    },
+                                    {
+                                        "description": "Anyone on a course at a higher standard than A level if they are studying at a UK institution, on a course which:"
+                                    },
+                                    {
+                                        "list": [
+                                            "lasts for at least 1 academic year",
+                                            "involves at least 24 weeks per year, and",
+                                            "involves at least 21 hours of term-time study, classes or work experience per week (including unstructured study)"
+                                        ]
+                                    }
+                                ]
+                            },
                             "options": [{
                                     "label": "Yes",
                                     "value": "Yes"
@@ -669,9 +715,11 @@
                         "id": "arrive-in-uk-question",
                         "title": "If you were not born in the United Kingdom, when did you most recently arrive to live here?",
                         "number": "10",
-                        "guidance": [{
-                            "description": "<strong>Exclude</strong> short visits away from the UK"
-                        }],
+                        "guidance": {
+                            "content": [{
+                                "description": "<strong>Exclude</strong> short visits away from the UK"
+                            }]
+                        },
                         "type": "General",
                         "answers": [{
                             "id": "arrive-in-uk-answer",
@@ -701,7 +749,13 @@
                         "answers": [{
                             "id": "length-of-stay-answer",
                             "mandatory": false,
-                            "guidance": "If you arrived in the United Kingdom before May 2016, please select ‘12 months or more’",
+                            "guidance": {
+                                "show_guidance": "Show further guidance",
+                                "hide_guidance": "Hide further guidance",
+                                "content": [{
+                                    "description": "If you arrived in the United Kingdom before May 2016, please select ‘12 months or more’"
+                                }]
+                            },
                             "options": [{
                                     "label": "Less than 6 months",
                                     "value": "Less than 6 months"
@@ -732,9 +786,11 @@
                         "title": "Do you look after, or give any help or support to family members, friends, neighbours or others because of either:",
                         "number": "13",
                         "description": "<div> <ul> <li>Long-term physical or mental ill-health/disability?</li> <li>Problems related to old age?</li></ul></div>",
-                        "guidance": [{
-                            "description": "<strong>Exclude</strong> anything you do as part of your paid employment"
-                        }],
+                        "guidance": {
+                            "content": [{
+                                "description": "<strong>Exclude</strong> anything you do as part of your paid employment"
+                            }]
+                        },
                         "type": "General",
                         "answers": [{
                             "id": "carer-answer",
@@ -777,7 +833,23 @@
                                     "id": "national-identity-england-answer",
                                     "label": "Select all that apply",
                                     "mandatory": false,
-                                    "guidance": "<p>You can choose more than one national identity.</p><p>It is for you to choose your national identity or identities. For example this could be about the country or countries where you feel you belong, or think of as home.</p><p>It is not dependent on your ethnic group or legal nationality (citizenship).</p><p>Select all that apply. If your national identity isn’t listed, select ‘Other’ and enter the national identity.</p>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "description": "You can choose more than one national identity."
+                                            },
+                                            {
+                                                "description": "It is for you to choose your national identity or identities. For example this could be about the country or countries where you feel you belong, or think of as home."
+                                            },
+                                            {
+                                                "description": "It is not dependent on your ethnic group or legal nationality (citizenship)."
+                                            },
+                                            {
+                                                "description": "Select all that apply. If your national identity isn’t listed, select ‘Other’ and enter the national identity."
+                                            }
+                                        ]
+                                    },
                                     "options": [{
                                             "label": "English",
                                             "value": "English"
@@ -831,7 +903,23 @@
                                     "id": "national-identity-wales-answer",
                                     "label": "Select all that apply",
                                     "mandatory": false,
-                                    "guidance": "<p>You can choose more than one national identity.</p><p>It is for you to choose your national identity or identities. For example this could be about the country or countries where you feel you belong, or think of as home.</p><p>It is not dependent on your ethnic group or legal nationality (citizenship).</p><p>Select all that apply. If your national identity isn’t listed, select ‘Other’ and enter the national identity.</p>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "description": "You can choose more than one national identity."
+                                            },
+                                            {
+                                                "description": "It is for you to choose your national identity or identities. For example this could be about the country or countries where you feel you belong, or think of as home."
+                                            },
+                                            {
+                                                "description": "It is not dependent on your ethnic group or legal nationality (citizenship)."
+                                            },
+                                            {
+                                                "description": "Select all that apply. If your national identity isn’t listed, select ‘Other’ and enter the national identity."
+                                            }
+                                        ]
+                                    },
                                     "options": [{
                                             "label": "Welsh",
                                             "value": "Welsh"
@@ -894,7 +982,20 @@
                             "answers": [{
                                 "id": "ethnic-group-england-answer",
                                 "mandatory": false,
-                                "guidance": "<p>It is for you to choose your ethnic group. For example this could be your family or cultural background, or it could be how you would describe yourself.</p><p>Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Other ethnic group’. You will then be able to write in the ethnic group you prefer to identify as at the next question.</p>",
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                            "description": "It is for you to choose your ethnic group. For example this could be your family or cultural background, or it could be how you would describe yourself."
+                                        },
+                                        {
+                                            "description": "Please select the answer you think is most appropriate."
+                                        },
+                                        {
+                                            "description": "If you don’t feel the options apply to you, select ‘Other ethnic group’. You will then be able to write in the ethnic group you prefer to identify as at the next question."
+                                        }
+                                    ]
+                                },
                                 "options": [{
                                         "label": "White",
                                         "value": "White",
@@ -939,7 +1040,20 @@
                             "answers": [{
                                 "id": "ethnic-group-wales-answer",
                                 "mandatory": false,
-                                "guidance": "<p>It is for you to choose your ethnic group. For example this could be your family or cultural background, or it could be how you would describe yourself.</p><p>Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Other ethnic group’.  You will then able to write in the ethnic group you prefer to identify as at the next question.</p>",
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                            "description": "It is for you to choose your ethnic group. For example this could be your family or cultural background, or it could be how you would describe yourself."
+                                        },
+                                        {
+                                            "description": "Please select the answer you think is most appropriate."
+                                        },
+                                        {
+                                            "description": "If you don’t feel the options apply to you, select ‘Other ethnic group’. You will then be able to write in the ethnic group you prefer to identify as at the next question."
+                                        }
+                                    ]
+                                },
                                 "options": [{
                                         "label": "White",
                                         "value": "White",
@@ -1119,7 +1233,17 @@
                             "type": "General",
                             "answers": [{
                                     "id": "white-ethnic-group-england-answer",
-                                    "guidance": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "description": "The options are based on the answer to the previous question. Please select the answer you think is most appropriate."
+                                            },
+                                            {
+                                                "description": "If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group."
+                                            }
+                                        ]
+                                    },
                                     "mandatory": false,
                                     "options": [{
                                             "label": "English / Welsh / Scottish / Northern Irish / British",
@@ -1164,7 +1288,17 @@
                             "type": "General",
                             "answers": [{
                                     "id": "white-ethnic-group-wales-answer",
-                                    "guidance": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>",
+                                    "guidance": {
+                                        "show_guidance": "Show further guidance",
+                                        "hide_guidance": "Hide further guidance",
+                                        "content": [{
+                                                "description": "The options are based on the answer to the previous question. Please select the answer you think is most appropriate."
+                                            },
+                                            {
+                                                "description": "If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group."
+                                            }
+                                        ]
+                                    },
                                     "mandatory": false,
                                     "options": [{
                                             "label": "Welsh / English / Scottish / Northern Irish / British",
@@ -1245,7 +1379,17 @@
                         "type": "General",
                         "answers": [{
                                 "id": "mixed-ethnic-group-answer",
-                                "guidance": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>",
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                            "description": "The options are based on the answer to the previous question. Please select the answer you think is most appropriate."
+                                        },
+                                        {
+                                            "description": "If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group."
+                                        }
+                                    ]
+                                },
                                 "mandatory": false,
                                 "options": [{
                                         "label": "White and Black Caribbean",
@@ -1319,7 +1463,17 @@
                         "answers": [{
                                 "id": "asian-ethnic-group-answer",
                                 "mandatory": false,
-                                "guidance": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>",
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                            "description": "The options are based on the answer to the previous question. Please select the answer you think is most appropriate."
+                                        },
+                                        {
+                                            "description": "If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group."
+                                        }
+                                    ]
+                                },
                                 "options": [{
                                         "label": "Indian",
                                         "value": "Indian"
@@ -1396,7 +1550,17 @@
                         "answers": [{
                                 "id": "black-ethnic-group-answer",
                                 "mandatory": false,
-                                "guidance": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>",
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                            "description": "The options are based on the answer to the previous question. Please select the answer you think is most appropriate."
+                                        },
+                                        {
+                                            "description": "If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group."
+                                        }
+                                    ]
+                                },
                                 "options": [{
                                         "label": "African",
                                         "value": "African"
@@ -1465,7 +1629,17 @@
                         "answers": [{
                                 "id": "other-ethnic-group-answer",
                                 "mandatory": false,
-                                "guidance": "<p>The options are based on the answer to the previous question. Please select the answer you think is most appropriate.</p><p>If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group.</p>",
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                            "description": "The options are based on the answer to the previous question. Please select the answer you think is most appropriate."
+                                        },
+                                        {
+                                            "description": "If you don’t feel the options apply to you, select ‘Any other ...’ and write in your ethnic group."
+                                        }
+                                    ]
+                                },
                                 "options": [{
                                         "label": "Arab",
                                         "value": "Arab"
@@ -1531,7 +1705,33 @@
                         "answers": [{
                                 "id": "sexual-identity-answer",
                                 "mandatory": false,
-                                "guidance": "<p>It is for you to decide how to choose your answer.</p><p>If you are unsure of the meaning of any words used, the following might help:</p><ul><li>‘Heterosexual or Straight’ means that a person is, for example, attracted to people of the opposite sex/gender</li><li>‘Gay or Lesbian’ means that a person is, for example, attracted to people of the same sex/gender</li><li>‘Bisexual’ means that a person is, for example, attracted to people of both sexes/any gender</li></ul><p><strong>Identity not listed</strong></p><p>If none of the first three answer options apply to you, please select ‘Other’ and enter your preferred answer.</p><p>This question is voluntary; you can leave it blank if you prefer.</p>",
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                            "description": "It is for you to decide how to choose your answer."
+                                        },
+                                        {
+                                            "description": "If you are unsure of the meaning of any words used, the following might help:"
+                                        },
+                                        {
+                                            "list": [
+                                                "‘Heterosexual or Straight’ means that a person is, for example, attracted to people of the opposite sex/gender",
+                                                "‘Gay or Lesbian’ means that a person is, for example, attracted to people of the same sex/gender",
+                                                "‘Bisexual’ means that a person is, for example, attracted to people of both sexes/any gender"
+                                            ]
+                                        },
+                                        {
+                                            "title": "Identity not listed"
+                                        },
+                                        {
+                                            "description": "If none of the first three answer options apply to you, please select ‘Other’ and enter your preferred answer."
+                                        },
+                                        {
+                                            "description": "This question is voluntary; you can leave it blank if you prefer."
+                                        }
+                                    ]
+                                },
                                 "options": [{
                                         "label": "Heterosexual or Straight",
                                         "value": "Heterosexual or Straight"
@@ -1916,7 +2116,13 @@
                         "answers": [{
                                 "id": "past-usual-address-answer",
                                 "mandatory": false,
-                                "guidance": "In most cases your usual address will be the permanent or family home that you were living in.",
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                        "description": "In most cases your usual address will be the permanent or family home that you were living in."
+                                    }]
+                                },
                                 "options": [{
                                         "label": "This address",
                                         "value": "This address"
@@ -2106,9 +2312,11 @@
                         "id": "disability-question",
                         "title": "Are your day-to-day activities limited because of a health problem or disability which has lasted, or is expected to last, at least 12 months?",
                         "number": "24",
-                        "guidance": [{
-                            "description": "<strong>Include</strong> Problems related to old age"
-                        }],
+                        "guidance": {
+                            "content": [{
+                                "description": "<strong>Include</strong> Problems related to old age"
+                            }]
+                        },
                         "type": "General",
                         "answers": [{
                             "id": "disability-answer",
@@ -2325,9 +2533,11 @@
                         "id": "volunteering-question",
                         "title": "Thinking of the last 12 months, have you taken part in any volunteering for any groups, clubs or organisations?",
                         "number": "27",
-                        "guidance": [{
-                            "description": "<strong>Exclude</strong> any court ordered activities"
-                        }],
+                        "guidance": {
+                            "content": [{
+                                "description": "<strong>Exclude</strong> any court ordered activities"
+                            }]
+                        },
                         "type": "General",
                         "answers": [{
                             "id": "volunteering-answer",
@@ -2366,9 +2576,11 @@
                         "title": "Last week were you:",
                         "number": "28",
                         "description": "Select all that apply",
-                        "guidance": [{
-                            "description": "<strong>Include</strong> any paid work, including casual or temporary work, even if only for one hour"
-                        }],
+                        "guidance": {
+                            "content": [{
+                                "description": "<strong>Include</strong> any paid work, including casual or temporary work, even if only for one hour"
+                            }]
+                        },
                         "type": "General",
                         "answers": [{
                             "id": "employment-type-answer",
@@ -2617,7 +2829,23 @@
                         "answers": [{
                             "id": "ever-worked-answer",
                             "mandatory": false,
-                            "guidance": "<p>If you had a full-time or part-time job in the past select ‘Yes’</p><p>This includes work outside of the United Kingdom.</p><p>Please provide an answer even if you are retired.</p><p>If you have never worked, or only ever worked in voluntary/unpaid jobs, select ‘No’.</p>",
+                            "guidance": {
+                                "show_guidance": "Show further guidance",
+                                "hide_guidance": "Hide further guidance",
+                                "content": [{
+                                        "description": "If you had a full-time or part-time job in the past select ‘Yes’"
+                                    },
+                                    {
+                                        "description": "This includes work outside of the United Kingdom."
+                                    },
+                                    {
+                                        "description": "Please provide an answer even if you are retired."
+                                    },
+                                    {
+                                        "description": "If you have never worked, or only ever worked in voluntary/unpaid jobs, select ‘No’."
+                                    }
+                                ]
+                            },
                             "options": [{
                                     "label": "Yes",
                                     "value": "Yes"
@@ -2668,9 +2896,11 @@
                         "id": "main-job-question",
                         "title": "In your main job, are (were) you:",
                         "number": "35",
-                        "guidance": [{
-                            "description": "<p>If you are not working answer the remaining questions about your last main job.</p><p>Your main job is the job which you usually work (worked) the most hours</p>"
-                        }],
+                        "guidance": {
+                            "content": [{
+                                "description": "<p>If you are not working answer the remaining questions about your last main job.</p><p>Your main job is the job which you usually work (worked) the most hours</p>"
+                            }]
+                        },
                         "type": "General",
                         "answers": [{
                             "id": "main-job-answer",
@@ -2704,15 +2934,30 @@
                         "id": "job-title-question",
                         "title": "What is (was) your full and specific job title?",
                         "number": "36",
-                        "guidance": [{
-                            "description": "<p>For example, <b>primary school teacher, car mechanic, district nurse, structural engineer</b></p><p>Do not state your grade or pay band</p>"
-                        }],
+                        "guidance": {
+                            "content": [{
+                                "description": "<p>For example, <b>primary school teacher, car mechanic, district nurse, structural engineer</b></p><p>Do not state your grade or pay band</p>"
+                            }]
+                        },
                         "type": "General",
                         "answers": [{
                             "id": "job-title-answer",
                             "label": "Job title",
                             "mandatory": false,
-                            "guidance": "<p>Please enter your job title in the space provided.</p><p>Do not state your grade or pay band.</p><p>If you are not sure of your job title please give the best information you can.</p>",
+                            "guidance": {
+                                "show_guidance": "Show further guidance",
+                                "hide_guidance": "Hide further guidance",
+                                "content": [{
+                                        "description": "Please enter your job title in the space provided."
+                                    },
+                                    {
+                                        "description": "Do not state your grade or pay band."
+                                    },
+                                    {
+                                        "description": "If you are not sure of your job title please give the best information you can."
+                                    }
+                                ]
+                            },
                             "type": "TextField"
                         }]
                     }]
@@ -2734,7 +2979,17 @@
                             "id": "job-description-answer",
                             "label": "Description",
                             "mandatory": false,
-                            "guidance": "<p>Please enter a brief description of what you do or did in your main job. Your main job is the job in which you usually work (or worked) the most hours.</p><p>Please give the best information you can even if you’re not sure or can’t remember all the details.</p>",
+                            "guidance": {
+                                "show_guidance": "Show further guidance",
+                                "hide_guidance": "Hide further guidance",
+                                "content": [{
+                                        "description": "Please enter a brief description of what you do or did in your main job. Your main job is the job in which you usually work (or worked) the most hours."
+                                    },
+                                    {
+                                        "description": "Please give the best information you can even if you’re not sure or can’t remember all the details."
+                                    }
+                                ]
+                            },
                             "type": "TextArea"
                         }]
                     }]
@@ -2751,19 +3006,37 @@
                         "id": "employers-business-question",
                         "title": "At your workplace what is (was) the main activity of your employer or business?",
                         "number": "38",
-                        "guidance": [{
-                            "list": [
-                                "For example, <b>primary education, repairing cars, contract catering, computer servicing</b>",
-                                "If you are (were) a civil servant, write <b>government</b>",
-                                "If you are (were) a local government officer, write <b>local government</b> and give the name of the department within the local authority"
-                            ]
-                        }],
+                        "guidance": {
+                            "content": [{
+                                "list": [
+                                    "For example, <b>primary education, repairing cars, contract catering, computer servicing</b>",
+                                    "If you are (were) a civil servant, write <b>government</b>",
+                                    "If you are (were) a local government officer, write <b>local government</b> and give the name of the department within the local authority"
+                                ]
+                            }]
+                        },
                         "type": "General",
                         "answers": [{
                             "id": "employers-business-answer",
                             "label": "Description",
                             "mandatory": false,
-                            "guidance": "<p>Enter the main activity of your employer or business.</p><p>Another way of describing main activity is the industry that your employer or business works in.</p><p>If you are not sure of the main activity of your employer or business please give the best information you can.</p><p>If you are employed through an agency please enter the main activity of the business you are working for, not the agency.</p>",
+                            "guidance": {
+                                "show_guidance": "Show further guidance",
+                                "hide_guidance": "Hide further guidance",
+                                "content": [{
+                                        "description": "Enter the main activity of your employer or business."
+                                    },
+                                    {
+                                        "description": "Another way of describing main activity is the industry that your employer or business works in."
+                                    },
+                                    {
+                                        "description": "If you are not sure of the main activity of your employer or business please give the best information you can."
+                                    },
+                                    {
+                                        "description": "If you are employed through an agency please enter the main activity of the business you are working for, not the agency."
+                                    }
+                                ]
+                            },
                             "type": "TextArea"
                         }]
                     }]
@@ -2830,15 +3103,30 @@
                         "id": "business-name-question",
                         "title": "In your main job, what is (was) the name of the organisation or business you work (worked) for?",
                         "number": "39a",
-                        "guidance": [{
-                            "description": "If you were self-employed in your own organisation or business, enter the name"
-                        }],
+                        "guidance": {
+                            "content": [{
+                                "description": "If you were self-employed in your own organisation or business, enter the name"
+                            }]
+                        },
                         "type": "General",
                         "answers": [{
                             "id": "business-name-answer",
                             "label": "Organisation or business name",
                             "mandatory": false,
-                            "guidance": "<p>This question is asking for the name of the organisation or business that you work (or worked) for in your main job.</p><p>If you can’t remember the name of the organisation, please give the best information you can.</p><p>If you are employed through an agency please enter the name of the business you are working for, not the agency.</p>",
+                            "guidance": {
+                                "show_guidance": "Show further guidance",
+                                "hide_guidance": "Hide further guidance",
+                                "content": [{
+                                        "description": "This question is asking for the name of the organisation or business that you work (or worked) for in your main job."
+                                    },
+                                    {
+                                        "description": "If you can’t remember the name of the organisation, please give the best information you can."
+                                    },
+                                    {
+                                        "description": "If you are employed through an agency please enter the name of the business you are working for, not the agency."
+                                    }
+                                ]
+                            },
                             "type": "TextField"
                         }]
                     }]
@@ -2857,14 +3145,16 @@
                         "id": "questionnaire-completed-question",
                         "title": "",
                         "type": "General",
-                        "guidance": [{
-                            "title": "Please note:",
-                            "list": [
-                                "By submitting your responses, you are declaring that you have completed to the best of your knowledge and belief.",
-                                "If you do not submit, your responses will be automatically submitted when the Census 2017 Test closes.",
-                                "After submission you will have an opportunity to provide feedback on your experience."
-                            ]
-                        }]
+                        "guidance": {
+                            "content": [{
+                                "title": "Please note:",
+                                "list": [
+                                    "By submitting your responses, you are declaring that you have completed to the best of your knowledge and belief.",
+                                    "If you do not submit, your responses will be automatically submitted when the Census 2017 Test closes.",
+                                    "After submission you will have an opportunity to provide feedback on your experience."
+                                ]
+                            }]
+                        }
                     }]
                 }]
             }

--- a/data/en/mci_refresh.json
+++ b/data/en/mci_refresh.json
@@ -27,7 +27,6 @@
                     "id": "reporting-period-section",
                     "questions": [{
                         "answers": [{
-                                "guidance": "",
                                 "id": "period-from",
                                 "alias": "period_from",
                                 "label": "Period from",
@@ -43,7 +42,6 @@
                                 }
                             },
                             {
-                                "guidance": "",
                                 "id": "period-to",
                                 "alias": "period_to",
                                 "label": "Period to",
@@ -75,27 +73,28 @@
                     "description": "",
                     "id": "total-turnover-section",
                     "questions": [{
-                        "guidance": [{
-                                "title": "Include",
-                                "list": [
-                                    "VAT",
-                                    "internet sales",
-                                    "retail sales from outlets in Great Britain to customers abroad"
-                                ]
-                            },
-                            {
-                                "title": "Exclude",
-                                "list": [
-                                    "revenue from mobile phone network commission and top-up",
-                                    "sales from catering facilities used by customers",
-                                    "lottery sales and commission from lottery sales",
-                                    "sales of car accessories and motor vehicles",
-                                    "NHS receipts"
-                                ]
-                            }
-                        ],
+                        "guidance": {
+                            "content": [{
+                                    "title": "Include",
+                                    "list": [
+                                        "VAT",
+                                        "internet sales",
+                                        "retail sales from outlets in Great Britain to customers abroad"
+                                    ]
+                                },
+                                {
+                                    "title": "Exclude",
+                                    "list": [
+                                        "revenue from mobile phone network commission and top-up",
+                                        "sales from catering facilities used by customers",
+                                        "lottery sales and commission from lottery sales",
+                                        "sales of car accessories and motor vehicles",
+                                        "NHS receipts"
+                                    ]
+                                }
+                            ]
+                        },
                         "answers": [{
-                            "guidance": "",
                             "id": "total-retail-turnover",
                             "alias": "total_turnover",
                             "description": "Round to the nearest (\u00a3) pound. Do not  include pence",
@@ -129,23 +128,24 @@
                     "description": "",
                     "id": "total-food-sales-section",
                     "questions": [{
-                        "guidance": [{
-                                "title": "Include",
-                                "list": [
-                                    "all fresh food",
-                                    "other food for human consumption (except chocolate and sugar confectionery)",
-                                    "soft drinks"
-                                ]
-                            },
-                            {
-                                "title": "Exclude",
-                                "list": [
-                                    "sales from catering facilities used by customers"
-                                ]
-                            }
-                        ],
+                        "guidance": {
+                            "content": [{
+                                    "title": "Include",
+                                    "list": [
+                                        "all fresh food",
+                                        "other food for human consumption (except chocolate and sugar confectionery)",
+                                        "soft drinks"
+                                    ]
+                                },
+                                {
+                                    "title": "Exclude",
+                                    "list": [
+                                        "sales from catering facilities used by customers"
+                                    ]
+                                }
+                            ]
+                        },
                         "answers": [{
-                            "guidance": "",
                             "description": "Round to the nearest (\u00a3) pound. Do not  include pence",
                             "id": "total-sales-food",
                             "label": "Food",
@@ -177,16 +177,17 @@
                     "description": "",
                     "id": "total-alcohol-sales-section",
                     "questions": [{
-                        "guidance": [{
-                            "title": "Include",
-                            "list": [
-                                "alcoholic drink",
-                                "chocolate and sugar confectionery",
-                                "tobacco and smokers\u2019 requisites"
-                            ]
-                        }],
+                        "guidance": {
+                            "content": [{
+                                "title": "Include",
+                                "list": [
+                                    "alcoholic drink",
+                                    "chocolate and sugar confectionery",
+                                    "tobacco and smokers\u2019 requisites"
+                                ]
+                            }]
+                        },
                         "answers": [{
-                            "guidance": "",
                             "description": "Round to the nearest (\u00a3) pound. Do not  include pence",
                             "id": "total-sales-alcohol",
                             "label": "Alcohol, confectionery and tobacco",
@@ -218,18 +219,19 @@
                     "description": "",
                     "id": "total-clothing-sales-section",
                     "questions": [{
-                        "guidance": [{
-                            "title": "Include",
-                            "list": [
-                                "clothing and footwear",
-                                "clothing fabrics",
-                                "haberdashery and furs",
-                                "leather and travel goods",
-                                "handbags and umbrellas"
-                            ]
-                        }],
+                        "guidance": {
+                            "content": [{
+                                "title": "Include",
+                                "list": [
+                                    "clothing and footwear",
+                                    "clothing fabrics",
+                                    "haberdashery and furs",
+                                    "leather and travel goods",
+                                    "handbags and umbrellas"
+                                ]
+                            }]
+                        },
                         "answers": [{
-                            "guidance": "",
                             "description": "Round to the nearest (\u00a3) pound. Do not  include pence",
                             "id": "total-sales-clothing",
                             "label": "Clothing and footwear",
@@ -262,7 +264,33 @@
                     "id": "total-household-goods-sales-section",
                     "questions": [{
                         "answers": [{
-                            "guidance": "<div> <h4>Include</h4><ul> <li>carpets, rugs and other floor coverings</li> <li>furniture</li> <li>household textiles and soft furnishings</li> <li>prints and picture frames</li> <li>antiques and works of art</li> <li>domestic electrical and gas appliances, audio/visual equipment and home computers</li> <li>lighting and minor electrical supplies</li> <li>records, compact discs, audio and video tapes</li> <li>musical instruments and goods</li> <li>decorators\u2019 and DIY supplies</li> <li>lawn-mowers</li> <li>hardware</li> <li>china, glassware and cutlery</li> <li>novelties, souvenirs and gifts</li> <li>e-cigarettes</li> </ul></div>",
+                            "guidance": {
+                                "show_guidance": "Show household goods items to include/exclude",
+                                "hide_guidance": "Hide household goods items to include/exclude",
+                                "content": [{
+                                        "title": "Include"
+                                    },
+                                    {
+                                        "list": [
+                                            "carpets, rugs and other floor coverings",
+                                            "furniture",
+                                            "household textiles and soft furnishings",
+                                            "prints and picture frames",
+                                            "antiques and works of art",
+                                            "domestic electrical and gas appliances, audio/visual equipment and home computers",
+                                            "lighting and minor electrical supplies",
+                                            "records, compact discs, audio and video tapes",
+                                            "musical instruments and goods",
+                                            "decorators\u2019 and DIY supplies",
+                                            "lawn-mowers",
+                                            "hardware",
+                                            "china, glassware and cutlery",
+                                            "novelties, souvenirs and gifts",
+                                            "e-cigarettes"
+                                        ]
+                                    }
+                                ]
+                            },
                             "description": "Round to the nearest (\u00a3) pound. Do not  include pence",
                             "id": "total-sales-household-goods",
                             "label": "Household goods",
@@ -295,7 +323,44 @@
                     "id": "total-other-goods-sales-section",
                     "questions": [{
                         "answers": [{
-                            "guidance": "<h4>Include</h4> <ul>  <li>toiletries and medications (except NHS receipts)</li> <li>newspapers and periodicals</li> <li>books, stationery and office supplies</li> <li>photographic and optical goods</li> <li>spectacles, contact lenses and sunglasses</li> <li>toys and games</li> <li>cycles and cycle accessories</li> <li>sport and camping equipment</li> <li>jewellery</li> <li>silverware and plate, clocks and watches</li> <li>household cleaning products and kitchen paper products</li> <li>pets, pets\u2019 requisites and pet foods</li> <li>cut flowers, plants, seeds and other garden sundries</li> <li>other new and second hand goods</li> <li>mobile phones</li> </ul><h4>Exclude</h4> <ul> <li>revenue from mobile phone network commission and top up </li> <li>lottery sales and commission from lottery sales</li> <li>sales of car accessories and motor vehicles</li> <li>NHS receipts</li> </ul>",
+                            "guidance": {
+                                "show_guidance": "Show sales items to include/exclude",
+                                "hide_guidance": "Hide sales items to include/exclude",
+                                "content": [{
+                                        "title": "Include"
+                                    },
+                                    {
+                                        "list": [
+                                            "toiletries and medications (except NHS receipts)",
+                                            "newspapers and periodicals",
+                                            "books, stationery and office supplies",
+                                            "photographic and optical goods",
+                                            "spectacles, contact lenses and sunglasses",
+                                            "toys and games",
+                                            "cycles and cycle accessories",
+                                            "sport and camping equipment",
+                                            "jewellery",
+                                            "silverware and plate, clocks and watches",
+                                            "household cleaning products and kitchen paper products",
+                                            "pets, pets\u2019 requisites and pet foods",
+                                            "cut flowers, plants, seeds and other garden sundries",
+                                            "other new and second hand goods",
+                                            "Mobile phones"
+                                        ]
+                                    },
+                                    {
+                                        "title": "Exclude"
+                                    },
+                                    {
+                                        "list": [
+                                            "revenue from mobile phone network commission and top up ",
+                                            "lottery sales and commission from lottery sales",
+                                            "sales of car accessories and motor vehicles",
+                                            "NHS receipts"
+                                        ]
+                                    }
+                                ]
+                            },
                             "description": "Round to the nearest (\u00a3) pound. Do not  include pence",
                             "id": "total-sales-other-goods",
                             "label": "Other goods",
@@ -327,14 +392,15 @@
                     "description": "",
                     "id": "total-internet-sales-section",
                     "questions": [{
-                        "guidance": [{
-                            "title": "Include",
-                            "list": [
-                                "VAT"
-                            ]
-                        }],
+                        "guidance": {
+                            "content": [{
+                                "title": "Include",
+                                "list": [
+                                    "VAT"
+                                ]
+                            }]
+                        },
                         "answers": [{
-                            "guidance": "",
                             "description": "Round to the nearest (\u00a3) pound. Do not  include pence",
                             "id": "internet-sales",
                             "label": "Internet sales",
@@ -366,24 +432,25 @@
                     "description": "",
                     "id": "total-automotive-fuel-sales-section",
                     "questions": [{
-                        "guidance": [{
-                                "title": "Include",
-                                "list": [
-                                    "VAT",
-                                    "sales of fuel owned by you",
-                                    "sales of other items not paid a commission for"
-                                ]
-                            },
-                            {
-                                "title": "Exclude",
-                                "list": [
-                                    "sales of fuel not owned by you",
-                                    "any commissions"
-                                ]
-                            }
-                        ],
+                        "guidance": {
+                            "content": [{
+                                    "title": "Include",
+                                    "list": [
+                                        "VAT",
+                                        "sales of fuel owned by you",
+                                        "sales of other items not paid a commission for"
+                                    ]
+                                },
+                                {
+                                    "title": "Exclude",
+                                    "list": [
+                                        "sales of fuel not owned by you",
+                                        "any commissions"
+                                    ]
+                                }
+                            ]
+                        },
                         "answers": [{
-                            "guidance": "",
                             "description": "Round to the nearest (\u00a3) pound. Do not  include pence",
                             "id": "total-sales-automotive-fuel",
                             "label": "Automotive fuel",
@@ -430,16 +497,18 @@
                     "description": "",
                     "id": "significant-change-section",
                     "questions": [{
-                        "guidance": [{
-                            "title": "Include",
-                            "list": [
-                                "in-store / online promotions",
-                                "special events (e.g. sporting events)",
-                                "calendar events (e.g. Christmas, Easter, Bank Holiday)",
-                                "weather",
-                                "store closures/openings"
-                            ]
-                        }],
+                        "guidance": {
+                            "content": [{
+                                "title": "Include",
+                                "list": [
+                                    "in-store / online promotions",
+                                    "special events (e.g. sporting events)",
+                                    "calendar events (e.g. Christmas, Easter, Bank Holiday)",
+                                    "weather",
+                                    "store closures/openings"
+                                ]
+                            }]
+                        },
                         "answers": [{
                             "description": "",
                             "id": "significant-change-established-answer",
@@ -544,7 +613,32 @@
                     "id": "change-comment-section",
                     "questions": [{
                         "answers": [{
-                            "guidance": "<h4>\u2018In-store promotion\u2019</h4><ul>\u201COffer on wine for the whole month. The promotion was available in-store and online, contributing to an increase in both total turnover and internet sales.\u201D</ul><h4>\u2018Special events (e.g. sporting events)\u2019</h4> <ul>\u201CThis was the month before the start of  Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (e.g., televisions and audio equipment). This led to an increase in sales both in-store and online.\u201D</ul><h4>\u2018Weather\u2019</h4> <ul>\u201CThe bad weather has decreased our sales of summer clothing. This has led to a reduction in total turnover and internet sales this month.\u201D</ul>",
+                            "guidance": {
+                                "show_guidance": "Show examples of commentary on changes to total retail turnover",
+                                "hide_guidance": "Hide examples of commentary on changes to total retail turnover",
+                                "content": [{
+                                        "description": "Examples of commentary:"
+                                    },
+                                    {
+                                        "title": "\u2018In-store promotion\u2019"
+                                    },
+                                    {
+                                        "description": "\u201COffer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales.\u201D"
+                                    },
+                                    {
+                                        "title": "\u2018Special events (for example, sporting events)\u2019"
+                                    },
+                                    {
+                                        "description": "\u201CThis was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online.\u201D"
+                                    },
+                                    {
+                                        "title": "\u2018Weather\u2019"
+                                    },
+                                    {
+                                        "description": "\u201CThe bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month.\u201D"
+                                    }
+                                ]
+                            },
                             "id": "change-comment",
                             "label": "Comments",
                             "mandatory": true,
@@ -573,26 +667,27 @@
                     "description": "",
                     "id": "total-employees-section",
                     "questions": [{
-                        "guidance": [{
-                                "title": "Include",
-                                "list": [
-                                    "all workers paid directly from this business\u2019s payroll(s)",
-                                    "those temporarily absent but still being paid, for example on maternity leave"
-                                ]
-                            },
-                            {
-                                "title": "Exclude",
-                                "list": [
-                                    "agency workers paid directly from the agency payroll",
-                                    "voluntary workers",
-                                    "former employees only receiving pension",
-                                    "self-employed workers",
-                                    "working owners who are not paid via PAYE"
-                                ]
-                            }
-                        ],
+                        "guidance": {
+                            "content": [{
+                                    "title": "Include",
+                                    "list": [
+                                        "all workers paid directly from this business\u2019s payroll(s)",
+                                        "those temporarily absent but still being paid, for example on maternity leave"
+                                    ]
+                                },
+                                {
+                                    "title": "Exclude",
+                                    "list": [
+                                        "agency workers paid directly from the agency payroll",
+                                        "voluntary workers",
+                                        "former employees only receiving pension",
+                                        "self-employed workers",
+                                        "working owners who are not paid via PAYE"
+                                    ]
+                                }
+                            ]
+                        },
                         "answers": [{
-                            "guidance": "",
                             "id": "total-number-employees",
                             "alias": "employee_count",
                             "label": "Total number of employees",
@@ -625,26 +720,27 @@
                     "description": "",
                     "id": "employee-breakdown-section",
                     "questions": [{
-                        "guidance": [{
-                                "title": "Include",
-                                "list": [
-                                    "all workers paid directly from this business\u2019s payroll(s)",
-                                    "those temporarily absent but still being paid, for example on maternity leave"
-                                ]
-                            },
-                            {
-                                "title": "Exclude",
-                                "list": [
-                                    "agency workers paid directly from the agency payroll",
-                                    "voluntary workers",
-                                    "former employees only receiving pension",
-                                    "self-employed workers",
-                                    "working owners who are not paid via PAYE"
-                                ]
-                            }
-                        ],
+                        "guidance": {
+                            "content": [{
+                                    "title": "Include",
+                                    "list": [
+                                        "all workers paid directly from this business\u2019s payroll(s)",
+                                        "those temporarily absent but still being paid, for example on maternity leave"
+                                    ]
+                                },
+                                {
+                                    "title": "Exclude",
+                                    "list": [
+                                        "agency workers paid directly from the agency payroll",
+                                        "voluntary workers",
+                                        "former employees only receiving pension",
+                                        "self-employed workers",
+                                        "working owners who are not paid via PAYE"
+                                    ]
+                                }
+                            ]
+                        },
                         "answers": [{
-                                "guidance": "",
                                 "id": "number-male-employees-over-30-hours",
                                 "label": "Number of male employees working more than 30 hours per week",
                                 "mandatory": false,
@@ -660,7 +756,6 @@
                                 }
                             },
                             {
-                                "guidance": "",
                                 "id": "number-male-employees-under-30-hours",
                                 "label": "Number of male employees working 30 hours or less per week",
                                 "mandatory": false,
@@ -676,7 +771,7 @@
                                 }
                             },
                             {
-                                "guidance": "",
+
                                 "id": "number-female-employees-over-30-hours",
                                 "label": "Number of female employees working more than 30 hours per week",
                                 "mandatory": false,
@@ -692,7 +787,6 @@
                                 }
                             },
                             {
-                                "guidance": "",
                                 "id": "number-female-employees-under-30-hours",
                                 "label": "Number of female employees working 30 hours or less per week",
                                 "mandatory": false,

--- a/data/en/multiple_answers.json
+++ b/data/en/multiple_answers.json
@@ -15,7 +15,6 @@
                     "id": "personal-details-section",
                     "questions": [{
                         "answers": [{
-                                "guidance": "",
                                 "id": "first-name-answer",
                                 "label": "What is your first name",
                                 "mandatory": false,
@@ -24,7 +23,6 @@
                                 "type": "TextField"
                             },
                             {
-                                "guidance": "",
                                 "id": "surname-answer",
                                 "label": "What is your surname",
                                 "mandatory": false,

--- a/data/en/test_checkbox.json
+++ b/data/en/test_checkbox.json
@@ -21,7 +21,6 @@
                     "id": "mandatory-checkbox-section",
                     "questions": [{
                         "answers": [{
-                                "guidance": "",
                                 "id": "mandatory-checkbox-answer",
                                 "label": "",
                                 "mandatory": true,
@@ -94,7 +93,6 @@
                     "id": "non-mandatory-checkbox-section",
                     "questions": [{
                         "answers": [{
-                                "guidance": "",
                                 "id": "non-mandatory-checkbox-answer",
                                 "label": "",
                                 "mandatory": false,

--- a/data/en/test_conditional_routing.json
+++ b/data/en/test_conditional_routing.json
@@ -34,7 +34,6 @@
                                 }
                             ],
                             "q_code": "1",
-                            "guidance": "",
                             "id": "conditional-routing-answer",
                             "label": "Which conditional question should we jump to?",
                             "mandatory": true,

--- a/data/en/test_currency.json
+++ b/data/en/test_currency.json
@@ -21,7 +21,6 @@
                     "id": "section",
                     "questions": [{
                         "answers": [{
-                            "guidance": "",
                             "id": "answer",
                             "label": "How much did you spend?",
                             "mandatory": false,

--- a/data/en/test_dates.json
+++ b/data/en/test_dates.json
@@ -16,7 +16,6 @@
                     "id": "date-section",
                     "questions": [{
                             "answers": [{
-                                    "guidance": "",
                                     "id": "date-range-from",
                                     "label": "Period from",
                                     "mandatory": true,
@@ -31,7 +30,6 @@
                                     }
                                 },
                                 {
-                                    "guidance": "",
                                     "id": "date-range-to",
                                     "label": "Period to",
                                     "mandatory": true,
@@ -53,7 +51,6 @@
                         },
                         {
                             "answers": [{
-                                "guidance": "",
                                 "id": "month-year-answer",
                                 "label": "Date",
                                 "mandatory": true,
@@ -74,7 +71,6 @@
                         },
                         {
                             "answers": [{
-                                "guidance": "",
                                 "id": "single-date-answer",
                                 "label": "Date",
                                 "mandatory": true,
@@ -95,7 +91,6 @@
                         },
                         {
                             "answers": [{
-                                "guidance": "",
                                 "id": "non-mandatory-date-answer",
                                 "label": "Date",
                                 "mandatory": false,

--- a/data/en/test_final_confirmation.json
+++ b/data/en/test_final_confirmation.json
@@ -29,7 +29,6 @@
                         "title": "What is your favourite breakfast food",
                         "questions": [{
                             "answers": [{
-                                "guidance": "",
                                 "id": "breakfast-answer",
                                 "label": "What is your favourite breakfast food",
                                 "mandatory": false,

--- a/data/en/test_household_question.json
+++ b/data/en/test_household_question.json
@@ -21,15 +21,17 @@
                     "questions": [{
                         "id": "household-composition-question",
                         "title": "Who usually lives here?",
-                        "guidance": [{
-                            "title": "Include",
-                            "list": [
-                                "Yourself, if this is your permanent or family home",
-                                "Family members including partners, children and babies born on or before 9 April 2017",
-                                "Students and/or school children who live away from home during term time",
-                                "Housemates, tenants or lodgers"
-                            ]
-                        }],
+                        "guidance": {
+                            "content": [{
+                                "title": "Include",
+                                "list": [
+                                    "Yourself, if this is your permanent or family home",
+                                    "Family members including partners, children and babies born on or before 9 April 2017",
+                                    "Students and/or school children who live away from home during term time",
+                                    "Housemates, tenants or lodgers"
+                                ]
+                            }]
+                        },
                         "type": "RepeatingAnswer",
                         "answers": [{
                                 "id": "first-name",
@@ -71,19 +73,20 @@
                         "id": "household-composition-further",
                         "title": "Is this everyone for whom this address is their permanent or family home?",
                         "type": "General",
-                        "guidance": [{
-                            "title": "Include",
-                            "list": [
-                                "People who usually live outside the UK who are staying in the UK for <b>three months or more</b>",
-                                "People who work away from home within the UK  if this is their permanent or family home",
-                                "Members of the Armed Forces if this is their permanent or family home",
-                                "People who are temporarily outside the UK for <b>less than 12 months</b>",
-                                "People staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends",
-                                "Other people who usually live here, including anyone temporarily away from home "
-                            ]
-                        }],
+                        "guidance": {
+                            "content": [{
+                                "title": "Include",
+                                "list": [
+                                    "People who usually live outside the UK who are staying in the UK for <b>three months or more</b>",
+                                    "People who work away from home within the UK  if this is their permanent or family home",
+                                    "Members of the Armed Forces if this is their permanent or family home",
+                                    "People who are temporarily outside the UK for <b>less than 12 months</b>",
+                                    "People staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends",
+                                    "Other people who usually live here, including anyone temporarily away from home "
+                                ]
+                            }]
+                        },
                         "answers": [{
-                            "guidance": "",
                             "id": "household-composition-add-another",
                             "label": "",
                             "mandatory": true,

--- a/data/en/test_interstitial_page.json
+++ b/data/en/test_interstitial_page.json
@@ -27,7 +27,6 @@
                     "id": "breakfast-section",
                     "questions": [{
                         "answers": [{
-                            "guidance": "",
                             "id": "favourite-breakfast",
                             "label": "What is your favourite breakfast food",
                             "mandatory": false,
@@ -70,7 +69,6 @@
                     "id": "lunch-section",
                     "questions": [{
                         "answers": [{
-                            "guidance": "",
                             "id": "favourite-lunch",
                             "label": "What is your favourite lunchtime food",
                             "mandatory": false,

--- a/data/en/test_language.json
+++ b/data/en/test_language.json
@@ -3,10 +3,10 @@
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "0",
-    "title": "English Langauage Survey",
+    "title": "English Language Survey",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
-    "description": "A questionnaire to demonstrate english langauge",
+    "description": "A questionnaire to demonstrate english language",
     "groups": [{
         "id": "english-group",
         "title": "",

--- a/data/en/test_language_cy.json
+++ b/data/en/test_language_cy.json
@@ -3,10 +3,10 @@
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "0",
-    "title": "Welsh Langauage Survey",
+    "title": "Welsh Language Survey",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
-    "description": "A questionnaire to demonstrate welsh langauge",
+    "description": "A questionnaire to demonstrate welsh language",
     "groups": [{
         "id": "welsh-group",
         "title": "",

--- a/data/en/test_markup.json
+++ b/data/en/test_markup.json
@@ -18,7 +18,13 @@
                     "id": "emphasis-section",
                     "questions": [{
                         "answers": [{
-                            "guidance": "Lorem ipsum dolor sit amet, <em>consectetur adipiscing elit</em>. Nulla vitae elit libero, a pharetra augue. Vestibulum id ligula porta felis euismod semper. Integer posuere erat a ante venenatis dapibus posuere velit aliquet.",
+                            "guidance": {
+                                "show_guidance": "Show lorem ipsum guidance",
+                                "hide_guidance": "hide lorem ipsum guidance",
+                                "content": [{
+                                    "description": "Lorem ipsum dolor sit amet, <em>consectetur adipiscing elit</em>. Nulla vitae elit libero, a pharetra augue. Vestibulum id ligula porta felis euismod semper. Integer posuere erat a ante venenatis dapibus posuere velit aliquet."
+                                }]
+                            },
                             "id": "answer",
                             "label": "What is the thing?",
                             "mandatory": false,

--- a/data/en/test_navigation.json
+++ b/data/en/test_navigation.json
@@ -17,7 +17,6 @@
                         "id": "insurance-type-section",
                         "questions": [{
                             "answers": [{
-                                "guidance": "",
                                 "id": "insurance-type-answer",
                                 "label": "",
                                 "mandatory": false,
@@ -54,7 +53,6 @@
                         "id": "insurance-address-section",
                         "questions": [{
                             "answers": [{
-                                "guidance": "",
                                 "id": "insurance-address-answer",
                                 "label": "",
                                 "mandatory": false,
@@ -102,7 +100,6 @@
                     "id": "house-type-section",
                     "questions": [{
                         "answers": [{
-                            "guidance": "",
                             "id": "house-type-answer",
                             "label": "",
                             "mandatory": false,
@@ -195,7 +192,6 @@
                             "type": "General",
                             "answers": [{
                                 "q_code": "3",
-                                "guidance": "",
                                 "id": "what-is-your-age",
                                 "label": "",
                                 "mandatory": false,
@@ -229,7 +225,6 @@
                             "type": "General",
                             "answers": [{
                                 "q_code": "4",
-                                "guidance": "",
                                 "id": "what-is-your-shoe-size",
                                 "label": "",
                                 "mandatory": false,
@@ -276,7 +271,6 @@
                         "id": "extra-cover-section",
                         "questions": [{
                             "answers": [{
-                                "guidance": "",
                                 "id": "extra-cover-answer",
                                 "label": "",
                                 "mandatory": true,
@@ -330,7 +324,6 @@
                         "id": "credit-card-section",
                         "questions": [{
                             "answers": [{
-                                "guidance": "",
                                 "id": "credit-card-answer",
                                 "label": "",
                                 "mandatory": true,
@@ -355,7 +348,6 @@
                         "id": "expiry-date-section",
                         "questions": [{
                             "answers": [{
-                                "guidance": "",
                                 "id": "expiry-date-answer",
                                 "label": "",
                                 "mandatory": true,
@@ -380,7 +372,6 @@
                         "id": "security-code-section",
                         "questions": [{
                             "answers": [{
-                                "guidance": "",
                                 "id": "security-code-answer",
                                 "label": "",
                                 "mandatory": true,

--- a/data/en/test_navigation_confirmation.json
+++ b/data/en/test_navigation_confirmation.json
@@ -17,7 +17,6 @@
                         "id": "insurance-type-section",
                         "questions": [{
                             "answers": [{
-                                "guidance": "",
                                 "id": "insurance-type-answer",
                                 "label": "",
                                 "mandatory": false,
@@ -54,7 +53,6 @@
                         "id": "insurance-address-section",
                         "questions": [{
                             "answers": [{
-                                "guidance": "",
                                 "id": "insurance-address-answer",
                                 "label": "",
                                 "mandatory": false,
@@ -102,7 +100,6 @@
                     "id": "house-type-section",
                     "questions": [{
                         "answers": [{
-                            "guidance": "",
                             "id": "house-type-answer",
                             "label": "",
                             "mandatory": false,
@@ -195,7 +192,6 @@
                             "type": "General",
                             "answers": [{
                                 "q_code": "3",
-                                "guidance": "",
                                 "id": "what-is-your-age",
                                 "label": "",
                                 "mandatory": false,
@@ -229,7 +225,6 @@
                             "type": "General",
                             "answers": [{
                                 "q_code": "4",
-                                "guidance": "",
                                 "id": "what-is-your-shoe-size",
                                 "label": "",
                                 "mandatory": false,
@@ -276,7 +271,6 @@
                         "id": "extra-cover-section",
                         "questions": [{
                             "answers": [{
-                                "guidance": "",
                                 "id": "extra-cover-answer",
                                 "label": "",
                                 "mandatory": true,
@@ -330,7 +324,6 @@
                         "id": "credit-card-section",
                         "questions": [{
                             "answers": [{
-                                "guidance": "",
                                 "id": "credit-card-answer",
                                 "label": "",
                                 "mandatory": true,
@@ -355,7 +348,6 @@
                         "id": "expiry-date-section",
                         "questions": [{
                             "answers": [{
-                                "guidance": "",
                                 "id": "expiry-date-answer",
                                 "label": "",
                                 "mandatory": true,
@@ -380,7 +372,6 @@
                         "id": "security-code-section",
                         "questions": [{
                             "answers": [{
-                                "guidance": "",
                                 "id": "security-code-answer",
                                 "label": "",
                                 "mandatory": true,

--- a/data/en/test_percentage.json
+++ b/data/en/test_percentage.json
@@ -23,7 +23,6 @@
                     "questions": [{
                         "answers": [{
                             "description": "Enter percentage of growth",
-                            "guidance": "",
                             "id": "answer",
                             "label": "New to the market 2012-2014",
                             "mandatory": false,

--- a/data/en/test_question_guidance.json
+++ b/data/en/test_question_guidance.json
@@ -18,62 +18,6 @@
             },
             {
                 "type": "Questionnaire",
-                "id": "block-test-guidance-all",
-                "title": "",
-                "sections": [{
-                    "id": "section-test-guidance-all",
-                    "title": "Section: Test guidance all",
-                    "description": "",
-                    "questions": [{
-                        "id": "question-test-guidance-all",
-                        "title": "Question: Test guidance all",
-                        "description": "<p>Testing all features of the guidance block enabled together</p>",
-                        "guidance": [{
-                                "title": "Include",
-                                "description": "<p>Guidance <b>include</b> description text</p>",
-                                "list": [
-                                    "Item Include 1",
-                                    "Item Include 2",
-                                    "Item Include 3",
-                                    "Item Include 4"
-                                ]
-                            },
-                            {
-                                "title": "Exclude",
-                                "description": "<p>Guidance <b>exclude</b> description text</p>",
-                                "list": [
-                                    "Item Exclude 1",
-                                    "Item Exclude 2",
-                                    "Item Exclude 3",
-                                    "Item Exclude 4"
-                                ]
-                            },
-                            {
-                                "title": "Other",
-                                "description": "<p>Guidance <b>other</b> description text</p>",
-                                "list": [
-                                    "Item Other 1",
-                                    "Item Other 2",
-                                    "Item Other 3",
-                                    "Item Other 4"
-                                ]
-                            }
-                        ],
-                        "type": "General",
-                        "answers": [{
-                            "guidance": "",
-                            "id": "answer-test-guidance-all",
-                            "label": "Text question",
-                            "mandatory": false,
-                            "options": [],
-                            "q_code": "0",
-                            "type": "TextField"
-                        }]
-                    }]
-                }]
-            },
-            {
-                "type": "Questionnaire",
                 "id": "block-test-guidance-title",
                 "title": "",
                 "sections": [{
@@ -83,18 +27,24 @@
                     "questions": [{
                         "id": "question-test-guidance-title",
                         "title": "Question: Test guidance title",
-                        "description": "<p>Testing combinations of the title within guidance</p>",
-                        "guidance": [{
-                                "title": "This one has a description but no list",
-                                "description": "<p>No list items below this text</p>"
-                            },
-                            {
-                                "title": "This one has no list or description"
-                            }
-                        ],
+                        "description": "Testing combinations of the title within guidance",
+                        "guidance": {
+                            "content": [{
+                                    "title": "This one has a description but no list"
+                                },
+                                {
+                                    "description": "No list items below this text"
+                                },
+                                {
+                                    "title": "This one has no list or description"
+                                },
+                                {
+                                    "description": "title, description, title, description"
+                                }
+                            ]
+                        },
                         "type": "General",
                         "answers": [{
-                            "guidance": "",
                             "id": "answer-test-guidance-title",
                             "label": "Text question",
                             "mandatory": false,
@@ -116,23 +66,26 @@
                     "questions": [{
                         "id": "question-test-guidance-description",
                         "title": "Question: Test guidance descriptions",
-                        "description": "<p>Tests the descriptions within guidance</p>",
-                        "guidance": [{
-                                "description": "<p>No title above this text, list below</p>",
-                                "list": [
-                                    "Item Include 1",
-                                    "Item Include 2",
-                                    "Item Include 3",
-                                    "Item Include 4"
-                                ]
-                            },
-                            {
-                                "description": "<p>Just description, no title above this text, no list below</p>"
-                            }
-                        ],
+                        "description": "Tests the descriptions within guidance",
+                        "guidance": {
+                            "content": [{
+                                    "description": "No title above this text, list below"
+                                },
+                                {
+                                    "list": [
+                                        "Item Include 1",
+                                        "Item Include 2",
+                                        "Item Include 3",
+                                        "Item Include 4"
+                                    ]
+                                },
+                                {
+                                    "description": "Just description, no title above this text, no list below"
+                                }
+                            ]
+                        },
                         "type": "General",
                         "answers": [{
-                            "guidance": "",
                             "id": "answer-test-guidance-description",
                             "label": "Text question",
                             "mandatory": false,
@@ -154,28 +107,226 @@
                     "questions": [{
                         "id": "question-test-guidance-lists",
                         "title": "Question: Test guidance lists (with no question description below)",
-                        "guidance": [{
-                                "title": "Title, no description, list follows",
-                                "list": [
-                                    "Item Include 1",
-                                    "Item Include 2",
-                                    "Item Include 3",
-                                    "Item Include 4"
-                                ]
-                            },
-                            {
-                                "list": [
-                                    "List with no title or description 1",
-                                    "List with no title or description 2",
-                                    "List with no title or description 3",
-                                    "List with no title or description 4"
-                                ]
-                            }
-                        ],
+                        "guidance": {
+                            "content": [{
+                                    "title": "Title, no description, list follows",
+                                    "list": [
+                                        "Item Include 1",
+                                        "Item Include 2",
+                                        "Item Include 3",
+                                        "Item Include 4"
+                                    ]
+                                },
+                                {
+                                    "list": [
+                                        "List with no title or description 1",
+                                        "List with no title or description 2",
+                                        "List with no title or description 3",
+                                        "List with no title or description 4"
+                                    ]
+                                }
+                            ]
+                        },
                         "type": "General",
                         "answers": [{
-                            "guidance": "",
                             "id": "answer-test-guidance-lists",
+                            "label": "Text question",
+                            "mandatory": false,
+                            "options": [],
+                            "q_code": "0",
+                            "type": "TextField"
+                        }]
+                    }]
+                }]
+            },
+            {
+                "type": "Questionnaire",
+                "id": "block-test-guidance-content-description",
+                "title": "",
+                "sections": [{
+                    "id": "section-test-guidance-content-description",
+                    "title": "Section: Test show guidance content description",
+                    "description": "",
+                    "questions": [{
+                        "id": "question-test-guidance-content-description",
+                        "title": "Question: Test show guidance content description",
+                        "guidance": {
+                            "content": [{
+                                "description": "Guidance with content description"
+                            }]
+                        },
+                        "type": "General",
+                        "answers": [{
+                            "guidance": {
+                                "show_guidance": "Show test guidance.",
+                                "hide_guidance": "Hide test guidance.",
+                                "content": [{
+                                    "description": "The text here is for description"
+                                }]
+                            },
+                            "id": "answer-test-guidance-content-description",
+                            "label": "Text question",
+                            "mandatory": false,
+                            "options": [],
+                            "q_code": "0",
+                            "type": "TextField"
+                        }]
+                    }]
+                }]
+            },
+            {
+                "type": "Questionnaire",
+                "id": "block-test-guidance-content-title",
+                "title": "",
+                "sections": [{
+                    "id": "section-test-guidance-content-title",
+                    "title": "Section: Test show guidance content title",
+                    "description": "",
+                    "questions": [{
+                        "id": "question-test-guidance-content-title",
+                        "title": "Question: Test show guidance content title",
+                        "guidance": {
+                            "content": [{
+                                "description": "Guidance with content title"
+                            }]
+                        },
+                        "type": "General",
+                        "answers": [{
+                            "guidance": {
+                                "show_guidance": "Show test guidance.",
+                                "hide_guidance": "Hide test guidance.",
+                                "content": [{
+                                    "title": "The text here is for a title"
+                                }]
+                            },
+                            "id": "answer-test-guidance-content-title",
+                            "label": "Text question",
+                            "mandatory": false,
+                            "options": [],
+                            "q_code": "0",
+                            "type": "TextField"
+                        }]
+                    }]
+                }]
+            },
+            {
+                "type": "Questionnaire",
+                "id": "block-test-guidance-content-list",
+                "title": "",
+                "sections": [{
+                    "id": "section-test-guidance-content-list",
+                    "title": "Section: Test show guidance content list",
+                    "description": "",
+                    "questions": [{
+                        "id": "question-test-guidance-content-list",
+                        "title": "Question: Test show guidance content list",
+                        "guidance": {
+                            "content": [{
+                                "title": "Guidance with content list"
+                            }]
+                        },
+                        "type": "General",
+                        "answers": [{
+                            "guidance": {
+                                "show_guidance": "Show test guidance.",
+                                "hide_guidance": "Hide test guidance.",
+                                "content": [{
+                                    "list": [
+                                        "The text here is for a list",
+                                        "Another list item",
+                                        "One more"
+                                    ]
+                                }]
+                            },
+                            "id": "answer-test-guidance-content-list",
+                            "label": "Text question",
+                            "mandatory": false,
+                            "options": [],
+                            "q_code": "0",
+                            "type": "TextField"
+                        }]
+                    }]
+                }]
+            },
+            {
+                "type": "Questionnaire",
+                "id": "block-test-guidance-all",
+                "title": "",
+                "sections": [{
+                    "id": "section-test-guidance-all",
+                    "title": "Section: Test guidance all",
+                    "description": "",
+                    "questions": [{
+                        "id": "question-test-guidance-all",
+                        "title": "Question: Test guidance all",
+                        "description": "Testing all features of the guidance block enabled together",
+                        "guidance": {
+                            "content": [{
+                                    "title": "Include"
+                                },
+                                {
+                                    "description": "<p>Guidance <b>include</b> description text</p>"
+                                },
+                                {
+                                    "list": [
+                                        "Item Include 1",
+                                        "Item Include 2",
+                                        "Item Include 3",
+                                        "Item Include 4"
+                                    ]
+                                },
+                                {
+                                    "title": "Exclude"
+                                },
+                                {
+                                    "description": "<p>Guidance <b>exclude</b> description text</p>"
+                                },
+                                {
+                                    "list": [
+                                        "Item Exclude 1",
+                                        "Item Exclude 2",
+                                        "Item Exclude 3",
+                                        "Item Exclude 4"
+                                    ]
+                                },
+                                {
+                                    "title": "Other"
+                                },
+                                {
+                                    "description": "<p>Guidance <b>other</b> description text</p>"
+                                },
+                                {
+                                    "list": [
+                                        "Item Other 1",
+                                        "Item Other 2",
+                                        "Item Other 3",
+                                        "Item Other 4"
+                                    ]
+                                }
+                            ]
+                        },
+                        "type": "General",
+                        "answers": [{
+                            "guidance": {
+                                "show_guidance": "Show test guidance.",
+                                "hide_guidance": "Hide test guidance.",
+                                "content": [{
+                                        "description": "The text here is for a description"
+                                    },
+                                    {
+                                        "description": "Here's some more description text"
+                                    },
+                                    {
+                                        "title": "This text here is the title for the list",
+                                        "list": [
+                                            "The text here is for a list",
+                                            "Another list item",
+                                            "One more"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "id": "answer-test-guidance-all",
                             "label": "Text question",
                             "mandatory": false,
                             "options": [],

--- a/data/en/test_radio.json
+++ b/data/en/test_radio.json
@@ -21,7 +21,6 @@
                     "id": "radio-mandatory-section",
                     "questions": [{
                         "answers": [{
-                                "guidance": "",
                                 "id": "radio-mandatory-answer",
                                 "label": "What is your favourite breakfast food",
                                 "mandatory": true,
@@ -58,7 +57,6 @@
                                 "parent_answer_id": "radio-mandatory-answer",
                                 "alias": "othervalue",
                                 "mandatory": false,
-                                "guidance": "",
                                 "id": "other-answer-mandatory",
                                 "label": "Please specify other",
                                 "q_code": "20",
@@ -86,7 +84,6 @@
                     "id": "radio-non-mandatory-section",
                     "questions": [{
                         "answers": [{
-                                "guidance": "",
                                 "id": "radio-non-mandatory-answer",
                                 "label": "What is your favourite breakfast food",
                                 "mandatory": false,
@@ -123,7 +120,6 @@
                                 "parent_answer_id": "radio-non-mandatory-answer",
                                 "mandatory": false,
                                 "alias": "",
-                                "guidance": "",
                                 "id": "other-answer-non-mandatory",
                                 "label": "Please specify other",
                                 "q_code": "20",

--- a/data/en/test_radio_checkbox_descriptions.json
+++ b/data/en/test_radio_checkbox_descriptions.json
@@ -18,7 +18,6 @@
                     "id": "checkbox-section",
                     "questions": [{
                         "answers": [{
-                            "guidance": "",
                             "id": "checkbox-answer",
                             "label": "Did this business make major changes in the following areas?",
                             "mandatory": true,
@@ -66,7 +65,6 @@
                     "id": "radio-section",
                     "questions": [{
                         "answers": [{
-                            "guidance": "",
                             "id": "radio-answer",
                             "label": "Did this business make major changes in the following areas?",
                             "mandatory": true,

--- a/data/en/test_relationship_household.json
+++ b/data/en/test_relationship_household.json
@@ -79,7 +79,6 @@
                         "answers": [{
                             "id": "who-is-related",
                             "label": "%(current_person)s is the &hellip; of %(other_person)s",
-                            "guidance": "",
                             "mandatory": false,
                             "q_code": "2",
                             "type": "Relationship",

--- a/data/en/test_repeating_and_conditional_routing.json
+++ b/data/en/test_repeating_and_conditional_routing.json
@@ -28,7 +28,6 @@
                             "type": "General",
                             "answers": [{
                                 "q_code": "2",
-                                "guidance": "",
                                 "id": "no-of-repeats-answer",
                                 "label": "How many times are we going to repeat?",
                                 "mandatory": true,
@@ -73,7 +72,6 @@
                                     }
                                 ],
                                 "q_code": "3",
-                                "guidance": "",
                                 "id": "conditional-answer",
                                 "label": "Which conditional question should we jump to?",
                                 "mandatory": true,
@@ -123,7 +121,6 @@
                             "type": "General",
                             "answers": [{
                                 "q_code": "4",
-                                "guidance": "",
                                 "id": "what-is-your-age",
                                 "label": "",
                                 "mandatory": true,
@@ -152,7 +149,6 @@
                             "type": "General",
                             "answers": [{
                                 "q_code": "5",
-                                "guidance": "",
                                 "id": "what-is-your-shoe-size",
                                 "label": "",
                                 "mandatory": true,

--- a/data/en/test_repeating_household.json
+++ b/data/en/test_repeating_household.json
@@ -77,7 +77,6 @@
                             "type": "General",
                             "answers": [{
                                 "q_code": "3",
-                                "guidance": "",
                                 "id": "what-is-your-age",
                                 "label": "What is their age?",
                                 "mandatory": true,
@@ -106,7 +105,6 @@
                             "type": "General",
                             "answers": [{
                                 "q_code": "4",
-                                "guidance": "",
                                 "id": "what-is-your-shoe-size",
                                 "label": "What is their shoe size?",
                                 "mandatory": true,

--- a/data/en/test_skip_condition.json
+++ b/data/en/test_skip_condition.json
@@ -17,7 +17,6 @@
                     "id": "food-section",
                     "questions": [{
                         "answers": [{
-                            "guidance": "",
                             "id": "food-answer",
                             "label": "What is your favourite breakfast food",
                             "mandatory": true,
@@ -52,7 +51,6 @@
                     "questions": [{
                         "answers": [{
                             "alias": "",
-                            "guidance": "",
                             "id": "drink-answer",
                             "label": "What is your favourite breakfast beverage",
                             "mandatory": true,

--- a/data/en/test_skip_condition_block.json
+++ b/data/en/test_skip_condition_block.json
@@ -24,7 +24,6 @@
                             "title": "Do you want to skip?",
                             "type": "General",
                             "answers": [{
-                                "guidance": "",
                                 "id": "do-you-want-to-skip-answer",
                                 "label": "Do you want to skip?",
                                 "mandatory": true,
@@ -60,7 +59,6 @@
                             "title": "Do you want to skip?",
                             "type": "General",
                             "answers": [{
-                                "guidance": "",
                                 "id": "should-skip-answer",
                                 "label": "Why didn't you skip the block?",
                                 "mandatory": true,

--- a/data/en/test_skip_condition_group.json
+++ b/data/en/test_skip_condition_group.json
@@ -24,7 +24,6 @@
                         "title": "Do you want to skip?",
                         "type": "General",
                         "answers": [{
-                            "guidance": "",
                             "id": "do-you-want-to-skip-answer",
                             "label": "Do you want to skip?",
                             "mandatory": true,
@@ -71,7 +70,6 @@
                         "title": "Do you want to skip?",
                         "type": "General",
                         "answers": [{
-                            "guidance": "",
                             "id": "should-skip-answer",
                             "label": "Why didn't you skip the group?",
                             "mandatory": true,
@@ -100,7 +98,6 @@
                             "title": "This group is required as a skipped group can't be the last group",
                             "type": "General",
                             "answers": [{
-                                "guidance": "",
                                 "id": "last-group-answer",
                                 "label": "This group is required as a skipped group can't be the last group",
                                 "mandatory": true,

--- a/data/en/test_textarea.json
+++ b/data/en/test_textarea.json
@@ -21,7 +21,6 @@
                     "id": "section",
                     "questions": [{
                         "answers": [{
-                            "guidance": "",
                             "id": "answer",
                             "label": "Enter your comments",
                             "mandatory": false,

--- a/data/en/test_textfield.json
+++ b/data/en/test_textfield.json
@@ -21,7 +21,6 @@
                     "id": "section",
                     "questions": [{
                         "answers": [{
-                            "guidance": "",
                             "id": "answer",
                             "label": "What is your name?",
                             "mandatory": false,

--- a/data/en/test_timeout.json
+++ b/data/en/test_timeout.json
@@ -20,7 +20,6 @@
                     "id": "timeout-section",
                     "questions": [{
                         "answers": [{
-                            "guidance": "",
                             "id": "timeout-answer",
                             "label": "Does the timeout appear?",
                             "mandatory": false,

--- a/data/schema/schema_v1.json
+++ b/data/schema/schema_v1.json
@@ -12,6 +12,34 @@
             "description": "A question code used by downstream systems to identify answers",
             "pattern": "^[0-9a-z]+$"
         },
+        "guidance_content": {
+            "description": "Allows customisation of guidance text",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "anyOf": [
+                    {"required": ["title"]},
+                    {"required": ["description"]},
+                    {"required": ["list"]}
+                ],
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "list": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
         "skip_condition": {
             "description": "Allows an element to be skipped when a condition has been met. By adding more than one `when` element it will evaluate as an or rule.",
             "type": "array",
@@ -323,23 +351,12 @@
                                                             "type": "string"
                                                         },
                                                         "guidance": {
-                                                            "type": "array",
-                                                            "items": {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "title": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "description": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "list": {
-                                                                        "type": "array",
-                                                                        "items": {
-                                                                            "type": "string"
-                                                                        }
-                                                                    }
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "content": {
+                                                                    "$ref": "#/definitions/guidance_content"
                                                                 }
+
                                                             }
                                                         },
                                                         "skip_condition": {
@@ -381,7 +398,20 @@
                                                                         "type": "string"
                                                                     },
                                                                     "guidance": {
-                                                                        "type": "string"
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "show_guidance":
+                                                                            {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "hide_guidance": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "content": {
+                                                                                "$ref": "#/definitions/guidance_content"
+                                                                            }
+
+                                                                        }
                                                                     },
                                                                     "description": {
                                                                         "type": "string"

--- a/tests/integration/questionnaire/test_questionnaire_question_guidance.py
+++ b/tests/integration/questionnaire/test_questionnaire_question_guidance.py
@@ -8,39 +8,7 @@ class TestQuestionnaireQuestionGuidance(IntegrationTestCase):
         self.launchSurvey('test', 'question_guidance')
         self.post(action='start_questionnaire')
 
-        # When we navigate to the block with all guidance features enabled
-        # Then we are presented with the question guidance with all features enabled
-        self.assertInUrl('block-test-guidance-all')
-
-        self.assertInPage('Test guidance all')
-        self.assertInPage('>Include<')
-        self.assertInPage('>Item Include 1<')
-        self.assertInPage('>Item Include 2<')
-        self.assertInPage('>Item Include 3<')
-        self.assertInPage('>Item Include 4<')
-
-        self.assertInPage('>Exclude<')
-        self.assertInPage('>Item Exclude 1<')
-        self.assertInPage('>Item Exclude 2<')
-        self.assertInPage('>Item Exclude 3<')
-        self.assertInPage('>Item Exclude 4<')
-
-        self.assertInPage('>Other<')
-        self.assertInPage('>Item Other 1<')
-        self.assertInPage('>Item Other 2<')
-        self.assertInPage('>Item Other 3<')
-        self.assertInPage('>Item Other 4<')
-
-        self.assertInPage('Guidance <b>include</b> description text')
-        self.assertInPage('Guidance <b>exclude</b> description text')
-        self.assertInPage('Guidance <b>other</b> description text')
-        self.assertInPage('Text question')
-        self.assertInPage('<input')
-
-        # When we continue to the next page with combinations of the guidance title
-        self.post(action='save_continue')
-
-        # Then I am presented with the title guidance correctly
+        # When I start the survey I am presented with the title guidance correctly
         self.assertInUrl('block-test-guidance-title')
 
         self.assertInPage('This one has a description but no list')
@@ -80,7 +48,77 @@ class TestQuestionnaireQuestionGuidance(IntegrationTestCase):
         self.assertInPage('Text question')
         self.assertInPage('<input')
 
-        # And I can continue to the summary page
+        # When we continue to the description content guidance page
+        self.post(action='save_continue')
+
+        # I can see the description content guidance
+        self.assertInUrl('block-test-guidance-content-description')
+        self.assertInPage('Test show guidance content description')
+        self.assertInPage('Guidance with content description')
+        self.assertInPage('Text question')
+        self.assertInPage('<input')
+        self.assertInPage('Show test guidance.')
+        self.assertInPage('The text here is for description')
+
+        # When we continue to the title content guidance page
+        self.post(action='save_continue')
+
+        # I can see the title content guidance
+        self.assertInUrl('block-test-guidance-content-title')
+        self.assertInPage('Test show guidance content title')
+        self.assertInPage('Guidance with content title')
+        self.assertInPage('Text question')
+        self.assertInPage('<input')
+        self.assertInPage('Show test guidance.')
+        self.assertInPage('The text here is for a title')
+
+        # When we continue to the list content guidance page
+        self.post(action='save_continue')
+
+        # I can see the list content guidance
+        self.assertInUrl('block-test-guidance-content-list')
+        self.assertInPage('Test show guidance content list')
+        self.assertInPage('Guidance with content list')
+        self.assertInPage('Text question')
+        self.assertInPage('<input')
+        self.assertInPage('Show test guidance.')
+        self.assertInPage('The text here is for a list')
+        self.assertInPage('Another list item')
+        self.assertInPage('One more')
+
+        # When we continue to the test all guidance page
+        self.post(action='save_continue')
+
+        # When we navigate to the block with all guidance features enabled
+        # Then we are presented with the question guidance with all features enabled
+        self.assertInUrl('block-test-guidance-all')
+
+        self.assertInPage('Test guidance all')
+        self.assertInPage('>Include<')
+        self.assertInPage('>Item Include 1<')
+        self.assertInPage('>Item Include 2<')
+        self.assertInPage('>Item Include 3<')
+        self.assertInPage('>Item Include 4<')
+
+        self.assertInPage('>Exclude<')
+        self.assertInPage('>Item Exclude 1<')
+        self.assertInPage('>Item Exclude 2<')
+        self.assertInPage('>Item Exclude 3<')
+        self.assertInPage('>Item Exclude 4<')
+
+        self.assertInPage('>Other<')
+        self.assertInPage('>Item Other 1<')
+        self.assertInPage('>Item Other 2<')
+        self.assertInPage('>Item Other 3<')
+        self.assertInPage('>Item Other 4<')
+
+        self.assertInPage('Guidance <b>include</b> description text')
+        self.assertInPage('Guidance <b>exclude</b> description text')
+        self.assertInPage('Guidance <b>other</b> description text')
+        self.assertInPage('Text question')
+        self.assertInPage('<input')
+
+        # When we continue we go to the summary page
         self.post(action='save_continue')
         self.assertInUrl('summary')
 


### PR DESCRIPTION
### What is the context of this PR?
- Having the ability to customise Show/Hide further guidance to match the questions.
- Changed the html templates to be able to use the 'repeating answer', 'relationship', 'question_guidance' & 'answer_guidance', added new template called 'guidance'.
- All schemas have been changed to work with the new style.
- No schemas have full custom guidance text, only the ability to provide it.

### How to review 
- Test schemas to see if show/hide is available without errors. (removed custom now).
- Naming suggestions.
- Check if there's anything missed.
- Check tests pass.
- mci-refresh.json will need updating to the same format