### PR TITLE
Updated selenium-standalone package to work with chrome 61

### DIFF
--- a/gulp/tests.js
+++ b/gulp/tests.js
@@ -59,22 +59,23 @@ export function functionalTests(done) {
     // need to be updated
     webdriverOpts.suite = yargs.argv.suite
 
-    // core suit is currently split between old and new
+    // core suite is currently split between old and new
     if (webdriverOpts.suite.includes('core')) {
       gutil.log('Running split core suite')
+
       return _runFunctionalTests(
-        paths.test.wdioConf,
+        paths.test.newWdioConf,
         webdriverOpts,
-        () => { _runFunctionalTests(paths.test.newWdioConf, webdriverOpts, done) }
+        () => { _runFunctionalTests(paths.test.wdioConf, webdriverOpts, done) }
       )
     }
     return _runFunctionalTests(paths.test.wdioConf, webdriverOpts)
   } else {
     // Run *all* the tests in one go
     return _runFunctionalTests(
-      paths.test.newWdioConf,
+      paths.test.wdioConf,
       {},
-      () => { _runFunctionalTests(paths.test.wdioConf, {}, done) }
+      () => { _runFunctionalTests(paths.test.newWdioConf, {}, done) }
     )
   }
 }

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "rollup-plugin-commonjs": "^8.1.0",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollupify": "^0.4.0",
-    "selenium-standalone": "^6.8.0",
+    "selenium-standalone": "^6.9.0",
     "selenium-webdriver": "^3.5.0",
     "sinon": "^3.0.0",
     "sinon-chai": "^2.13.0",

--- a/tests/new_functional/capabilities.js
+++ b/tests/new_functional/capabilities.js
@@ -22,13 +22,14 @@ const chromeNoJS = Object.assign(
 );
 
 const chromeHeadless = Object.assign(
+  {},
+  chrome,
   {
     name: 'Chrome Headless',
     chromeOptions: {
       args: ['--headless', '--window-size=1024,1158']
     }
-  },
-  chrome
+  }
 );
 
 const phantomjs = {

--- a/tests/new_functional/config.js
+++ b/tests/new_functional/config.js
@@ -44,14 +44,6 @@ let config = {
   }
 };
 
-const sauceLabsConfig = {
-  services: ['sauce'],
-  sauceConnect: true,
-  user: process.env.SAUCE_USERNAME,
-  key: process.env.SAUCE_ACCESS_KEY,
-  capabilities: [capabilities.firefox]
-};
-
 const browserStackConfig = {
   services: ['browserstack'],
   user: process.env.BROWSERSTACK_USER,
@@ -59,23 +51,32 @@ const browserStackConfig = {
   browserstackLocal: true
 }
 
-const phantomjsConfig = {
-  services: ['phantomjs'],
-  waitforTimeout: 3000,
-  capabilities: [capabilities.phantomjs],
-  maxInstances: 4,
-  phantomjsOpts: {
-    ignoreSslErrors: true
+const phantomjsConfig = Object.assign(
+  {},
+  config,
+  {
+    services: ['phantomjs'],
+    waitforTimeout: 3000,
+    capabilities: [capabilities.phantomjs],
+    maxInstances: 4,
+    phantomjsOpts: {
+      ignoreSslErrors: true
+    },
+    before: function() {
+      chaiAsPromised.transferPromiseness = browser.transferPromiseness;
+      browser.setViewportSize({
+        width: 1280,
+        height: 1024
+      });
+    }
   }
-
-};
+);
 
 const chromeHeadlessConfig = Object.assign(
   {},
   config,
   {
-    capabilities: [capabilities.chromeHeadless],
-    maxInstances: 4
+    capabilities: [capabilities.chromeHeadless]
   }
 );
 
@@ -83,9 +84,7 @@ if (process.env.TRAVIS === 'true') {
   config = chromeHeadlessConfig;
 
 } else {
-  if (argv.sauce) {
-    config = Object.assign(config, sauceLabsConfig);
-  } else if (argv.browserstack) {
+  if (argv.browserstack) {
     config = Object.assign(config, browserStackConfig);
   } else if (argv.headless) {
     config = Object.assign(config, phantomjsConfig);

--- a/tests/new_functional/wdio.conf.js
+++ b/tests/new_functional/wdio.conf.js
@@ -1,11 +1,11 @@
 //require('babel-register');
-const config = require('./config.js');
+const config = require('./config');
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 chai.config.includeStack = true;
 chai.Should();
 chai.use(chaiAsPromised);
 
-
 global.expect = chai.expect;
+
 exports.config = config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7310,9 +7310,9 @@ scss-tokenizer@^0.2.3:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
 
-selenium-standalone@^6.5.0, selenium-standalone@^6.7.0:
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/selenium-standalone/-/selenium-standalone-6.7.0.tgz#4039c7d2b4a108f962eee462186344372d762d30"
+selenium-standalone@^6.5.0, selenium-standalone@^6.9.0:
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/selenium-standalone/-/selenium-standalone-6.9.0.tgz#5805f403c82b48b4e136d8a97f1832aad7852bd5"
   dependencies:
     async "^2.1.4"
     commander "^2.9.0"
@@ -8452,11 +8452,7 @@ utils-merge@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
 
-uuid@^3.0.0, uuid@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
-
-uuid@^3.1.0:
+uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
@@ -8605,13 +8601,9 @@ wdio-browserstack-service@^0.1.4:
     request "^2.81.0"
     request-promise "^4.2.1"
 
-wdio-dot-reporter@^0.0.9:
+wdio-dot-reporter@^0.0.9, wdio-dot-reporter@~0.0.8:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/wdio-dot-reporter/-/wdio-dot-reporter-0.0.9.tgz#929b2adafd49d6b0534fda068e87319b47e38fe5"
-
-wdio-dot-reporter@~0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/wdio-dot-reporter/-/wdio-dot-reporter-0.0.8.tgz#36195576da0d998210c71948cbb65f5bf11bfc65"
 
 wdio-mocha-framework@^0.5.11:
   version "0.5.11"


### PR DESCRIPTION
### What is the context of this PR?
Travis builds started failing due to the release of Chrome 61 which we use in headless mode for the new_functional tests. This is a trial of the latest version of selenium standalone which should resolve this issue.

### How to review 
Builds should pass.