### PR TITLE
Eq 1113 refactor navigation

### DIFF
--- a/app/templates/partials/navigation.html
+++ b/app/templates/partials/navigation.html
@@ -7,7 +7,7 @@
       {% if nav_item.current_location %}
         <div>{{nav_item.link_name}}</div>
       {% else %}
-        <a class="nav__link" href="{{nav_item.link_url}}"
+        <a class="nav__link" href="{{nav_item.link_url}}" data-qa="{{ 'complete' if nav_item.completed else 'incomplete' }}"
           {{helpers.track('click', 'Navigation', 'Section link click', nav_item.link_url)}}>{{nav_item.link_name}}</a>
       {% endif %}
       </li>

--- a/data/en/1_0001.json
+++ b/data/en/1_0001.json
@@ -1,6 +1,66 @@
 {
     "data_version": "0.0.1",
     "description": "UK Innovation Survey",
+    "navigation": {
+        "visible": true,
+        "sections": [{
+                "title": "General Business Information",
+                "group_order": ["general-business-information"]
+            },
+            {
+                "title": "Business Strategy & Practices",
+                "group_order": ["business-strategy-practices"]
+            },
+            {
+                "title": "Innovation Investment",
+                "group_order": ["innovation-investment"]
+            },
+            {
+                "title": "Goods and Services Innovation",
+                "group_order": ["goods-services-innovation"]
+            },
+            {
+                "title": "Process Innovation",
+                "group_order": ["process-innovation"]
+            },
+            {
+                "title": "Constraints on Innovation ",
+                "group_order": ["constraints-on-innovation"]
+            },
+            {
+                "title": "Factors Affecting Innovation",
+                "group_order": ["factors-affecting-innovation"]
+            },
+            {
+                "title": "Information Needed for Innovation",
+                "group_order": ["information-needed-for-innovation"]
+            },
+            {
+                "title": "Co-operation on Innovation",
+                "group_order": ["co-operation-on-innovation"]
+            },
+            {
+                "title": "Public Financial Support for Innovation",
+                "group_order": ["public-financial-support-for-innovation"]
+            },
+            {
+                "title": "Turnover and Exports",
+                "group_order": ["turnover-and-exports"]
+            },
+            {
+                "title": "Employees and Skills",
+                "group_order": ["employees-and-skills"]
+            },
+            {
+                "title": "General Information",
+                "group_order": ["general-information"]
+            },
+            {
+                "title": "Submit answers",
+                "group_order": ["ready-to-submit"]
+            }
+        ]
+    },
     "groups": [{
             "blocks": [{
                     "type": "Introduction",
@@ -4896,7 +4956,6 @@
         "NEGATIVE_INTEGER": "The value cannot be negative. Please correct your answer.",
         "NOT_INTEGER": "The value you have entered is invalid. Please enter a numeric value."
     },
-    "navigation": true,
     "schema_version": "0.0.1",
     "survey_id": "144",
     "theme": "ukis",

--- a/data/en/1_0005.json
+++ b/data/en/1_0005.json
@@ -1,5 +1,45 @@
 {
     "data_version": "0.0.1",
+    "navigation": {
+        "visible": true,
+        "sections": [{
+                "title": "Introduction",
+                "group_order": ["introduction-group"]
+            },
+            {
+                "title": "Pay Pattern",
+                "group_order": ["pay-pattern"]
+            },
+            {
+                "title": "Weekly Pay",
+                "group_order": ["weekly-pay"]
+            },
+            {
+                "title": "Fortnightly Pay",
+                "group_order": ["fortnightly-pay"]
+            },
+            {
+                "title": "Calendar Monthly Pay",
+                "group_order": ["calendar-monthly"]
+            },
+            {
+                "title": "Four Weekly Pay",
+                "group_order": ["four-weekly-pay"]
+            },
+            {
+                "title": "Five Weekly Pay",
+                "group_order": ["five-weekly-pay"]
+            },
+            {
+                "title": "General Comments",
+                "group_order": ["general-comments-group"]
+            },
+            {
+                "title": "Summary",
+                "group_order": ["summary-group"]
+            }
+        ]
+    },
     "groups": [{
             "blocks": [{
                 "type": "Introduction",
@@ -719,8 +759,7 @@
                         "condition": "not set"
                     }]
                 }
-            ],
-            "completed_id": "weekly-pay-significant-changes-other"
+            ]
         },
         {
             "blocks": [{
@@ -1349,8 +1388,7 @@
                         "condition": "not set"
                     }]
                 }
-            ],
-            "completed_id": "fortnightly-pay-significant-changes-other"
+            ]
         },
         {
             "blocks": [{
@@ -1968,8 +2006,7 @@
                         "condition": "not set"
                     }]
                 }
-            ],
-            "completed_id": "calendar-monthly-pay-significant-changes-other"
+            ]
         },
         {
             "blocks": [{
@@ -2586,8 +2623,7 @@
                         "condition": "not set"
                     }]
                 }
-            ],
-            "completed_id": "four-weekly-pay-significant-changes-other"
+            ]
         },
         {
             "blocks": [{
@@ -3206,8 +3242,7 @@
                         "condition": "not set"
                     }]
                 }
