### PR TITLE
Fix timeout issue related to block on feedback template

### DIFF
--- a/app/templates/feedback.html
+++ b/app/templates/feedback.html
@@ -3,9 +3,9 @@
 {% block feedback %}
 {% endblock feedback %}
 
-{% block content %}
+{% block main %}
 <div class="feedback">
     <h1 class="saturn">Survey feedback</h1>
     {% include('partials/feedback_form.html') %}
 </div>
-{% endblock content %}
+{% endblock main %}


### PR DESCRIPTION
Form fields in feedback template (No JS) do not fade with modal present.

### What is the context of this PR?
Rendered contents of a leaf template should sit within a `{% block main %}` to ensure correct inheritance.

Fixes #1246

### How to review 
Steps to reproduce the behaviour:

1. Launch test_timeout.json
2. click on help us improve link
3. which opens the feedback on a new tab (non Javascript)
4. allow to time out

All elements that should be behind the modal are grey and disabled.
