### PR TITLE
Improves Other textfield answer display on summary screen

### DIFF
--- a/app/templates/partials/summary/checkbox.html
+++ b/app/templates/partials/summary/checkbox.html
@@ -1,5 +1,18 @@
+{% set not_answered = 'No answer provided' %}
 <ul class="u-m-no">
-  {% for selected_answer in answer.value %}
-    <li>{{selected_answer}}</li>
-  {% endfor %}
+      {% for selected_answer in answer.value %}
+        <li>{{selected_answer.label}}
+            {%- if answer.child_answer_value is not none and selected_answer.should_display_other %}
+            <ul>
+                <li>
+                    {%- if answer.child_answer_value == ''  -%}
+                        {{not_answered}}
+                    {%- else -%}
+                        {{ answer.child_answer_value }}
+                    {%- endif -%}
+                </li>
+            </ul>
+            {%- endif -%}
+        </li>
+      {% endfor %}
 </ul>

--- a/app/templates/partials/summary/radio.html
+++ b/app/templates/partials/summary/radio.html
@@ -1,0 +1,18 @@
+{% set not_answered = 'No answer provided' %}
+<ul class="u-m-no">
+    <li>{{answer.value}}
+    {%- if answer.child_answer_value is not none -%}
+        <ul>
+            <li>
+                {%- if answer.child_answer_value == ''  -%}
+                    {{not_answered}}
+                {%- else -%}
+                    {{ answer.child_answer_value }}
+                {%- endif -%}
+            </li>
+        </ul>
+        {%- endif -%}
+    </li>
+</ul>
+
+

--- a/app/templates/summary.html
+++ b/app/templates/summary.html
@@ -47,26 +47,24 @@
                 </div>
 
                 {% for answer in question.answers %}
+                      {% if question.answers|length > 1 and answer.label %}
+                        <div class="summary__question summary__question--sub">
+                          {{answer.label|striptags}}
+                        </div>
+                      {% endif %}
 
-                  {% if question.answers|length > 1 %}
-                    <div class="summary__question summary__question--sub">
-                      {{answer.label|striptags}}
-                    </div>
-                  {% endif %}
-
-                  <div class="summary__answer">
-                    <div class="summary__answer-text" id="{{answer.id}}-answer" data-qa="{{answer.id}}-answer">
-                      {%- if answer.value is none or answer.value == '' -%}
-                        {{not_answered}}
-                      {%- else -%}
-                        {% include theme(['partials/summary/' ~ answer.type ~ '.html', 'partials/summary/default.html']) %}
-                      {%- endif -%}
-                    </div>
-                    <div class="summary__edit">
-                      <a href="{{ section.link }}#{{answer.id}}" class="summary__edit-link" aria-describedby="{{answer.id}} {{answer.id}}-answer" data-qa="{{answer.id}}-edit" {{helpers.track('click', 'Summary', 'Edit click')}}>Edit <span class="u-vh">your answer</span></a>
-                    </div>
-                  </div>
-
+                      <div class="summary__answer">
+                        <div class="summary__answer-text" id="{{answer.id}}-answer" data-qa="{{answer.id}}-answer">
+                          {%- if answer.value is none or answer.value == '' -%}
+                            {{not_answered}}
+                          {%- else -%}
+                            {% include theme(['partials/summary/' ~ answer.type ~ '.html', 'partials/summary/default.html']) %}
+                          {%- endif -%}
+                        </div>
+                        <div class="summary__edit">
+                          <a href="{{ section.link }}#{{answer.id}}" class="summary__edit-link" aria-describedby="{{answer.id}} {{answer.id}}-answer" data-qa="{{answer.id}}-edit" {{helpers.track('click', 'Summary', 'Edit click')}}>Edit <span class="u-vh">your answer</span></a>
+                        </div>
+                      </div>
                 {% endfor %}
 
             {% endfor %}

--- a/app/templating/summary/answer.py
+++ b/app/templating/summary/answer.py
@@ -1,7 +1,9 @@
 class Answer:
 
-    def __init__(self, answer_schema, answer):
+    def __init__(self, answer_schema, answer, child_answer_value=None):
         self.id = answer_schema['id']
-        self.label = answer_schema['label'] if 'label' in answer_schema else None
+        self.label = answer_schema.get('label')
         self.value = answer
         self.type = answer_schema['type'].lower()
+        self.parent_answer_id = answer_schema.get('parent_answer_id')
+        self.child_answer_value = child_answer_value

--- a/tests/app/templating/summary/test_question.py
+++ b/tests/app/templating/summary/test_question.py
@@ -109,12 +109,12 @@ class TestQuestion(TestCase):
 
         # Then
         self.assertEqual(len(question.answers[0].value), 2)
-        self.assertEqual(question.answers[0].value[0], 'Light Side')
-        self.assertEqual(question.answers[0].value[1], 'Dark Side')
+        self.assertEqual(question.answers[0].value[0].label, 'Light Side')
+        self.assertEqual(question.answers[0].value[1].label, 'Dark Side')
 
     def test_checkbox_button_other_option_empty(self):
         # Given
