### PR TITLE
Restore conditional dates in RSI and MCI

### DIFF
--- a/app/submitter/converter.py
+++ b/app/submitter/converter.py
@@ -190,10 +190,15 @@ def _build_collection(metadata):
 
 
 def _build_metadata(metadata):
-    return {
+    downstream_metadata = {
         'user_id': metadata['user_id'],
         'ru_ref': metadata['ru_ref'],
+        'ref_period_start_date': metadata['ref_p_start_date'],
     }
+    if metadata.get('ref_p_end_date'):
+        downstream_metadata['ref_period_end_date'] = metadata['ref_p_end_date']
+
+    return downstream_metadata
 
 
 def _encode_value(value):

--- a/data/en/1_0102.json
+++ b/data/en/1_0102.json
@@ -82,6 +82,46 @@
                 }]
             },
             {
+                "questions": [{
+                    "type": "General",
+                    "answers": [{
+                        "type": "Radio",
+                        "id": "reporting-period-choice-answer",
+                        "options": [{
+                                "label": "Yes",
+                                "value": "Yes"
+                            },
+                            {
+                                "label": "No",
+                                "value": "No"
+                            }
+                        ],
+                        "mandatory": true
+                    }],
+                    "id": "reporting-period-choice-question",
+                    "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
+                }],
+                "type": "Questionnaire",
+                "title": "Reporting period",
+                "id": "reporting-period-choice",
+                "routing_rules": [{
+                        "goto": {
+                            "when": [{
+                                "value": "Yes",
+                                "id": "reporting-period-choice-answer",
+                                "condition": "equals"
+                            }],
+                            "id": "total-retail-turnover-block"
+                        }
+                    },
+                    {
+                        "goto": {
+                            "id": "reporting-period"
+                        }
+                    }
+                ]
+            },
+            {
                 "type": "Questionnaire",
                 "questions": [{
                     "type": "DateRange",

--- a/data/en/1_0112.json
+++ b/data/en/1_0112.json
@@ -124,8 +124,47 @@
                 }]
             },
             {
-                "type": "Questionnaire",
-                "id": "reporting-period",
+                "title": "Reporting period",
+                "routing_rules": [{
+                        "goto": {
+                            "when": [{
+                                "value": "Yes",
+                                "condition": "equals",
+                                "id": "reporting-period-choice-answer"
+                            }],
+                            "id": "total-retail-turnover-block"
+                        }
+                    },
+                    {
+                        "goto": {
+                            "id": "reporting-period"
+                        }
+                    }
+                ],
+                "questions": [{
+                    "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?",
+                    "type": "General",
+                    "id": "reporting-period-choice-question",
+                    "answers": [{
+                        "mandatory": true,
+                        "options": [{
+                                "label": "Yes",
+                                "value": "Yes"
+                            },
+                            {
+                                "label": "No",
+                                "value": "No"
+                            }
+                        ],
+                        "id": "reporting-period-choice-answer",
+                        "type": "Radio"
+                    }]
+                }],
+                "id": "reporting-period-choice",
+                "type": "Questionnaire"
+            },
+            {
+                "title": "Reporting period",
                 "questions": [{
                     "title": "What are the dates of the period that you will be reporting for?",
                     "type": "DateRange",
@@ -149,7 +188,9 @@
                             "type": "Date"
                         }
                     ]
-                }]
+                }],
+                "id": "reporting-period",
+                "type": "Questionnaire"
             },
             {
                 "type": "Questionnaire",

--- a/data/en/1_0203.json
+++ b/data/en/1_0203.json
@@ -173,6 +173,46 @@
             },
             {
                 "title": "Reporting period",
+                "routing_rules": [{
+                        "goto": {
+                            "when": [{
+                                "value": "Yes",
+                                "condition": "equals",
+                                "id": "reporting-period-choice-answer"
+                            }],
+                            "id": "total-retail-turnover-block"
+                        }
+                    },
+                    {
+                        "goto": {
+                            "id": "reporting-period"
+                        }
+                    }
+                ],
+                "questions": [{
+                    "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?",
+                    "type": "General",
+                    "id": "reporting-period-choice-question",
+                    "answers": [{
+                        "mandatory": true,
+                        "options": [{
+                                "label": "Yes",
+                                "value": "Yes"
+                            },
+                            {
+                                "label": "No",
+                                "value": "No"
+                            }
+                        ],
+                        "id": "reporting-period-choice-answer",
+                        "type": "Radio"
+                    }]
+                }],
+                "id": "reporting-period-choice",
+                "type": "Questionnaire"
+            },
+            {
+                "title": "Reporting period",
                 "questions": [{
                     "title": "What are the dates of the period that you will be reporting for?",
                     "type": "DateRange",

--- a/data/en/1_0205.json
+++ b/data/en/1_0205.json
@@ -186,8 +186,47 @@
                     }]
                 }]
             }, {
-                "type": "Questionnaire",
-                "id": "reporting-period",
+                "title": "Reporting period",
+                "routing_rules": [{
+                        "goto": {
+                            "when": [{
+                                "value": "Yes",
+                                "condition": "equals",
+                                "id": "reporting-period-choice-answer"
+                            }],
+                            "id": "total-retail-turnover-block"
+                        }
+                    },
+                    {
+                        "goto": {
+                            "id": "reporting-period"
+                        }
+                    }
+                ],
+                "questions": [{
+                    "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?",
+                    "type": "General",
+                    "id": "reporting-period-choice-question",
+                    "answers": [{
+                        "mandatory": true,
+                        "options": [{
+                                "label": "Yes",
+                                "value": "Yes"
+                            },
+                            {
+                                "label": "No",
+                                "value": "No"
+                            }
+                        ],
+                        "id": "reporting-period-choice-answer",
+                        "type": "Radio"
+                    }]
+                }],
+                "id": "reporting-period-choice",
+                "type": "Questionnaire"
+            },
+            {
+                "title": "Reporting period",
                 "questions": [{
                     "title": "What are the dates of the period that you will be reporting for?",
                     "type": "DateRange",
@@ -211,7 +250,9 @@
                             "type": "Date"
                         }
                     ]
-                }]
+                }],
+                "id": "reporting-period",
+                "type": "Questionnaire"
             },
             {
                 "type": "Questionnaire",

--- a/data/en/1_0213.json
+++ b/data/en/1_0213.json
@@ -218,8 +218,47 @@
                 }]
             },
             {
-                "type": "Questionnaire",
-                "id": "reporting-period",
+                "title": "Reporting period",
+                "routing_rules": [{
+                        "goto": {
+                            "when": [{
+                                "value": "Yes",
+                                "condition": "equals",
+                                "id": "reporting-period-choice-answer"
+                            }],
+                            "id": "total-retail-turnover-block"
+                        }
+                    },
+                    {
+                        "goto": {
+                            "id": "reporting-period"
+                        }
+                    }
+                ],
+                "questions": [{
+                    "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?",
+                    "type": "General",
+                    "id": "reporting-period-choice-question",
+                    "answers": [{
+                        "mandatory": true,
+                        "options": [{
+                                "label": "Yes",
+                                "value": "Yes"
+                            },
+                            {
+                                "label": "No",
+                                "value": "No"
+                            }
+                        ],
+                        "id": "reporting-period-choice-answer",
+                        "type": "Radio"
+                    }]
+                }],
+                "id": "reporting-period-choice",
+                "type": "Questionnaire"
+            },
+            {
+                "title": "Reporting period",
                 "questions": [{
                     "title": "What are the dates of the period that you will be reporting for?",
                     "type": "DateRange",
@@ -243,7 +282,9 @@
                             "type": "Date"
                         }
                     ]
-                }]
+                }],
+                "id": "reporting-period",
+                "type": "Questionnaire"
             },
             {
                 "type": "Questionnaire",

--- a/data/en/1_0215.json
+++ b/data/en/1_0215.json
@@ -235,8 +235,47 @@
                 }]
             },
             {
-                "type": "Questionnaire",
-                "id": "reporting-period",
+                "title": "Reporting period",
+                "routing_rules": [{
+                        "goto": {
+                            "when": [{
+                                "value": "Yes",
+                                "condition": "equals",
+                                "id": "reporting-period-choice-answer"
+                            }],
+                            "id": "total-retail-turnover-block"
+                        }
+                    },
+                    {
+                        "goto": {
+                            "id": "reporting-period"
+                        }
+                    }
+                ],
+                "questions": [{
+                    "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?",
+                    "type": "General",
+                    "id": "reporting-period-choice-question",
+                    "answers": [{
+                        "mandatory": true,
+                        "options": [{
+                                "label": "Yes",
+                                "value": "Yes"
+                            },
+                            {
+                                "label": "No",
+                                "value": "No"
+                            }
+                        ],
+                        "id": "reporting-period-choice-answer",
+                        "type": "Radio"
+                    }]
+                }],
+                "id": "reporting-period-choice",
+                "type": "Questionnaire"
+            },
+            {
+                "title": "Reporting period",
                 "questions": [{
                     "title": "What are the dates of the period that you will be reporting for?",
                     "type": "DateRange",
@@ -260,7 +299,9 @@
                             "type": "Date"
                         }
                     ]
-                }]
+                }],
+                "id": "reporting-period",
+                "type": "Questionnaire"
             },
             {
                 "type": "Questionnaire",

--- a/tests/integration/mci/test_mci_submission_data.py
+++ b/tests/integration/mci/test_mci_submission_data.py
@@ -59,6 +59,8 @@ class TestMciSubmissionData(IntegrationTestCase):
                     "20": "100000"
                 },
                 "metadata": {
+                    "ref_period_end_date": "2016-04-30",
+                    "ref_period_start_date": "2016-04-01",
                     "ru_ref": "123456789012A",
                     "user_id": "integration-test"
                 },

