### PR TITLE
displaying decimal places for currency on summary screen

### DIFF
--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -15,7 +15,7 @@ blueprint = flask.Blueprint('filters', __name__)
 @blueprint.app_template_filter()
 def format_currency(value):
     if value is not None and len(str(value)) > 0:
-        return "£{:,}".format(value)
+        return "£{:,.2f}".format(value)
     else:
         return ""
 

--- a/tests/app/test_jinja_filters.py
+++ b/tests/app/test_jinja_filters.py
@@ -14,6 +14,15 @@ from app.jinja_filters import format_number_to_alphabetic_letter
 
 class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
 
+    def test_format_currency_without_decimals(self):
+        # Given
+        currency = 1
+
+        # When
+        format_value = format_currency(currency)
+
+        self.assertEqual(format_value, '£1.00')
+
     def test_format_currency(self):
         # Given
         currency = 1.12


### PR DESCRIPTION
### What is the context of this PR?
All currency values piped in a survey or on the summary screen are shown with two decimal places

### How to review 
clone and run survey runner...summary screen should show currency with 2 DP. 