### PR TITLE
Stop ignoring /static/ folder in Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -56,7 +56,6 @@ venv
 .DS_Store
 
 node_modules/
-/static/
 tests/results
 tests/coverage
 tests/a11y


### PR DESCRIPTION
### What is the context of this PR?
Fixes styles missing in docker compose builds, see #1291

### How to review 
See steps in #1291