### PR TITLE
Remove map method from answer store

### DIFF
--- a/app/data_model/questionnaire_store.py
+++ b/app/data_model/questionnaire_store.py
@@ -35,7 +35,7 @@ class QuestionnaireStore:
     def delete(self):
         self._storage.delete()
         self.metadata = {}
-        self.answer_store.answers = []
+        self.answer_store.clear()
         self.completed_blocks = []
 
     def add_or_update(self):

--- a/app/questionnaire/navigation.py
+++ b/app/questionnaire/navigation.py
@@ -2,7 +2,6 @@ import copy
 from collections import defaultdict
 
 from structlog import get_logger
-from jinja2 import escape
 
 from app.helpers.schema_helper import SchemaHelper
 from app.questionnaire.location import Location
@@ -216,10 +215,9 @@ class Navigation(object):
         link_names = defaultdict(list)
 
         for answer_id in label_answer_ids:
-            answers = self.answer_store.filter(answer_id=answer_id)
-            for answer in answers:
+            for answer in self.answer_store.filter(answer_id=answer_id).escaped():
                 if answer['value']:
-                    link_names[answer['answer_instance']].append(escape(answer['value']))
+                    link_names[answer['answer_instance']].append(answer['value'])
 
         for link_name in link_names:
             link_names[link_name] = ' '.join(link_names[link_name])

--- a/app/questionnaire/rules.py
+++ b/app/questionnaire/rules.py
@@ -60,7 +60,7 @@ def evaluate_repeat(repeat_rule, answer_store):
     }
     if 'answer_id' in repeat_rule and 'type' in repeat_rule:
         repeat_index = repeat_rule['answer_id']
-        filtered = answer_store.filter(answer_id=repeat_index)
+        filtered = list(answer_store.filter(answer_id=repeat_index))
         repeat_function = repeat_functions[repeat_rule['type']]
         no_of_repeats = repeat_function(filtered)
 
@@ -114,9 +114,10 @@ def evaluate_when_rules(when_rules, metadata, answer_store, group_instance):
             answer_index = when_rule['id']
             filtered = answer_store.filter(answer_id=answer_index, group_instance=group_instance)
 
-            if len(filtered) > 1:
-                raise Exception('Multiple answers ({:d}) found evaluating when rule for answer ({})'.format(len(filtered), answer_index))
-            answer = filtered[0]['value'] if len(filtered) == 1 else None
+            if filtered.count() > 1:
+                raise Exception('Multiple answers ({:d}) found evaluating when rule for answer ({})'
+                                .format(filtered.count(), answer_index))
+            answer = filtered[0]['value'] if filtered.count() == 1 else None
             if not evaluate_rule(when_rule, answer):
                 return False
 

--- a/app/submitter/converter.py
+++ b/app/submitter/converter.py
@@ -135,12 +135,12 @@ def _get_checkbox_answer_data(answer_store, checkboxes_with_qcode, value):
             if 'child_answer_id' in option:
                 filtered = answer_store.filter(answer_id=option['child_answer_id'])
 
-                if len(filtered) > 1:
+                if filtered.count() > 1:
                     raise Exception('Multiple answers found for {}'.format(option['child_answer_id']))
 
                 # if the user has selected 'other' we need to find the value it refers to.
                 # when non-mandatory, the other box value can be empty, in this case we just use its value
-                checkbox_answer_data[option['q_code']] = filtered[0]['value'] if len(filtered) > 1 else option['value']
+                checkbox_answer_data[option['q_code']] = option['value']
             else:
                 checkbox_answer_data[option['q_code']] = user_answer
 

--- a/app/templating/summary/block.py
+++ b/app/templating/summary/block.py
@@ -3,12 +3,12 @@ from app.templating.summary.question import Question
 
 class Block:
 
-    def __init__(self, block_schema, answers_map, group_id, answer_store, metadata, url_for):
+    def __init__(self, block_schema, group_id, answer_store, metadata, url_for):
         self.id = block_schema['id']
         self.title = block_schema.get('title')
         self.number = block_schema.get('number')
         self.link = self._build_link(block_schema, group_id, metadata, url_for)