--- a/tests/integration/mwss/test_mwss_submission_data.py
+++ b/tests/integration/mwss/test_mwss_submission_data.py
@@ -20,6 +20,8 @@ class TestMwssSubmissionData(IntegrationTestCase):
                 "tx_id": tx_id,
                 "submitted_at": submitted_at,
                 "metadata": {
+                    "ref_period_end_date": "2016-04-30",
+                    "ref_period_start_date": "2016-04-01",
                     "user_id": "integration-test",
                     "ru_ref": "123456789012A"
                 },

--- a/tests/integration/qbs/test_qbs_submission_data.py
+++ b/tests/integration/qbs/test_qbs_submission_data.py
@@ -60,6 +60,8 @@ class TestQbsSubmissionData(IntegrationTestCase):
                 'type': 'uk.gov.ons.edc.eq:surveyresponse',
                 'version': '0.0.1',
                 'metadata': {
+                    'ref_period_end_date': '2016-04-30',
+                    'ref_period_start_date': '2016-04-01',
                     'ru_ref': '123456789012A',
                     'user_id': 'integration-test'
                 }

--- a/tests/integration/rsi/test_rsi_submission_data.py
+++ b/tests/integration/rsi/test_rsi_submission_data.py
@@ -60,6 +60,8 @@ class TestRsiSubmissionData(IntegrationTestCase):
                 "flushed": False,
                 "origin": "uk.gov.ons.edc.eq",
                 "metadata": {
+                    "ref_period_end_date": "2016-04-30",
+                    "ref_period_start_date": "2016-04-01",
                     "user_id": "integration-test",
                     "ru_ref": "123456789012A"
                 },
