### PR TITLE
Adds Jinja macro for email responses

### DIFF
--- a/app/templates/introduction.html
+++ b/app/templates/introduction.html
@@ -1,6 +1,6 @@
 {% extends theme('layouts/_onecol.html') %}
 
-{% import 'macros/helpers.html' as h %}
+{% import 'macros/helpers.html' as helpers %}
 
 {% block header %}
   {% include 'partials/header2.html' %}
@@ -42,7 +42,7 @@
               <dd class="dl__data mars">{{ meta.respondent.address.trading_as }}</dd>
             {% endif %}
             <dt id="details-changed-title" class="dl__title mercury">Change in details</dt>
-            <dd class="dl__data mars">{{h.telephone_number('details-changed-title')}} or email <a href="mailto:surveys@ons.gov.uk?subject=Change%20of%20details%20reference%20{{ meta.respondent.respondent_id }}" aria-describedby="details-changed-title">surveys@ons.gov.uk</a> if there have been any changes to your business name, address or structure</dd>
+            <dd class="dl__data mars">{{helpers.telephone_number('details-changed-title')}} or email {{helpers.email_address('details-changed-title', subject="Change of details reference " + meta.respondent.respondent_id)}} if there have been any changes to your business name, address or structure</dd>
           </dl>
         </div>
         <div class="grid__col col-6@s">

--- a/app/templates/macros/helpers.html
+++ b/app/templates/macros/helpers.html
@@ -19,3 +19,12 @@
   } %}
 <a href="tel:03001234931" {{attr|xmlattr}}>0300 1234 931</a>
 {%- endmacro -%}
+
+{%- macro email_address(aria_describedby=None, subject=None, class=None) -%}
+  {% set attr = {
+    "aria-describedby": aria_describedby,
+    "class": class
+  } %}
+<a href="mailto:surveys@ons.gov.uk{% if subject %}?subject={{ subject|urlencode }}{% endif %}" {{attr|xmlattr}}>surveys@ons.gov.uk</a>
+{%- endmacro -%}
+

--- a/app/templates/static/contact-us.html
+++ b/app/templates/static/contact-us.html
@@ -33,8 +33,7 @@
                                 Email
                             </h2>
                             <div class="question__description mars">
-                                <p><a href="mailto:surveys@ons.gov.uk"
-                                      target="_top">surveys@ons.gov.uk</a></p>
+                                <p>{{helpers.email_address()}}</p>
                             </div>
                             <h2 class="question__title neptune">
                                 Telephone


### PR DESCRIPTION
### What is the context of this PR?
Adds Jinja Macro to email address

### How to review 
As Email address is used in several places, A new macro has been added to helpers.html, so that changes to the email address only be made in one place.
To test run the app and check the introduction page, contact us and confirm that email address is a link and inspect.