### PR TITLE
Add AWS CLI to docker container to get secrets on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.4
 
-RUN pip install -U pipenv==8.2.7
+RUN pip install -U pipenv==8.2.7 \
+  && pip install -U awscli==1.11.174
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
### What is the context of this PR?
Adds the AWS CLI to the docker container so it can get the secrets from S3 on startup.

### How to review 
- Build and run the docker container
- Verify the `aws` command is working in the container e.g. `docker exec -ti eqsurveyrunner_eq-survey-runner_1 aws`