### PR TITLE
Correct label on MWSS Weekly pay guidance Q2.1

### DIFF
--- a/data/en/1_0005.json
+++ b/data/en/1_0005.json
@@ -356,7 +356,7 @@
                                     ]
                                 },
                                 {
-                                    "title": "Include:",
+                                    "title": "Exclude:",
                                     "list": [
                                         "trainees on government schemes",
                                         "employees working abroad unless paid directly from this business\u2019s GB payroll",


### PR DESCRIPTION
Run MWSS (1_0005) and select Weekly Pay pattern. On the first question the second guidance title should be Exclude.