-        self.questions = self._build_questions(block_schema, answers_map, answer_store, metadata)
+        self.questions = self._build_questions(block_schema, answer_store, metadata)
 
     @staticmethod
     def _build_link(block_schema, group_id, metadata, url_for):
@@ -23,10 +23,10 @@ class Block:
         return link
 
     @staticmethod
-    def _build_questions(block_schema, answers_map, answer_store, metadata):
+    def _build_questions(block_schema, answer_store, metadata):
         questions = []
         for question_schema in block_schema.get('questions', []):
-            question = Question(question_schema, answers_map, answer_store, metadata)
+            question = Question(question_schema, answer_store, metadata)
             if not question.is_skipped:
                 questions.append(question)
         return questions

--- a/app/templating/summary/group.py
+++ b/app/templating/summary/group.py
@@ -3,18 +3,18 @@ from app.templating.summary.block import Block
 
 class Group:
 
-    def __init__(self, group_schema, answers_map, path, answer_store, metadata, url_for):
+    def __init__(self, group_schema, path, answer_store, metadata, url_for):
         self.id = group_schema['id']
         self.title = group_schema['title']
-        self.blocks = self._build_blocks(group_schema, answers_map, path, answer_store, metadata, url_for)
+        self.blocks = self._build_blocks(group_schema, path, answer_store, metadata, url_for)
 
     @staticmethod
-    def _build_blocks(group_schema, answers_map, path, answer_store, metadata, url_for):
+    def _build_blocks(group_schema, path, answer_store, metadata, url_for):
         blocks = []
 
         for block in group_schema['blocks']:
             if block['id'] in [location.block_id for location in path] and \
                     block['type'] == 'Questionnaire':
-                blocks.extend([Block(block, answers_map, group_schema['id'], answer_store, metadata, url_for)])
+                blocks.extend([Block(block, group_schema['id'], answer_store, metadata, url_for)])
 
         return blocks

--- a/app/templating/summary_context.py
+++ b/app/templating/summary_context.py
@@ -1,5 +1,4 @@
 from flask import url_for
-from jinja2 import escape
 from app.helpers.schema_helper import SchemaHelper
 from app.questionnaire.path_finder import PathFinder
 from app.templating.summary.group import Group
@@ -17,14 +16,9 @@ def build_summary_rendering_context(schema_json, answer_store, metadata):
     path = navigator.get_full_routing_path()
     groups = []
 
-    answers_map = answer_store.map()
-    for answer_id, value in answers_map.items():
-        if isinstance(value, str):
-            answers_map[answer_id] = escape(value)
-
     for group in schema_json['groups']:
         if SchemaHelper.group_has_questions(group) \
                 and group['id'] in [location.group_id for location in path]:
-            groups.extend([Group(group, answers_map, path, answer_store, metadata, url_for)])
+            groups.extend([Group(group, path, answer_store, metadata, url_for)])
 
     return groups

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -339,16 +339,17 @@ def _household_answers_changed(answer_store):
     remove = [k for k in stripped_form if 'action[' in k]
     for k in remove:
         del stripped_form[k]
-    if len(household_answers) != len(stripped_form):
+    if household_answers.count() != len(stripped_form):
         return True
     for answer in request.form:
         answer_id, answer_index = extract_answer_id_and_instance(answer)
 
-        stored_answer = next(
-            (d for d in household_answers if d['answer_id'] == answer_id and
-             d['answer_instance'] == answer_index),
-            None,
-        )
+        try:
+            stored_answer = household_answers.filter(
+                answer_id=answer_id,
+                answer_instance=answer_index)[0]
+        except IndexError:
+            stored_answer = None
 
         if stored_answer and (stored_answer['value'] or '') != request.form[answer]:
             return True

--- a/tests/app/templating/summary/test_block.py
+++ b/tests/app/templating/summary/test_block.py
@@ -9,14 +9,14 @@ def build_block_schema(question_schema):
     block_schema = {
         'id': 'block_id',
         'title': 'A section title',
-        'number': "1",
+        'number': '1',
         'questions': question_schema
     }
     return block_schema
 
 
