### PR TITLE
eq-1237 Fix for footer links to contact/cookie page

### DIFF
--- a/app/templates/partials/footer2.html
+++ b/app/templates/partials/footer2.html
@@ -9,7 +9,7 @@
                     </div>
                     <ul class="list footer__list">
                         <li class="footer2-nav__item">
-                            <a href="http://localhost:5000/cookies-privacy"
+                            <a href="/cookies-privacy"
                                class="footer2__link" target="_blank">Cookies and privacy</a>
                         </li>
                     </ul>
@@ -26,7 +26,7 @@
                                 do</a>
                         </li>
                         <li class="footer2-nav__item">
-                            <a href="http://localhost:5000/contact-us" target="_blank"
+                            <a href="/contact-us" target="_blank"
                                class="footer2__link">Contact us</a>
                         </li>
                         <li class="footer2-nav__item">


### PR DESCRIPTION
previously links were hardcoded as 'localhost:5000' and not working

Resolves: #1237
See also: #1218

### How to review 
run survey runner and check links to cookies page and contact us page
