### PR TITLE
Eq issue 1224 survey feedback page missing h1

### DIFF
--- a/app/templates/feedback.html
+++ b/app/templates/feedback.html
@@ -1,10 +1,11 @@
 {% extends 'layouts/_onecol.html' %}
-
+{% block page_title %}{{_("Survey feedback")}}{% endblock page_title %}
 {% block feedback %}
 {% endblock feedback %}
 
 {% block content %}
 <div class="feedback">
+    <h1>Survey feedback</h1>
     {% include('partials/feedback_form.html') %}
 </div>
 {% endblock content %}

--- a/app/templates/partials/feedback_form.html
+++ b/app/templates/partials/feedback_form.html
@@ -1,4 +1,3 @@
-{% block page_titel %}{{_("Survey feedback")}}{% endblock %}
 <form method="POST" class="feeback__form {{ 'u-hidden' if feedback_form_hidden }}">
     {{ form.csrf_token }}
     <div class="group">


### PR DESCRIPTION
### What is the context of this PR?
Fixes: #1224 

### How to review 
There is now an H1 header "Survey feedback" on the standalone feedback form.