-def build_question_schema(id, answer_schemas):
-    return {'id': id, 'answers': answer_schemas, 'skipped': False, 'title': 'title', 'type': 'GENERAL'}
+def build_question_schema(_id, answer_schemas):
+    return {'id': _id, 'answers': answer_schemas, 'skipped': False, 'title': 'title', 'type': 'GENERAL'}
 
 
 class TestSection(TestCase):
@@ -27,18 +27,17 @@ class TestSection(TestCase):
         answer_schema = mock.MagicMock()
         question_schema = build_question_schema('question_id', [answer_schema])
         block_schema = build_block_schema([question_schema])
-        answers_map = mock.MagicMock()
         answer_store = mock.MagicMock()
         metadata = mock.MagicMock()
         url_for = mock.MagicMock()
 
         # When
-        block = Block(block_schema, answers_map, 'group_id', answer_store, metadata, url_for)
+        block = Block(block_schema, 'group_id', answer_store, metadata, url_for)
 
         # Then
         self.assertEqual(block.id, 'block_id')
         self.assertEqual(block.title, 'A section title')
-        self.assertEqual(block.number, "1")
+        self.assertEqual(block.number, '1')
         self.assertEqual(len(block.questions), 1)
 
     def test_create_section_with_multiple_questions(self):
@@ -48,13 +47,12 @@ class TestSection(TestCase):
         first_question_schema = build_question_schema('question_1', [first_answer_schema])
         second_question_schema = build_question_schema('question_2', [second_answer_schema])
         block_schema = build_block_schema([first_question_schema, second_question_schema])
-        answers_map = mock.MagicMock()
         answer_store = mock.MagicMock()
         metadata = mock.MagicMock()
         url_for = mock.MagicMock()
 
         # When
-        block = Block(block_schema, answers_map, 'group_id', answer_store, metadata, url_for)
+        block = Block(block_schema, 'group_id', answer_store, metadata, url_for)
 
         # Then
         self.assertEqual(len(block.questions), 2)

--- a/tests/app/templating/summary/test_question.py
+++ b/tests/app/templating/summary/test_question.py
@@ -5,18 +5,18 @@ import mock
 from app.templating.summary.question import Question
 from app.data_model.answer_store import Answer, AnswerStore
 
+
 class TestQuestion(TestCase):
 
     def test_create_question(self):
         # Given
-        answers_map = mock.MagicMock()
         answer_schema = mock.MagicMock()
-        answer_store = mock.MagicMock()
+        answer_store = AnswerStore()
         metadata = mock.MagicMock()
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answers_map, answer_store, metadata)
+        question = Question(question_schema, answer_store, metadata)
 
         # Then
         self.assertEqual(question.id, 'question_id')
@@ -25,14 +25,13 @@ class TestQuestion(TestCase):
 
     def test_create_question_with_no_answers(self):
         # Given
-        answers_map = {}
         answer_schema = mock.MagicMock()
-        answer_store = mock.MagicMock()
+        answer_store = AnswerStore()
         metadata = mock.MagicMock()
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answers_map, answer_store, metadata)
+        question = Question(question_schema, answer_store, metadata)
 
         # Then
         self.assertEqual(question.id, 'question_id')
@@ -41,16 +40,25 @@ class TestQuestion(TestCase):
 
     def test_create_question_with_multiple_answers(self):
         # Given
-        answers_map = {'answer_1': 'Han',
-                   'answer_2': 'Solo'}
-        answer_store = mock.MagicMock()
+        answer_store = AnswerStore([{
+            'answer_id': 'answer_1',
+            'block_id': '',
+            'value': 'Han',
+            'answer_instance': 0,
+        }, {
+            'answer_id': 'answer_2',
+            'block_id': '',
+            'value': 'Solo',
+            'answer_instance': 0,
+        }])
         metadata = mock.MagicMock()
         first_answer_schema = {'id': 'answer_1', 'label': 'First name', 'type': 'text'}
         second_answer_schema = {'id': 'answer_2', 'label': 'Surname', 'type': 'text'}
-        question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [first_answer_schema, second_answer_schema]}
+        question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL',
+                           'answers': [first_answer_schema, second_answer_schema]}
 
         # When
-        question = Question(question_schema, answers_map, answer_store, metadata)
+        question = Question(question_schema, answer_store, metadata)
 
         # Then
         self.assertEqual(len(question.answers), 2)
