### PR TITLE
Consistently handle contact telephone number as a link

### DIFF
--- a/app/templates/introduction.html
+++ b/app/templates/introduction.html
@@ -44,7 +44,7 @@
               <dd class="dl__data mars">{{ meta.respondent.address.trading_as }}</dd>
             {% endif %}
             <dt id="details-changed-title" class="dl__title mercury">Change in details</dt>
-            <dd class="dl__data mars">Call <a href="tel:0300 1234 931" aria-describedby="details-changed-title">0300 1234 931</a> or email <a href="mailto:surveys@ons.gov.uk?subject=Change%20of%20details%20reference%20{{ meta.respondent.respondent_id }}" aria-describedby="details-changed-title">surveys@ons.gov.uk</a> if there have been any changes to your business name, address or structure</dd>
+            <dd class="dl__data mars">{{h.telephone_number('details-changed-title')}} or email <a href="mailto:surveys@ons.gov.uk?subject=Change%20of%20details%20reference%20{{ meta.respondent.respondent_id }}" aria-describedby="details-changed-title">surveys@ons.gov.uk</a> if there have been any changes to your business name, address or structure</dd>
           </dl>
         </div>
         <div class="grid__col col-6@s">

--- a/app/templates/layouts/_error.html
+++ b/app/templates/layouts/_error.html
@@ -1,5 +1,5 @@
 {% extends 'layouts/_twocol.html' %}
-
+{% import 'macros/helpers.html' as helpers %}
 {% block page_title %}{{_("Error")}} {{status_code}}{% endblock %}
 
 {% block main %}
@@ -14,9 +14,7 @@
         {%- endfor -%}
       </ul>
     {%- endif -%}
-
-
-    <p class="u-mb-no">If the problem continues please call <a class="info__link" href="tel:03001234931" aria-describedby="survey-help">0300 1234 931</a></p>
+    <p class="u-mb-no">If the problem continues please call {{helpers.telephone_number('survey-help')}}</p>
   </div>
 
   {{answer_guidance}}
@@ -27,3 +25,4 @@
     <div>{{ua.os.family}} ({{ua.os.major or '0'}}.{{ua.os.minor or '0'}}.{{ua.os.patch or '0'}})</div>
   </div>
 {% endblock %}
+

--- a/app/templates/macros/helpers.html
+++ b/app/templates/macros/helpers.html
@@ -11,3 +11,11 @@
   } %}
   {{attr|xmlattr}}
 {%- endmacro -%}
+
+{%- macro telephone_number(aria_describedby=None, class=None) -%}
+  {% set attr = {
+    "aria-describedby": aria_describedby,
+    "class": class
+  } %}
+<a href="tel:03001234931" {{attr|xmlattr}}>0300 1234 931</a>
+{%- endmacro -%}

--- a/app/templates/static/contact-us.html
+++ b/app/templates/static/contact-us.html
@@ -1,4 +1,5 @@
 {% extends 'layouts/_twocol.html' %}
+{% import 'macros/helpers.html' as helpers %}
 
 {% set survey_title  = 'About ONS' %}
 
@@ -39,7 +40,7 @@
                                 Telephone
                             </h2>
                             <div class="question__description mars">
-                                <p>0300 1234 931</p>
+                                <p>{{helpers.telephone_number()}}</p>
                             </div>
                             <div class="question__description mars">
                                 <p>Opening hours:</p>


### PR DESCRIPTION
### What is the context of this PR?
Card asked for telephone number on contact screen to be link

### How to review 
As contact number is used in several places, A new macro has been added to helpers.html, so that changes to the number need only be made in one place.
To test run the app and check the introduction page, contact us and also force an error to check the error message link 

Fixes #1260