### PR TITLE
Fix 500 error on unauthenticated thank you page request

### DIFF
--- a/app/helpers/path_finder_helper.py
+++ b/app/helpers/path_finder_helper.py
@@ -1,13 +1,14 @@
 from functools import wraps
 
 from flask import g
-from flask_login import current_user
+from flask_login import current_user, login_required
 from werkzeug.local import LocalProxy
 
 from app.globals import get_answer_store, get_metadata
 from app.questionnaire.path_finder import PathFinder
 
 
+@login_required
 def get_path_finder():
     finder = getattr(g, 'path_finder', None)
 

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -184,7 +184,6 @@ def get_thank_you(eq_id, form_type, collection_id):  # pylint: disable=unused-ar
         return _redirect_to_latest_location(routing_path, collection_id, eq_id, form_type)
 
 
-@login_required
 def _redirect_to_latest_location(routing_path, collection_id, eq_id, form_type):
     latest_location = path_finder.get_latest_location(get_completed_blocks(current_user),
                                                       routing_path=routing_path)

--- a/tests/app/app_context_test_case.py
+++ b/tests/app/app_context_test_case.py
@@ -8,11 +8,15 @@ class AppContextTestCase(unittest.TestCase):
     unittest.TestCase that creates a Flask app context on setUp
     and destroys it on tearDown
     """
+    LOGIN_DISABLED = False
+
     def setUp(self):
         setting_overrides = {
             "EQ_SERVER_SIDE_STORAGE_DATABASE_DRIVER": "sqlite",
-            "EQ_SERVER_SIDE_STORAGE_DATABASE_NAME": ""
+            "EQ_SERVER_SIDE_STORAGE_DATABASE_NAME": "",
+            "LOGIN_DISABLED": self.LOGIN_DISABLED
         }
+
         self._app = create_app(setting_overrides)
         self._app.config['SERVER_NAME'] = 'test'
         self._app_context = self._app.app_context()

--- a/tests/app/helpers/test_path_finder_helper.py
+++ b/tests/app/helpers/test_path_finder_helper.py
@@ -9,6 +9,9 @@ from app.helpers.path_finder_helper import path_finder
 @patch('app.helpers.path_finder_helper.get_metadata')
 @patch('app.helpers.path_finder_helper.get_answer_store')
 class TestPathFinderHelper(AppContextTestCase):
+
+    LOGIN_DISABLED = True
+
     def test_path_finder_instantiated_once(self, mock_path_finder, _, __):
         g.schema_json = {}
 

--- a/tests/integration/questionnaire/test_questionnaire_thank_you.py
+++ b/tests/integration/questionnaire/test_questionnaire_thank_you.py
@@ -1,0 +1,8 @@
+from tests.integration.integration_test_case import IntegrationTestCase
+
+
+class TestQuestionnaireThankYou(IntegrationTestCase):
+
+    def test_thank_you_unauthenticated(self):
+        self.get('/questionnaire/test/0205/ce/thank-you')
+        self.assertStatusUnauthorised()


### PR DESCRIPTION
After the recent changes in #1222 a HTTP 500 error was being generated when visiting a thank-you page URL without a cookie. This was due to path finder trying to access the questionnaire store without any user context. The fix applies the @login_required decorator to the path finder global. This generates a 401 error when called without a user session.

Fixes: #1277

### How to review 
- Visit `/questionnaire/1/0001/0/thank-you` on a survey runner environment (ensure you don't have a session cookie)
- Verify that a 401 'Your session has expired' page is displayed