### PR TITLE
Bind tx_id to logger for all requests

### DIFF
--- a/app/views/errors.py
+++ b/app/views/errors.py
@@ -22,12 +22,6 @@ class MultipleSurveyError(Exception):
     pass
 
 
-@errors_blueprint.after_request
-def add_cache_control(response):
-    response.cache_control.no_cache = True
-    return response
-
-
 @errors_blueprint.app_errorhandler(401)
 @errors_blueprint.app_errorhandler(NoTokenException)
 def unauthorized(error=None):
@@ -73,6 +67,10 @@ def http_exception(error):
 
 
 def log_exception(error, status_code):
+    metadata = get_metadata(current_user)
+    if metadata:
+        logger.bind(tx_id=metadata['tx_id'])
+
     if error:
         logger.error('an error has occurred', exc_info=error, url=request.url, status_code=status_code)
     else:

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -40,13 +40,16 @@ questionnaire_blueprint = Blueprint(name='questionnaire',
 
 @questionnaire_blueprint.before_request
 def before_request():
-    values = request.view_args
-    logger.info('questionnaire request', eq_id=values['eq_id'], form_type=values['form_type'],
-                ce_id=values['collection_id'], method=request.method, url_path=request.full_path)
-
     metadata = get_metadata(current_user)
     if metadata:
         logger.bind(tx_id=metadata['tx_id'])
+
+    values = request.view_args
+    logger.bind(eq_id=values['eq_id'], form_type=values['form_type'],
+                ce_id=values['collection_id'])
+    logger.info('questionnaire request', method=request.method, url_path=request.full_path)
+
+    if metadata:
         g.schema_json = load_schema_from_metadata(metadata)
         _check_same_survey(values['eq_id'], values['form_type'], values['collection_id'])
 


### PR DESCRIPTION
### What is the context of this PR?
tx_id was not being logged for all questionnaire requests so this has not been added.
tx_id was not being logged in any error logs so this has now been added to log on error messages where we have a metadata.

### How to review 
Test that all log messages contain a `tx_id`