-        answers = {'answer_1': ['other', '']}
+        answers = {'answer_1': ['Other option label', '']}
         options = [{
             'label': 'Light Side',
             'value': 'Light Side',
@@ -134,21 +134,53 @@ class TestQuestion(TestCase):
 
         # Then
         self.assertEqual(len(question.answers[0].value), 1)
-        self.assertEqual(question.answers[0].value[0], 'Other option label')
+        self.assertEqual(question.answers[0].value[0].label, 'Other option label')
+        self.assertEqual(question.answers[0].value[0].should_display_other, True)
+
+    def test_checkbox_answer_with_other_value_returns_the_value(self):
+        # Given
+        answers = {'answer_1': ['Light Side', 'Other'], 'child_answer': 'Test'}
+        options = [{
+            'label': 'Light Side',
+            'value': 'Light Side',
+        },
+            {
+            "label": "Other",
+            "value": "Other",
+            "child_answer_id": "child_answer"
+        }]
+        answer_schema = [{
+            'id': 'answer_1',
+            'label': 'Which side?',
+            'type': 'Checkbox',
+            'options': options
+        },
+            {
+            "parent_answer_id": "answer_1",
+            "id": "child_answer",
+            "type": "TextField"
+        }]
+        question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL',
+                           'answers': answer_schema}
+
+        # When
+        question = Question(question_schema, answers)
+
+        # Then
+        self.assertEqual(len(question.answers[0].value), 2)
+        self.assertEqual(question.answers[0].child_answer_value, 'Test')
 
     def test_checkbox_button_other_option_text(self):
         # Given
-        answers = {'answer_1': ['Light Side', 'other', 'Neither']}
+        answers = {'answer_1': ['Light Side', 'other'], 'child_answer': 'Neither'}
         options = [{
             'label': 'Light Side',
             'value': 'Light Side',
           },
           {
-            'label': 'Other',
+            'label': 'other',
             'value': 'other',
-            "other": {
-              "label": "Please specify other"
-            }
+            'child_answer_id': 'child_answer'
           }]
         answer_schema = {'id': 'answer_1', 'label': 'Which side?', 'type': 'Checkbox', 'options': options}
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
@@ -158,8 +190,8 @@ class TestQuestion(TestCase):
 
         # Then
         self.assertEqual(len(question.answers[0].value), 2)
-        self.assertEqual(question.answers[0].value[0], 'Light Side')
-        self.assertEqual(question.answers[0].value[1], 'Neither')
+        self.assertEqual(question.answers[0].value[0].label, 'Light Side')
+        self.assertEqual(question.answers[0].child_answer_value, 'Neither')
 
     def test_checkbox_button_none_selected_should_be_none(self):
         # Given
@@ -238,6 +270,34 @@ class TestQuestion(TestCase):
 
         # Then
         self.assertEqual(question.answers[0].value, None)
+
+    def test_radio_answer_with_other_value_returns_the_value(self):
+        # Given
+        answers = {'answer_1': 'Other', 'child_answer': 'Test'}
+        options = [{
+            'label': 'Other',
+            'value': 'Other',
+            "child_answer_id": "child_answer"
+        }]
+        answer_schema = [{
+            'id': 'answer_1',
+            'label': 'Which side?',
+            'type': 'Radio',
+            'options': options
+        },
+            {
+                "parent_answer_id": "answer_1",
+                "id": "child_answer",
+                "type": "TextField"
+            }]
+        question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL',
+                           'answers': answer_schema}
+
+        # When
+        question = Question(question_schema, answers)
+
+        # Then
+        self.assertEqual(question.answers[0].child_answer_value, 'Test')
 
     def test_question_should_be_skipped(self):
         # Given

--- a/tests/functional/spec/checkbox.spec.js
+++ b/tests/functional/spec/checkbox.spec.js
@@ -77,7 +77,7 @@ describe('Checkbox with "other" option', function() {
      NonMandatoryCheckboxPage.clickOther().setOtherInputField('The other value').submit();
 
      // Then
-     expect(SummaryPage.getNonMandatoryOtherAnswer()).to.have.string('The other value');
+     expect(SummaryPage.getNonMandatoryAnswer()).to.have.string('The other value');
   })
 
   it('Given I have previously added text in other texfiled and saved, when I uncheck other options and select a different checkbox as answer, then the text entered in other field must be wiped.', function() {

--- a/tests/functional/spec/radio.spec.js
+++ b/tests/functional/spec/radio.spec.js
@@ -29,7 +29,7 @@ describe('Radio button with "other" option', function() {
 
 
     //Then
-    expect(SummaryPage.getMandatoryOtherAnswer()).to.contain('Hello')
+    expect(SummaryPage.getMandatoryAnswer()).to.contain('Hello')
   })
 
   it('Given a mandatory radio answer, when I select "Other" and submit without completing the other input field, then an error must be displayed.', function() {


### PR DESCRIPTION
### What is the context of this PR?
Improves Other text field answer display on summary screen

### How to review 
Launch test_checkbox and test_radio schemas
Add values to the Other 'text field' and confirm 
That the display on the summary screen is as per the new designs attached to the trello card.

https://trello.com/c/LatUHa9o/1066-other-answers-on-summary-screen
