### PR TITLE
Fix 500 Error from /session-expired and /signed-out

### DIFF
--- a/app/helpers/session_helper.py
+++ b/app/helpers/session_helper.py
@@ -1,4 +1,4 @@
-from flask import current_app, session
+from flask import current_app
 from flask_login import current_user, logout_user
 
 from app.globals import get_questionnaire_store
@@ -18,6 +18,3 @@ def end_session_with_schema_context(schema=None):
         schema = load_schema_from_metadata(metadata)
 
     _remove_survey_session_data()
-
-    session['theme'] = schema['theme']
-    session['survey_title'] = schema['title']

--- a/app/views/session.py
+++ b/app/views/session.py
@@ -1,6 +1,5 @@
 from flask import Blueprint, current_app, redirect, request, session
 from flask_login import current_user, login_required
-from flask_themes2 import render_theme_template
 
 from werkzeug.exceptions import NotFound, Unauthorized
 
@@ -13,7 +12,7 @@ from app.questionnaire.path_finder import PathFinder
 from app.storage.metadata_parser import parse_metadata
 from app.utilities.schema import load_schema_from_metadata
 from app.helpers.session_helper import end_session_with_schema_context
-from app.templating.template_renderer import TemplateRenderer
+from app.views.errors import render_template
 
 logger = get_logger()
 
@@ -68,6 +67,9 @@ def login():
 
     json = load_schema_from_metadata(metadata)
 
+    session['theme'] = json['theme']
+    session['survey_title'] = json['title']
+
     navigator = PathFinder(json, get_answer_store(current_user), metadata)
     current_location = navigator.get_latest_location(get_completed_blocks(current_user))
 
@@ -92,9 +94,7 @@ def get_session_expired():
     if current_user.is_active:
         end_session_with_schema_context()
 
-    return render_theme_template(session['theme'], template_name='session-expired.html',
-                                 analytics_ua_id=current_app.config['EQ_UA_ID'],
-                                 survey_title=TemplateRenderer.safe_content(session['survey_title']))
+    return render_template('session-expired.html')
 
 
 @session_blueprint.route('/signed-out', methods=["GET"])
@@ -102,6 +102,4 @@ def get_sign_out():
     if current_user.is_active:
         end_session_with_schema_context()
 
-    return render_theme_template(session['theme'], template_name='signed-out.html',
-                                 analytics_ua_id=current_app.config['EQ_UA_ID'],
-                                 survey_title=TemplateRenderer.safe_content(session['survey_title']))
+    return render_template('signed-out.html')

--- a/tests/integration/views/test_session.py
+++ b/tests/integration/views/test_session.py
@@ -1,0 +1,12 @@
+from tests.integration.integration_test_case import IntegrationTestCase
+
+
+class TestSession(IntegrationTestCase):
+
+    def test_session_expired(self):
+        self.get('/session-expired')
+        self.assertInPage('Your session has expired')
+
+    def test_session_signed_out(self):
+        self.get('/signed-out')
+        self.assertInPage('Your survey has been saved')


### PR DESCRIPTION
### What is the context of this PR?
feature includes:

- when signed in user gets session-expired/signed-out with theme and title of survey
launched

- when not signed in (and no cookie) theme is set as default and no title

Resolves: #1230


Describe what you have changed and why, link to other PRs or Issues as appropriate.

### How to review 
Load survey runner launch a survey and navigate to 'localhost:5000/session-expired' or 'localhost:5000/signed-out'. page should match survey and survey title. 

Load survey, delet cookie, then navigate to above pages....user should see default page and no title
