### PR TITLE
Remove virtual env warning from app script

### DIFF
--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-if [ -n "$VIRTUAL_ENV" ]; then
-  echo "Already in virtual environment $VIRTUAL_ENV"
-else
-  echo "You need to be in a virtual environment please!"
-fi
-
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 


### PR DESCRIPTION
virtualenv does not currently set the VIRTUAL_ENV environment variable when activate_this.py is used (https://github.com/pypa/virtualenv/pull/1057). pipenv run uses activate_this.py rather than one of the other activation scripts. We should also not care about reporting a lack of virtual environment now that we use Pipenv to manage it.