@@ -59,16 +67,25 @@ class TestQuestion(TestCase):
 
     def test_merge_date_range_answers(self):
         # Given
-        answers_map = {'answer_1': '13/02/2016',
-                       'answer_2': '13/09/2016'}
-        answer_store = mock.MagicMock()
+        answer_store = AnswerStore([{
+            'answer_id': 'answer_1',
+            'block_id': '',
+            'value': '13/02/2016',
+            'answer_instance': 0,
+        }, {
+            'answer_id': 'answer_2',
+            'block_id': '',
+            'value': '13/09/2016',
+            'answer_instance': 0,
+        }])
         metadata = mock.MagicMock()
         first_date_answer_schema = {'id': 'answer_1', 'label': 'From', 'type': 'date'}
         second_date_answer_schema = {'id': 'answer_2', 'label': 'To', 'type': 'date'}
-        question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'DateRange', 'answers': [first_date_answer_schema, second_date_answer_schema]}
+        question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'DateRange',
+                           'answers': [first_date_answer_schema, second_date_answer_schema]}
 
         # When
-        question = Question(question_schema, answers_map, answer_store, metadata)
+        question = Question(question_schema, answer_store, metadata)
 
         # Then
         self.assertEqual(len(question.answers), 1)
@@ -77,11 +94,27 @@ class TestQuestion(TestCase):
 
     def test_merge_multiple_date_range_answers(self):
         # Given
-        answers_map = {'answer_1': '13/02/2016',
-                       'answer_2': '13/09/2016',
-                       'answer_3': '13/03/2016',
-                       'answer_4': '13/10/2016'}
-        answer_store = mock.MagicMock()
+        answer_store = AnswerStore([{
+            'answer_id': 'answer_1',
+            'block_id': '',
+            'value': '13/02/2016',
+            'answer_instance': 0,
+        }, {
+            'answer_id': 'answer_2',
+            'block_id': '',
+            'value': '13/09/2016',
+            'answer_instance': 0,
+        }, {
+            'answer_id': 'answer_3',
+            'block_id': '',
+            'value': '13/03/2016',
+            'answer_instance': 0,
+        }, {
+            'answer_id': 'answer_4',
+            'block_id': '',
+            'value': '13/10/2016',
+            'answer_instance': 0,
+        }])
         metadata = mock.MagicMock()
         first_date_answer_schema = {'id': 'answer_1', 'label': 'From', 'type': 'date'}
         second_date_answer_schema = {'id': 'answer_2', 'label': 'To', 'type': 'date'}
@@ -91,7 +124,7 @@ class TestQuestion(TestCase):
                            [first_date_answer_schema, second_date_answer_schema, third_date_answer_schema, fourth_date_answer_schema]}
 
         # When
-        question = Question(question_schema, answers_map, answer_store, metadata)
+        question = Question(question_schema, answer_store, metadata)
 
         # Then
         self.assertEqual(len(question.answers), 2)
@@ -102,22 +135,26 @@ class TestQuestion(TestCase):
 
     def test_checkbox_button_options(self):
         # Given
-        answers_map = {'answer_1': ['Light Side', 'Dark Side']}
+        answer_store = AnswerStore([{
+            'answer_id': 'answer_1',
+            'block_id': '',
+            'value': ['Light Side', 'Dark Side'],
+            'answer_instance': 0,
+        }])
+
         options = [{
             'label': 'Light Side',
             'value': 'Light Side',
-          },
-          {
+        }, {
             'label': 'Dark Side',
             'value': 'Dark Side',
-          }]
-        answer_store = mock.MagicMock()
+        }]
         metadata = mock.MagicMock()
         answer_schema = {'id': 'answer_1', 'label': 'Which side?', 'type': 'Checkbox', 'options': options}
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answers_map, answer_store, metadata)
+        question = Question(question_schema, answer_store, metadata)
 
         # Then
         self.assertEqual(len(question.answers[0].value), 2)
@@ -126,25 +163,28 @@ class TestQuestion(TestCase):
 
     def test_checkbox_button_other_option_empty(self):
         # Given
