### PR TITLE
Fix for #1247, able to submit with invalid answer id

### DIFF
--- a/app/submitter/converter.py
+++ b/app/submitter/converter.py
@@ -89,11 +89,17 @@ def convert_answers_to_data(answer_store, questionnaire_json, routing_path):
         answer_schema_list = SchemaHelper.get_answers_by_id_for_block(block_json)
 
         for answer in answers_in_block:
-            answer_schema = answer_schema_list[answer['answer_id']]
+            try:
+                answer_schema = answer_schema_list[answer['answer_id']]
+            except KeyError:
+                logger.error("No matching answer schema found in the store")
+                continue
+
             value = answer['value']
 
             if answer_schema is not None and value is not None and 'parent_answer_id' not in answer_schema:
-                if answer_schema['type'] != 'Checkbox' or any('q_code' not in option for option in answer_schema['options']):
+                if answer_schema['type'] != 'Checkbox' or any('q_code' not in option for option in
+                                                              answer_schema['options']):
                     if 'q_code' not in answer_schema:
                         continue
 


### PR DESCRIPTION
### What is the context of this PR?
scenario:
- when SR launched and data entered and then 'saved for later'
- if the answer id was changed in survey json schema
- then SR launched and going back to saved data

previously:
- resulted in a 500 error

currently:
- allows submission

### How to review 
run scenario described in context, on submission should now see successful submission not a 500

Fixes #1247
