### PR TITLE
Removing conditional dates and revert content from RSI and MCI surveys

### DIFF
--- a/data/en/1_0102.json
+++ b/data/en/1_0102.json
@@ -12,115 +12,27 @@
                 "type": "Introduction",
                 "id": "introduction",
                 "primary_content": [{
-                    "id": "get-started",
-                    "title": "Get started",
+                    "id": "use-of-information",
                     "content": [{
-                            "description": "On average it takes 10 minutes to complete this survey once you’ve collected the information."
+                        "description": "<p>The information supplied is used to produce monthly estimates of the total retail sales in Great Britain where retailing is defined as the sale of goods to the general public for household consumption. The Retail Sales Index is a key indicator of the progress of the economy. It is also used to help estimate consumer spending on retail goods and the output of the retail sector, both of which feed into the compilation of the National Accounts. The results are also used by the Bank of England and HM Treasury to inform decision making by government and in formulating financial policies. The results <a href=\"http://www.ons.gov.uk/businessindustryandtrade/retailindustry\">are published on our website</a>.</p>"
+                    }]
+                }, {
+                    "id": "information-to-provide",
+                    "type": "Basic",
+                    "title": "You will be asked to provide information for the business, including:",
+                    "content": [{
+                            "list": [
+                                "value of total retail turnover",
+                                "value of internet sales",
+
+                                "reasons for changes to figures"
+                            ]
                         },
                         {
-                            "description": "Data should relate to all sites in England, Scotland and Wales. You can provide informed estimates if actual figures aren't available."
-                        },
-                        {
-                            "description": "All information you provide is strictly confidential."
+                            "description": "<strong>If actual figures are not available, please provide informed estimates.</strong>"
                         }
                     ]
-                }],
-                "preview_content": {
-                    "id": "preview",
-                    "title": "Information you need",
-                    "content": [{
-                        "title": "",
-                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
-                    }],
-                    "questions": [{
-                        "question": "Total retail turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "VAT",
-                                "internet sales",
-                                "retail sales from outlets in Great Britain to customers abroad"
-                            ]
-                        }, {
-                            "description": "Exclude:",
-                            "list": [
-                                "revenue from mobile phone network commission and top-up",
-                                "sales from catering facilities used by customers",
-                                "lottery sales and commission from lottery sales",
-                                "sales of car accessories and motor vehicles",
-                                "NHS receipts"
-                            ]
-                        }]
-                    }, {
-                        "question": "Internet sales",
-                        "content": [{
-                            "description": "Include: VAT"
-                        }]
-                    }, {
-                        "question": "Significant changes to the total retail turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "in-store / online promotions",
-                                "special events (e.g.  sporting events)",
-                                "calendar events (e.g.  Christmas, Easter, Bank Holiday)",
-                                "weather",
-                                "store closures/openings"
-                            ]
-                        }]
-                    }]
-                },
-                "secondary_content": [{
-                    "id": "how-we-use-your-data",
-                    "title": "How we use your data",
-                    "content": [{
-                        "list": [
-                            "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
-                            "The information you supply is used to produce monthly estimates of the total retail sales in Great Britain. It is also used to help estimate consumer spending on retail goods and the output of the retail sector, both of which feed into the compilation of the UK National Accounts."
-                        ]
-                    }]
                 }]