-        answer_store = mock.MagicMock()
+        answer_store = AnswerStore([{
+            'answer_id': 'answer_1',
+            'block_id': '',
+            'value': ['Other option label', ''],
+            'answer_instance': 0,
+        }])
         metadata = mock.MagicMock()
-        answers_map = {'answer_1': ['Other option label', '']}
         options = [{
             'label': 'Light Side',
             'value': 'Light Side',
-          },
-          {
+        }, {
             'label': 'Other option label',
             'value': 'other',
-            "other": {
-              "label": "Please specify other"
+            'other': {
+                'label': 'Please specify other'
             }
-          }]
+        }]
         answer_schema = {'id': 'answer_1', 'label': 'Which side?', 'type': 'Checkbox', 'options': options}
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answers_map, answer_store, metadata)
+        question = Question(question_schema, answer_store, metadata)
 
         # Then
         self.assertEqual(len(question.answers[0].value), 1)
@@ -153,34 +193,41 @@ class TestQuestion(TestCase):
 
     def test_checkbox_answer_with_other_value_returns_the_value(self):
         # Given
-        answer_store = mock.MagicMock()
+        answer_store = AnswerStore([{
+            'answer_id': 'answer_1',
+            'block_id': '',
+            'value': ['Light Side', 'Other'],
+            'answer_instance': 0,
+        }, {
+            'answer_id': 'child_answer',
+            'block_id': '',
+            'value': 'Test',
+            'answer_instance': 0,
+        }])
         metadata = mock.MagicMock()
-        answers_map = {'answer_1': ['Light Side', 'Other'], 'child_answer': 'Test'}
         options = [{
             'label': 'Light Side',
             'value': 'Light Side',
-        },
-            {
-            "label": "Other",
-            "value": "Other",
-            "child_answer_id": "child_answer"
+        }, {
+            'label': 'Other',
+            'value': 'Other',
+            'child_answer_id': 'child_answer'
         }]
         answer_schema = [{
             'id': 'answer_1',
             'label': 'Which side?',
             'type': 'Checkbox',
             'options': options
-        },
-            {
-            "parent_answer_id": "answer_1",
-            "id": "child_answer",
-            "type": "TextField"
+        }, {
+            'parent_answer_id': 'answer_1',
+            'id': 'child_answer',
+            'type': 'TextField'
         }]
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL',
                            'answers': answer_schema}
 
         # When
-        question = Question(question_schema, answers_map, answer_store, metadata)
+        question = Question(question_schema, answer_store, metadata)
 
         # Then
         self.assertEqual(len(question.answers[0].value), 2)
@@ -188,23 +235,31 @@ class TestQuestion(TestCase):
 
     def test_checkbox_button_other_option_text(self):
         # Given
-        answer_store = mock.MagicMock()
+        answer_store = AnswerStore([{
+            'answer_id': 'answer_1',
+            'block_id': '',
+            'value': ['Light Side', 'other'],
+            'answer_instance': 0,
+        }, {
+            'answer_id': 'child_answer',
+            'block_id': '',
+            'value': 'Neither',
+            'answer_instance': 0,
+        }])
         metadata = mock.MagicMock()
-        answers_map = {'answer_1': ['Light Side', 'other'], 'child_answer': 'Neither'}
         options = [{
             'label': 'Light Side',
             'value': 'Light Side',
-          },
-          {
+        }, {
             'label': 'other',
             'value': 'other',
             'child_answer_id': 'child_answer'
-          }]
+        }]
         answer_schema = {'id': 'answer_1', 'label': 'Which side?', 'type': 'Checkbox', 'options': options}
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answers_map, answer_store, metadata)
+        question = Question(question_schema, answer_store, metadata)
 
         # Then
         self.assertEqual(len(question.answers[0].value), 2)
@@ -213,116 +268,138 @@ class TestQuestion(TestCase):
 
     def test_checkbox_button_none_selected_should_be_none(self):
         # Given
-        answer_store = mock.MagicMock()
+        answer_store = AnswerStore([{
+            'answer_id': 'answer_1',
+            'block_id': '',
+            'value': [],
+            'answer_instance': 0,
+        }])
         metadata = mock.MagicMock()
