### PR TITLE
Bullet point from MWSS five weekly pay removed

### DIFF
--- a/data/en/1_0005.json
+++ b/data/en/1_0005.json
@@ -2668,7 +2668,6 @@
                                     "title": "Include:",
                                     "list": [
                                         "overtime and shift allowance payments",
-                                        "advanced holiday pay",
                                         "pay award arrears",
                                         "bonuses or commissions",
                                         "voluntary employee contributions to, and annual profit from, profit related pay schemes"


### PR DESCRIPTION
### What is the context of this PR?
The second bullet point from the include list in the five weekly gross pay question has been removed

### How to review 
1) Launch 1_0005 (MWSS) in app
2) Navigate to five weekly gross pay question
3) Should only be 4 bullet points in include and should not see 'advanced holiday pay'