### PR TITLE
Fixes exponential numeric values issue

### DIFF
--- a/app/validation/validators.py
+++ b/app/validation/validators.py
@@ -27,6 +27,9 @@ class NumberCheck(object):
         except (ValueError, TypeError, InvalidOperation, AttributeError):
             raise validators.StopValidation(self.message)
 
+        if 'e' in field.raw_data[0].lower():
+            raise validators.StopValidation(self.message)
+
 
 class ResponseRequired(object):
     """

--- a/tests/app/validation/test_number_validator.py
+++ b/tests/app/validation/test_number_validator.py
@@ -48,6 +48,18 @@ class TestNumberValidator(unittest.TestCase):
 
         self.assertEqual(error_messages['INVALID_NUMBER'], str(ite.exception))
 
+    def test_numeric_exponential_invalid(self):
+        validator = NumberCheck()
+
+        mock_form = Mock()
+        mock_field = Mock()
+        mock_field.raw_data = ['2E2']
+
+        with self.assertRaises(StopValidation) as ite:
+            validator(mock_form, mock_field)
+
+        self.assertEqual(error_messages['INVALID_NUMBER'], str(ite.exception))
+
     def test_decimal_number_invalid(self):
         validator = DecimalPlaces(2)
 


### PR DESCRIPTION
### What is the context of this PR?
This will now restrict the respondent to enter exponential values with in numeric fields (Example: 2e2)

### How to review 
Launch any business survey where you can enter a numeric value
Enter a numeric value as: 2e2 and submit
Must now throw an error: Enter a number.