-        answers_map = {'answer_1': []}
         options = [{
             'label': 'Light Side',
             'value': 'Light Side',
-          }]
+        }]
         answer_schema = {'id': 'answer_1', 'label': 'Which side?', 'type': 'Checkbox', 'options': options}
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answers_map, answer_store, metadata)
+        question = Question(question_schema, answer_store, metadata)
 
         # Then
         self.assertEqual(question.answers[0].value, None)
 
     def test_radio_button_other_option_empty(self):
         # Given
-        answer_store = mock.MagicMock()
+        answer_store = AnswerStore([{
+            'answer_id': 'answer_1',
+            'block_id': '',
+            'value': '',
+            'answer_instance': 0,
+        }])
         metadata = mock.MagicMock()
-        answers_map = {'answer_1': ''}
         options = [{
             'label': 'Light Side',
             'value': 'Light Side',
-          },
-          {
+        }, {
             'label': 'Other option label',
             'value': 'other',
-            "other": {
-              "label": "Please specify other"
+            'other': {
+                'label': 'Please specify other'
             }
-          }]
+        }]
         answer_schema = {'id': 'answer_1', 'label': 'Which side?', 'type': 'Radio', 'options': options}
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answers_map, answer_store, metadata)
+        question = Question(question_schema, answer_store, metadata)
 
         # Then
         self.assertEqual(question.answers[0].value, 'Other option label')
 
     def test_radio_button_other_option_text(self):
         # Given
-        answer_store = mock.MagicMock()
+        answer_store = AnswerStore([{
+            'answer_id': 'answer_1',
+            'block_id': '',
+            'value': 'I want to be on the dark side',
+            'answer_instance': 0,
+        }])
         metadata = mock.MagicMock()
-        answers_map = {'answer_1': 'I want to be on the dark side'}
         options = [{
             'label': 'Light Side',
             'value': 'Light Side',
-          },
-          {
+        }, {
             'label': 'Other option label',
             'value': 'other',
-            "other": {
-              "label": "Please specify other"
+            'other': {
+                'label': 'Please specify other'
             }
-          }]
+        }]
         answer_schema = {'id': 'answer_1', 'label': 'Which side?', 'type': 'Radio', 'options': options}
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answers_map, answer_store, metadata)
+        question = Question(question_schema, answer_store, metadata)
 
         # Then
         self.assertEqual(question.answers[0].value, 'I want to be on the dark side')
 
     def test_radio_button_none_selected_should_be_none(self):
         # Given
-        answer_store = mock.MagicMock()
+        answer_store = AnswerStore([{
+            'answer_id': 'answer_1',
+            'block_id': '',
+            'value': None,
+            'answer_instance': 0,
+        }])
         metadata = mock.MagicMock()
-        answers_map = {'answer_1': None}
         options = [{
             'label': 'Light Side',
             'value': 'Light Side',
-          }]
+        }]
         answer_schema = {'id': 'answer_1', 'label': 'Which side?', 'type': 'Radio', 'options': options}
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answers_map, answer_store, metadata)
+        question = Question(question_schema, answer_store, metadata)
 
         # Then
         self.assertEqual(question.answers[0].value, None)
 
     def test_radio_answer_with_other_value_returns_the_value(self):
         # Given
-        answer_store = mock.MagicMock()
+        answer_store = AnswerStore([{
+            'answer_id': 'answer_1',
+            'block_id': '',
+            'value': 'Other',
+            'answer_instance': 0,
+        }, {
+            'answer_id': 'child_answer',
+            'block_id': '',
+            'value': 'Test',
+            'answer_instance': 0,
+        }])
         metadata = mock.MagicMock()
-        answers_map = {'answer_1': 'Other', 'child_answer': 'Test'}
         options = [{
             'label': 'Other',
             'value': 'Other',
-            "child_answer_id": "child_answer"
+            'child_answer_id': 'child_answer'
         }]
         answer_schema = [{
             'id': 'answer_1',
             'label': 'Which side?',
             'type': 'Radio',
             'options': options
-        },
-            {
-                "parent_answer_id": "answer_1",
-                "id": "child_answer",
-                "type": "TextField"
-            }]
+        }, {
+            'parent_answer_id': 'answer_1',
+            'id': 'child_answer',
+            'type': 'TextField'
+        }]
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL',
                            'answers': answer_schema}
 
         # When
