### PR TITLE
Remove setViewportSize from functional test

### DIFF
--- a/tests/new_functional/spec/simultaneous-surveys.spec.js
+++ b/tests/new_functional/spec/simultaneous-surveys.spec.js
@@ -17,7 +17,6 @@ describe('Given the user launches two surveys', function() {
 
     let launchSecondTab = browser
         .newWindow('/status', this.secondTab)
-        .setViewportSize({ width: 1024, height: 1158 })
         .then( () => {
           return helpers.openQuestionnaire('test_textarea.json');
         });


### PR DESCRIPTION
### What is the context of this PR?
We've started getting errors while modifying the viewport size during functional tests. Since this is not required this will test whether the build will succeed without this step.

### How to review 
Travis builds pass.