-            },
-            {
-                "questions": [{
-                    "type": "General",
-                    "answers": [{
-                        "type": "Radio",
-                        "q_code": "d12",
-                        "id": "reporting-period-choice-answer",
-                        "options": [{
-                                "label": "Yes",
-                                "value": "Yes"
-                            },
-                            {
-                                "label": "No",
-                                "value": "No"
-                            }
-                        ],
-                        "mandatory": true
-                    }],
-                    "id": "reporting-period-choice-question",
-                    "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
-                }],
-                "type": "Questionnaire",
-                "title": "Reporting period",
-                "id": "reporting-period-choice",
-                "routing_rules": [{
-                        "goto": {
-                            "when": [{
-                                "value": "Yes",
-                                "id": "reporting-period-choice-answer",
-                                "condition": "equals"
-                            }],
-                            "id": "total-retail-turnover-block"
-                        }
-                    },
-                    {
-                        "goto": {
-                            "id": "reporting-period"
-                        }
-                    }
-                ]
             },
             {
                 "type": "Questionnaire",

--- a/data/en/1_0112.json
+++ b/data/en/1_0112.json
@@ -12,159 +12,32 @@
                 "type": "Introduction",
                 "id": "introduction",
                 "primary_content": [{
-                    "id": "get-started",
-                    "title": "Get started",
+                    "id": "use-of-information",
                     "content": [{
-                            "description": "On average it takes 10 minutes to complete this survey once you’ve collected the information."
+                        "description": "<p>The information supplied is used to produce monthly estimates of the total retail sales in Great Britain where retailing is defined as the sale of goods to the general public for household consumption. The Retail Sales Index is a key indicator of the progress of the economy. It is also used to help estimate consumer spending on retail goods and the output of the retail sector, both of which feed into the compilation of the National Accounts. The results are also used by the Bank of England and HM Treasury to inform decision making by government and in formulating financial policies. The results <a href=\"http://www.ons.gov.uk/businessindustryandtrade/retailindustry\">are published on our website</a>.</p>"
+                    }]
+                }, {
+                    "id": "information-to-provide",
+                    "type": "Basic",
+                    "title": "You will be asked to provide information for the business, including:",
+                    "content": [{
+                            "list": [
+                                "value of total retail turnover",
+                                "value of internet sales",
+                                "number of employees",
+                                "reasons for changes to figures"
+                            ]
                         },
                         {
-                            "description": "Data should relate to all sites in England, Scotland and Wales. You can provide informed estimates if actual figures aren't available.All information you provide is strictly confidential."
+                            "description": "<strong>If actual figures are not available, please provide informed estimates.</strong>"
                         }
                     ]
-                }],
-                "preview_content": {
-                    "id": "preview",
-                    "title": "Information you need",
-                    "content": [{
-                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
-                    }],
-                    "questions": [{
-                        "question": "Total retail turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "VAT",
-                                "internet sales",
-                                "retail sales from outlets in Great Britain to customers abroad"
-                            ]
-                        }, {
-                            "description": "Exclude:",
-                            "list": [
-                                "revenue from mobile phone network commission and top-up",
-                                "sales from catering facilities used by customers",
-                                "lottery sales and commission from lottery sales",
-                                "sales of car accessories and motor vehicles",
-                                "NHS receipts"
-                            ]
-                        }]
-                    }, {
-                        "question": "Internet sales",
-                        "content": [{
-                            "description": "Include: VAT"
-                        }]
-                    }, {
-                        "question": "Significant changes to the total retail turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "in-store / online promotions",
-                                "special events (e.g.  sporting events)",
-                                "calendar events (e.g.  Christmas, Easter, Bank Holiday)",
-                                "weather",
-                                "store closures/openings"
-                            ]
-                        }]
-                    }, {
-                        "question": "Employees",
-                        "content": [{
-                            "title": "Number of employees",
-                            "description": "Include:",
-                            "list": [
-                                "all workers paid directly from this business's payroll(s)",
-                                "those temporarily absent but still being paid, for example on maternity leave"
-                            ]
-                        }, {
-                            "description": "Exclude:",
-                            "list": [
-                                "agency workers paid directly from the agency payroll",
-                                "voluntary workers",
-                                "former employees only receiving a pension",
-                                "self-employed workers",
-                                "working owners who are not paid via PAYE"
-                            ]
-                        }]
-                    }, {
-                        "question": "Working hours",
-                        "content": [{
-                            "description": "The number of:",
-                            "list": [
-                                "male employees working more than 30 hours per week",
-                                "male employees working 30 hours or less per week",
-                                "female employees working more than 30 hours per week",
-                                "female employees working 30 hours or less per week"
-                            ]
-                        }, {
-                            "description": "Include:",
-                            "list": [
-                                "all workers paid directly from this business's payroll(s)",
-                                "those temporarily absent but still being paid, for example on maternity leave"
-                            ]
-                        }, {
-                            "description": "Exclude:",
-                            "list": [
-                                "agency workers paid directly from the agency payroll",
-                                "voluntary workers",
-                                "former employees only receiving a pension",
-                                "self-employed workers",
-                                "working owners who are not paid via PAYE"
-                            ]
-                        }]
-                    }]
-                },
-                "secondary_content": [{
-                    "id": "how-we-use-your-data",
-                    "title": "How we use your data",
-                    "content": [{
-                        "list": [
-                            "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
-                            "The information you supply is used to produce monthly estimates of the total retail sales in Great Britain. It is also used to help estimate consumer spending on retail goods and the output of the retail sector, both of which feed into the compilation of the UK National Accounts."
-                        ]
-                    }]
                 }]
             },
             {
-                "title": "Reporting period",
-                "routing_rules": [{
-                        "goto": {
-                            "when": [{
-                                "value": "Yes",
-                                "condition": "equals",
-                                "id": "reporting-period-choice-answer"
-                            }],
-                            "id": "total-retail-turnover-block"
-                        }
-                    },
-                    {
-                        "goto": {
-                            "id": "reporting-period"
-                        }
-                    }
-                ],
-                "questions": [{
-                    "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?",
-                    "type": "General",
-                    "id": "reporting-period-choice-question",
-                    "answers": [{
-                        "mandatory": true,
-                        "options": [{
-                                "label": "Yes",
-                                "value": "Yes"
-                            },
-                            {
-                                "label": "No",
-                                "value": "No"
-                            }
-                        ],
-                        "id": "reporting-period-choice-answer",
-                        "q_code": "d12",
-                        "type": "Radio"
-                    }]
-                }],
-                "id": "reporting-period-choice",
-                "type": "Questionnaire"
-            },
-            {
-                "title": "Reporting period",
+                "type": "Questionnaire",
+                "id": "reporting-period",
+                "description": "",
                 "questions": [{
                     "title": "What are the dates of the period that you will be reporting for?",
                     "type": "DateRange",
@@ -188,9 +61,7 @@
                             "type": "Date"
                         }
                     ]
-                }],
-                "id": "reporting-period",
-                "type": "Questionnaire"
+                }]
             },
             {
                 "type": "Questionnaire",

--- a/data/en/1_0203.json
+++ b/data/en/1_0203.json
@@ -12,208 +12,31 @@
                 "type": "Introduction",
                 "id": "introduction",
                 "primary_content": [{
-                    "id": "get-started",
-                    "title": "Get started",
+                    "id": "use-of-information",
                     "content": [{
-                            "description": "On average it takes 10 minutes to complete this survey once you’ve collected the information."
+                        "description": "<p>The information supplied is used to produce monthly estimates of the total retail sales in Great Britain where retailing is defined as the sale of goods to the general public for household consumption. The Retail Sales Index is a key indicator of the progress of the economy. It is also used to help estimate consumer spending on retail goods and the output of the retail sector, both of which feed into the compilation of the National Accounts. The results are also used by the Bank of England and HM Treasury to inform decision making by government and in formulating financial policies. The results <a href=\"http://www.ons.gov.uk/businessindustryandtrade/retailindustry\">are published on our website</a>.</p>"
+                    }]
+                }, {
+                    "id": "information-to-provide",
+                    "type": "Basic",
+                    "title": "You will be asked to provide information for the business, including:",
+                    "content": [{
+                            "list": [
+                                "value of total retail turnover",
+                                "value of internet sales",
+                                "reasons for changes to figures"
+                            ]
                         },
                         {
-                            "description": "Data should relate to all sites in England, Scotland and Wales. You can provide informed estimates if actual figures aren't available."
-                        },
-                        {
-                            "description": "All information you provide is strictly confidential."
+                            "description": "<strong>If actual figures are not available, please provide informed estimates.</strong>"
                         }
                     ]
-                }],
-                "preview_content": {
-                    "id": "preview",
-                    "title": "Information you need",
-                    "content": [{
-                            "description": "The total retail turnover must be less than or equal to the value of food sales, alcohol, confectionary and tobacco sales, clothing and footwear sales,  household goods, and other goods."
-                        },
-                        {
-                            "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
-                        }
-                    ],
-                    "questions": [{
-                        "question": "Total retail turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "VAT",
-                                "internet sales",
-                                "retail sales from outlets in Great Britain to customers abroad"
-                            ]
-                        }, {
-                            "description": "Exclude:",
-                            "list": [
-                                "revenue from mobile phone network commission and top-up",
-                                "sales from catering facilities used by customers",
-                                "lottery sales and commission from lottery sales",
-                                "sales of car accessories and motor vehicles",
-                                "NHS receipts"
-                            ]
-                        }]
-                    }, {
-                        "question": "Food sales",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "all fresh food",
-                                "other food for human consumption (except chocolate and sugar confectionery)",
-                                "soft drinks"
-                            ]
-                        }, {
-                            "description": "Exclude:",
-                            "list": [
-                                "sales from catering facilities used by customers"
-                            ]
-                        }]
-                    }, {
-                        "question": "Alcohol, confectionary and tobacco sales",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "chocolate and sugar confectionery",
-                                "tobacco and smokers’ requisites"
-                            ]
-                        }]
-                    }, {
-                        "question": "Clothing and footwear sales",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "clothing fabrics",
-                                "haberdashery and furs",
-                                "leather and travel goods",
-                                "handbags and umbrellas"
-                            ]
-                        }]
-                    }, {
-                        "question": "Household goods sales",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "carpets, rugs and other floor coverings",
-                                "furniture",
-                                "household textiles and soft furnishings",
-                                "prints and picture frames",
-                                "antiques and works of art",
-                                "domestic electrical and gas appliances, audio/visual equipment and home computers",
-                                "lighting and minor electrical supplies",
-                                "records, compact discs, audio and video tapes",
-                                "musical instruments and goods",
-                                "decorators’ and DIY supplies",
-                                "lawn-mowers",
-                                "hardware",
-                                "china, glassware and cutlery",
-                                "novelties, souvenirs and gifts",
-                                "e-cigarettes"
-                            ]
-                        }]
-                    }, {
-                        "question": "Other sales",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "toiletries and medications (except NHS receipts)",
-                                "newspapers and periodicals",
-                                "books, stationery and office supplies",
-                                "photographic and optical goods",
-                                "spectacles, contact lenses and sunglasses",
-                                "toys and games",
-                                "cycles and cycle accessories",
-                                "sport and camping equipment",
-                                "jewellery",
-                                "silverware and plates, clocks and watches",
-                                "household cleaning products and kitchen paper products",
-                                "pets, pets’ requisites and pet foods",
-                                "cut flowers, plants, seeds and other garden sundries",
-                                "other new and secondhand goods",
-                                "mobile phones"
-                            ]
-                        }, {
-                            "description": "Exclude:",
-                            "list": [
-                                "revenue from mobile phone network commission and top up",
-                                "lottery sales and commission from lottery sales",
-                                "sales of car accessories and motor vehicles",
-                                "NHS receipts"
-                            ]
-                        }]
-                    }, {
-                        "question": "Internet sales",
-                        "content": [{
-                            "description": "Include: VAT"
-                        }]
-                    }, {
-                        "question": "Significant changes to the total retail turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "in-store / online promotions",
-                                "special events (e.g.  sporting events)",
-                                "calendar events (e.g.  Christmas, Easter, Bank Holiday)",
-                                "weather",
-                                "store closures/openings"
-                            ]
-                        }]
-                    }]
-                },
-                "secondary_content": [{
-                    "id": "how-we-use-your-data",
-                    "title": "How we use your data",
-                    "content": [{
-                        "list": [
-                            "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
-                            "The information you supply is used to produce monthly estimates of the total retail sales in Great Britain. It is also used to help estimate consumer spending on retail goods and the output of the retail sector, both of which feed into the compilation of the UK National Accounts."
-                        ]
-                    }]
                 }]
             },
             {
-                "title": "Reporting period",
-                "routing_rules": [{
-                        "goto": {
-                            "when": [{
-                                "value": "Yes",
-                                "condition": "equals",
-                                "id": "reporting-period-choice-answer"
-                            }],
-                            "id": "total-retail-turnover-block"
-                        }
-                    },
-                    {
-                        "goto": {
-                            "id": "reporting-period"
-                        }
-                    }
-                ],
-                "questions": [{
-                    "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?",
-                    "type": "General",
-                    "id": "reporting-period-choice-question",
-                    "answers": [{
-                        "mandatory": true,
-                        "options": [{
-                                "label": "Yes",
-                                "value": "Yes"
-                            },
-                            {
-                                "label": "No",
-                                "value": "No"
-                            }
-                        ],
-                        "id": "reporting-period-choice-answer",
-                        "q_code": "d12",
-                        "type": "Radio"
-                    }]
-                }],
-                "id": "reporting-period-choice",
-                "type": "Questionnaire"
-            },
-            {
-                "title": "Reporting period",
+                "type": "Questionnaire",
+                "id": "reporting-period",
+                "description": "",
                 "questions": [{
                     "title": "What are the dates of the period that you will be reporting for?",
                     "type": "DateRange",
@@ -237,11 +60,8 @@
                             "type": "Date"
                         }
                     ]
-                }],
-                "id": "reporting-period",
-                "type": "Questionnaire"
-            },
-            {
+                }]
+            }, {
                 "type": "Questionnaire",
                 "id": "total-retail-turnover-block",
                 "description": "",

--- a/data/en/1_0205.json
+++ b/data/en/1_0205.json
@@ -12,223 +12,30 @@
                 "type": "Introduction",
                 "id": "introduction",
                 "primary_content": [{
-                    "id": "get-started",
-                    "title": "Get started",
+                    "id": "use-of-information",
                     "content": [{
-                            "description": "On average it takes 10 minutes to complete this survey once you’ve collected the information."
+                        "description": "<p>The information supplied is used to produce monthly estimates of the total retail sales in Great Britain where retailing is defined as the sale of goods to the general public for household consumption. The Retail Sales Index is a key indicator of the progress of the economy. It is also used to help estimate consumer spending on retail goods and the output of the retail sector, both of which feed into the compilation of the National Accounts. The results are also used by the Bank of England and HM Treasury to inform decision making by government and in formulating financial policies. The results <a href=\"http://www.ons.gov.uk/businessindustryandtrade/retailindustry\">are published on our website</a>.</p>"
+                    }]
+                }, {
+                    "id": "information-to-provide",
+                    "type": "Basic",
+                    "title": "You will be asked to provide information for the business, including:",
+                    "content": [{
+                            "list": [
+                                "value of total retail turnover",
+                                "value of internet sales",
+                                "reasons for changes to figures"
+                            ]
                         },
                         {
-                            "description": "Data should relate to all sites in England, Scotland and Wales. You can provide informed estimates if actual figures aren't available."
-                        },
-                        {
-                            "description": "All information you provide is strictly confidential."
+                            "description": "<strong>If actual figures are not available, please provide informed estimates.</strong>"
                         }
                     ]
-                }],
-                "preview_content": {
-                    "id": "preview",
-                    "title": "Information you need",
-                    "content": [{
-                            "description": "The total retail turnover must be less than or equal to the value of food sales, alcohol, confectionary and tobacco sales, clothing and footwear sales,  household goods, and other goods."
-                        },
-                        {
-                            "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
-                        }
-                    ],
-                    "questions": [{
-                        "question": "Total retail turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "VAT",
-                                "internet sales",
-                                "retail sales from outlets in Great Britain to customers abroad"
-                            ]
-                        }, {
-                            "description": "Exclude:",
-                            "list": [
-                                "revenue from mobile phone network commission and top-up",
-                                "sales from catering facilities used by customers",
-                                "lottery sales and commission from lottery sales",
-                                "sales of car accessories and motor vehicles",
-                                "NHS receipts"
-                            ]
-                        }]
-                    }, {
-                        "question": "Food sales",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "all fresh food",
-                                "other food for human consumption (except chocolate and sugar confectionery)",
-                                "soft drinks"
-                            ]
-                        }, {
-                            "description": "Exclude:",
-                            "list": [
-                                "sales from catering facilities used by customers"
-                            ]
-                        }]
-                    }, {
-                        "question": "Alcohol, confectionary and tobacco sales",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "chocolate and sugar confectionery",
-                                "tobacco and smokers’ requisites"
-                            ]
-                        }]
-                    }, {
-                        "question": "Clothing and footwear sales",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "clothing fabrics",
-                                "haberdashery and furs",
-                                "leather and travel goods",
-                                "handbags and umbrellas"
-                            ]
-                        }]
-                    }, {
-                        "question": "Household goods sales",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "carpets, rugs and other floor coverings",
-                                "furniture",
-                                "household textiles and soft furnishings",
-                                "prints and picture frames",
-                                "antiques and works of art",
-                                "domestic electrical and gas appliances, audio/visual equipment and home computers",
-                                "lighting and minor electrical supplies",
-                                "records, compact discs, audio and video tapes",
-                                "musical instruments and goods",
-                                "decorators’ and DIY supplies",
-                                "lawn-mowers",
-                                "hardware",
-                                "china, glassware and cutlery",
-                                "novelties, souvenirs and gifts",
-                                "e-cigarettes"
-                            ]
-                        }]
-                    }, {
-                        "question": "Other sales",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "toiletries and medications (except NHS receipts)",
-                                "newspapers and periodicals",
-                                "books, stationery and office supplies",
-                                "photographic and optical goods",
-                                "spectacles, contact lenses and sunglasses",
-                                "toys and games",
-                                "cycles and cycle accessories",
-                                "sport and camping equipment",
-                                "jewellery",
-                                "silverware and plates, clocks and watches",
-                                "household cleaning products and kitchen paper products",
-                                "pets, pets’ requisites and pet foods",
-                                "cut flowers, plants, seeds and other garden sundries",
-                                "other new and secondhand goods",
-                                "mobile phones"
-                            ]
-                        }, {
-                            "description": "Exclude:",
-                            "list": [
-                                "revenue from mobile phone network commission and top up",
-                                "lottery sales and commission from lottery sales",
-                                "sales of car accessories and motor vehicles",
-                                "NHS receipts"
-                            ]
-                        }]
-                    }, {
-                        "question": "Internet sales",
-                        "content": [{
-                            "description": "Include: VAT"
-                        }]
-                    }, {
-                        "question": "Automotive fuel",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "VAT",
-                                "sales of fuel owned by you",
-                                "sales of other items not paid a commission for"
-                            ]
-                        }, {
-                            "description": "Exclude:",
-                            "list": [
-                                "sales of fuel not own"
-                            ]
-                        }]
-                    }, {
-                        "question": "Significant changes to the total retail turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "in-store / online promotions",
-                                "special events (e.g.  sporting events)",
-                                "calendar events (e.g.  Christmas, Easter, Bank Holiday)",
-                                "weather",
-                                "store closures/openings"
-                            ]
-                        }]
-                    }]
-                },
-                "secondary_content": [{
-                    "id": "how-we-use-your-data",
-                    "title": "How we use your data",
-                    "content": [{
-                        "list": [
-                            "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
-                            "The information you supply is used to produce monthly estimates of the total retail sales in Great Britain. It is also used to help estimate consumer spending on retail goods and the output of the retail sector, both of which feed into the compilation of the UK National Accounts."
-                        ]
-                    }]
                 }]