@@ -158,6 +160,8 @@ class TestRsiSubmissionData(IntegrationTestCase):
                 },
                 "origin": "uk.gov.ons.edc.eq",
                 "metadata": {
+                    "ref_period_end_date": "2016-04-30",
+                    "ref_period_start_date": "2016-04-01",
                     "ru_ref": "123456789012A",
                     "user_id": "integration-test"
                 },

--- a/tests/integration/ukis/test_ukis_submission_data.py
+++ b/tests/integration/ukis/test_ukis_submission_data.py
@@ -161,6 +161,8 @@ class TestUkisSubmissionData(IntegrationTestCase):
                     "exercise_sid": "789"
                 },
                 "metadata": {
+                    "ref_period_end_date": "2016-04-30",
+                    "ref_period_start_date": "2016-04-01",
                     "ru_ref": "123456789012A",
                     "user_id": "integration-test"
                 },

--- a/tests/integration/views/test_dump.py
+++ b/tests/integration/views/test_dump.py
@@ -127,7 +127,6 @@ class TestDumpSubmission(IntegrationTestCase):
 
         # And the JSON response contains the data I submitted
         actual = json.loads(self.getResponseData())
-
         # tx_id and submitted_at are dynamic; so copy them over
         expected = {
             'submission': {
@@ -145,6 +144,8 @@ class TestDumpSubmission(IntegrationTestCase):
                 },
                 'data': {},
                 'metadata': {
+                    'ref_period_end_date': '2016-04-30',
+                    'ref_period_start_date': '2016-04-01',
                     'ru_ref': '123456789012A',
                     'user_id': 'integration-test'
                 }
@@ -191,6 +192,8 @@ class TestDumpSubmission(IntegrationTestCase):
                     '20': 'Bacon'
                 },
                 'metadata': {
+                    'ref_period_end_date': '2016-04-30',
+                    'ref_period_start_date': '2016-04-01',
                     'ru_ref': '123456789012A',
                     'user_id': 'integration-test'
                 }


### PR DESCRIPTION
### What is the context of this PR?
Conditional date logic has been applied to the RSI questionnaires.
trello: https://trello.com/c/i6VoTxPX/1346-restore-conditional-dates-to-rsi-and-mci 

(https://drive.google.com/drive/folders/0BwTdPM-J8JFBa2F4RFQyTlN2bms)

### How to review 
Launch all the MCI/RSI surveys (0102,0112,0203,0205,0213 and 0215)
and verify that the surveys have preview questions on the landing page
On clicking start survey must be presented with conditional dates question
and Period Start and end date are now added to the metadata (verify by dumping the answers) 
Also ensure that dummy q_code d12 is no longer part of the JSON
