### PR TITLE
Enable no-sandbox on chrome headless

### DIFF
--- a/tests/karma/karma.conf.js
+++ b/tests/karma/karma.conf.js
@@ -40,7 +40,14 @@ module.exports = function(config) {
 
     reporters: ['mocha', 'progress', 'coverage'],
 
-    browsers: ['ChromeHeadless'],
+    browsers: ['ChromeHeadlessNoSandbox'],
+
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox']
+      }
+    },
 
     coverageReporter: {
       dir : 'coverage/',

--- a/tests/new_functional/capabilities.js
+++ b/tests/new_functional/capabilities.js
@@ -27,7 +27,7 @@ const chromeHeadless = Object.assign(
   {
     name: 'Chrome Headless',
     chromeOptions: {
-      args: ['--headless', '--window-size=1024,1158']
+      args: ['--headless', '--window-size=1024,1158', '--no-sandbox']
     }
   }
 );


### PR DESCRIPTION
This allows the Functional Tests to run correctly in Concourse

### What is the context of this PR?
`--no-sandbox` is required for chrome headless to run properly inside a docker container
Headless chrome does not run properly in docker when running in a sandbox https://github.com/SeleniumHQ/docker-selenium/issues/520

### How to review 
Test that the functional tests can run inside a docker container.