-        question = Question(question_schema, answers_map, answer_store, metadata)
+        question = Question(question_schema, answer_store, metadata)
 
         # Then
         self.assertEqual(question.answers[0].child_answer_value, 'Test')
@@ -330,10 +407,9 @@ class TestQuestion(TestCase):
     def test_question_should_be_skipped(self):
         # Given
         metadata = mock.MagicMock()
-        answers_map = {'answer_1': 'skip me'}
         answer = Answer(
-            answer_id="answer_1",
-            value="skip me",
+            answer_id='answer_1',
+            value='skip me',
         )
         answer_store = AnswerStore()
         answer_store.add(answer)
@@ -343,7 +419,7 @@ class TestQuestion(TestCase):
                            'skip_conditions': skip_conditions}
 
         # When
-        question = Question(question_schema, answers_map, answer_store, metadata)
+        question = Question(question_schema, answer_store, metadata)
 
         # Then
         self.assertTrue(question.is_skipped)
@@ -351,7 +427,6 @@ class TestQuestion(TestCase):
     def test_question_with_no_answers_should_not_be_skipped(self):
         # Given
         metadata = mock.MagicMock()
-        answers_map = {}
         answer_store = AnswerStore()
         answer_schema = {'id': 'answer_1', 'title': '', 'type': '', 'label': ''}
         skip_conditions = [{'when': [{'id': 'answer_1', 'condition': 'equals', 'value': 'skip me'}]}]
@@ -359,26 +434,36 @@ class TestQuestion(TestCase):
                            'skip_conditions': skip_conditions}
 
         # When
-        question = Question(question_schema, answers_map, answer_store, metadata)
+        question = Question(question_schema, answer_store, metadata)
 
         # Then
         self.assertFalse(question.is_skipped)
 
     def test_build_answers_repeating_answers(self):
         # Given
-        answer_store = mock.MagicMock()
+        answer_store = AnswerStore([{
+            'answer_id': 'answer',
+            'block_id': '',
+            'value': 'value',
+            'answer_instance': 0,
+        }, {
+            'answer_id': 'answer',
+            'block_id': '',
+            'value': 'value1',
+            'answer_instance': 0,
+        }, {
+            'answer_id': 'answer',
+            'block_id': '',
+            'value': 'value2',
+            'answer_instance': 0,
+        }])
         metadata = mock.MagicMock()
-        answers_map = {
-            'answer': 'value',
-            'answer_1': 'value1',
-            'answer_2': 'value2',
-        }
         answer_schema = {'id': 'answer', 'title': '', 'type': '', 'label': ''}
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'RepeatingAnswer',
                            'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answers_map, answer_store, metadata)
+        question = Question(question_schema, answer_store, metadata)
 
         # Then
         self.assertEqual(len(question.answers), 3)

--- a/tests/app/templating/test_summary_context.py
+++ b/tests/app/templating/test_summary_context.py
@@ -45,8 +45,12 @@ class TestSummaryContext(AppContextTestCase):
         self.assertEqual(len(context), 1)
 
     def test_summary_context_html_encodes_answers(self):
