### PR TITLE
Changed the name of the action button

### DIFF
--- a/app/templates/layouts/_questionnaire.html
+++ b/app/templates/layouts/_questionnaire.html
@@ -34,7 +34,7 @@
       {% endblock form_content %}
 
       {% block submit_button %}
-      <button class="btn btn--primary btn--lg" data-qa="btn-submit" type="submit" name="action[save_continue]">{{submit_btn_text or "Save and continue"}}</button>
+      <button class="btn btn--primary btn--lg" data-qa="btn-submit" type="submit" name="action[save_continue]">{{submit_btn_text or "Continue"}}</button>
       {% endblock %}
 
       <div class="u-mb-m">

--- a/tests/integration/census/test_census_communal_submission_data.py
+++ b/tests/integration/census/test_census_communal_submission_data.py
@@ -135,7 +135,7 @@ class TestCensusCommunalSubmissionData(IntegrationTestCase):
         # We are in the questionnaire
         self.assertInPage('Establishment')
         self.assertInPage('How would you describe your establishment?')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
 
         # When I submit an answer
         self.post(post_data={'establishment-type-answer': ['Hotel']})

--- a/tests/integration/census/test_census_household_submission_data.py
+++ b/tests/integration/census/test_census_household_submission_data.py
@@ -1110,7 +1110,7 @@ class TestCensusHouseholdSubmissionData(IntegrationTestCase):
     def complete_who_lives_here_section(self):
         # We are in the questionnaire
         self.assertInPage('Who lives here?')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
         # In Who lives here? Section
 
         self.post(post_data={'permanent-or-family-home-answer': ['Yes']})

