### PR TITLE
Fix failing Lint test on Navigation functional test

### DIFF
--- a/tests/new_functional/spec/navigation.spec.js
+++ b/tests/new_functional/spec/navigation.spec.js
@@ -195,6 +195,6 @@ describe('Navigation', function() {
     .then(helpers.isSectionComplete('Payment Details')).should.eventually.be.false
     .click(SecurityCodeInterstitialPage.submit())
     .then(helpers.isSectionComplete('Payment Details')).should.eventually.be.true;
-  };
+  }
 
 });


### PR DESCRIPTION
Remove semi colon from line 198

### What is the context of this PR?
Fix:
 { [ESLintError: Unnecessary semicolon.]
  name: 'ESLintError',
  message: 'Unnecessary semicolon.',
  fileName: '/home/travis/build/ONSdigital/eq-survey-runner/tests/new_functional/spec/navigation.spec.js',
  lineNumber: 198,
  showStack: false,
  showProperties: true,
  plugin: 'gulp-eslint',
  __safety: { toString: [Function: bound ] } }
error Command failed with exit code 1.
