### PR TITLE
eq-1190 allow conditional date piping

### DIFF
--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -43,6 +43,29 @@ def format_date(value):
     return value.strftime('%-d %B %Y')
 
 
+@blueprint.app_template_filter()
+def format_conditional_date(date1=None, date2=None):
+    """
+    This function format_conditional_date accepts two dates, a user submitted date and a metadata date
+
+    :param date1 user entered date
+    :param date2 is metadata date
+    :return: the value of the date to be piped
+    """
+    if date1:
+        date = date1
+    else:
+        date = date2
+
+    if date is None:
+        raise Exception("No valid dates passed to format_conditional_dates filter")
+
+    if isinstance(date, datetime):
+        return format_date(date)
+    else:
+        return format_date(datetime.strptime(date, "%d/%m/%Y"))
+
+
 def format_str_as_short_date(value):
     return datetime.strptime(value, "%d/%m/%Y").strftime('%d %B %Y')
 
@@ -96,5 +119,10 @@ def format_number_to_alphabetic_letter(number):
 
 
 @blueprint.app_context_processor
-def utility_processor():
+def start_end_date_check():
     return dict(format_start_end_date=format_start_end_date)
+
+
+@blueprint.app_context_processor
+def conditional_dates_check():
+    return dict(format_conditional_date=format_conditional_date)

--- a/app/templating/template_renderer.py
+++ b/app/templating/template_renderer.py
@@ -5,17 +5,21 @@ import json
 import re
 from jinja2 import Environment
 
-from app.jinja_filters import format_date, format_currency, format_household_member_name, format_household_summary, format_str_as_date
+from app.jinja_filters import format_date, format_currency, format_household_member_name, \
+    format_household_summary, format_str_as_date, format_conditional_date
 
 
 class TemplateRenderer:
     def __init__(self):
         self.environment = Environment()
+
         self.environment.filters['format_date'] = format_date
         self.environment.filters['format_str_as_date'] = format_str_as_date
         self.environment.filters['format_currency'] = format_currency
         self.environment.filters['format_household_name'] = format_household_member_name
         self.environment.filters['format_household_summary'] = format_household_summary
