### PR TITLE
Convert all the data types into a string for data version 0.0.1

### DIFF
--- a/app/submitter/converter.py
+++ b/app/submitter/converter.py
@@ -194,12 +194,13 @@ def _build_metadata(metadata):
 
 
 def _encode_value(value):
-    if isinstance(value, int):
-        return str(value)
-    elif isinstance(value, str) and value == '':
-        return None
+    if isinstance(value, str):
+        if value == '':
+            return None
+        else:
+            return value
     else:
-        return value
+        return str(value)
 
 
 def convert_feedback(message, name, email, url, metadata, survey_id):

--- a/tests/app/submitter/test_converter.py
+++ b/tests/app/submitter/test_converter.py
@@ -150,6 +150,78 @@ class TestConverter(SurveyRunnerTestCase):
             # Check the converter correctly
             self.assertEqual("0", answer_object["data"]["003"])
 
+    def test_answer_with_float(self):
+        with self.application.test_request_context():
+            user_answer = [create_answer('GHI', 10.02, group_id='group-1', block_id='block-1')]
+
+            questionnaire = {
+                "survey_id": "021",
+                "data_version": "0.0.1",
+                "groups": [
+                    {
+                        "id": "group-1",
+                        "blocks": [
+                            {
+                                "id": "block-1",
+                                "questions": [{
+                                    "id": 'question-2',
+                                    "answers": [
+                                        {
+                                            "id": "GHI",
+                                            "type": "TextField",
+                                            "q_code": "003"
+                                        }
+                                    ]
+                                }]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            routing_path = [Location(group_id='group-1', group_instance=0, block_id='block-1')]
+
+            answer_object = convert_answers(metadata, questionnaire, AnswerStore(user_answer), routing_path)
+
+            # Check the converter correctly
+            self.assertEqual("10.02", answer_object["data"]["003"])
+
+    def test_answer_with_string(self):
+        with self.application.test_request_context():
+            user_answer = [create_answer('GHI', "String test + !", group_id='group-1', block_id='block-1')]
+
+            questionnaire = {
+                "survey_id": "021",
+                "data_version": "0.0.1",
+                "groups": [
+                    {
+                        "id": "group-1",
+                        "blocks": [
+                            {
+                                "id": "block-1",
+                                "questions": [{
+                                    "id": 'question-2',
+                                    "answers": [
+                                        {
+                                            "id": "GHI",
+                                            "type": "TextField",
+                                            "q_code": "003"
+                                        }
+                                    ]
+                                }]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            routing_path = [Location(group_id='group-1', group_instance=0, block_id='block-1')]
+
+            answer_object = convert_answers(metadata, questionnaire, AnswerStore(user_answer), routing_path)
+
+            # Check the converter correctly
+            self.assertEqual("String test + !", answer_object["data"]["003"])
+
     def test_answer_with_multiple_instances(self):
         with self.application.test_request_context():
             user_answer = [create_answer('GHI', 0, group_id='group-1', block_id='block-1'),

--- a/tests/integration/mwss/test_mwss_submission_data.py
+++ b/tests/integration/mwss/test_mwss_submission_data.py
@@ -37,7 +37,7 @@ class TestMwssSubmissionData(IntegrationTestCase):
                     "60": "10",
                     "70": "20",
                     "80": "30",
-                    "100": 50.58,
+                    "100": "50.58",
                     "110": "01/04/2016",
                     "120": "20%",
                     "130": "Calendar monthly",


### PR DESCRIPTION
### What is the context of this PR?
Converts all data types entered into a string and pushes it to SDX

### How to review 
Launch any survey with dumper
enter different data type values into fields
and verify the dump

Expected: All the values entered must be displayed as strings on the dump
