### PR TITLE
Fix summary page inline feedback

### DIFF
--- a/app/templates/confirmation.html
+++ b/app/templates/confirmation.html
@@ -1,4 +1,4 @@
-{% extends 'layouts/_questionnaire.html' %}
+{% extends theme('layouts/_questionnaire.html') %}
 
 {% block page_title %}{{_("Submit answers")}} - {{survey_title}}{% endblock %}
 

--- a/app/templates/interstitial.html
+++ b/app/templates/interstitial.html
@@ -1,4 +1,4 @@
-{% extends 'layouts/_questionnaire.html' %}
+{% extends theme('layouts/_questionnaire.html') %}
 
 {% set submit_btn_text = 'Continue' %}
 

--- a/app/templates/layouts/_questionnaire.html
+++ b/app/templates/layouts/_questionnaire.html
@@ -12,7 +12,6 @@
 {% set block = content.block %}
 {% set form = content.form %}
 
-
 {% block sidebar %}
   {% if navigation %}
     {% include theme('partials/navigation.html') %}
@@ -21,7 +20,7 @@
 
 {% block main %}
 
-    {% include theme('partials/feedback/expandable_inline.html') %}
+    {% block inline_feedback %}{% include theme('partials/feedback/expandable_inline.html') %}{% endblock %}
 
     {% block form_errors %}{% endblock %}
 

--- a/app/templates/summary.html
+++ b/app/templates/summary.html
@@ -15,6 +15,8 @@
 
 {% block main -%}
 
+{% block inline_feedback %}{{ super() }}{% endblock %}
+
 <div>
   <h1 class="saturn">Your responses</h1>
   <div class="print__message panel panel--simple panel--error">


### PR DESCRIPTION
Adds inline_feedback block for rendering independently of main.

Fixes: #1293 

### How to review 
Launch any business survey
navigate to summary screen
click on help us improve
should appear top of page
