### PR TITLE
Eq allow decimal places mwss pay increase

### DIFF
--- a/data/en/1_0005.json
+++ b/data/en/1_0005.json
@@ -733,6 +733,7 @@
                                     "max_value": {
                                         "value": 100
                                     },
+                                    "decimal_places": 2,
                                     "validation": {
                                         "messages": {
                                             "NUMBER_TOO_LARGE": "The maximum value allowed is 100. Please correct your answer."
@@ -1365,6 +1366,7 @@
                                     "max_value": {
                                         "value": 100
                                     },
+                                    "decimal_places": 2,
                                     "validation": {
                                         "messages": {
                                             "NUMBER_TOO_LARGE": "The maximum value allowed is 100. Please correct your answer."
@@ -1986,6 +1988,7 @@
                                     "max_value": {
                                         "value": 100
                                     },
+                                    "decimal_places": 2,
                                     "validation": {
                                         "messages": {
                                             "NUMBER_TOO_LARGE": "The maximum value allowed is 100. Please correct your answer."
@@ -2606,6 +2609,7 @@
                                     "max_value": {
                                         "value": 100
                                     },
+                                    "decimal_places": 2,
                                     "validation": {
                                         "messages": {
                                             "NUMBER_TOO_LARGE": "The maximum value allowed is 100. Please correct your answer."
@@ -3228,6 +3232,7 @@
                                     "max_value": {
                                         "value": 100
                                     },
+                                    "decimal_places": 2,
                                     "validation": {
                                         "messages": {
                                             "NUMBER_TOO_LARGE": "The maximum value allowed is 100. Please correct your answer."

--- a/tests/integration/mwss/test_mwss_submission_data.py
+++ b/tests/integration/mwss/test_mwss_submission_data.py
@@ -37,7 +37,7 @@ class TestMwssSubmissionData(IntegrationTestCase):
                     "60": "10",
                     "70": "20",
                     "80": "30",
-                    "100": "50",
+                    "100": 50.58,
                     "110": "01/04/2016",
                     "120": "20%",
                     "130": "Calendar monthly",
@@ -169,7 +169,7 @@ class TestMwssSubmissionData(IntegrationTestCase):
 
         form_data = {
             # Percentage increase of pay rate
-            'weekly-pay-significant-changes-pay-rates-increase-percent-increase-answer': '50',
+            'weekly-pay-significant-changes-pay-rates-increase-percent-increase-answer': '50.58',
             # figures are back dated, from when
             'weekly-pay-significant-changes-pay-rates-increase-date-from-answer-day': '01',
             'weekly-pay-significant-changes-pay-rates-increase-date-from-answer-month': '4',


### PR DESCRIPTION
### What is the context of this PR?

This change will now allow respondents to enter 2 decimal places for MWSS 'pay increases' percentage field.

### How to review 

Launch MWSS survey 
Scenario 1: navigate to 2.10, 3.10, 4.10, 5.10 & 6.10 questions and enter percentage with 2 decimal places.
make sure the entered values are pushed down streams (dump)
Scenario 2: enter more than 2 decimal place must throw an error "Enter a number rounded to 2 decimal places."