--- a/tests/integration/census/test_census_individual_submission_data.py
+++ b/tests/integration/census/test_census_individual_submission_data.py
@@ -483,7 +483,7 @@ class TestCensusIndividualSubmissionData(IntegrationTestCase):
 
         # We are in the questionnaire
         self.assertInPage('What is your name?')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
 
         post_data = [
             {

--- a/tests/integration/mci/test_clear_error.py
+++ b/tests/integration/mci/test_clear_error.py
@@ -21,7 +21,7 @@ class TestClearError(IntegrationTestCase):
         # We are in the Questionnaire
         self.assertInPage('>Monthly Business Survey - Retail Sales Index</')
         self.assertInPage('What are the dates of the sales period you are reporting for?')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
 
         # check with have some guidance
         self.assertInPage('alcoholic drink')

--- a/tests/integration/mci/test_clear_value.py
+++ b/tests/integration/mci/test_clear_value.py
@@ -21,7 +21,7 @@ class TestClearValue(IntegrationTestCase):
         # We are in the Questionnaire
         self.assertInPage('>Monthly Business Survey - Retail Sales Index</')
         self.assertInPage('What are the dates of the sales period you are reporting for?')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
 
         # check with have some guidance
         self.assertInPage('alcoholic drink')

--- a/tests/integration/mci/test_empty_comments.py
+++ b/tests/integration/mci/test_empty_comments.py
@@ -17,7 +17,7 @@ class TestEmptyComments(IntegrationTestCase):
         # We are in the Questionnaire
         self.assertInPage('>Monthly Business Survey - Retail Sales Index</')
         self.assertInPage('What are the dates of the sales period you are reporting for?')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
 
         # We fill in our answers
         form_data = {

--- a/tests/integration/mci/test_empty_submission.py
+++ b/tests/integration/mci/test_empty_submission.py
@@ -19,7 +19,7 @@ class TestEmptySubmission(IntegrationTestCase):
 
         # We are in the Questionnaire
         self.assertInPage('What are the dates of the sales period you are reporting for?')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
 
         form_data = {
             # Start Date

--- a/tests/integration/mci/test_happy_path.py
+++ b/tests/integration/mci/test_happy_path.py
@@ -22,7 +22,7 @@ class TestHappyPath(IntegrationTestCase):
         # We are in the Questionnaire
         self.assertInPage('>Monthly Business Survey - Retail Sales Index</')
         self.assertInPage('What are the dates of the sales period you are reporting for?')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
 
         # check with have some guidance
         self.assertInPage('alcoholic drink')

--- a/tests/integration/mci/test_mci_submission_data.py
+++ b/tests/integration/mci/test_mci_submission_data.py
@@ -22,7 +22,7 @@ class TestMciSubmissionData(IntegrationTestCase):
         # We are in the Questionnaire
         self.assertInPage('>Monthly Business Survey - Retail Sales Index</')
         self.assertInPage('What are the dates of the sales period you are reporting for?')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
 
         # We fill in our answers
         form_data = {

--- a/tests/integration/mci/test_submission_with_errors.py
+++ b/tests/integration/mci/test_submission_with_errors.py
@@ -17,7 +17,7 @@ class TestSubmissionWithErrors(IntegrationTestCase):
         # We are in the Questionnaire
         self.assertInPage('>Monthly Business Survey - Retail Sales Index</')
         self.assertInPage('What are the dates of the sales period you are reporting for?')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
 
         form_data = {
             # Start Date

--- a/tests/integration/mwss/test_mwss_submission_data.py
+++ b/tests/integration/mwss/test_mwss_submission_data.py
@@ -142,7 +142,7 @@ class TestMwssSubmissionData(IntegrationTestCase):
         # We are in the Questionnaire
         self.assertInPage('>Monthly Wages and Salaries Survey</')
         self.assertInPage('Please indicate how frequently employees are paid:')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
 
         # When I submit an answer
         form_data = {'pay-pattern-frequency-answer': ['Weekly', 'Fortnightly',

--- a/tests/integration/qbs/test_qbs_submission_data.py
+++ b/tests/integration/qbs/test_qbs_submission_data.py
@@ -19,7 +19,7 @@ class TestQbsSubmissionData(IntegrationTestCase):
         # We are in the Questionnaire
         self.assertInPage('>Quarterly Business Survey</')
         self.assertInPage('On 1 April 2016 what was the number of employees for Integration Tests?')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
 
         # When I submit an answer
         self.post(post_data={'number-of-employees-male-more-30-hours': '1',

--- a/tests/integration/rsi/test_rsi_submission_data.py
+++ b/tests/integration/rsi/test_rsi_submission_data.py
@@ -16,7 +16,7 @@ class TestRsiSubmissionData(IntegrationTestCase):
         # We are in the Questionnaire
         self.assertInPage('>Monthly Business Survey - Retail Sales Index</')
         self.assertInPage('What are the dates of the period that you will be reporting for?')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
 
         # When I submit an answer
         form_data = {
@@ -92,7 +92,7 @@ class TestRsiSubmissionData(IntegrationTestCase):
         # We are in the Questionnaire
         self.assertInPage('>Monthly Business Survey - Retail Sales Index</')
         self.assertInPage('What are the dates of the period that you will be reporting for?')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
 
         # When I submit an answer
         form_data = {

--- a/tests/integration/star_wars/test_navigation.py
+++ b/tests/integration/star_wars/test_navigation.py
@@ -68,7 +68,7 @@ class TestNavigation(StarWarsTestCase):
         self.assertInUrl('thank-you')
 
     def _check_quiz_first_page(self):
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
         self.assertInPage('Star Wars Quiz')
         self.assertInPage('May the force be with you young EQ developer')
 

--- a/tests/integration/ukis/test_ukis_submission_data.py
+++ b/tests/integration/ukis/test_ukis_submission_data.py
@@ -221,7 +221,7 @@ class TestUkisSubmissionData(IntegrationTestCase):
         # We are in General Information section
 
         self.assertInPage('General Information')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
         self.post(post_data={'additional-comments-answer': 'Downstream data coverage test'})
         self.post(post_data={'general-information-hours-answer': '50',
                              'how-long-minutes-answer': '23'})
@@ -232,7 +232,7 @@ class TestUkisSubmissionData(IntegrationTestCase):
         # We are in Employees and Skills section
 
         self.assertInPage('Employees and Skills')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
         self.post(post_data={'employees-2014-answer': '100'})
         self.post(post_data={'employees-2016-answer': '120'})
         self.post(post_data={'employees-qualifications-2016-science-answer': '90',
@@ -253,7 +253,7 @@ class TestUkisSubmissionData(IntegrationTestCase):
         # We are in Turnover and Exports section
 
         self.assertInPage('Turnover and Exports')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
         self.post(post_data={'turnover-2014-answer': '3500'})
         self.post(post_data={'turnover-2016-answer': '4500'})
         self.post(post_data={'exports-2016-answer': '5500'})
@@ -268,7 +268,7 @@ class TestUkisSubmissionData(IntegrationTestCase):
         # We are in Public Financial Support for Innovation section
 
         self.assertInPage('Public Financial Support for Innovation')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
         self.post(post_data={'public-financial-support-authorities-answer': 'Yes',
                              'public-financial-support-central-government-answer': 'No',
                              'public-financial-support-eu-answer': 'Yes'})
@@ -284,7 +284,7 @@ class TestUkisSubmissionData(IntegrationTestCase):
         # We are in Co-operation on Innovation section
 
         self.assertInPage('Co-operation on Innovation')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
         form_data = {'years-internal-investment-r-d-answer': ['UK Regional',
                                                               'UK National',
                                                               'European Countries',
@@ -331,7 +331,7 @@ class TestUkisSubmissionData(IntegrationTestCase):
         # We are in Information Needed for Innovation section
 
         self.assertInPage('Information Needed for Innovation')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
         self.post(post_data={'importances-information-innovation-answer': 'High'})
         self.post(post_data={'importances-information-suppliers-answer': 'Medium'})
         self.post(post_data={'importances-information-client-answer': 'Low'})
@@ -353,7 +353,7 @@ class TestUkisSubmissionData(IntegrationTestCase):
     def factors_affecting_innovation_section(self):
         # We are in Factors Affecting Innovation section
         self.assertInPage('Factors Affecting Innovation')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
         self.post(post_data={'factors-affecting-increasing-range-answer': 'High'})
         self.post(post_data={'factors-affecting-new-markets-answer': 'Medium'})
         self.post(post_data={'factors-affecting-market-share-answer': 'Low'})
@@ -376,7 +376,7 @@ class TestUkisSubmissionData(IntegrationTestCase):
         # We are in Constraints on Innovation section
 
         self.assertInPage('Constraints on Innovation')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
         self.post(post_data={'constraints-innovation-activities-abandoned-answser': 'Yes',
                              'constraints-innovation-activities-scaled-back-answser': 'No',
                              'constraints-innovation-activities-ongoing-2016-answser': 'Yes'})
@@ -404,7 +404,7 @@ class TestUkisSubmissionData(IntegrationTestCase):
         # We are in Process Innovation section
 
         self.assertInPage('Process Innovation')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
         self.post(post_data={'process-improved-answer': 'Yes'})
         form_data = {'developed-processes-answer': ['This business or enterprise group',
                                                     'This business with other businesses or organisations',
@@ -423,7 +423,7 @@ class TestUkisSubmissionData(IntegrationTestCase):
         # We are in Goods and Services Innovation section
 
         self.assertInPage('Goods and Services Innovation')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
         self.post(post_data={'introducing-significantly-improved-goods-answer': 'Yes'})
         form_data = {'gentity-developed-these-goods-answer': ['This business or enterprise group',
                                                               'This business with other businesses or organisations',
@@ -452,7 +452,7 @@ class TestUkisSubmissionData(IntegrationTestCase):
         # We are in Innovation Investment section
 
         self.assertInPage('Innovation Investment')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
         self.post(post_data={'internal-investment-r-d-answer': 'Yes'})
         form_data = {'years-internal-investment-r-d-answer': ['2014',
                                                               '2015',
@@ -492,7 +492,7 @@ class TestUkisSubmissionData(IntegrationTestCase):
         # We are in Business Strategy and Practices section
 
         self.assertInPage('Business Strategy and Practices')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
         self.post(post_data={'business-changes-business-practices-answer': 'Yes',
                              'business-changes-organising-answer': 'No',
                              'business-changes-external-relationships-answer': 'Yes',
@@ -510,7 +510,7 @@ class TestUkisSubmissionData(IntegrationTestCase):
 
         self.assertInPage('>UK Innovation Survey</')
         self.assertInPage('General Business Information')
-        self.assertInPage('>Save and continue<')
+        self.assertInPage('>Continue<')
 
         # In General Business Information section
         form_data = {'geographic-markets-answer': ['UK regional within approximately 100 miles of this business',


### PR DESCRIPTION
### What is the context of this PR?
Change the button from "Save and continue" to "Continue" on all pages except introduction and summary pages for all surveys (including UKIS and census)

Card: https://trello.com/c/bNZbFVWM/1453-change-name-of-button

### How to review 
Run survey runner and open up a survey to check that the button is renamed also check on Census and UKIS.
