### PR TITLE
Use ChromeHeadless for old function tests

### DIFF
--- a/tests/functional/capabilities.js
+++ b/tests/functional/capabilities.js
@@ -15,6 +15,17 @@ export const chrome = {
   ...defaultCapabilities
 }
 
+export const chromeHeadless = {
+  browserName: 'chrome',
+  browser_version: '48.0',
+  os: 'OS X',
+  os_version: 'Yosemite',
+  chromeOptions: {
+    args: ['--headless', '--window-size=1024,1158', '--no-sandbox']
+  },
+  ...defaultCapabilities
+}
+
 export const chromeNoJS = {
   ...chrome,
   name: 'Chrome (No JavaScript)',

--- a/tests/functional/config.js
+++ b/tests/functional/config.js
@@ -1,5 +1,5 @@
 import {paths} from '../../gulp/paths'
-import {chrome, firefox, phantomjs} from './capabilities'
+import {chrome, firefox, chromeHeadless} from './capabilities'
 import {argv} from 'yargs'
 
 let config = {
@@ -59,26 +59,14 @@ const browserStackConfig = {
   browserstackLocal: true
 }
 
-const phantomjsConfig = {
-  services: ['phantomjs'],
-  waitforTimeout: 3000,
-  capabilities: [phantomjs],
-  maxInstances: 4,
-  phantomjsOpts: {
-    ignoreSslErrors: true
-  },
-  before: function() {
-    browser.setViewportSize({
-      width: 1280,
-      height: 1024
-    })
-  }
+const chromeHeadlessConfig = {
+  capabilities: [chromeHeadless]
 }
 
 if (process.env.TRAVIS === 'true') {
   config = {
     ...config,
-    ...phantomjsConfig,
+    ...chromeHeadlessConfig,
     logLevel: 'silent'
   }
 } else {
@@ -87,7 +75,7 @@ if (process.env.TRAVIS === 'true') {
   } else if (argv.browserstack) {
     config = Object.assign(config, browserStackConfig)
   } else if (argv.headless) {
-    config = Object.assign(config, phantomjsConfig)
+    config = Object.assign(config, chromeHeadlessConfig)
   }
 }
 


### PR DESCRIPTION
### What is the context of this PR?
The old functional tests are currently using PhantomJS. This is not very stable and causes issues in Travis and Concourse.

### How to review 
Do the tests run properly in Travis and Concourse?
