### PR TITLE
Fix expandable (JS) feedback form not fading out with rest of page

### DIFF
--- a/app/templates/introduction.html
+++ b/app/templates/introduction.html
@@ -10,11 +10,12 @@
 {% endblock %}
 
 {% block subheader %}
-{% set form = content.form %}
-{% include theme('partials/feedback/expandable_inline.html') %}
+{% include theme('partials/feedback_call_to_action.html') %}
 
 {{super()}}
 {% endblock subheader %}
+
+{% set form = content.form %}
 
 {%- if legal_basis == 'StatisticsOfTradeAct' -%}
   {% set legal_text = "Your response is legally required" %}
@@ -23,6 +24,8 @@
 {% block page_title %}{{survey_title}}{% endblock %}
 
 {% block main %}
+
+  {% include theme('partials/feedback/expandable_inline.html') %}
 
   {% block business_details %}
 

--- a/app/templates/layouts/_questionnaire.html
+++ b/app/templates/layouts/_questionnaire.html
@@ -4,7 +4,7 @@
 {% block page_title %}{{page_title}}{% endblock %}
 
 {% block subheader %}
-{% include theme('partials/feedback/expandable_inline.html') %}
+{% include theme('partials/feedback_call_to_action.html') %}
 
 {{super()}}
 {% endblock subheader %}
@@ -20,6 +20,8 @@
 {% endblock %}
 
 {% block main %}
+
+    {% include theme('partials/feedback/expandable_inline.html') %}
 
     {% block form_errors %}{% endblock %}
 

--- a/app/templates/partials/feedback/expandable_inline.html
+++ b/app/templates/partials/feedback/expandable_inline.html
@@ -1,5 +1,3 @@
-{% import 'macros/helpers.html' as helpers %}
-{% include theme('partials/feedback_call_to_action.html') %}
 <div class="feedback__inline js-feedback-inline is-collapsed">
     <div class="feedback__border">
         {% include theme('partials/feedback_form.html') %}


### PR DESCRIPTION
Inline, expandable feedback form is not greyed out with the rest of the page upon timeout.

Fixes: #1280

### What is the context of this PR?
Keeps CTA elements in subheader but moves expandable feedback form into main block. Ensures helpers import are consistent.

### How to review 
- Open expandable feedback form and check it fades/greys out with the rest of the page on timeout.
- Tests (spec=inline-feedback) all pass.
