### PR TITLE
Added population of path finder in g

### DIFF
--- a/app/helpers/path_finder_helper.py
+++ b/app/helpers/path_finder_helper.py
@@ -7,12 +7,13 @@ from app.questionnaire.path_finder import PathFinder
 
 
 def get_path_finder():
-    finder = getattr(g, '_path_finder', None)
+    finder = getattr(g, 'path_finder', None)
 
     if finder is None:
         metadata = get_metadata(current_user)
         answer_store = get_answer_store(current_user)
         finder = PathFinder(g.schema_json, answer_store, metadata)
+        g.path_finder = finder
 
     return finder
 

--- a/tests/app/helpers/test_path_finder_helper.py
+++ b/tests/app/helpers/test_path_finder_helper.py
@@ -1,0 +1,21 @@
+from unittest.mock import patch
+from flask import g
+from tests.app.app_context_test_case import AppContextTestCase
+
+from app.helpers.path_finder_helper import path_finder
+
+
+@patch('app.helpers.path_finder_helper.PathFinder')
+@patch('app.helpers.path_finder_helper.get_metadata')
+@patch('app.helpers.path_finder_helper.get_answer_store')
+class TestPathFinderHelper(AppContextTestCase):
+    def test_path_finder_instantiated_once(self, mock_path_finder, _, __):
+        g.schema_json = {}
+
+        # Werkzeug LocalProxy only instantiates an object on
+        # attribute access. We use an example of a fake
+        # method call to check the mock (which will be the PathFinder
+        # class outside of this test) is only called once.
+        path_finder.some_method_call()
+        path_finder.some_method_call()
+        self.assertEqual(1, len(mock_path_finder.mock_calls))


### PR DESCRIPTION
### What is the context of this PR?
Before this the helper always returned a new path finder object which
made most of the code in the helper pointless.

### How to review 
All functional behaviour should be the same as before. If you set a breakpoint within the `if` you should find that you only hit it once per request to the questionnaire blueprint.
