### PR TITLE
Use Travis to build Docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,14 @@ cache:
 script:
     - yarn compile
     - ./scripts/run.sh
+after_script:
+    - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+    - export TAG=`if [ "$TRAVIS_PULL_REQUEST_BRANCH" == "" ]; then echo "latest"; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi`
+    - docker build -t onsdigital/eq-survey-runner:$TAG -f Dockerfile .
+    - docker build -t onsdigital/eq-survey-runner-static:$TAG -f Dockerfile.static .
+    - echo "Pushing with tag [$TAG]"
+    - docker push onsdigital/eq-survey-runner:$TAG
+    - docker push onsdigital/eq-survey-runner-static:$TAG
 after_success:
     - bash <(curl -s https://codecov.io/bash)
     - pip install codacy-coverage


### PR DESCRIPTION
### What is the context of this PR?
This will make Travis build docker images on master merges for `onsdigital/eq-survey-runner` and `onsdigital/eq-survey-runner-static`
This will also build images for PRs which will make testing local changes on ECR a lot easier

### How to review 
Are the Docker images on Docker Hub for the PR? They should have the tag name of the branch `travis-build-docker-images`

https://hub.docker.com/r/onsdigital/eq-survey-runner/tags/
https://hub.docker.com/r/onsdigital/eq-survey-runner-static/tags/