### PR TITLE
Fix redundant code generating a HTTP 500 error

### DIFF
--- a/app/helpers/session_helper.py
+++ b/app/helpers/session_helper.py
@@ -1,20 +1,8 @@
 from flask import current_app
-from flask_login import current_user, logout_user
-
-from app.globals import get_questionnaire_store
-from app.utilities.schema import load_schema_from_metadata
+from flask_login import logout_user
 
 
-def _remove_survey_session_data():
+def remove_survey_session_data():
     current_app.eq['session_storage'].delete_session_from_db()
     current_app.eq['session_storage'].remove_user_ik()
     logout_user()
-
-
-def end_session_with_schema_context(schema=None):
-    if schema is None:
-        questionnaire_store = get_questionnaire_store(current_user.user_id, current_user.user_ik)
-        metadata = questionnaire_store.metadata
-        schema = load_schema_from_metadata(metadata)
-
-    _remove_survey_session_data()

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -12,7 +12,7 @@ from app.globals import get_answer_store, get_completed_blocks, get_metadata, ge
 from app.helpers.form_helper import get_form_for_location, post_form_for_location
 from app.helpers.schema_helper import SchemaHelper
 from app.helpers.path_finder_helper import path_finder
-from app.helpers.session_helper import end_session_with_schema_context, _remove_survey_session_data
+from app.helpers.session_helper import remove_survey_session_data
 from app.helpers import template_helper
 from app.questionnaire.location import Location
 from app.questionnaire.navigation import Navigation
@@ -282,7 +282,7 @@ def submit_answers(eq_id, form_type, collection_id):
             metadata['ru_ref'])
 
         get_questionnaire_store(current_user.user_id, current_user.user_ik).delete()
-        _remove_survey_session_data()
+        remove_survey_session_data()
 
         return redirect(url_for(
             '.get_thank_you',
@@ -316,7 +316,7 @@ def _save_sign_out(this_location, form):
             questionnaire_store.completed_blocks.remove(this_location)
             questionnaire_store.add_or_update()
 
-        end_session_with_schema_context(schema=g.schema_json)
+        remove_survey_session_data()
 
         return redirect(url_for('session.get_sign_out'))
 

--- a/app/views/session.py
+++ b/app/views/session.py
@@ -11,7 +11,7 @@ from app.globals import get_answer_store, get_completed_blocks
 from app.questionnaire.path_finder import PathFinder
 from app.storage.metadata_parser import parse_metadata
 from app.utilities.schema import load_schema_from_metadata
-from app.helpers.session_helper import end_session_with_schema_context
+from app.helpers.session_helper import remove_survey_session_data
 from app.views.errors import render_template
 
 logger = get_logger()
@@ -85,14 +85,14 @@ def get_timeout_continue():
 @session_blueprint.route('/expire-session', methods=["POST"])
 @login_required
 def post_expire_session():
-    end_session_with_schema_context()
+    remove_survey_session_data()
     return get_session_expired()
 
 
 @session_blueprint.route('/session-expired', methods=["GET"])
 def get_session_expired():
     if current_user.is_active:
-        end_session_with_schema_context()
+        remove_survey_session_data()
 
     return render_template('session-expired.html')
 
@@ -100,6 +100,6 @@ def get_session_expired():
 @session_blueprint.route('/signed-out', methods=["GET"])
 def get_sign_out():
     if current_user.is_active:
-        end_session_with_schema_context()
+        remove_survey_session_data()
 
     return render_template('signed-out.html')


### PR DESCRIPTION
Session helper [`end_session_with_schema_context`](https://github.com/ONSdigital/eq-survey-runner/commit/339f0baadda65717227968e421973fbe080f8d81#diff-94ead32a421bdfa2e563a3fe15b53589R14) was necessary before template function refactor to add theme context to a session but is now redundant and has been removed.

### What is the context of this PR?
Following the amendments to [how templates are rendered](https://github.com/ONSdigital/eq-survey-runner/commit/ad4f69a0b564141e90305da46721a9cf0ce2beac), the helper method `end_session_with_schema_context` is no longer required and in fact can cause an error when trying to use metadata after a submission #1266.

### How to review 
Ensure all references to old function (`end_session_with_schema_context`) has been removed; all tests pass; and themes are still rendered after signing out / submitting.