-        answer_store = AnswerStore()
-        answer_store.map = MagicMock(return_value={'choose-your-side-answer': """<>"'&"""})
+        answer_store = AnswerStore([{
+            'answer_id': 'choose-your-side-answer',
+            'block_id': '',
+            'value': """<>"'&""",
+            'answer_instance': 0,
+        }])
 
         routing_path = [Location(
             block_id='choose-your-side-block',

--- a/tests/integration/questionnaire/test_questionnaire_remove_repeat_answers.py
+++ b/tests/integration/questionnaire/test_questionnaire_remove_repeat_answers.py
@@ -7,6 +7,9 @@ class TestQuestionnaireRemoveRepeatAnswers(IntegrationTestCase):
 
     def test_should_remove_household_composition_answer_when_no_answer(self):
         with patch('app.views.questionnaire.get_answer_store') as get_answer_store:
+            # avoid TypeError when trying to compare MagicMock and int in rules.py
+            get_answer_store.return_value.filter.return_value.count.return_value = 1
+
             # Given
             self.launchSurvey('census', 'household')
 
@@ -18,6 +21,9 @@ class TestQuestionnaireRemoveRepeatAnswers(IntegrationTestCase):
 
     def test_should_not_remove_answers_when_yes_answer(self):
         with patch('app.views.questionnaire.get_answer_store') as get_answer_store:
+            # avoid TypeError when trying to compare MagicMock and int in rules.py
+            get_answer_store.return_value.filter.return_value.count.return_value = 1
+
             # Given
             self.launchSurvey('census', 'household')
 
@@ -29,6 +35,9 @@ class TestQuestionnaireRemoveRepeatAnswers(IntegrationTestCase):
 
     def test_should_remove_all_repeating_groups(self):
         with patch('app.views.questionnaire.get_answer_store') as get_answer_store:
+            # avoid TypeError when trying to compare MagicMock and int in rules.py
+            get_answer_store.return_value.filter.return_value.count.return_value = 1
+
             # Given
             self.launchSurvey('census', 'household')
 

--- a/tests/integration/views/test_questionnaire.py
+++ b/tests/integration/views/test_questionnaire.py
@@ -234,7 +234,7 @@ class TestQuestionnaire(IntegrationTestCase):
         remove_empty_household_members_from_answer_store(self.question_store.answer_store, 'who-lives-here')
 
         for answer in answers:
-            self.assertFalse(self.question_store.answer_store.exists(answer))
+            self.assertIsNone(self.question_store.answer_store.find(answer))
 
     def test_remove_empty_household_members_values_entered_are_stored(self):
         g.schema_json = load_schema_file('census_household.json')
@@ -299,10 +299,10 @@ class TestQuestionnaire(IntegrationTestCase):
         remove_empty_household_members_from_answer_store(self.question_store.answer_store, 'who-lives-here')
 
         for answer in answered:
-            self.assertTrue(self.question_store.answer_store.exists(answer))
+            self.assertIsNotNone(self.question_store.answer_store.find(answer))
 
         for answer in unanswered:
-            self.assertFalse(self.question_store.answer_store.exists(answer))
+            self.assertIsNone(self.question_store.answer_store.find(answer))
 
     def test_remove_empty_household_members_partial_answers_are_stored(self):
         g.schema_json = load_schema_file('census_household.json')
@@ -388,10 +388,10 @@ class TestQuestionnaire(IntegrationTestCase):
         remove_empty_household_members_from_answer_store(self.question_store.answer_store, 'who-lives-here')
 
         for answer in answered:
-            self.assertTrue(self.question_store.answer_store.exists(answer))
+            self.assertIsNotNone(self.question_store.answer_store.find(answer))
 
         for answer in partially_answered:
-            self.assertTrue(self.question_store.answer_store.exists(answer))
+            self.assertIsNotNone(self.question_store.answer_store.find(answer))
 
     def test_remove_empty_household_members_middle_name_only_not_stored(self):
         g.schema_json = load_schema_file('census_household.json')
@@ -427,7 +427,7 @@ class TestQuestionnaire(IntegrationTestCase):
         remove_empty_household_members_from_answer_store(self.question_store.answer_store, 'who-lives-here')
 
         for answer in unanswered:
-            self.assertFalse(self.question_store.answer_store.exists(answer))
+            self.assertIsNone(self.question_store.answer_store.find(answer))
 
     def test_given_introduction_page_when_get_page_title_then_defaults_to_survey_title(self):
         # Given


### PR DESCRIPTION
### What is the context of this PR?
From @ajmaddaford: "The Answer Store map method was originally created to output a WTForms POST data compatible format. This is then used to serialise the form data back into the WTForms form object. 

The map method has since been used in the summary context, accessing the answer values from this flattened list. Accessing the answers in this way is unclear and from https://github.com/ONSdigital/eq-survey-runner/pull/1158 will mean both the mapped answer values (used for answer values) and the answer store are being used."

Latest changes include adding method chaining to the answer store objects as well as reducing the overall complexity of building summary context.

### How to review 
* Complete survey and check summary page displays expected results
* Ensure changes are clear and obvious
* Check tests all pass across environments
