### PR TITLE
BrowserStack integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: node_js
 node_js: 6
 env:
   global:
-    - EQ_ENABLE_CACHE=True
     - EQ_RUN_LOCAL_LINT=True
     - EQ_RUN_LOCAL_TESTS=True
     - EQ_RUN_LOCAL=True

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Command                                    | Task
 `yarn test_unit`                        | Watches the unit tests via Karma
 `yarn test_functional`                  | Runs the functional tests through a local Selenium instance (requires app running on localhost:5000)
 `yarn test_functional_sauce`            | Runs the functional tests through Sauce Labs (requires app running on localhost:5000)
+`yarn test_functional_browserstack`     | Runs the functional tests through BrowserStack (requires app running on localhost:5000)
 `yarn lint`                             | Lints the JS, reporting errors/warnings.
 `yarn format`                           | Format the json schemas.
 

--- a/app/views/session.py
+++ b/app/views/session.py
@@ -25,6 +25,11 @@ def add_cache_control(response):
     return response
 
 
+@session_blueprint.route('/session', methods=['HEAD'])
+def login_head():
+    return '', 204
+
+
 @session_blueprint.route('/session', methods=['GET'])
 def login():
     """

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test_unit_no_watch": "gulp test:scripts:unit",
     "test_functional": "gulp test:scripts:functional",
     "test_functional_sauce": "gulp test:scripts:functional --sauce",
+    "test_functional_browserstack": "gulp test:scripts:functional --browserstack",
     "test_functional_headless": "gulp test:scripts:functional --headless",
     "a11y": "gulp test:a11ym",
     "format": "gulp format:json"
@@ -38,6 +39,7 @@
     "browser-sync": "^2.11.0",
     "browserify": "~13.1.0",
     "browserify-shim": "^3.8.12",
+    "browserstack-local": "^1.3.0",
     "chai": "^3.4.1",
     "chai-as-promised": "^5.1.0",
     "del": "^2.2.2",
@@ -125,6 +127,7 @@
     "vinyl-source-stream": "~1.1.0",
     "vinyl-transform": "^1.0.0",
     "watchify": "~3.7.0",
+    "wdio-browserstack-service": "^0.1.4",
     "wdio-dot-reporter": "^0.0.8",
     "wdio-mocha-framework": "^0.5.10",
     "wdio-phantomjs-service": "^0.2.2",

--- a/tests/functional/capabilities.js
+++ b/tests/functional/capabilities.js
@@ -1,21 +1,23 @@
 const defaultCapabilities = {
+  'project': 'EQ Survey Runner',
   'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
   'build': process.env.TRAVIS_BUILD_NUMBER,
   'public': true,
-  'maxInstances': 1
+  'maxInstances': 1,
+  'browserstack.local': true
 }
 
 export const chrome = {
-  name: 'Chrome 48 | OS X 10.11',
   browserName: 'chrome',
-  version: '48.0',
-  platform: 'OS X 10.11',
+  browser_version: '48.0',
+  os: 'OS X',
+  os_version: 'Yosemite',
   ...defaultCapabilities
 }
 
 export const chromeNoJS = {
   ...chrome,
-  name: 'Chrome (No JavaScript) 48 | OS X 10.11',
+  name: 'Chrome (No JavaScript)',
   chromeOptions: {
     prefs: {'profile.managed_default_content_settings.javascript': 2}
   }
@@ -27,48 +29,47 @@ export const phantomjs = {
 }
 
 export const firefox = {
-  name: 'Firefox 43 | OS X 10.11',
   browserName: 'firefox',
   version: '43.0',
-  platform: 'OS X 10.11',
+  os: 'OS X',
   ...defaultCapabilities
 }
 
 export const edge = {
-  name: 'MS Edge | Windows 10',
   browserName: 'microsoftedge',
-  platform: 'Windows 10',
+  os: 'Windows',
+  os_version: '10',
   ...defaultCapabilities
 }
 
 export const ie11 = {
-  name: 'IE11 | Windows 7',
   browserName: 'internet explorer',
   version: '11.0',
-  platform: 'Windows 7',
+  os: 'Windows',
+  os_version: '7',
   ...defaultCapabilities
 }
 
 export const ie10 = {
-  name: 'IE10 | Windows 7',
   browserName: 'internet explorer',
   version: '10.0',
-  platform: 'Windows 7',
+  os: 'Windows',
+  os_version: '7',
   ...defaultCapabilities
 }
 
 export const ie9 = {
-  name: 'IE9 | Windows 7',
   browserName: 'internet explorer',
   version: '9.0',
-  platform: 'Windows 7',
+  os: 'Windows',
+  os_version: '7',
   ...defaultCapabilities
 }
 
 export const ie8 = {
-  name: 'IE8 | Windows XP',
   browserName: 'internet explorer',
   version: '8.0',
-  platform: 'Windows XP',
+  os: 'Windows',
+  os_version: 'XP',
   ...defaultCapabilities
 }

--- a/tests/functional/config.js
+++ b/tests/functional/config.js
@@ -52,6 +52,13 @@ const sauceLabsConfig = {
   capabilities: [firefox]
 }
 
+const browserStackConfig = {
+  services: ['browserstack'],
+  user: process.env.BROWSERSTACK_USER,
+  key: process.env.BROWSERSTACK_ACCESS_KEY,
+  browserstackLocal: true
+}
+
 const phantomjsConfig = {
   services: ['phantomjs'],
   waitforTimeout: 3000,
@@ -76,15 +83,11 @@ if (process.env.TRAVIS === 'true') {
   }
 } else {
   if (argv.sauce) {
-    config = {
-      ...config,
-      ...sauceLabsConfig
-    }
+    config = Object.assign(config, sauceLabsConfig)
+  } else if (argv.browserstack) {
+    config = Object.assign(config, browserStackConfig)
   } else if (argv.headless) {
-    config = {
-      ...config,
-      ...phantomjsConfig
-    }
+    config = Object.assign(config, phantomjsConfig)
   }
 }
 

--- a/tests/functional/helpers.js
+++ b/tests/functional/helpers.js
@@ -4,14 +4,12 @@ import {generateToken} from './jwt_helper'
 
 export {landingPage}
 
-export const getUri = uri => browser.options.baseUrl + uri
-
 export const getRandomString = length => sampleSize('ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789', length).join('')
 
 export const startCensusQuestionnaire = (schema, sexualIdentity = false, region = 'GB-ENG', language = 'en') => {
   generateToken(schema, getRandomString(10), getRandomString(10), null, null, region, language, sexualIdentity)
     .then(function(token) {
-      return browser.url('http://localhost:5000/session?token=' + token)
+      return browser.url('/session?token=' + token)
     })
 
   browser.pause(1000) // Shudder!!!
@@ -20,7 +18,7 @@ export const startCensusQuestionnaire = (schema, sexualIdentity = false, region 
 export function openQuestionnaire(schema, userId = getRandomString(10), collectionId = getRandomString(10), periodId = '201605', periodStr = 'May 2016') {
   generateToken(schema, userId, collectionId, periodId, periodStr)
     .then(function(token) {
-      return browser.url('http://localhost:5000/session?token=' + token)
+      return browser.url('/session?token=' + token)
     })
 
   browser.pause(1000) // Shudder!!!

--- a/tests/integration/session/test_login.py
+++ b/tests/integration/session/test_login.py
@@ -66,3 +66,16 @@ class TestLogin(IntegrationTestCase):
 
         # Then
         self.assertStatusNotFound()
+
+
+    def test_http_head_request_to_login_returns_successfully_and_get_still_works(self):
+        # Given
+        token = self.token_generator.create_token('0205', '1')
+
+        # When
+        self._client.head('/session?token=' + token.decode(), as_tuple=True, follow_redirects=True)
+        self.get('/session?token=' + token.decode())
+
+        # Then
+        self.assertStatusOK()
+        self.assertInUrl('/questionnaire/1/0205')

--- a/tests/new_functional/capabilities.js
+++ b/tests/new_functional/capabilities.js
@@ -1,20 +1,22 @@
 const defaultCapabilities = {
+  'project': 'EQ Survey Runner',
   'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
   'build': process.env.TRAVIS_BUILD_NUMBER,
   'public': true,
-  'maxInstances': 1
+  'maxInstances': 1,
+  'browserstack.local': true
 };
 
 const chrome = Object.assign({
-  name: 'Chrome 48 | OS X 10.11',
   browserName: 'chrome',
   version: '48.0',
-  platform: 'OS X 10.11'
+  os: 'OS X',
+  os_version: 'Yosemite'
 }, defaultCapabilities);
 
 const chromeNoJS = Object.assign(
   {
-    name: 'Chrome (No JavaScript) 48 | OS X 10.11',
+    name: 'Chrome (No JavaScript)',
     chromeOptions: {
       prefs: {'profile.managed_default_content_settings.javascript': 2}
     }
@@ -29,7 +31,6 @@ const phantomjs = {
 
 const firefox = Object.assign(
   {
-    name: 'Firefox 43 | OS X 10.11',
     browserName: 'firefox',
     version: '43.0',
     platform: 'OS X 10.11'
@@ -37,14 +38,12 @@ const firefox = Object.assign(
 
 const edge = Object.assign(
   {
-    name: 'MS Edge | Windows 10',
     browserName: 'microsoftedge',
     platform: 'Windows 10'
   }, defaultCapabilities);
 
 const ie11 = Object.assign(
   {
-    name: 'IE11 | Windows 7',
     browserName: 'internet explorer',
     version: '11.0',
     platform: 'Windows 7'
@@ -52,7 +51,6 @@ const ie11 = Object.assign(
 
 const ie10 = Object.assign(
   {
-    name: 'IE10 | Windows 7',
     browserName: 'internet explorer',
     version: '10.0',
     platform: 'Windows 7'
@@ -60,7 +58,6 @@ const ie10 = Object.assign(
 
 const ie9 = Object.assign(
   {
-    name: 'IE9 | Windows 7',
     browserName: 'internet explorer',
     version: '9.0',
     platform: 'Windows 7'
@@ -68,7 +65,6 @@ const ie9 = Object.assign(
 
 const ie8 = Object.assign(
   {
-    name: 'IE8 | Windows XP',
     browserName: 'internet explorer',
     version: '8.0',
     platform: 'Windows XP'

--- a/tests/new_functional/config.js
+++ b/tests/new_functional/config.js
@@ -53,6 +53,13 @@ const sauceLabsConfig = {
   capabilities: [capabilities.firefox]
 };
 
+const browserStackConfig = {
+  services: ['browserstack'],
+  user: process.env.BROWSERSTACK_USER,
+  key: process.env.BROWSERSTACK_ACCESS_KEY,
+  browserstackLocal: true
+}
+
 const phantomjsConfig = {
   services: ['phantomjs'],
   waitforTimeout: 3000,
@@ -81,6 +88,8 @@ if (process.env.TRAVIS === 'true') {
 } else {
   if (argv.sauce) {
     config = Object.assign(config, sauceLabsConfig);
+  } else if (argv.browserstack) {
+    config = Object.assign(config, browserStackConfig);
   } else if (argv.headless) {
     config = Object.assign(config, phantomjsConfig);
   }


### PR DESCRIPTION
### What is the context of this PR?
Added capability to run functional tests via BrowserStack from the command line. Using the BrowserStack local tunnel.

### How to review 

Trigger the tests locally by running the following command.

`BROWSERSTACK_USER=#### BROWSERSTACK_ACCESS_KEY=#### yarn test_functional_browserstack`