-            },
-            {
-                "title": "Reporting period",
-                "routing_rules": [{
-                        "goto": {
-                            "when": [{
-                                "value": "Yes",
-                                "condition": "equals",
-                                "id": "reporting-period-choice-answer"
-                            }],
-                            "id": "total-retail-turnover-block"
-                        }
-                    },
-                    {
-                        "goto": {
-                            "id": "reporting-period"
-                        }
-                    }
-                ],
-                "questions": [{
-                    "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?",
-                    "type": "General",
-                    "id": "reporting-period-choice-question",
-                    "answers": [{
-                        "mandatory": true,
-                        "options": [{
-                                "label": "Yes",
-                                "value": "Yes"
-                            },
-                            {
-                                "label": "No",
-                                "value": "No"
-                            }
-                        ],
-                        "id": "reporting-period-choice-answer",
-                        "q_code": "d12",
-                        "type": "Radio"
-                    }]
-                }],
-                "id": "reporting-period-choice",
-                "type": "Questionnaire"
-            },
-            {
-                "title": "Reporting period",
+            }, {
+                "type": "Questionnaire",
+                "id": "reporting-period",
+                "description": "",
                 "questions": [{
                     "title": "What are the dates of the period that you will be reporting for?",
                     "type": "DateRange",
@@ -252,9 +59,7 @@
                             "type": "Date"
                         }
                     ]
-                }],
-                "id": "reporting-period",
-                "type": "Questionnaire"
+                }]
             },
             {
                 "type": "Questionnaire",

--- a/data/en/1_0213.json
+++ b/data/en/1_0213.json
@@ -12,254 +12,32 @@
                 "type": "Introduction",
                 "id": "introduction",
                 "primary_content": [{
-                    "id": "get-started",
-                    "title": "Get started",
+                    "id": "use-of-information",
                     "content": [{
-                            "description": "On average it takes 10 minutes to complete this survey once you’ve collected the information."
+                        "description": "<p>The information supplied is used to produce monthly estimates of the total retail sales in Great Britain where retailing is defined as the sale of goods to the general public for household consumption. The Retail Sales Index is a key indicator of the progress of the economy. It is also used to help estimate consumer spending on retail goods and the output of the retail sector, both of which feed into the compilation of the National Accounts. The results are also used by the Bank of England and HM Treasury to inform decision making by government and in formulating financial policies. The results <a href=\"http://www.ons.gov.uk/businessindustryandtrade/retailindustry\">are published on our website</a>.</p>"
+                    }]
+                }, {
+                    "id": "information-to-provide",
+                    "type": "Basic",
+                    "title": "You will be asked to provide information for the business, including:",
+                    "content": [{
+                            "list": [
+                                "value of total retail turnover",
+                                "value of internet sales",
+                                "number of employees",
+                                "reasons for changes to figures"
+                            ]
                         },
                         {
-                            "description": "Data should relate to all sites in England, Scotland and Wales. You can provide informed estimates if actual figures aren't available."
-                        },
-                        {
-                            "description": "All information you provide is strictly confidential."
+                            "description": "<strong>If actual figures are not available, please provide informed estimates.</strong>"
                         }
                     ]
-                }],
-                "preview_content": {
-                    "id": "preview",
-                    "title": "Information you need",
-                    "content": [{
-                            "description": "The total retail turnover must be less than or equal to the value of food sales, alcohol, confectionary and tobacco sales, clothing and footwear sales,  household goods, and other goods."
-                        },
-                        {
-                            "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
-                        }
-                    ],
-                    "questions": [{
-                        "question": "Total retail turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "VAT",
-                                "internet sales",
-                                "retail sales from outlets in Great Britain to customers abroad"
-                            ]
-                        }, {
-                            "description": "Exclude:",
-                            "list": [
-                                "revenue from mobile phone network commission and top-up",
-                                "sales from catering facilities used by customers",
-                                "lottery sales and commission from lottery sales",
-                                "sales of car accessories and motor vehicles",
-                                "NHS receipts"
-                            ]
-                        }]
-                    }, {
-                        "question": "Food sales",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "all fresh food",
-                                "other food for human consumption (except chocolate and sugar confectionery)",
-                                "soft drinks"
-                            ]
-                        }, {
-                            "description": "Exclude:",
-                            "list": [
-                                "sales from catering facilities used by customers"
-                            ]
-                        }]
-                    }, {
-                        "question": "Alcohol, confectionary and tobacco sales",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "chocolate and sugar confectionery",
-                                "tobacco and smokers’ requisites"
-                            ]
-                        }]
-                    }, {
-                        "question": "Clothing and footwear sales",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "clothing fabrics",
-                                "haberdashery and furs",
-                                "leather and travel goods",
-                                "handbags and umbrellas"
-                            ]
-                        }]
-                    }, {
-                        "question": "Household goods sales",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "carpets, rugs and other floor coverings",
-                                "furniture",
-                                "household textiles and soft furnishings",
-                                "prints and picture frames",
-                                "antiques and works of art",
-                                "domestic electrical and gas appliances, audio/visual equipment and home computers",
-                                "lighting and minor electrical supplies",
-                                "records, compact discs, audio and video tapes",
-                                "musical instruments and goods",
-                                "decorators’ and DIY supplies",
-                                "lawn-mowers",
-                                "hardware",
-                                "china, glassware and cutlery",
-                                "novelties, souvenirs and gifts",
-                                "e-cigarettes"
-                            ]
-                        }]
-                    }, {
-                        "question": "Other sales",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "toiletries and medications (except NHS receipts)",
-                                "newspapers and periodicals",
-                                "books, stationery and office supplies",
-                                "photographic and optical goods",
-                                "spectacles, contact lenses and sunglasses",
-                                "toys and games",
-                                "cycles and cycle accessories",
-                                "sport and camping equipment",
-                                "jewellery",
-                                "silverware and plates, clocks and watches",
-                                "household cleaning products and kitchen paper products",
-                                "pets, pets’ requisites and pet foods",
-                                "cut flowers, plants, seeds and other garden sundries",
-                                "other new and secondhand goods",
-                                "mobile phones"
-                            ]
-                        }, {
-                            "description": "Exclude:",
-                            "list": [
-                                "revenue from mobile phone network commission and top up",
-                                "lottery sales and commission from lottery sales",
-                                "sales of car accessories and motor vehicles",
-                                "NHS receipts"
-                            ]
-                        }]
-                    }, {
-                        "question": "Internet sales",
-                        "content": [{
-                            "description": "Include: VAT"
-                        }]
-                    }, {
-                        "question": "Significant changes to the total retail turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "in-store / online promotions",
-                                "special events (e.g.  sporting events)",
-                                "calendar events (e.g.  Christmas, Easter, Bank Holiday)",
-                                "weather",
-                                "store closures/openings"
-                            ]
-                        }]
-                    }, {
-                        "question": "Employees",
-                        "content": [{
-                            "title": "Number of employees",
-                            "description": "Include:",
-                            "list": [
-                                "all workers paid directly from this business's payroll(s)",
-                                "those temporarily absent but still being paid, for example on maternity leave"
-                            ]
-                        }, {
-                            "description": "Exclude:",
-                            "list": [
-                                "agency workers paid directly from the agency payroll",
-                                "voluntary workers",
-                                "former employees only receiving a pension",
-                                "self-employed workers",
-                                "working owners who are not paid via PAYE"
-                            ]
-                        }]
-                    }, {
-                        "question": "Working hours",
-                        "content": [{
-                            "description": "The number of:",
-                            "list": [
-                                "male employees working more than 30 hours per week",
-                                "male employees working 30 hours or less per week",
-                                "female employees working more than 30 hours per week",
-                                "female employees working 30 hours or less per week"
-                            ]
-                        }, {
-                            "description": "Include:",
-                            "list": [
-                                "all workers paid directly from this business's payroll(s)",
-                                "those temporarily absent but still being paid, for example on maternity leave"
-                            ]
-
-                        }, {
-                            "description": "Exclude:",
-                            "list": [
-                                "agency workers paid directly from the agency payroll",
-                                "voluntary workers",
-                                "former employees only receiving a pension",
-                                "self-employed workers",
-                                "working owners who are not paid via PAYE"
-                            ]
-                        }]
-                    }]
-                },
-                "secondary_content": [{
-                    "id": "how-we-use-your-data",
-                    "title": "How we use your data",
-                    "content": [{
-                        "list": [
-                            "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
-                            "The information you supply is used to produce monthly estimates of the total retail sales in Great Britain. It is also used to help estimate consumer spending on retail goods and the output of the retail sector, both of which feed into the compilation of the UK National Accounts."
-                        ]
-                    }]
                 }]
             },
             {
-                "title": "Reporting period",
-                "routing_rules": [{
-                        "goto": {
-                            "when": [{
-                                "value": "Yes",
-                                "condition": "equals",
-                                "id": "reporting-period-choice-answer"
-                            }],
-                            "id": "total-retail-turnover-block"
-                        }
-                    },
-                    {
-                        "goto": {
-                            "id": "reporting-period"
-                        }
-                    }
-                ],
-                "questions": [{
-                    "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?",
-                    "type": "General",
-                    "id": "reporting-period-choice-question",
-                    "answers": [{
-                        "mandatory": true,
-                        "options": [{
-                                "label": "Yes",
-                                "value": "Yes"
-                            },
-                            {
-                                "label": "No",
-                                "value": "No"
-                            }
-                        ],
-                        "id": "reporting-period-choice-answer",
-                        "q_code": "d12",
-                        "type": "Radio"
-                    }]
-                }],
-                "id": "reporting-period-choice",
-                "type": "Questionnaire"
-            },
-            {
-                "title": "Reporting period",
+                "type": "Questionnaire",
+                "id": "reporting-period",
+                "description": "",
                 "questions": [{
                     "title": "What are the dates of the period that you will be reporting for?",
                     "type": "DateRange",
@@ -283,11 +61,8 @@
                             "type": "Date"
                         }
                     ]
-                }],
-                "id": "reporting-period",
-                "type": "Questionnaire"
-            },
-            {
+                }]
+            }, {
                 "type": "Questionnaire",
                 "id": "total-retail-turnover-block",
                 "description": "",

--- a/data/en/1_0215.json
+++ b/data/en/1_0215.json
@@ -13,270 +13,32 @@
                 "id": "introduction",
 
                 "primary_content": [{
-                    "id": "get-started",
-                    "title": "Get started",
+                    "id": "use-of-information",
                     "content": [{
-                            "description": "On average it takes 15 minutes to complete this survey once you’ve collected the information."
+                        "description": "<p>The information supplied is used to produce monthly estimates of the total retail sales in Great Britain where retailing is defined as the sale of goods to the general public for household consumption. The Retail Sales Index is a key indicator of the progress of the economy. It is also used to help estimate consumer spending on retail goods and the output of the retail sector, both of which feed into the compilation of the National Accounts. The results are also used by the Bank of England and HM Treasury to inform decision making by government and in formulating financial policies. The results <a href=\"http://www.ons.gov.uk/businessindustryandtrade/retailindustry\">are published on our website</a>.</p>"
+                    }]
+                }, {
+                    "id": "information-to-provide",
+                    "type": "Basic",
+                    "title": "You will be asked to provide information for the business, including:",
+                    "content": [{
+                            "list": [
+                                "value of total retail turnover",
+                                "value of internet sales",
+                                "number of employees",
+                                "reasons for changes to figures"
+                            ]
                         },
                         {
-                            "description": "Data should relate to all sites in England, Scotland and Wales. You can provide informed estimates if actual figures aren't available."
-                        },
-                        {
-                            "description": "All information you provide is strictly confidential."
+                            "description": "<strong>If actual figures are not available, please provide informed estimates.</strong>"
                         }
                     ]
-                }],
-                "preview_content": {
-                    "id": "preview",
-                    "title": "Information you need",
-                    "content": [{
-                            "description": "The total retail turnover must be less than or equal to the value of food sales, alcohol, confectionary and tobacco sales, clothing and footwear sales,  household goods, and other goods."
-                        },
-                        {
-                            "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
-                        }
-                    ],
-                    "questions": [{
-                        "question": "Total retail turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "VAT",
-                                "internet sales",
-                                "retail sales from outlets in Great Britain to customers abroad"
-                            ]
-                        }, {
-                            "description": "Exclude:",
-                            "list": [
-                                "revenue from mobile phone network commission and top-up",
-                                "sales from catering facilities used by customers",
-                                "lottery sales and commission from lottery sales",
-                                "sales of car accessories and motor vehicles",
-                                "NHS receipts"
-                            ]
-                        }]
-                    }, {
-                        "question": "Food sales",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "all fresh food",
-                                "other food for human consumption (except chocolate and sugar confectionery)",
-                                "soft drinks"
-                            ]
-                        }, {
-                            "description": "Exclude:",
-                            "list": [
-                                "sales from catering facilities used by customers"
-                            ]
-                        }]
-                    }, {
-                        "question": "Alcohol, confectionary and tobacco sales",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "chocolate and sugar confectionery",
-                                "tobacco and smokers’ requisites"
-                            ]
-                        }]
-                    }, {
-                        "question": "Clothing and footwear sales",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "clothing fabrics",
-                                "haberdashery and furs",
-                                "leather and travel goods",
-                                "handbags and umbrellas"
-                            ]
-                        }]
-                    }, {
-                        "question": "Household goods sales",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "carpets, rugs and other floor coverings",
-                                "furniture",
-                                "household textiles and soft furnishings",
-                                "prints and picture frames",
-                                "antiques and works of art",
-                                "domestic electrical and gas appliances, audio/visual equipment and home computers",
-                                "lighting and minor electrical supplies",
-                                "records, compact discs, audio and video tapes",
-                                "musical instruments and goods",
-                                "decorators’ and DIY supplies",
-                                "lawn-mowers",
-                                "hardware",
-                                "china, glassware and cutlery",
-                                "novelties, souvenirs and gifts",
-                                "e-cigarettes"
-                            ]
-                        }]
-                    }, {
-                        "question": "Other sales",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "toiletries and medications (except NHS receipts)",
-                                "newspapers and periodicals",
-                                "books, stationery and office supplies",
-                                "photographic and optical goods",
-                                "spectacles, contact lenses and sunglasses",
-                                "toys and games",
-                                "cycles and cycle accessories",
-                                "sport and camping equipment",
-                                "jewellery",
-                                "silverware and plates, clocks and watches",
-                                "household cleaning products and kitchen paper products",
-                                "pets, pets’ requisites and pet foods",
-                                "cut flowers, plants, seeds and other garden sundries",
-                                "other new and secondhand goods",
-                                "mobile phones"
-                            ]
-                        }, {
-                            "description": "Exclude:",
-                            "list": [
-                                "revenue from mobile phone network commission and top up",
-                                "lottery sales and commission from lottery sales",
-                                "sales of car accessories and motor vehicles",
-                                "NHS receipts"
-                            ]
-                        }]
-                    }, {
-                        "question": "Internet sales",
-                        "content": [{
-                            "description": "Include: VAT"
-                        }]
-                    }, {
-                        "question": "Automotive fuel",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "VAT",
-                                "sales of fuel owned by you",
-                                "sales of other items not paid a commission for"
-                            ]
-                        }, {
-                            "description": "Exclude:",
-                            "list": [
-                                "sales of fuel not owned by you",
-                                "any commissions"
-                            ]
-                        }]
-                    }, {
-                        "question": "Significant changes to the total retail turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "in-store / online promotions",
-                                "special events (e.g.  sporting events)",
-                                "calendar events (e.g.  Christmas, Easter, Bank Holiday)",
-                                "weather",
-                                "store closures/openings"
-                            ]
-                        }]
-                    }, {
-                        "question": "Employees",
-                        "content": [{
-                            "title": "Number of employees",
-                            "description": "Include:",
-                            "list": [
-                                "all workers paid directly from this business's payroll(s)",
-                                "those temporarily absent but still being paid, for example on maternity leave"
-                            ]
-                        }, {
-                            "description": "Exclude:",
-                            "list": [
-                                "agency workers paid directly from the agency payroll",
-                                "voluntary workers",
-                                "former employees only receiving a pension",
-                                "self-employed workers",
-                                "working owners who are not paid via PAYE"
-                            ]
-                        }]
-                    }, {
-                        "question": "Working hours",
-                        "content": [{
-                            "description": "The number of:",
-                            "list": [
-                                "male employees working more than 30 hours per week",
-                                "male employees working 30 hours or less per week",
-                                "female employees working more than 30 hours per week",
-                                "female employees working 30 hours or less per week"
-                            ]
-                        }, {
-                            "description": "Include:",
-                            "list": [
-                                "all workers paid directly from this business's payroll(s)",
-                                "those temporarily absent but still being paid, for example on maternity leave"
-                            ]
-
-                        }, {
-                            "description": "Exclude:",
-                            "list": [
-                                "agency workers paid directly from the agency payroll",
-                                "voluntary workers",
-                                "former employees only receiving a pension",
-                                "self-employed workers",
-                                "working owners who are not paid via PAYE"
-                            ]
-                        }]
-                    }]
-                },
-                "secondary_content": [{
-                    "id": "how-we-use-your-data",
-                    "title": "How we use your data",
-                    "content": [{
-                        "list": [
-                            "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
-                            "The information you supply is used to produce monthly estimates of the total retail sales in Great Britain. It is also used to help estimate consumer spending on retail goods and the output of the retail sector, both of which feed into the compilation of the UK National Accounts."
-                        ]
-                    }]
                 }]
             },
             {
-                "title": "Reporting period",
-                "routing_rules": [{
-                        "goto": {
-                            "when": [{
-                                "value": "Yes",
-                                "condition": "equals",
-                                "id": "reporting-period-choice-answer"
-                            }],
-                            "id": "total-retail-turnover-block"
-                        }
-                    },
-                    {
-                        "goto": {
-                            "id": "reporting-period"
-                        }
-                    }
-                ],
-                "questions": [{
-                    "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?",
-                    "type": "General",
-                    "id": "reporting-period-choice-question",
-                    "answers": [{
-                        "mandatory": true,
-                        "options": [{
-                                "label": "Yes",
-                                "value": "Yes"
-                            },
-                            {
-                                "label": "No",
-                                "value": "No"
-                            }
-                        ],
-                        "id": "reporting-period-choice-answer",
-                        "q_code": "d12",
-                        "type": "Radio"
-                    }]
-                }],
-                "id": "reporting-period-choice",
-                "type": "Questionnaire"
-            },
-            {
-                "title": "Reporting period",
+                "type": "Questionnaire",
+                "id": "reporting-period",
+                "description": "",
                 "questions": [{
                     "title": "What are the dates of the period that you will be reporting for?",
                     "type": "DateRange",
@@ -300,11 +62,8 @@
                             "type": "Date"
                         }
                     ]
-                }],
-                "id": "reporting-period",
-                "type": "Questionnaire"
-            },
-            {
+                }]
+            }, {
                 "type": "Questionnaire",
                 "id": "total-retail-turnover-block",
                 "description": "",


### PR DESCRIPTION
### What is the context of this PR?
- All RSI and MCI types are reverted to their previous versions

- All survey launch pages for RSI and MCI types are reverted to their previous versions

See also: #1208, #1210

### How to review 
Launch all RSI & MCI surveys and compare that they all match previous version
Surveys:
0102
0112
0203
0205
0213
0215
