### PR TITLE
Remove decimal places from RSI/MCI surveys due to downstream issues

### DIFF
--- a/data/en/1_0102.json
+++ b/data/en/1_0102.json
@@ -183,7 +183,7 @@
                         "q_code": "20",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "id": "total-turnover-question",
                     "title": "For the period {{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}\u2019s <em>total retail turnover</em>?",
@@ -212,7 +212,7 @@
                         "q_code": "21",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "id": "internet-sales-question",
                     "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>internet</em> sales?",

--- a/data/en/1_0112.json
+++ b/data/en/1_0112.json
@@ -225,7 +225,7 @@
                         "q_code": "20",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "id": "total-turnover-question",
                     "title": "For the period {{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}\u2019s <em>total retail turnover</em>?",
@@ -254,7 +254,7 @@
                         "q_code": "21",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "id": "internet-sales-question",
                     "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>internet</em> sales?",

--- a/data/en/1_0203.json
+++ b/data/en/1_0203.json
@@ -274,7 +274,7 @@
                         "q_code": "20",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "description": "",
                     "id": "total-turnover-question",
@@ -312,7 +312,7 @@
                         "q_code": "22",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "description": "",
                     "id": "total-sales-food-question",
@@ -343,7 +343,7 @@
                         "q_code": "23",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "description": "",
                     "id": "total-sales-alcohol-question",
@@ -376,7 +376,7 @@
                         "q_code": "24",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "description": "",
                     "id": "total-sales-clothing-question",
@@ -421,7 +421,7 @@
                         "q_code": "25",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
 
                     }],
                     "id": "total-sales-household-goods-question",
@@ -476,7 +476,7 @@
                         "q_code": "26",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "description": "",
                     "id": "total-sales-other-goods-question",
@@ -506,7 +506,7 @@
                         "q_code": "21",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "description": "",
                     "id": "internet-sales-question",

--- a/data/en/1_0205.json
+++ b/data/en/1_0205.json
@@ -288,7 +288,7 @@
                         "q_code": "20",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "description": "",
                     "id": "total-turnover-question",
@@ -326,7 +326,7 @@
                         "q_code": "22",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "id": "total-sales-food-question",
                     "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>food</em> sales?",
@@ -356,7 +356,7 @@
                         "q_code": "23",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "description": "",
                     "id": "total-sales-alcohol-question",
@@ -389,7 +389,7 @@
                         "q_code": "24",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "id": "total-sales-clothing-question",
                     "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>clothing and footwear</em> sales?",
@@ -433,7 +433,7 @@
                         "q_code": "25",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "id": "total-sales-household-goods-question",
                     "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of sales for <em>household goods</em>?",
@@ -489,7 +489,7 @@
                         "q_code": "26",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "id": "total-sales-other-goods-question",
                     "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>other</em> sales?",
@@ -518,7 +518,7 @@
                         "q_code": "21",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "id": "internet-sales-question",
                     "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>internet</em> sales?",
@@ -556,7 +556,7 @@
                         "q_code": "27",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "id": "total-sales-automotive-fuel-question",
                     "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>automotive fuel</em> sales?",

--- a/data/en/1_0213.json
+++ b/data/en/1_0213.json
@@ -320,7 +320,7 @@
                         "q_code": "20",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "id": "total-turnover-question",
                     "title": "For the period {{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}\u2019s <em>total retail turnover</em>?",
@@ -357,7 +357,7 @@
                         "q_code": "22",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "id": "total-sales-food-question",
                     "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>food</em> sales?",
@@ -387,7 +387,7 @@
                         "q_code": "23",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "id": "total-sales-alcohol-question",
                     "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>alcohol, confectionery and tobacco</em> sales?",
@@ -419,7 +419,7 @@
                         "q_code": "24",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "id": "total-sales-clothing-question",
                     "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>clothing and footwear</em> sales?",
@@ -463,7 +463,7 @@
                         "q_code": "25",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "id": "total-sales-household-goods-question",
                     "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of sales for <em>household goods</em>?",
@@ -517,7 +517,7 @@
                         "q_code": "26",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "id": "total-sales-other-goods-question",
                     "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>other</em> sales?",
@@ -545,7 +545,7 @@
                         "q_code": "21",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "id": "internet-sales-question",
                     "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>internet</em> sales?",

--- a/data/en/1_0215.json
+++ b/data/en/1_0215.json
@@ -337,7 +337,7 @@
                         "q_code": "20",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "id": "total-turnover-question",
                     "title": "For the period {{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}\u2019s <em>total retail turnover</em>?",
@@ -374,7 +374,7 @@
                         "q_code": "22",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "id": "total-sales-food-question",
                     "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>food</em> sales?",
@@ -404,7 +404,7 @@
                         "q_code": "23",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "id": "total-sales-alcohol-question",
                     "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>alcohol, confectionery and tobacco</em> sales?",
@@ -436,7 +436,7 @@
                         "q_code": "24",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "id": "total-sales-clothing-question",
                     "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>clothing and footwear</em> sales?",
@@ -483,7 +483,7 @@
                         "q_code": "25",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "id": "total-sales-household-goods-question",
                     "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of sales for <em>household goods</em>?",
@@ -541,7 +541,7 @@
                         "q_code": "26",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "id": "total-sales-other-goods-question",
                     "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>other</em> sales?",
@@ -569,7 +569,7 @@
                         "q_code": "21",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "id": "internet-sales-question",
                     "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>internet</em> sales?",
@@ -608,7 +608,7 @@
                         "q_code": "27",
                         "type": "Currency",
                         "currency": "GBP",
-                        "decimal_places": 2
+                        "description": "Round to the nearest (\u00a3) pound. Do not  include pence"
                     }],
                     "id": "total-sales-automotive-fuel-question",
                     "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>automotive fuel</em> sales?",


### PR DESCRIPTION
### What is the context of this PR?
Remove decimal places feature from RSI/MCI JSON schemas and re-added description items for rounding to nearest pound. Comma changes unchanged

### How to review 
Run the app and review the surveys. Tested locally and all seems ok
