### PR TITLE
Removed default KID and added logging for KID use

### DIFF
--- a/app/authentication/authenticator.py
+++ b/app/authentication/authenticator.py
@@ -83,8 +83,7 @@ def decrypt_token(encrypted_token):
 
     jwt_token = decrypt_jwe(encrypted_token=encrypted_token,
                             secret_store=current_app.eq['secret_store'],
-                            purpose=KEY_PURPOSE_AUTHENTICATION,
-                            default_kid='EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY')
+                            purpose=KEY_PURPOSE_AUTHENTICATION)
 
     decrypted_token = decode_jwt(jwt_token=jwt_token,
                                  secret_store=current_app.eq['secret_store'],

--- a/tests/app/cryptography/test_token_helper.py
+++ b/tests/app/cryptography/test_token_helper.py
@@ -87,15 +87,13 @@ class TestTokenHelper(TestCase): # pylint: disable=too-many-public-methods
 
         self.assert_in_decrypt_exception(jwe.decode(), "Algorithm not allowed")
 
-    def test_missing_kid_uses_default(self):
+    def test_missing_kid(self):
         jwe_protected_header = bytes('{"alg":"RSA-OAEP","enc":"A256GCM"}', 'utf-8')
 
         encoder = Encoder(*self.encoder_args)
         jwe = encoder.encrypt_token(VALID_SIGNED_JWT.encode(), self.kid, jwe_protected_header=jwe_protected_header)
 
-        jwt = decrypt_jwe(jwe.decode(), self.secret_store, KEY_PURPOSE_AUTHENTICATION, "EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY")
-
-        self.assertIsNotNone(jwt)
+        self.assert_in_decrypt_exception(jwe.decode(), "Missing kid")
 
     def test_invalid_enc(self):
         jwe_protected_header = bytes('{"alg":"PBES2_HS256_A128KW","enc":"A128GCM","kid":"' + self.kid + '"}', 'utf-8')


### PR DESCRIPTION
### What is the context of this PR?
I have removed the default KID of `EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY` when no KID is passed for the JWE.
This is because all upstream systems are passing a KID for the JWE

### How to review 
Check that you are still able to authenticate.