-            ],
-            "completed_id": "five-weekly-pay-significant-changes-other"
+            ]
         },
         {
             "blocks": [{
@@ -3261,7 +3296,6 @@
         "NEGATIVE_INTEGER": "The value cannot be negative. Please correct your answer.",
         "NOT_INTEGER": "The value you have entered is invalid. Please enter a numeric value."
     },
-    "navigation": true,
     "schema_version": "0.0.1",
     "survey_id": "134",
     "theme": "default",

--- a/data/en/census_household.json
+++ b/data/en/census_household.json
@@ -7,15 +7,33 @@
     "description": "Census England Household Schema",
     "theme": "census",
     "legal_basis": "Voluntary",
-    "navigation": true,
+    "navigation": {
+        "visible": true,
+        "sections": [{
+                "title": "Who lives here?",
+                "group_order": ["who-lives-here", "who-lives-here-relationship", "who-lives-here-interstitial"]
+            },
+            {
+                "title": "Household and Accommodation",
+                "group_order": ["household-and-accommodation"]
+            },
+            {
+                "title_from_answers": ["first-name", "last-name"],
+                "group_order": ["household-member"]
+            },
+            {
+                "title": "Visitors",
+                "group_order": ["visitors", "visitors-interstitial"]
+            },
+            {
+                "title": "Submit answers",
+                "group_order": ["questionnaire-completed"]
+            }
+        ]
+    },
     "groups": [{
             "id": "who-lives-here",
             "title": "Who lives here?",
-            "completed_id": "who-lives-here-completed",
-            "highlight_when": [
-                "who-lives-here-relationship",
-                "who-lives-here-interstitial"
-            ],
             "blocks": [{
                     "type": "Questionnaire",
                     "id": "permanent-or-family-home",
@@ -452,7 +470,6 @@
         {
             "id": "household-and-accommodation",
             "title": "Household and Accommodation",
-            "completed_id": "household-and-accommodation-completed",
             "blocks": [{
                     "type": "Questionnaire",
                     "id": "type-of-accommodation",
@@ -894,11 +911,7 @@
             "routing_rules": [{
                 "repeat": {
                     "type": "answer_count",
-                    "answer_id": "first-name",
-                    "navigation_label_answer_ids": [
-                        "first-name",
-                        "last-name"
-                    ]
+                    "answer_id": "first-name"
                 }
             }],
             "blocks": [{
@@ -4238,10 +4251,6 @@
         {
             "id": "visitors",
             "title": "Visitors",
-            "highlight_when": [
-                "visitors-interstitial"
-            ],
-            "completed_id": "visitors-completed",
             "routing_rules": [{
                 "repeat": {
                     "type": "answer_value",
@@ -4448,7 +4457,6 @@
         {
             "id": "visitors-interstitial",
             "title": "Visitors",
-            "hide_in_navigation": true,
             "skip_conditions": [{
                     "when": [{
                         "id": "overnight-visitors-answer",

--- a/data/en/test_final_confirmation.json
+++ b/data/en/test_final_confirmation.json
@@ -7,7 +7,18 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to demo final confirmation to submit.",
-    "navigation": true,
+    "navigation": {
+        "visible": true,
+        "sections": [{
+                "title": "First group",
+                "group_order": ["final-confirmation"]
+            },
+            {
+                "title": "Submit answers",
+                "group_order": ["confirmation-group"]
+            }
+        ]
+    },
     "messages": {
         "INTEGER_TOO_LARGE": "Number is too large",
         "NEGATIVE_INTEGER": "Number cannot be less than zero",

--- a/data/en/test_navigation.json
+++ b/data/en/test_navigation.json
@@ -1,13 +1,54 @@
 {
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
-    "data_version": "0.0.1",
+    "data_version": "0.0.2",
     "survey_id": "999",
     "title": "Home Insurance",
     "description": "Home Insurance",
     "theme": "census",
     "legal_basis": "Voluntary",
-    "navigation": true,
+    "navigation": {
+        "visible": true,
+        "sections": [{
+                "title": "Property Details",
+                "group_order": ["property-details"]
+            },
+            {
+                "title": "House Details",
+                "group_order": ["house-details"]
+            },
+            {
+                "title": "Property Interstitial",
+                "group_order": ["property-interstitial-group"]
+            },
+            {
+                "title": "Household Composition",
+                "group_order": ["multiple-questions-group"]
+            },
+            {
+                "title_from_answers": ["first-name", "last-name"],
+                "group_order": ["repeating-group"]
+            },
+            {
+                "title": "Extra Cover",
+                "group_order": ["extra-cover"]
+            },
+            {
+                "title": "Extra Cover Items",
+                "group_order": ["extra-cover-items-group"]
+            },
+            {
+                "title": "Payment Details",
+                "group_order": ["skip-payment-group", "payment-details"]
+
+            },
+            {
+                "title": "Summary",
+                "group_order": ["summary-group"]
+
+            }
+        ]
+    },
     "groups": [{
             "blocks": [{
                     "type": "Questionnaire",
@@ -57,7 +98,7 @@
                                 "label": "",
                                 "mandatory": false,
                                 "options": [],
-                                "q_code": "1",
+                                "q_code": "2",
                                 "type": "TextArea"
                             }],
                             "description": "",
@@ -68,33 +109,29 @@
                         "title": "Property Details"
                     }],
                     "title": "House Insurance"
-                },
-                {
-                    "type": "Interstitial",
-                    "id": "property-interstitial",
-                    "title": "Property Details Interstitial Page",
-                    "sections": [{
-                        "description": "",
-                        "id": "property-interstitial-section",
-                        "questions": [{
-                            "description": "You have successfully completed the property details section. Next we want to know who lives in the house.",
-                            "answers": [],
-                            "id": "property-interstitial-question",
-                            "title": "Property Details",
-                            "type": "General"
-                        }],
-                        "title": ""
-                    }]
                 }
             ],
             "id": "property-details",
-            "title": "Property Details",
-            "completed_id": "property-interstitial"
+            "title": "Property Details"
         },
         {
             "blocks": [{
                 "type": "Questionnaire",
                 "id": "house-type",
+                "skip_conditions": [{
+                        "when": [{
+                            "id": "insurance-type-answer",
+                            "condition": "equals",
+                            "value": "Contents"
+                        }]
+                    },
+                    {
+                        "when": [{
+                            "id": "insurance-type-answer",
+                            "condition": "not set"
+                        }]
+                    }
+                ],
                 "sections": [{
                     "description": "",
                     "id": "house-type-section",
@@ -116,7 +153,7 @@
                                     "value": "Terrace"
                                 }
                             ],
-                            "q_code": "12",
+                            "q_code": "3",
                             "type": "Radio"
                         }],
                         "description": "",
@@ -129,21 +166,35 @@
                 "title": "House Details"
             }],
             "id": "house-details",
-            "skip_conditions": [{
-                    "when": [{
-                        "id": "insurance-type-answer",
-                        "condition": "equals",
-                        "value": "Contents"
-                    }]
-                },
-                {
-                    "when": [{
-                        "id": "insurance-type-answer",
-                        "condition": "not set"
-                    }]
-                }
-            ],
             "title": "House Details"
+        },
+        {
+            "blocks": [{
+                "type": "Interstitial",
+                "id": "property-interstitial",
+                "title": "Property Details Interstitial Page",
+                "sections": [{
+                    "description": "",
+                    "id": "property-interstitial-section",
+                    "questions": [{
+                        "description": "You have successfully completed the Property Details section. No need to answer House Type questions for contents only.",
+                        "answers": [],
+                        "id": "property-interstitial-question",
+                        "title": "Property Details",
+                        "type": "General"
+                    }],
+                    "title": ""
+                }]
+            }],
+            "id": "property-interstitial-group",
+            "title": "Property Interstitial",
+            "skip_conditions": [{
+                "when": [{
+                    "id": "insurance-type-answer",
+                    "condition": "not equals",
+                    "value": "Contents"
+                }]
+            }]
         },
         {
             "blocks": [{
@@ -152,29 +203,48 @@
                 "sections": [{
                     "id": "section",
                     "questions": [{
-                        "description": "",
                         "id": "household-composition-question",
-                        "title": "Who usually lives at the property?",
-                        "description": "",
+                        "title": "List the names of everyone  who lives here.",
+                        "number": "2",
+                        "guidance": {
+                            "content": [{
+                                "title": "Include",
+                                "list": [
+                                    "Yourself, if this is your permanent or family home",
+                                    "Family members including partners, children and babies born on or before 9 April 2017",
+                                    "Students and, or school children who live away from home during term time",
+                                    "Housemates tenants or lodgers"
+                                ]
+                            }]
+                        },
                         "type": "RepeatingAnswer",
                         "answers": [{
-                            "alias": "person_full_name",
-                            "id": "household-full-name",
-                            "label": "Full Name",
-                            "mandatory": true,
-                            "options": [],
-                            "q_code": "1",
-                            "type": "TextField",
-                            "repeats": true
-                        }]
+                                "alias": "first_name",
+                                "id": "first-name",
+                                "label": "First name",
+                                "mandatory": true,
+                                "type": "TextField",
+                                "validation": {
+                                    "messages": {
+                                        "MANDATORY": "Please enter a name or remove the person to continue"
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "last_name",
+                                "id": "last-name",
+                                "label": "Last name",
+                                "mandatory": false,
+                                "type": "TextField"
+                            }
+                        ]
                     }],
                     "title": "Household Details"
                 }],
                 "title": "Household Details"
             }],
             "id": "multiple-questions-group",
-            "title": "Household Details",
-            "completed_id": "household-composition"
+            "title": "Household Details"
         },
         {
             "blocks": [{
@@ -182,7 +252,7 @@
                     "id": "repeating-block-1",
                     "title": "Block 2",
                     "sections": [{
-                        "title": "{{answers.person_full_name[group_instance]}}",
+                        "title": "{{answers.first_name[group_instance]}} {{answers.last_name[group_instance]}}",
                         "description": "",
                         "id": "over-16-section",
                         "questions": [{
@@ -191,7 +261,6 @@
                             "description": "",
                             "type": "General",
                             "answers": [{
-                                "q_code": "3",
                                 "id": "what-is-your-age",
                                 "label": "",
                                 "mandatory": false,
@@ -204,7 +273,7 @@
                                         "value": "No"
                                     }
                                 ],
-                                "q_code": "1",
+                                "q_code": "5",
                                 "type": "Radio"
                             }]
                         }]
@@ -215,7 +284,7 @@
                     "id": "repeating-block-2",
                     "title": "Block 3",
                     "sections": [{
-                        "title": "{{answers.person_full_name[group_instance]}}",
+                        "title": "{{answers.first_name[group_instance]}} {{answers.last_name[group_instance]}}",
                         "description": "",
                         "id": "working-status-section",
                         "questions": [{
@@ -224,7 +293,7 @@
                             "description": "What is the working status of this person?",
                             "type": "General",
                             "answers": [{
-                                "q_code": "4",
+                                "q_code": "6",
                                 "id": "what-is-your-shoe-size",
                                 "label": "",
                                 "mandatory": false,
@@ -245,7 +314,6 @@
                                         "value": "Unmployed"
                                     }
                                 ],
-                                "q_code": "1",
                                 "type": "Radio"
                             }]
                         }]
@@ -257,65 +325,161 @@
             "routing_rules": [{
                 "repeat": {
                     "type": "answer_count",
-                    "answer_id": "household-full-name"
+                    "answer_id": "first-name"
                 }
-            }],
-            "completed_id": "repeating-block-2"
+            }]
         },
         {
             "blocks": [{
-                    "type": "Questionnaire",
-                    "id": "extra-cover-block",
-                    "sections": [{
-                        "description": "",
-                        "id": "extra-cover-section",
-                        "questions": [{
-                            "answers": [{
-                                "id": "extra-cover-answer",
-                                "label": "",
-                                "mandatory": true,
-                                "options": [],
-                                "q_code": "1",
-                                "type": "PositiveInteger",
-                                "validation": {
-                                    "messages": {
-                                        "INTEGER_TOO_LARGE": "Thats hotter then the sun, Jar Jar Binks you must be",
-                                        "NEGATIVE_INTEGER": "How can it be negative?",
-                                        "NOT_INTEGER": "Please only enter whole numbers into the field."
-                                    }
+                "type": "Questionnaire",
+                "id": "extra-cover-block",
+                "sections": [{
+                    "description": "",
+                    "id": "extra-cover-section",
+                    "questions": [{
+                        "answers": [{
+                            "id": "extra-cover-answer",
+                            "label": "",
+                            "mandatory": true,
+                            "options": [],
+                            "q_code": "7",
+                            "type": "PositiveInteger",
+                            "validation": {
+                                "messages": {
+                                    "INTEGER_TOO_LARGE": "Thats hotter then the sun, Jar Jar Binks you must be",
+                                    "NEGATIVE_INTEGER": "How can it be negative?",
+                                    "NOT_INTEGER": "Please only enter whole numbers into the field."
                                 }
-                            }],
-                            "description": "",
-                            "id": "extra-cover-question",
-                            "title": "Please list any special items you have",
-                            "type": "General"
+                            }
                         }],
-                        "title": "Extra Cover"
-                    }],
-                    "title": "House Insurance"
-                },
-                {
-                    "type": "Interstitial",
-                    "id": "extra-cover-interstitial",
-                    "title": "Special items Interstitial Page",
-                    "sections": [{
                         "description": "",
-                        "id": "extra-cover-interstitial-section",
-                        "questions": [{
-                            "description": "You have successfully completed the special items section. Next we want to know about your payment details.",
-                            "answers": [],
-                            "id": "extra-cover-interstitial-question",
-                            "title": "Extra Cover",
-                            "type": "General"
-                        }],
-                        "title": ""
-                    }]
-                }
-            ],
+                        "id": "extra-cover-question",
+                        "title": "Please list any special items you have",
+                        "type": "General"
+                    }],
+                    "title": "Extra Cover"
+                }],
+                "title": "House Insurance"
+            }],
             "id": "extra-cover",
             "title": "Extra Cover"
         },
         {
+            "id": "extra-cover-items-group",
+            "title": "Extra Cover Items",
+            "routing_rules": [{
+                "repeat": {
+                    "type": "answer_value",
+                    "answer_id": "extra-cover-answer"
+                }
+            }],
+            "blocks": [{
+                    "type": "Questionnaire",
+                    "id": "extra-cover-items",
+                    "title": "Extra Cover",
+                    "sections": [{
+                        "id": "extra-cover-items-section",
+                        "title": "Extra Cover {{group_instance + 1}}",
+                        "questions": [{
+                            "id": "extra-cover-items-question",
+                            "title": "What is the item you want to insure {{group_instance + 1}}?",
+                            "number": "1",
+                            "type": "General",
+                            "answers": [{
+                                "id": "extra-cover-items-answer",
+                                "label": "Item",
+                                "mandatory": false,
+                                "type": "TextField",
+                                "q_code": "8"
+                            }]
+                        }]
+                    }]
+                },
+                {
+                    "type": "Questionnaire",
+                    "id": "extra-cover-items-radio",
+                    "title": "Continue",
+                    "sections": [{
+                        "title": "Continue to next",
+                        "description": "",
+                        "id": "extra-cover-items-radio-section",
+                        "questions": [{
+                            "id": "extra-cover-items-radio-question",
+                            "title": "Tick either?",
+                            "description": "",
+                            "type": "General",
+                            "answers": [{
+                                "id": "extra-cover-items-radio-answer",
+                                "label": "",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    }
+                                ],
+                                "q_code": "9",
+                                "type": "Radio"
+                            }]
+                        }]
+                    }]
+                }
+            ]
+        },
+        {
+            "id": "skip-payment-group",
+            "title": "Are you ready for payment?",
+            "blocks": [{
+                "type": "Questionnaire",
+                "id": "skip-payment",
+                "title": "Skip Payent",
+                "sections": [{
+                    "title": "Skip Payment",
+                    "description": "",
+                    "id": "skip-payment-section",
+                    "questions": [{
+                        "id": "skip-payment-question",
+                        "title": "Would you like to skip the payment collection?",
+                        "description": "",
+                        "type": "General",
+                        "answers": [{
+                            "id": "skip-payment-answer",
+                            "label": "",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Yes",
+                                    "value": "Yes"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "No"
+                                }
+                            ],
+                            "q_code": "10",
+                            "type": "Radio"
+                        }]
+                    }]
+                }]
+            }]
+        },
+        {
+            "skip_conditions": [{
+                    "when": [{
+                        "id": "skip-payment-answer",
+                        "condition": "equals",
+                        "value": "Yes"
+                    }]
+                },
+                {
+                    "when": [{
+                        "id": "skip-payment-answer",
+                        "condition": "not set"
+                    }]
+                }
+            ],
             "blocks": [{
                     "type": "Questionnaire",
                     "id": "credit-card",
@@ -328,7 +492,7 @@
                                 "label": "",
                                 "mandatory": true,
                                 "options": [],
-                                "q_code": "1",
+                                "q_code": "11",
                                 "type": "PositiveInteger"
                             }],
                             "description": "The long one in the middle of the card please",
@@ -352,7 +516,7 @@
                                 "label": "",
                                 "mandatory": true,
                                 "options": [],
-                                "q_code": "1",
+                                "q_code": "12",
                                 "type": "TextField"
                             }],
                             "description": "",
@@ -376,7 +540,7 @@
                                 "label": "",
                                 "mandatory": true,
                                 "options": [],
-                                "q_code": "1",
+                                "q_code": "13",
                                 "type": "TextField"
                             }],
                             "description": "Its the last 3 numbers",
@@ -387,6 +551,38 @@
                         "title": "Payment Details"
                     }],
                     "title": "Home Insurance"
+                },
+                {
+                    "type": "Questionnaire",
+                    "id": "skip-interstitial",
+                    "title": "Skip Interstitial",
+                    "sections": [{
+                        "title": "Skip Interstitial",
+                        "description": "",
+                        "id": "skip-interstitial-section",
+                        "questions": [{
+                            "id": "skip-interstitial-question",
+                            "title": "Would you like to skip the interstitial page?",
+                            "description": "",
+                            "type": "General",
+                            "answers": [{
+                                "q_code": "14",
+                                "id": "skip-interstitial-answer",
+                                "label": "",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
+                        }]
+                    }]
                 },
                 {
                     "type": "Interstitial",
@@ -403,42 +599,18 @@
                             "type": "General"
                         }],
                         "title": ""
+                    }],
+                    "skip_conditions": [{
+                        "when": [{
+                            "id": "skip-interstitial-answer",
+                            "condition": "equals",
+                            "value": "Yes"
+                        }]
                     }]
                 }
             ],
             "id": "payment-details",
             "title": "Payment Details"
-        },
-        {
-            "id": "extra-cover-items-group",
-            "title": "Extra Cover Items",
-            "routing_rules": [{
-                "repeat": {
-                    "type": "answer_value",
-                    "answer_id": "extra-cover-answer"
-                }
-            }],
-            "blocks": [{
-                "type": "Questionnaire",
-                "id": "extra-cover-items",
-                "title": "Extra Cover",
-                "sections": [{
-                    "id": "extra-cover-items-section",
-                    "title": "Extra Cover {{group_instance + 1}}",
-                    "questions": [{
-                        "id": "extra-cover-items-question",
-                        "title": "What is the item you want to insure {{group_instance + 1}}?",
-                        "number": "1",
-                        "type": "General",
-                        "answers": [{
-                            "id": "extra-cover-items-answer",
-                            "label": "Item",
-                            "mandatory": false,
-                            "type": "TextField"
-                        }]
-                    }]
-                }]
-            }]
         },
         {
             "blocks": [{

--- a/data/en/test_navigation_confirmation.json
+++ b/data/en/test_navigation_confirmation.json
@@ -1,13 +1,48 @@
 {
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
-    "data_version": "0.0.1",
+    "data_version": "0.0.2",
     "survey_id": "999",
     "title": "Home Insurance",
     "description": "Home Insurance",
     "theme": "census",
     "legal_basis": "Voluntary",
-    "navigation": true,
+    "navigation": {
+        "visible": true,
+        "sections": [{
+                "title": "Property Details",
+                "group_order": ["property-details"]
+            },
+            {
+                "title": "House Details",
+                "group_order": ["house-details"]
+            },
+            {
+                "title": "Household Details",
+                "group_order": ["multiple-questions-group"]
+            },
+            {
+                "title_from_answers": ["household-full-name"],
+                "group_order": ["repeating-group"]
+            },
+            {
+                "title": "Extra Cover",
+                "group_order": ["extra-cover"]
+            },
+            {
+                "title": "Payment Details",
+                "group_order": ["payment-details"]
+            },
+            {
+                "title": "Extra Cover Items",
+                "group_order": ["extra-cover-items-group"]
+            },
+            {
+                "title": "Submit answers",
+                "group_order": ["confirmation-group"]
+            }
+        ]
+    },
     "groups": [{
             "blocks": [{
                     "type": "Questionnaire",
@@ -88,8 +123,7 @@
                 }
             ],
             "id": "property-details",
-            "title": "Property Details",
-            "completed_id": "property-interstitial"
+            "title": "Property Details"
         },
         {
             "blocks": [{
@@ -173,8 +207,7 @@
                 "title": "Household Details"
             }],
             "id": "multiple-questions-group",
-            "title": "Household Details",
-            "completed_id": "household-composition"
+            "title": "Household Details"
         },
         {
             "blocks": [{
@@ -259,8 +292,7 @@
                     "type": "answer_count",
                     "answer_id": "household-full-name"
                 }
-            }],
-            "completed_id": "repeating-block-2"
+            }]
         },
         {
             "blocks": [{

--- a/data/en/test_percentage.json
+++ b/data/en/test_percentage.json
@@ -12,7 +12,18 @@
         "NEGATIVE_INTEGER": "Number cannot be less than zero",
         "NOT_INTEGER": "Please enter an integer"
     },
-    "navigation": true,
+    "navigation": {
+        "visible": true,
+        "sections": [{
+                "title": "Percent Input",
+                "group_order": ["group"]
+            },
+            {
+                "title": "Summary",
+                "group_order": ["summary-group"]
+            }
+        ]
+    },
     "groups": [{
             "blocks": [{
                 "type": "Questionnaire",

--- a/data/en/test_repeating_household.json
+++ b/data/en/test_repeating_household.json
@@ -7,7 +7,28 @@
     "description": "",
     "theme": "census",
     "legal_basis": "Voluntary",
-    "navigation": true,
+    "navigation": {
+        "visible": true,
+        "sections": [{
+                "title": "Group 1",
+                "group_order": [
+                    "multiple-questions-group"
+                ]
+            },
+            {
+                "title_from_answers": ["first-name"],
+                "group_order": [
+                    "repeating-group"
+                ]
+            },
+            {
+                "title": "Summary",
+                "group_order": [
+                    "summary-group"
+                ]
+            }
+        ]
+    },
     "groups": [{
             "blocks": [{
                     "type": "Introduction",
@@ -59,7 +80,7 @@
                 }
             ],
             "id": "multiple-questions-group",
-            "title": ""
+            "title": "Group 1"
         },
         {
             "blocks": [{
@@ -124,11 +145,7 @@
             "routing_rules": [{
                 "repeat": {
                     "type": "answer_count",
-                    "answer_id": "first-name",
-                    "navigation_label_answer_ids": [
-                        "first-name",
-                        "last-name"
-                    ]
+                    "answer_id": "first-name"
                 }
             }]
         },

--- a/data/schema/schema_v1.json
+++ b/data/schema/schema_v1.json
@@ -134,14 +134,6 @@
         },
         "routing_rules": {
             "type": "array",
-            "navigation_label_answer_ids": {
-                "type": "array",
-                "items": {
-                    "type": "string"
-                },
-                "minItems": 1,
-                "uniqueItems": true
-            },
             "items": {
                 "type": "object",
                 "properties": {
@@ -245,7 +237,34 @@
             ]
         },
         "navigation": {
-            "type": "boolean"
+            "type": "object",
+            "properties": {
+                "visible":
+                {
+                    "type": "boolean"
+                },
+                "sections": {
+                    "type": "array",
+                    "items": {
+                        "title": "string",
+                        "title_from_answers": "array",
+                        "group_order": "array",
+                        "required": [
+                           "group_order"
+                        ],
+                        "oneOf": [{
+                            "required": [
+                               "title"
+                           ]
+                        },
+                        {
+                           "required": [
+                                "title_from_answers"
+                            ]
+                        }]
+                    }
+                }
+            }
         },
         "messages": {
             "$ref": "#/definitions/messages"

--- a/tests/app/helpers/test_schema_helper.py
+++ b/tests/app/helpers/test_schema_helper.py
@@ -67,8 +67,7 @@ class TestSchemaHelper(unittest.TestCase):
         self.assertEqual(
             {
                 'type': 'answer_count',
-                'answer_id': 'first-name',
-                'navigation_label_answer_ids': ['first-name', 'last-name'],
+                'answer_id': 'first-name'
             }, rule)
 
     def test_get_answers_that_repeat_in_block(self):

--- a/tests/app/questionnaire/test_navigation.py
+++ b/tests/app/questionnaire/test_navigation.py
@@ -28,7 +28,7 @@ class TestNavigation(AppContextTestCase):
                 'link_url': Location('property-details', 0, 'insurance-type').url(metadata)
             },
             {
-                'link_name': 'Household Details',
+                'link_name': 'Household Composition',
                 'highlight': False,
                 'repeating': False,
                 'completed': False,
@@ -46,7 +46,7 @@ class TestNavigation(AppContextTestCase):
                 'highlight': False,
                 'repeating': False,
                 'completed': False,
-                'link_url': Location('payment-details', 0, 'credit-card').url(metadata)
+                'link_url': Location('skip-payment-group', 0, 'skip-payment').url(metadata)
             }
         ]
 
@@ -59,44 +59,64 @@ class TestNavigation(AppContextTestCase):
             "collection_exercise_sid": '999',
             "form_type": "some_form"
         }
+
+        answer_store = AnswerStore()
+
+        answer_1 = Answer(
+            value="Contents",
+            group_instance=0,
+            block_id='insurance-type',
+            group_id='property-details',
+            answer_instance=0,
+            answer_id='insurance-type-answer'
+        )
+
+        answer_store.add(answer_1)
+
         completed_blocks = [
-            Location('property-details', 0, 'introduction'),
             Location('property-details', 0, 'insurance-type'),
-            Location('property-details', 0, 'insurance-address'),
-            Location('property-details', 0, 'property-interstitial')
+            Location('property-details', 0, 'insurance-address')
         ]
 
-        navigation = Navigation(survey, AnswerStore(), metadata, completed_blocks=completed_blocks)
+        navigation = Navigation(survey, answer_store, metadata, completed_blocks=completed_blocks)
 
         user_navigation = [
             {
-                'completed': True,
                 'link_name': 'Property Details',
                 'highlight': True,
                 'repeating': False,
-                'link_url': Location('property-details', 0, 'insurance-type').url(metadata),
+                'completed': True,
+                'link_url': Location('property-details', 0, 'insurance-type').url(metadata)
             },
             {
-                'completed': False,
-                'link_name': 'Household Details',
+                'link_name': 'Property Interstitial',
                 'highlight': False,
                 'repeating': False,
-                'link_url': Location('multiple-questions-group', 0, 'household-composition').url(metadata),
+                'completed': False,
+                'link_url': Location('property-interstitial-group', 0, 'property-interstitial').url(metadata)
             },
             {
+                'link_name': 'Household Composition',
+                'highlight': False,
+                'repeating': False,
                 'completed': False,
+                'link_url': Location('multiple-questions-group', 0, 'household-composition').url(metadata)
+            },
+            {
                 'link_name': 'Extra Cover',
                 'highlight': False,
                 'repeating': False,
+                'completed': False,
                 'link_url': Location('extra-cover', 0, 'extra-cover-block').url(metadata)
             },
             {
-                'completed': False,
                 'link_name': 'Payment Details',
                 'highlight': False,
                 'repeating': False,
-                'link_url': Location('payment-details', 0, 'credit-card').url(metadata)
+                'completed': False,
+                'link_url': Location('skip-payment-group', 0, 'skip-payment').url(metadata)
             }
+
         ]
         self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
 
@@ -110,7 +130,6 @@ class TestNavigation(AppContextTestCase):
         }
 
         completed_blocks = [
-            Location('property-details', 0, 'introduction'),
             Location('multiple-questions-group', 0, 'household-composition'),
             Location('repeating-group', 0, 'repeating-block-1'),
             Location('repeating-group', 0, 'repeating-block-2'),
@@ -124,7 +143,7 @@ class TestNavigation(AppContextTestCase):
             {
                 'group_instance': 0,
                 'answer_instance': 0,
-                'answer_id': 'household-full-name',
+                'answer_id': 'first-name',
                 'value': 'Jim',
                 'group_id': 'multiple-questions-group',
                 'block_id': 'household-composition'
@@ -132,7 +151,7 @@ class TestNavigation(AppContextTestCase):
             {
                 'group_instance': 0,
                 'answer_instance': 1,
-                'answer_id': 'household-full-name',
+                'answer_id': 'first-name',
                 'value': 'Ben',
                 'group_id': 'multiple-questions-group',
                 'block_id': 'household-composition'
@@ -180,10 +199,10 @@ class TestNavigation(AppContextTestCase):
                 'link_url': Location('property-details', 0, 'insurance-type').url(metadata)
             },
             {
-                'link_name': 'Household Details',
+                'link_name': 'Household Composition',
+                'highlight': False,
                 'repeating': False,
                 'completed': True,
-                'highlight': False,
                 'link_url': Location('multiple-questions-group', 0, 'household-composition').url(metadata)
             },
             {
@@ -212,7 +231,7 @@ class TestNavigation(AppContextTestCase):
                 'repeating': False,
                 'completed': False,
                 'highlight': False,
-                'link_url': Location('payment-details', 0, 'credit-card').url(metadata)
+                'link_url': Location('skip-payment-group', 0, 'skip-payment').url(metadata)
             }
         ]
 
@@ -227,10 +246,8 @@ class TestNavigation(AppContextTestCase):
         }
 
         completed_blocks = [
-            Location('property-details', 0, 'introduction'),
-            Location('property-details', 0, 'insurance-type'),
-            Location('property-details', 0, 'personal-interstitial'),
-            Location('extra-cover', 0, 'extra-cover-block'),
+            Location('multiple-questions-group', 0, 'household-composition'),
+            Location('extra-cover', 0, 'extra-cover-block')
         ]
 
         answer_store = AnswerStore()
@@ -238,7 +255,7 @@ class TestNavigation(AppContextTestCase):
         answer_1 = Answer(
             answer_instance=0,
             group_id='multiple-questions-group',
-            answer_id='household-full-name',
+            answer_id='first-name',
             block_id='household-composition',
             group_instance=0,
             value='Person1'
@@ -246,7 +263,7 @@ class TestNavigation(AppContextTestCase):
         answer_2 = Answer(
             answer_instance=1,
             group_id='multiple-questions-group',
-            answer_id='household-full-name',
+            answer_id='first-name',
             block_id='household-composition',
             group_instance=0,
             value='Person2'
@@ -275,11 +292,11 @@ class TestNavigation(AppContextTestCase):
                 'link_url': Location('property-details', 0, 'insurance-type').url(metadata)
             },
             {
-                'completed': False,
+                'link_name': 'Household Composition',
                 'highlight': False,
                 'repeating': False,
-                'link_name': 'Household Details',
-                'link_url': Location('multiple-questions-group', 0, 'household-composition').url(metadata),
+                'completed': True,
+                'link_url': Location('multiple-questions-group', 0, 'household-composition').url(metadata)
             },
             {
                 'completed': False,
@@ -296,7 +313,7 @@ class TestNavigation(AppContextTestCase):
                 'link_url': Location('repeating-group', 1, 'repeating-block-1').url(metadata),
             },
             {
-                'completed': False,
+                'completed': True,
                 'highlight': False,
                 'repeating': False,
                 'link_name': 'Extra Cover',
@@ -306,15 +323,15 @@ class TestNavigation(AppContextTestCase):
                 'completed': False,
                 'highlight': False,
                 'repeating': False,
-                'link_name': 'Payment Details',
-                'link_url': Location('payment-details', 0, 'credit-card').url(metadata),
+                'link_name': 'Extra Cover Items',
+                'link_url': Location('extra-cover-items-group', 0, 'extra-cover-items').url(metadata)
             },
             {
                 'completed': False,
                 'highlight': False,
                 'repeating': False,
-                'link_name': 'Extra Cover Items',
-                'link_url': Location('extra-cover-items-group', 0, 'extra-cover-items').url(metadata)
+                'link_name': 'Payment Details',
+                'link_url': Location('skip-payment-group', 0, 'skip-payment').url(metadata),
             }
         ]
 
@@ -329,11 +346,11 @@ class TestNavigation(AppContextTestCase):
         }
 
         completed_blocks = [
-            Location('property-details', 0, 'introduction'),
             Location('extra-cover', 0, 'extra-cover-block'),
-            Location('extra-cover', 0, 'extra-cover-interstitial'),
             Location('extra-cover-items-group', 0, 'extra-cover-items'),
+            Location('extra-cover-items-group', 0, 'extra-cover-items-radio'),
             Location('extra-cover-items-group', 1, 'extra-cover-items'),
+            Location('extra-cover-items-group', 1, 'extra-cover-items-radio'),
         ]
 
         answer_store = AnswerStore()
@@ -341,31 +358,51 @@ class TestNavigation(AppContextTestCase):
         answer_1 = Answer(
             value=2,
             group_instance=0,
-            block_id='extra-cover-block',
             group_id='extra-cover',
-            answer_instance=0,
-            answer_id='extra-cover-answer'
+            block_id='extra-cover-block',
+            answer_id='extra-cover-answer',
+            answer_instance=0
+
         )
         answer_2 = Answer(
-            value='2',
+            value='1',
             group_instance=0,
-            block_id='extra-cover-items',
             group_id='extra-cover-items-group',
-            answer_instance=0,
-            answer_id='extra-cover-items-answer'
-        )
-        answer_3 = Answer(
-            value='2',
-            group_instance=1,
             block_id='extra-cover-items',
-            group_id='extra-cover-items-group',
             answer_id='extra-cover-items-answer',
             answer_instance=0
         )
+        answer_3 = Answer(
+            value='Yes',
+            group_instance=0,
+            group_id='extra-cover-items-group',
+            block_id='extra-cover-items-radio',
+            answer_id='extra-cover-items-radio-answer',
+            answer_instance=0
+        )
+        answer_4 = Answer(
+            value='2',
+            group_instance=1,
+            group_id='extra-cover-items-group',
+            block_id='extra-cover-items',
+            answer_id='extra-cover-items-answer',
+            answer_instance=0
+        )
+        answer_5 = Answer(
+            value='Yes',
+            group_instance=1,
+            group_id='extra-cover-items-group',
+            block_id='extra-cover-items-radio',
+            answer_id='extra-cover-items-radio-answer',
+            answer_instance=0
+        )
+
 
         answer_store.add(answer_1)
         answer_store.add(answer_2)
         answer_store.add(answer_3)
+        answer_store.add(answer_4)
+        answer_store.add(answer_5)
 
         navigation = Navigation(survey, answer_store, metadata, completed_blocks=completed_blocks)
 
@@ -378,10 +415,10 @@ class TestNavigation(AppContextTestCase):
                 'link_url': Location('property-details', 0, 'insurance-type').url(metadata)
             },
             {
-                'repeating': False,
+                'link_name': 'Household Composition',
                 'highlight': False,
+                'repeating': False,
                 'completed': False,
-                'link_name': 'Household Details',
                 'link_url': Location('multiple-questions-group', 0, 'household-composition').url(metadata)
             },
             {
@@ -394,22 +431,22 @@ class TestNavigation(AppContextTestCase):
             {
                 'repeating': False,
                 'highlight': False,
-                'completed': False,
-                'link_name': 'Payment Details',
-                'link_url': Location('payment-details', 0, 'credit-card').url(metadata)
+                'completed': True,
+                'link_name': 'Extra Cover Items',
+                'link_url': Location('extra-cover-items-group', 0, 'extra-cover-items').url(metadata)
             },
             {
                 'repeating': False,
                 'highlight': False,
-                'completed': True,
-                'link_name': 'Extra Cover Items',
-                'link_url': Location('extra-cover-items-group', 0, 'extra-cover-items').url(metadata)
+                'completed': False,
+                'link_name': 'Payment Details',
+                'link_url': Location('skip-payment-group', 0, 'skip-payment').url(metadata)
             }
         ]
         self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
 
     def test_navigation_repeating_group_link_name_format(self):
-        survey = load_schema_file("test_repeating_household.json")
+        survey = load_schema_file("test_navigation.json")
         metadata = {
             "eq_id": '1',
             "collection_exercise_sid": '999',
@@ -417,7 +454,6 @@ class TestNavigation(AppContextTestCase):
         }
 
         completed_blocks = [
-            Location('multiple-questions-group', 0, 'introduction'),
             Location('multiple-questions-group', 0, 'household-composition'),
         ]
 
@@ -434,60 +470,49 @@ class TestNavigation(AppContextTestCase):
         answer_2 = Answer(
             block_id='household-composition',
             answer_instance=0,
-            answer_id='middle-names',
-            group_id='multiple-questions-group',
-            group_instance=0,
-            value=None
-        )
-        answer_3 = Answer(
-            block_id='household-composition',
-            answer_instance=0,
             answer_id='last-name',
             group_id='multiple-questions-group',
             group_instance=0,
             value='Bloggs'
         )
-        answer_4 = Answer(
+        answer_3 = Answer(
             block_id='household-composition',
             answer_instance=1,
             answer_id='first-name',
             group_id='multiple-questions-group',
             group_instance=0,
-            value='Jim'
+            value='Jane'
         )
-        answer_5 = Answer(
+        answer_4 = Answer(
             block_id='household-composition',
             answer_instance=1,
             answer_id='last-name',
             group_id='multiple-questions-group',
             group_instance=0,
-            value=None
-        )
-        answer_6 = Answer(
-            block_id='household-composition',
-            answer_instance=1,
-            answer_id='middle-names',
-            group_id='multiple-questions-group',
-            group_instance=0,
-            value=None
+            value='Doe'
         )
 
         answer_store.add(answer_1)
         answer_store.add(answer_2)
         answer_store.add(answer_3)
         answer_store.add(answer_4)
-        answer_store.add(answer_5)
-        answer_store.add(answer_6)
 
         navigation = Navigation(survey, answer_store, metadata, completed_blocks=completed_blocks)
 
         user_navigation = [
             {
+                'link_name': 'Property Details',
+                'highlight': True,
+                'repeating': False,
+                'completed': False,
+                'link_url': Location('property-details', 0, 'insurance-type').url(metadata)
+            },
+            {
                 'repeating': False,
                 'completed': True,
                 'highlight': False,
-                'link_name': '',
-                'link_url': Location('multiple-questions-group', 0, 'introduction').url(metadata)
+                'link_name': 'Household Composition',
+                'link_url': Location('multiple-questions-group', 0, 'household-composition').url(metadata)
             },
             {
                 'repeating': True,
@@ -498,10 +523,24 @@ class TestNavigation(AppContextTestCase):
             },
             {
                 'repeating': True,
-                'link_name': 'Jim',
+                'link_name': 'Jane Doe',
                 'completed': False,
                 'highlight': False,
                 'link_url': Location('repeating-group', 1, 'repeating-block-1').url(metadata)
+            },
+            {
+                'link_name': 'Extra Cover',
+                'highlight': False,
+                'repeating': False,
+                'completed': False,
+                'link_url': Location('extra-cover', 0, 'extra-cover-block').url(metadata)
+            },
+            {
+                'link_name': 'Payment Details',
+                'highlight': False,
+                'repeating': False,
+                'completed': False,
+                'link_url': Location('skip-payment-group', 0, 'skip-payment').url(metadata)
             }
         ]
 
@@ -521,7 +560,7 @@ class TestNavigation(AppContextTestCase):
         answer_store = AnswerStore()
 
         answer_1 = Answer(
-            value="Contents",
+            value="Buildings",
             group_instance=0,
             block_id='insurance-type',
             group_id='property-details',
@@ -534,7 +573,7 @@ class TestNavigation(AppContextTestCase):
         navigation = Navigation(survey, answer_store, metadata, completed_blocks=completed_blocks)
         user_navigation = navigation.build_navigation('property-details', 0)
         link_names = [d['link_name'] for d in user_navigation]
-        self.assertNotIn('House Details', link_names)
+        self.assertNotIn('Property Interstitial', link_names)
 
     def test_navigation_skip_condition_show_group(self):
         survey = load_schema_file("test_navigation.json")
@@ -550,7 +589,7 @@ class TestNavigation(AppContextTestCase):
         answer_store = AnswerStore()
 
         answer_1 = Answer(
-            value="Buildings",
+            value="Contents",
             group_instance=0,
             block_id='insurance-type',
             group_id='property-details',
@@ -564,7 +603,7 @@ class TestNavigation(AppContextTestCase):
 
         user_navigation = navigation.build_navigation('property-details', 0)
         link_names = [d['link_name'] for d in user_navigation]
-        self.assertIn('House Details', link_names)
+        self.assertIn('Property Interstitial', link_names)
 
     def test_navigation_skip_condition_change_answer(self):
         survey = load_schema_file("test_navigation.json")
@@ -580,7 +619,7 @@ class TestNavigation(AppContextTestCase):
         answer_store = AnswerStore()
 
         answer_1 = Answer(
-            value="Buildings",
+            value="Contents",
             group_instance=0,
             block_id='insurance-type',
             group_id='property-details',
@@ -593,10 +632,10 @@ class TestNavigation(AppContextTestCase):
 
         user_navigation = navigation.build_navigation('property-details', 0)
         link_names = [d['link_name'] for d in user_navigation]
-        self.assertIn('House Details', link_names)
+        self.assertIn('Property Interstitial', link_names)
 
         change_answer = Answer(
-            value="Contents",
+            value="Buildings",
             group_instance=0,
             block_id='insurance-type',
             group_id='property-details',
@@ -608,12 +647,12 @@ class TestNavigation(AppContextTestCase):
 
         user_navigation = navigation.build_navigation('property-details', 0)
         link_names = [d['link_name'] for d in user_navigation]
-        self.assertNotIn('House Details', link_names)
+        self.assertNotIn('Property Interstitial', link_names)
 
     def test_build_navigation_returns_none_when_schema_navigation_is_false(self):
         # Given
         survey = load_schema_file("test_navigation.json")
-        survey['navigation'] = False
+        survey['navigation'] = {"visible": False}
         completed_blocks = []
         metadata = {}
         navigation = Navigation(survey, AnswerStore(), metadata, completed_blocks)
@@ -641,7 +680,7 @@ class TestNavigation(AppContextTestCase):
     def test_build_navigation_returns_navigation_when_schema_navigation_is_true(self):
         # Given
         survey = load_schema_file("test_navigation.json")
-        survey['navigation'] = True
+        survey['navigation'] = {"visible": True, "sections": [{"title": "Nav", "group_order": ["property-details"]}]}
         completed_blocks = []
         metadata = {
             "eq_id": '1',
@@ -952,7 +991,15 @@ class TestNavigation(AppContextTestCase):
         survey = load_schema_file("test_navigation.json")
 
         # Payment details group not displayed in navigation
-        survey['groups'][5]['hide_in_navigation'] = True
+        survey['navigation'] = {"sections": [{"title": "Property Details", "group_order": ["property-details",
+                                                                                           "property-interstitial-group",
+                                                                                           "house-details",
+                                                                                           "multiple-questions-group",
+                                                                                           "repeating-group",
+                                                                                           "extra-cover",
+                                                                                           "extra-cover-items-group",
+                                                                                           "skip-payment-group",
+                                                                                           "payment-details"]}]}
 
         metadata = {
             "eq_id": '1',
@@ -1004,10 +1051,10 @@ class TestNavigation(AppContextTestCase):
 
         navigation_links = navigation.build_navigation('property-details', 0)
         self.assertNotIn(confirmation_link, navigation_links)
-        self.assertEqual(len(navigation_links), 3)
+        self.assertEqual(len(navigation_links), 1)
 
     def test_build_navigation_submit_answers_link_not_visible_when_no_completed_blocks(self):
-        survey = load_schema_file("census_household.json")
+        survey = load_schema_file("test_navigation.json")
 
         metadata = {
             "eq_id": '1',
@@ -1021,16 +1068,16 @@ class TestNavigation(AppContextTestCase):
         navigation = Navigation(survey, AnswerStore(), metadata, completed_blocks, routing_path)
 
         confirmation_link = {
-            'link_name': 'Submit answers',
+            'link_name': 'Summary',
             'highlight': False,
             'repeating': False,
             'completed': False,
-            'link_url': Location('questionnaire-completed', 0, 'confirmation').url(metadata)
+            'link_url': Location('summary-group', 0, 'summary').url(metadata)
         }
 
-        navigation_links = navigation.build_navigation('permanent-or-family-home', 0)
+        navigation_links = navigation.build_navigation('property-details', 0)
         self.assertNotIn(confirmation_link, navigation_links)
-        self.assertEqual(len(navigation_links), 2)
+        self.assertEqual(len(navigation_links), 4)
 
     def test_build_navigation_summary_link_hidden_when_not_on_routing_path(self):
         survey = load_schema_file("test_navigation.json")

--- a/tests/new_functional/helpers.js
+++ b/tests/new_functional/helpers.js
@@ -81,6 +81,26 @@ function isViewSectionsVisible() {
   return browser.isExisting(viewSectionsLink) && browser.isVisibleWithinViewport(viewSectionsLink);
 }
 
+function navigationLink(linkName) {
+    return 'a=' + linkName
+}
+
+function isSectionComplete(linkName) {
+    return isSectionCompleteBind.bind(null, linkName)
+}
+
+function isSectionCompleteBind(linkName) {
+  return browser
+    .element(navigationLink(linkName))
+    .getAttribute('data-qa')
+    .then(function (data_qa_string) {
+      if (data_qa_string === 'complete') {
+        return true
+      }
+      return false
+    });
+}
+
 module.exports = {
   landingPage,
   getUri,
@@ -95,5 +115,7 @@ module.exports = {
   setMobileViewport,
   openMobileNavigation,
   closeMobileNavigation,
-  isViewSectionsVisible
-};
+  isViewSectionsVisible,
+  navigationLink,
+  isSectionComplete
+}

--- a/tests/new_functional/pages/surveys/navigation/credit-card.page.js
+++ b/tests/new_functional/pages/surveys/navigation/credit-card.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class CreditCardPage extends QuestionPage {
+
+  constructor() {
+    super('credit-card');
+  }
+
+  answer() {
+    return '#credit-card-answer';
+  }
+
+  answerLabel() { return '#label-credit-card-answer'; }
+
+}
+module.exports = new CreditCardPage();

--- a/tests/new_functional/pages/surveys/navigation/expiry-date.page.js
+++ b/tests/new_functional/pages/surveys/navigation/expiry-date.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class ExpiryDatePage extends QuestionPage {
+
+  constructor() {
+    super('expiry-date');
+  }
+
+  answer() {
+    return '#expiry-date-answer';
+  }
+
+  answerLabel() { return '#label-expiry-date-answer'; }
+
+}
+module.exports = new ExpiryDatePage();

--- a/tests/new_functional/pages/surveys/navigation/extra-cover-block.page.js
+++ b/tests/new_functional/pages/surveys/navigation/extra-cover-block.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class ExtraCoverBlockPage extends QuestionPage {
+
+  constructor() {
+    super('extra-cover-block');
+  }
+
+  answer() {
+    return '#extra-cover-answer';
+  }
+
+  answerLabel() { return '#label-extra-cover-answer'; }
+
+}
+module.exports = new ExtraCoverBlockPage();

--- a/tests/new_functional/pages/surveys/navigation/extra-cover-items-radio.page.js
+++ b/tests/new_functional/pages/surveys/navigation/extra-cover-items-radio.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class ExtraCoverItemsRadioPage extends QuestionPage {
+
+  constructor() {
+    super('extra-cover-items-radio');
+  }
+
+  yes() {
+    return '#extra-cover-items-radio-answer-0';
+  }
+
+  yesLabel() { return '#label-extra-cover-items-radio-answer-0'; }
+
+  no() {
+    return '#extra-cover-items-radio-answer-1';
+  }
+
+  noLabel() { return '#label-extra-cover-items-radio-answer-1'; }
+
+}
+module.exports = new ExtraCoverItemsRadioPage();

--- a/tests/new_functional/pages/surveys/navigation/extra-cover-items.page.js
+++ b/tests/new_functional/pages/surveys/navigation/extra-cover-items.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class ExtraCoverItemsPage extends QuestionPage {
+
+  constructor() {
+    super('extra-cover-items');
+  }
+
+  answer() {
+    return '#extra-cover-items-answer';
+  }
+
+  answerLabel() { return '#label-extra-cover-items-answer'; }
+
+}
+module.exports = new ExtraCoverItemsPage();

--- a/tests/new_functional/pages/surveys/navigation/house-type.page.js
+++ b/tests/new_functional/pages/surveys/navigation/house-type.page.js
@@ -1,0 +1,29 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class HouseTypePage extends QuestionPage {
+
+  constructor() {
+    super('house-type');
+  }
+
+  detached() {
+    return '#house-type-answer-0';
+  }
+
+  detachedLabel() { return '#label-house-type-answer-0'; }
+
+  semiDetached() {
+    return '#house-type-answer-1';
+  }
+
+  semiDetachedLabel() { return '#label-house-type-answer-1'; }
+
+  terrace() {
+    return '#house-type-answer-2';
+  }
+
+  terraceLabel() { return '#label-house-type-answer-2'; }
+
+}
+module.exports = new HouseTypePage();

--- a/tests/new_functional/pages/surveys/navigation/household-composition.page.js
+++ b/tests/new_functional/pages/surveys/navigation/household-composition.page.js
@@ -1,0 +1,28 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class HouseholdCompositionPage extends QuestionPage {
+
+  constructor() {
+    super('household-composition');
+  }
+
+  addPerson() {
+    return 'button[name="action[add_answer]"]';
+  }
+
+  removePerson(index=1) {
+    return 'button[value="' + index + '"]';
+    // Have to check whether it's visible in test code
+  }
+
+  firstName(index = '') {
+    return '#household-0-first-name' + index;
+  }
+
+  lastName(index = '') {
+    return '#household-0-last-name' + index;
+  }
+
+}
+module.exports = new HouseholdCompositionPage();

--- a/tests/new_functional/pages/surveys/navigation/insurance-address.page.js
+++ b/tests/new_functional/pages/surveys/navigation/insurance-address.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class InsuranceAddressPage extends QuestionPage {
+
+  constructor() {
+    super('insurance-address');
+  }
+
+  answer() {
+    return '#insurance-address-answer';
+  }
+
+  answerLabel() { return '#label-insurance-address-answer'; }
+
+}
+module.exports = new InsuranceAddressPage();

--- a/tests/new_functional/pages/surveys/navigation/insurance-type.page.js
+++ b/tests/new_functional/pages/surveys/navigation/insurance-type.page.js
@@ -1,0 +1,29 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class InsuranceTypePage extends QuestionPage {
+
+  constructor() {
+    super('insurance-type');
+  }
+
+  buildings() {
+    return '#insurance-type-answer-0';
+  }
+
+  buildingsLabel() { return '#label-insurance-type-answer-0'; }
+
+  contents() {
+    return '#insurance-type-answer-1';
+  }
+
+  contentsLabel() { return '#label-insurance-type-answer-1'; }
+
+  both() {
+    return '#insurance-type-answer-2';
+  }
+
+  bothLabel() { return '#label-insurance-type-answer-2'; }
+
+}
+module.exports = new InsuranceTypePage();

--- a/tests/new_functional/pages/surveys/navigation/property-interstitial.page.js
+++ b/tests/new_functional/pages/surveys/navigation/property-interstitial.page.js
@@ -1,0 +1,11 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class PropertyInterstitialPage extends QuestionPage {
+
+  constructor() {
+    super('property-interstitial');
+  }
+
+}
+module.exports = new PropertyInterstitialPage();

--- a/tests/new_functional/pages/surveys/navigation/repeating-block-1.page.js
+++ b/tests/new_functional/pages/surveys/navigation/repeating-block-1.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class RepeatingBlock1Page extends QuestionPage {
+
+  constructor() {
+    super('repeating-block-1');
+  }
+
+  yes() {
+    return '#what-is-your-age-0';
+  }
+
+  yesLabel() { return '#label-what-is-your-age-0'; }
+
+  no() {
+    return '#what-is-your-age-1';
+  }
+
+  noLabel() { return '#label-what-is-your-age-1'; }
+
+}
+module.exports = new RepeatingBlock1Page();

--- a/tests/new_functional/pages/surveys/navigation/repeating-block-2.page.js
+++ b/tests/new_functional/pages/surveys/navigation/repeating-block-2.page.js
@@ -1,0 +1,35 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class RepeatingBlock2Page extends QuestionPage {
+
+  constructor() {
+    super('repeating-block-2');
+  }
+
+  fullTimeStudent() {
+    return '#what-is-your-shoe-size-0';
+  }
+
+  fullTimeStudentLabel() { return '#label-what-is-your-shoe-size-0'; }
+
+  employed() {
+    return '#what-is-your-shoe-size-1';
+  }
+
+  employedLabel() { return '#label-what-is-your-shoe-size-1'; }
+
+  selfEmployed() {
+    return '#what-is-your-shoe-size-2';
+  }
+
+  selfEmployedLabel() { return '#label-what-is-your-shoe-size-2'; }
+
+  unmployed() {
+    return '#what-is-your-shoe-size-3';
+  }
+
+  unmployedLabel() { return '#label-what-is-your-shoe-size-3'; }
+
+}
+module.exports = new RepeatingBlock2Page();

--- a/tests/new_functional/pages/surveys/navigation/security-code-interstitial.page.js
+++ b/tests/new_functional/pages/surveys/navigation/security-code-interstitial.page.js
@@ -1,0 +1,11 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class SecurityCodeInterstitialPage extends QuestionPage {
+
+  constructor() {
+    super('security-code-interstitial');
+  }
+
+}
+module.exports = new SecurityCodeInterstitialPage();

--- a/tests/new_functional/pages/surveys/navigation/security-code.page.js
+++ b/tests/new_functional/pages/surveys/navigation/security-code.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class SecurityCodePage extends QuestionPage {
+
+  constructor() {
+    super('security-code');
+  }
+
+  answer() {
+    return '#security-code-answer';
+  }
+
+  answerLabel() { return '#label-security-code-answer'; }
+
+}
+module.exports = new SecurityCodePage();

--- a/tests/new_functional/pages/surveys/navigation/skip-interstitial.page.js
+++ b/tests/new_functional/pages/surveys/navigation/skip-interstitial.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class SkipInterstitialPage extends QuestionPage {
+
+  constructor() {
+    super('skip-interstitial');
+  }
+
+  yes() {
+    return '#skip-interstitial-answer-0';
+  }
+
+  yesLabel() { return '#label-skip-interstitial-answer-0'; }
+
+  no() {
+    return '#skip-interstitial-answer-1';
+  }
+
+  noLabel() { return '#label-skip-interstitial-answer-1'; }
+
+}
+module.exports = new SkipInterstitialPage();

--- a/tests/new_functional/pages/surveys/navigation/skip-payment.page.js
+++ b/tests/new_functional/pages/surveys/navigation/skip-payment.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class SkipPaymentPage extends QuestionPage {
+
+  constructor() {
+    super('skip-payment');
+  }
+
+  yes() {
+    return '#skip-payment-answer-0';
+  }
+
+  yesLabel() { return '#label-skip-payment-answer-0'; }
+
+  no() {
+    return '#skip-payment-answer-1';
+  }
+
+  noLabel() { return '#label-skip-payment-answer-1'; }
+
+}
+module.exports = new SkipPaymentPage();

--- a/tests/new_functional/pages/surveys/navigation/summary.page.js
+++ b/tests/new_functional/pages/surveys/navigation/summary.page.js
@@ -1,0 +1,11 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+}
+module.exports = new SummaryPage();

--- a/tests/new_functional/spec/navigation.spec.js
+++ b/tests/new_functional/spec/navigation.spec.js
@@ -1,0 +1,200 @@
+const helpers = require('../helpers');
+const CreditCardPage = require('../pages/surveys/navigation/credit-card.page.js');
+const ExpiryDate = require('../pages/surveys/navigation/expiry-date.page.js');
+const ExtraCoverBlockPage = require('../pages/surveys/navigation/extra-cover-block.page.js');
+const ExtraCoverItemsPage = require('../pages/surveys/navigation/extra-cover-items.page.js');
+const ExtraCoverItemsRadioPage = require('../pages/surveys/navigation/extra-cover-items-radio.page.js');
+const HouseTypePage = require('../pages/surveys/navigation/house-type.page.js');
+const HouseholdCompositionPage = require('../pages/surveys/navigation/household-composition.page.js');
+const InsuranceAddressPage = require('../pages/surveys/navigation/insurance-address.page.js');
+const InsuranceTypePage = require('../pages/surveys/navigation/insurance-type.page.js');
+const RepeatingBlock1Page = require('../pages/surveys/navigation/repeating-block-1.page.js');
+const RepeatingBlock2Page = require('../pages/surveys/navigation/repeating-block-2.page.js');
+const SecurityCodePage = require('../pages/surveys/navigation/security-code.page.js');
+const SecurityCodeInterstitialPage = require('../pages/surveys/navigation/security-code-interstitial.page.js');
+const SkipInterstitialPage = require('../pages/surveys/navigation/skip-interstitial.page.js');
+const SkipPaymentPage = require('../pages/surveys/navigation/skip-payment.page.js');
+const SummaryPage = require('../pages/surveys/navigation/summary.page.js');
+
+
+
+describe('Navigation', function() {
+
+
+  it('Given a page with navigation, a user should be able to see it', function() {
+    return helpers.openQuestionnaire('test_navigation.json').then(() => {
+      return browser
+        .isVisible('#section-nav').should.eventually.be.true;
+      });
+  });
+
+  it('Given I complete all questions, all links are visible, navigateable and appropriately completed', function() {
+    return helpers.openQuestionnaire('test_navigation.json')
+    .then(completeAllQuestions)
+    .then(() => {
+      return browser
+        .getUrl().should.eventually.contain(SummaryPage.pageName)
+        .click(helpers.navigationLink('Property Details'))
+        .getUrl().should.eventually.contain(InsuranceTypePage.pageName)
+        .click(helpers.navigationLink('House Details'))
+        .getUrl().should.eventually.contain(HouseTypePage.pageName)
+        .click(helpers.navigationLink('Household Composition'))
+        .getUrl().should.eventually.contain(HouseholdCompositionPage.pageName)
+        .click(helpers.navigationLink('Test User'))
+        .getUrl().should.eventually.contain(RepeatingBlock1Page.pageName)
+        .click(helpers.navigationLink('Extra Cover'))
+        .getUrl().should.eventually.contain(ExtraCoverBlockPage.pageName)
+        .click(helpers.navigationLink('Extra Cover Items'))
+        .getUrl().should.eventually.contain(ExtraCoverItemsPage.pageName)
+        .click(helpers.navigationLink('Payment Details'))
+        .getUrl().should.eventually.contain(SkipPaymentPage.pageName)
+        .click(helpers.navigationLink('Summary'))
+        .getUrl().should.eventually.contain(SummaryPage.pageName);
+      });
+  });
+
+  it('Given I complete all questions then incomplete one, then summary should disappear', function() {
+    return helpers.openQuestionnaire('test_navigation.json')
+    .then(completeAllQuestions)
+    .then(() => {
+      return browser
+        .getUrl().should.eventually.contain(SummaryPage.pageName)
+        .click(helpers.navigationLink('Extra Cover'))
+        .setValue(ExtraCoverBlockPage.answer(), '2')
+        .click(ExtraCoverBlockPage.submit())
+        .isVisible(helpers.navigationLink('Summary')).should.eventually.be.false;
+      });
+  });
+
+  it('Given I add members to a repeating navigation group, additional member links should appear and work', function() {
+    return helpers.openQuestionnaire('test_navigation.json').then(() => {
+      return browser
+        .click(helpers.navigationLink('Household Composition'))
+        .setValue(HouseholdCompositionPage.firstName(), 'Test')
+        .setValue(HouseholdCompositionPage.lastName(), 'User')
+        .click(HouseholdCompositionPage.addPerson())
+        .setValue(HouseholdCompositionPage.firstName('_1'), 'Another')
+        .setValue(HouseholdCompositionPage.lastName('_1'), 'User')
+        .isVisible(helpers.navigationLink('Test User')).should.eventually.be.false
+        .isVisible(helpers.navigationLink('Another User')).should.eventually.be.false
+        .click(HouseholdCompositionPage.submit())
+        .isVisible(helpers.navigationLink('Test User')).should.eventually.be.true
+        .isVisible(helpers.navigationLink('Another User')).should.eventually.be.true
+        .click(helpers.navigationLink('Another User'))
+        .getUrl().should.eventually.contain(RepeatingBlock1Page.pageName);
+      });
+  });
+
+  it('Given I add multiple members to repeating navigation group, completed status should be independent', function() {
+    return helpers.openQuestionnaire('test_navigation.json').then(() => {
+      return browser
+        .click(helpers.navigationLink('Household Composition'))
+        .setValue(HouseholdCompositionPage.firstName(), 'Test')
+        .setValue(HouseholdCompositionPage.lastName(), 'User')
+        .click(HouseholdCompositionPage.addPerson())
+        .setValue(HouseholdCompositionPage.firstName('_1'), 'Another')
+        .setValue(HouseholdCompositionPage.lastName('_1'), 'User')
+        .click(HouseholdCompositionPage.submit())
+        .isVisible(helpers.navigationLink('Test User')).should.eventually.be.true
+        .isVisible(helpers.navigationLink('Another User')).should.eventually.be.true
+        .click(RepeatingBlock1Page.yes())
+        .click(RepeatingBlock1Page.submit())
+        .click(RepeatingBlock2Page.employed())
+        .then(helpers.isSectionComplete('Test User')).should.eventually.be.false
+        .then(helpers.isSectionComplete('Another User')).should.eventually.be.false
+        .click(RepeatingBlock2Page.submit())
+        .then(helpers.isSectionComplete('Test User')).should.eventually.be.true
+        .then(helpers.isSectionComplete('Another User')).should.eventually.be.false;
+      });
+  });
+
+  it('Given I add then remove members of a repeating navigation group, additional member links should disappear', function() {
+    return helpers.openQuestionnaire('test_navigation.json').then(() => {
+      return browser
+        .click(helpers.navigationLink('Household Composition'))
+        .setValue(HouseholdCompositionPage.firstName(), 'Test')
+        .setValue(HouseholdCompositionPage.lastName(), 'User')
+        .click(HouseholdCompositionPage.addPerson())
+        .setValue(HouseholdCompositionPage.firstName('_1'), 'Another')
+        .setValue(HouseholdCompositionPage.lastName('_1'), 'User')
+        .click(HouseholdCompositionPage.submit())
+        .isVisible(helpers.navigationLink('Test User')).should.eventually.be.true
+        .isVisible(helpers.navigationLink('Another User')).should.eventually.be.true
+        .click(helpers.navigationLink('Household Composition'))
+        .click(HouseholdCompositionPage.removePerson())
+        // Wait until page refresh
+        .waitUntil(function () {
+          return browser.elements(HouseholdCompositionPage.removePerson()).then(function (e) {
+            return e.value.length === 0;
+          });
+        }, 2000, 'Person not removed in time')
+        .click(HouseholdCompositionPage.submit())
+        .isVisible(helpers.navigationLink('Test User')).should.eventually.be.true
+        .isVisible(helpers.navigationLink('Another User')).should.eventually.be.false;
+      });
+  });
+
+  it('Given I set a repeating group back to zero, added single repeating group link should disappear', function() {
+    return helpers.openQuestionnaire('test_navigation.json').then(() => {
+      return browser
+        .click(helpers.navigationLink('Extra Cover'))
+        .setValue(ExtraCoverBlockPage.answer(), '1')
+        .isVisible(helpers.navigationLink('Extra Cover Items')).should.eventually.be.false
+        .click(ExtraCoverBlockPage.submit())
+        .isVisible(helpers.navigationLink('Extra Cover Items')).should.eventually.be.true
+        .click(helpers.navigationLink('Extra Cover'))
+        .setValue(ExtraCoverBlockPage.answer(), '0')
+        .click(ExtraCoverBlockPage.submit())
+        .isVisible(helpers.navigationLink('Extra Cover Items')).should.eventually.be.false;
+      });
+  });
+
+  function completeAllQuestions() {
+  return browser
+    .click(InsuranceTypePage.both())
+    .click(InsuranceTypePage.submit())
+    .setValue(InsuranceAddressPage.answer(), 'Address')
+    .then(helpers.isSectionComplete('Property Details')).should.eventually.be.false
+    .click(InsuranceAddressPage.submit())
+    .then(helpers.isSectionComplete('Property Details')).should.eventually.be.true
+    .click(HouseTypePage.detached())
+    .then(helpers.isSectionComplete('House Details')).should.eventually.be.false
+    .click(HouseTypePage.submit())
+    .then(helpers.isSectionComplete('House Details')).should.eventually.be.true
+    .setValue(HouseholdCompositionPage.firstName(), 'Test')
+    .setValue(HouseholdCompositionPage.lastName(), 'User')
+    .then(helpers.isSectionComplete('Household Composition')).should.eventually.be.false
+    .click(HouseholdCompositionPage.submit())
+    .then(helpers.isSectionComplete('Household Composition')).should.eventually.be.true
+    .click(RepeatingBlock1Page.yes())
+    .click(RepeatingBlock1Page.submit())
+    .click(RepeatingBlock2Page.employed())
+    .then(helpers.isSectionComplete('Test User')).should.eventually.be.false
+    .click(RepeatingBlock2Page.submit())
+    .then(helpers.isSectionComplete('Test User')).should.eventually.be.true
+    .setValue(ExtraCoverBlockPage.answer(), '1')
+    .then(helpers.isSectionComplete('Extra Cover')).should.eventually.be.false
+    .click(ExtraCoverBlockPage.submit())
+    .then(helpers.isSectionComplete('Extra Cover')).should.eventually.be.true
+    .setValue(ExtraCoverItemsPage.answer(), '1')
+    .click(ExtraCoverItemsPage.submit())
+    .click(ExtraCoverItemsRadioPage.yes())
+    .then(helpers.isSectionComplete('Extra Cover Items')).should.eventually.be.false
+    .click(ExtraCoverItemsRadioPage.submit())
+    .then(helpers.isSectionComplete('Extra Cover Items')).should.eventually.be.true
+    .click(SkipPaymentPage.no())
+    .click(SkipPaymentPage.submit())
+    .setValue(CreditCardPage.answer(), '1234567890')
+    .click(CreditCardPage.submit())
+    .setValue(ExpiryDate.answer(), '1234')
+    .click(ExpiryDate.submit())
+    .setValue(SecurityCodePage.answer(), '123')
+    .click(SecurityCodePage.submit())
+    .click(SkipInterstitialPage.no())
+    .click(SkipInterstitialPage.submit())
+    .then(helpers.isSectionComplete('Payment Details')).should.eventually.be.false
+    .click(SecurityCodeInterstitialPage.submit())
+    .then(helpers.isSectionComplete('Payment Details')).should.eventually.be.true;
+  };
+
+});


### PR DESCRIPTION
### What is the context of this PR?
Currently the Navigation has been overloaded into the groups in the schema. This was done based on the assumption there was a one-to-one mapping between a group and a navigation section. As the groups have been used to control flow and repeating, this is not the case. 

We should re-implement navigation to be defined outside of the group structure in the schema

### How to review 
- It is possible to identify which groups need to be completed for a navigation item to be marked as complete (get a tick) - multiple groups are allowed.
- What constitutes a group being complete is defined by the blocks within it and the route taken (all routed blocks must be completed).
- The group to jump to when using a navigation link can be specified. Only one group can be given.
- The title of the navigation link (section) can be customised.

