### PR TITLE
Fix MWSS Calendar monthly routing error

### DIFF
--- a/data/en/1_0005.json
+++ b/data/en/1_0005.json
@@ -294,7 +294,7 @@
                         },
                         {
                             "goto": {
-                                "group": "calendar-monthly-pay",
+                                "group": "calendar-monthly",
                                 "when": [{
                                     "id": "pay-pattern-frequency-answer",
                                     "condition": "contains",

--- a/tests/app/data/test_invalid_routing_block.json
+++ b/tests/app/data/test_invalid_routing_block.json
@@ -3,7 +3,7 @@
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "023",
-    "title": "Test Invalid Routing",
+    "title": "Test Invalid Routing Block ID",
     "description": "",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",

--- a/tests/app/data/test_invalid_routing_group.json
+++ b/tests/app/data/test_invalid_routing_group.json
@@ -1,0 +1,98 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "survey_id": "0",
+    "title": "Test Invalid Routing To Group",
+    "description": "",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "groups": [{
+            "id": "which-group",
+            "title": "What group do you want to go to?",
+            "blocks": [{
+                "type": "Questionnaire",
+                "id": "which-group-block",
+                "description": "",
+                "title": "Pick your next group?",
+                "questions": [{
+                    "description": "",
+                    "id": "which-group-question",
+                    "title": "Select Group",
+                    "type": "General",
+                    "answers": [{
+                        "id": "which-group-answer",
+                        "label": "Choose next group",
+                        "mandatory": true,
+                        "options": [{
+                                "label": "Group 1",
+                                "value": "group1"
+                            },
+                            {
+                                "label": "Group 2",
+                                "value": "group2"
+                            }
+                        ],
+                        "type": "Radio",
+                        "validation": {
+                            "messages": {}
+                        }
+                    }]
+                }],
+                "routing_rules": [{
+                        "goto": {
+                            "group": "group1",
+                            "when": [{
+                                "id": "which-group-answer",
+                                "condition": "equals",
+                                "value": "group1"
+                            }]
+                        }
+                    },
+                    {
+                        "goto": {
+                            "group": "invalid-group",
+                            "when": [{
+                                "id": "which-group-answer",
+                                "condition": "equals",
+                                "value": "group2"
+                            }]
+                        }
+                    }
+                ]
+            }]
+        },
+        {
+            "id": "group1",
+            "title": "This is Group 1",
+            "blocks": [{
+                "type": "Questionnaire",
+                "id": "group1-block",
+                "routing_rules": [],
+                "description": "",
+                "title": "Did you want Group 1?",
+                "questions": [{
+                    "description": "",
+                    "id": "group1-question",
+                    "title": "Did you want Group 1?",
+                    "type": "General",
+                    "answers": [{
+                        "id": "group1-answer",
+                        "label": "Why did you choose Group 1?",
+                        "mandatory": true,
+                        "options": [],
+                        "type": "TextArea"
+                    }]
+                }]
+            }]
+        },
+        {
+            "blocks": [{
+                "type": "Summary",
+                "id": "summary"
+            }],
+            "id": "summary-group",
+            "title": "Summary"
+        }
+    ]
+}


### PR DESCRIPTION
Fixes an issue with MWSS that had a routing rule to a group that didn't
exist. Also adds a schema validation test to validate all schemas with
routing rules to groups only route to groups that exist.

Fixes: #1249

### What is the context of this PR?
See #1249

### How to review 
- Start an MWSS survey
- Choose just "Calendar monthly" as a pay period
- Confirm choice
- Confirm 500 error doesn't occur