### PR TITLE
Added FLASK_DEBUG env var export to dev settings

### DIFF
--- a/scripts/dev_settings.sh
+++ b/scripts/dev_settings.sh
@@ -28,4 +28,7 @@ if [ -z "$EQ_SERVER_SIDE_STORAGE_DATABASE_NAME" ]; then
   export EQ_SERVER_SIDE_STORAGE_DATABASE_NAME="//tmp/questionnaire.db"
 fi
 
+export FLASK_DEBUG=1
+
+
 python scripts/generate_secrets.py jwt-test-keys/


### PR DESCRIPTION
### What is the context of this PR?

The latest version of Flask defaults to not running in debug mode which has stopped the dev server from watching files for changes. 

This PR adds the FLASK_DEBUG=1 env var to dev settings which switches on the file watcher.

### How to review 

Run the server and make some code changes; the server should automatically restart.