+
+        self.environment.globals['format_conditional_date'] = format_conditional_date
 
     def render(self, renderable, **context):
         """

--- a/data/en/test_conditional_dates.json
+++ b/data/en/test_conditional_dates.json
@@ -1,0 +1,97 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "survey_id": "023",
+    "title": "Date formats",
+    "description": "A test schema for different date formats",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "groups": [{
+        "blocks": [{
+                "type": "Questionnaire",
+                "id": "date-block",
+                "sections": [{
+                    "description": "",
+                    "id": "date-section",
+                    "questions": [{
+                        "answers": [{
+                                "alias": "date_start_from",
+                                "id": "date-start-from",
+                                "label": "Period from",
+                                "mandatory": false,
+                                "options": [],
+                                "q_code": "1111",
+                                "type": "Date",
+                                "validation": {
+                                    "messages": {
+                                        "INVALID_DATE": "The date entered is not valid.  Please correct your answer.",
+                                        "MANDATORY": "Please provide an answer to continue."
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "date_end_to",
+                                "id": "date-end-to",
+                                "label": "Period to",
+                                "mandatory": false,
+                                "options": [],
+                                "q_code": "1112",
+                                "type": "Date",
+                                "validation": {
+                                    "messages": {
+                                        "INVALID_DATE": "The date entered is not valid.  Please correct your answer.",
+                                        "MANDATORY": "Please provide an answer to continue."
+                                    }
+                                }
+                            }
+                        ],
+                        "description": "",
+                        "id": "date-pipe-question",
+                        "title": "Pipe range",
+                        "type": "DateRange"
+                    }],
+                    "title": "Date Examples"
+                }],
+                "title": "Date Examples"
+            },
+            {
+                "type": "Questionnaire",
+                "id": "date-value-test",
+                "sections": [{
+                    "description": "A test to see if dates are correctly passed",
+                    "id": "total-date-test",
+                    "questions": [{
+                        "answers": [{
+                            "id": "date-test-answer",
+                            "label": "Piped dates",
+                            "mandatory": false,
+                            "options": [],
+                            "q_code": "20",
+                            "type": "Integer",
+                            "validation": {
+                                "messages": {
+                                    "INTEGER_TOO_LARGE": "The maximum value allowed is 9999999999. Please correct your answer.",
+                                    "MANDATORY": "Please provide a value, even if your value is 0.",
+                                    "NEGATIVE_INTEGER": "The value cannot be negative. Please correct your answer.",
+                                    "NOT_INTEGER": "Please only enter whole numbers into the field."
+                                }
+                            }
+                        }],
+                        "id": "total-retail-turnover-question",
+                        "title": "For the period {{ format_conditional_date (answers.date_start_from, exercise.start_date)}} to {{ format_conditional_date (answers.date_end_to, exercise.end_date)}}, what was the value of the business’s total retail turnover?",
+                        "type": "General"
+                    }],
+                    "title": "Conditional Date Validation"
+                }],
+                "title": "Conditional Date Validation"
+            },
+            {
+                "type": "Summary",
+                "id": "summary"
+            }
+        ],
+        "id": "dates",
+        "title": ""
+    }]
+}

--- a/tests/app/templating/test_template_renderer.py
+++ b/tests/app/templating/test_template_renderer.py
@@ -146,6 +146,13 @@ class TestTemplateRenderer(unittest.TestCase):
 
         self.assertEqual(safe_content, 'Is … correct?')
 
+    def test_should_replace_jinja_template_condtional_dates(self):
+        content = 'Is {{ format_condtional_date(meta.survey.start_date, meta.survey.end_date)}} correct?'
+
+        safe_content = TemplateRenderer.safe_content(content)
+
+        self.assertEqual(safe_content, 'Is … correct?')
+
     def test_should_replace_simple_html_tags(self):
         content = 'This <em>string contains</em> <p><strong>some</strong></p><i>HTML</i>tags?'
 

--- a/tests/app/test_jinja_filters.py
+++ b/tests/app/test_jinja_filters.py
@@ -3,7 +3,8 @@ from unittest import TestCase
 
 from mock import Mock
 
-from app.jinja_filters import format_date, format_currency, format_multilined_string, format_percentage, format_start_end_date
+from app.jinja_filters import format_date, format_conditional_date, format_currency, format_multilined_string, \
+     format_percentage, format_start_end_date
 from app.jinja_filters import format_household_member_name
 from app.jinja_filters import format_str_as_date
 from app.jinja_filters import format_str_as_date_range
@@ -94,6 +95,53 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         format_value = format_date(date)
 
         self.assertEqual(format_value, '1 January 2017')
+
+    def test_format_conditional_date_not_date(self):
+        # Given       no test for integers this check was removed from jinja_filters
+
+        invalid_input = [('1', None),
+                         ('1/1/1', None)]
+
+        # When
+        for nonsense in invalid_input:
+            date1 = nonsense[0]
+            date2 = nonsense[1]
+            with self.assertRaises(Exception) as exception:
+                format_conditional_date(date1, date2)
+        # Then
+            self.assertIn("does not match format '%d/%m/%Y'", str(exception.exception))
+
+    def test_format_conditional_date_not_set(self):
+        # Given
+
+        # When
+        with self.assertRaises(Exception) as exception:
+            format_conditional_date(None, None)
+
+        # Then
+        self.assertIn("No valid dates passed to format_conditional_dates filter", str(exception.exception))
+
+    def test_format_conditional_date(self):
+        # Given
+
+        datelist = [('12/01/2016', '12/02/2016', '12 January 2016'),
+                    ('23/12/2017', None, '23 December 2017'),
+                    (datetime(2019, 5, 12), None, '12 May 2019'),
+                    (None, datetime(2017, 6, 22), '22 June 2017'),
+                    ('12/08/2017', datetime(2017, 9, 10), '12 August 2017'),
+                    (datetime(2018, 4, 7), "12/3/2018", '7 April 2018'),
+                    (None, datetime(2017, 10, 12), '12 October 2017'),
+                    (datetime(2019, 10, 12), datetime(2017, 9, 12), '12 October 2019')]
+
+        # When
+        for triple in datelist:
+            date1 = triple[0]
+            date2 = triple[1]
+            #dates = (date1, date2)
+            format_value = format_conditional_date(date1, date2)
+
+            # Then
+            self.assertEqual(format_value, triple[2])
 
     def test_format_start_end_date(self):
         # Given

--- a/tests/new_functional/pages/surveys/dates_conditional/date-block.page.js
+++ b/tests/new_functional/pages/surveys/dates_conditional/date-block.page.js
@@ -1,0 +1,35 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class DateBlockPage extends QuestionPage {
+
+  constructor() {
+    super('date-block');
+  }
+
+  dateStartFromday() {
+    return '#date-start-from-day';
+  }
+
+  dateStartFrommonth() {
+    return '#date-start-from-month';
+  }
+
+  dateStartFromyear() {
+    return '#date-start-from-year';
+  }
+
+  dateEndToday() {
+    return '#date-end-to-day';
+  }
+
+  dateEndTomonth() {
+    return '#date-end-to-month';
+  }
+
+  dateEndToyear() {
+    return '#date-end-to-year';
+  }
+
+}
+module.exports = new DateBlockPage();

--- a/tests/new_functional/pages/surveys/dates_conditional/date-value-test.page.js
+++ b/tests/new_functional/pages/surveys/dates_conditional/date-value-test.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class DateValueTestPage extends QuestionPage {
+
+  constructor() {
+    super('date-value-test');
+  }
+
+  answer() {
+    return '#date-test-answer';
+  }
+
+  answerLabel() { return '#label-date-test-answer'; }
+
+}
+module.exports = new DateValueTestPage();

--- a/tests/new_functional/pages/surveys/dates_conditional/summary.page.js
+++ b/tests/new_functional/pages/surveys/dates_conditional/summary.page.js
@@ -1,0 +1,19 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  answer() {
+    return '#date-start-from-answer';
+  }
+
+  otheranswer() {
+    return '#date-test-answer-answer';
+  }
+
+}
+module.exports = new SummaryPage();

--- a/tests/new_functional/spec/dates_conditional.spec.js
+++ b/tests/new_functional/spec/dates_conditional.spec.js
@@ -1,0 +1,57 @@
+const helpers = require('../helpers');
+
+const DatesPage = require('../pages/surveys/dates_conditional/date-block.page');
+const DatesConfirmationPage = require('../pages/surveys/dates_conditional/date-value-test.page');
+const SummaryPage = require('../pages/surveys/dates_conditional/summary.page');
+
+describe('Piped Dates', function () {
+
+  it('Given the test_conditional_dates survey is selected when dates are entered then the summary screen shows the conditional piped dates entered formatted', function() {
+
+            // Given the test_dates survey is selected
+            return helpers.openQuestionnaire('test_conditional_dates.json').then(() => {
+            return browser
+
+                    // When dates are entered
+                .setValue(DatesPage.dateStartFromday(), 11)
+                .selectByValue(DatesPage.dateStartFrommonth(), 10)
+                .setValue(DatesPage.dateStartFromyear(), 2017)
+                .setValue(DatesPage.dateEndToday(), 3)
+                .selectByValue(DatesPage.dateEndTomonth(), 12)
+                .setValue(DatesPage.dateEndToyear(), 2017)
+                .click(DatesPage.submit())
+                .setValue(DatesConfirmationPage.answer(), 1)
+                .click(DatesConfirmationPage.submit())
+
+                // Then the summary screen shows the dates entered formatted
+
+                .getText(SummaryPage.answer()).should.eventually.contain('11 October 2017 to 03 December 2017');
+
+})
+        })
+
+  it('Given the test_conditional_dates survey is selected when no dates are entered then the summary screen shows the conditional piped dates entered formatted', function() {
+
+            // Given the test_dates survey is selected
+           return helpers.openQuestionnaire('test_conditional_dates.json').then(() => {
+           return browser
+
+                    // When dates are entered
+                .setValue(DatesPage.dateStartFromday(), '')
+                .selectByValue(DatesPage.dateStartFrommonth(), '')
+                .setValue(DatesPage.dateStartFromyear(), '')
+                .setValue(DatesPage.dateEndToday(), '')
+                .selectByValue(DatesPage.dateEndTomonth(), '')
+                .setValue(DatesPage.dateEndToyear(), '')
+                .click(DatesPage.submit())
+                .setValue(DatesConfirmationPage.answer(), 2)
+                .click(DatesConfirmationPage.submit())
+
+
+            // Then the summary screen shows the dates entered formatted
+
+           .getText(SummaryPage.answer()).should.eventually.contain('No answer provided');
+
+         })
+       })
+})


### PR DESCRIPTION
this change allows a choice between submitted dates or default to metadata dates

### What is the context of this PR?
New def format_cond_date added to jinja_filters.py and change reflected in template_renderer.py
This allows the use of default dates from metadata

### How to review 
I modified an existing json (not checked in), made the date entry fields non-mandatory, created an alias for the period-from and period-to answers (cf with census-household.json). I then added the following to a title held in the subsequent questions in the json 
```
{{[answers.period_to, exercise.start_date]|format_cond_date}}
{{[answers.period_from, exercise.end_date]|format_cond_date}}
```
where period_from and period_to are the aliases and exercise.start_date/end_date are the metadata values. Tested for blank dates, invalid dates 