### PR TITLE
Update docker compose file to point at correct launcher image.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - "5000:5000"
 
   go-launch-a-survey:
-    image: onsdigital/go-launch-a-survey:load-schemas-from-register
+    image: onsdigital/go-launch-a-survey:latest
     environment:
       SURVEY_RUNNER_URL: http://localhost:5000
       SURVEY_REGISTER_URL: http://eq-survey-register:8080/


### PR DESCRIPTION
### What is the context of this PR?
Noticed while testing author preview that the `docker-compose.yml` configuration still points at a branch version of the `go-launch-a-survey` service.
This PR updates the docker compose configuration to use the latest image.

### How to review 
Able to launch the service using `docker-compose up`
