### PR TITLE
Navigation completeness from routing path

### DIFF
--- a/app/questionnaire/rules.py
+++ b/app/questionnaire/rules.py
@@ -140,7 +140,7 @@ def get_metadata_value(metadata, keys):
 
 
 def is_goto_rule(rule):
-    return any(key in rule.get('goto', {}) for key in ('when', 'id'))
+    return any(key in rule.get('goto', {}) for key in ('when', 'id', 'group'))
 
 
 def _contains_in_dict(metadata, keys):

--- a/data/en/test_navigation.json
+++ b/data/en/test_navigation.json
@@ -5,7 +5,7 @@
     "survey_id": "999",
     "title": "Home Insurance",
     "description": "Home Insurance",
-    "theme": "census",
+    "theme": "default",
     "legal_basis": "Voluntary",
     "navigation": {
         "visible": true,

--- a/data/en/test_navigation_completeness.json
+++ b/data/en/test_navigation_completeness.json
@@ -1,0 +1,166 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "survey_id": "023",
+    "title": "Test Navigation Completeness",
+    "description": "",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "navigation": {
+        "visible": true,
+        "sections": [{
+                "title": "Coffee",
+                "group_order": ["coffee-group"]
+            },
+            {
+                "title": "Toast",
+                "group_order": ["toast-group"]
+            }
+        ]
+    },
+    "groups": [{
+            "blocks": [{
+                    "type": "Questionnaire",
+                    "id": "coffee",
+                    "title": "Coffee",
+                    "description": "",
+                    "questions": [{
+                        "id": "question-coffee",
+                        "title": "Do you drink coffee?",
+                        "description": "",
+                        "type": "General",
+                        "answers": [{
+                            "options": [{
+                                    "label": "Yes",
+                                    "value": "yes",
+                                    "description": ""
+                                },
+                                {
+                                    "label": "No, I prefer tea",
+                                    "value": "no",
+                                    "description": ""
+                                }
+                            ],
+                            "q_code": "1",
+                            "id": "coffee-answer",
+                            "label": "Which conditional question should we jump to?",
+                            "mandatory": true,
+                            "type": "Radio"
+                        }]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "id": "response-yes",
+                                "when": [{
+                                    "id": "coffee-answer",
+                                    "condition": "equals",
+                                    "value": "yes"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "id": "response-no",
+                                "when": [{
+                                    "id": "coffee-answer",
+                                    "condition": "equals",
+                                    "value": "no"
+                                }]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Questionnaire",
+                    "id": "response-yes",
+                    "title": "Yes, I do drink coffee",
+                    "description": "",
+                    "questions": [{
+                        "id": "response-yes-question",
+                        "title": "How many cups of coffee do you drink a day?",
+                        "description": "",
+                        "type": "General",
+                        "answers": [{
+                            "id": "response-yes-number-of-cups",
+                            "label": "Number of cups",
+                            "mandatory": true,
+                            "options": [],
+                            "q_code": "2",
+                            "type": "Number"
+                        }]
+                    }],
+                    "routing_rules": [{
+                        "goto": {
+                            "group": "toast-group"
+                        }
+                    }]
+                },
+                {
+                    "type": "Questionnaire",
+                    "id": "response-no",
+                    "title": "No, I prefer tea",
+                    "description": "",
+                    "questions": [{
+                        "id": "response-no-question",
+                        "title": "How many cups of tea do you drink a day?",
+                        "description": "",
+                        "type": "General",
+                        "answers": [{
+                            "id": "response-no-number-of-cups",
+                            "label": "Number of cups",
+                            "mandatory": true,
+                            "options": [],
+                            "q_code": "2",
+                            "type": "Number"
+                        }]
+                    }]
+                }
+            ],
+            "id": "coffee-group",
+            "title": "Coffee Group"
+        },
+        {
+            "blocks": [{
+                "type": "Questionnaire",
+                "id": "toast",
+                "title": "Toast",
+                "description": "",
+                "questions": [{
+                    "id": "question-toast",
+                    "title": "Do you eat Toast",
+                    "description": "",
+                    "type": "General",
+                    "answers": [{
+                        "options": [{
+                                "label": "Yes",
+                                "value": "yes",
+                                "description": ""
+                            },
+                            {
+                                "label": "No",
+                                "value": "no",
+                                "description": ""
+                            }
+                        ],
+                        "q_code": "1",
+                        "id": "toast-answer",
+                        "mandatory": true,
+                        "type": "Radio"
+                    }]
+                }]
+            }],
+            "id": "toast-group",
+            "title": "Toast Group"
+        },
+        {
+            "blocks": [{
+                "type": "Summary",
+                "id": "summary"
+            }],
+            "id": "summary-group",
+            "title": "Summary"
+        }
+
+    ]
+}

--- a/data/en/test_routing_on_multiple_select.json
+++ b/data/en/test_routing_on_multiple_select.json
@@ -43,7 +43,7 @@
                             "id": "block3",
                             "when": [{
                                 "id": "passports-answer",
-                                "condition": "equals",
+                                "condition": "contains",
                                 "value": "United Kingdom"
                             }]
                         }

--- a/tests/app/questionnaire/test_navigation.py
+++ b/tests/app/questionnaire/test_navigation.py
@@ -17,7 +17,7 @@ class TestNavigation(AppContextTestCase):
             'form_type': 'some_form'
         }
 
-        navigation = Navigation(survey, AnswerStore(), metadata)
+        navigation = Navigation(survey, AnswerStore(), metadata, [], [])
 
         user_navigation = [
             {
@@ -78,7 +78,11 @@ class TestNavigation(AppContextTestCase):
             Location('property-details', 0, 'insurance-address')
         ]
 
-        navigation = Navigation(survey, answer_store, metadata, completed_blocks=completed_blocks)
+        routing_path = [
+            Location('property-details', 0, 'insurance-type')
+        ]
+
+        navigation = Navigation(survey, answer_store, metadata, completed_blocks, routing_path)
 
         user_navigation = [
             {
@@ -137,7 +141,15 @@ class TestNavigation(AppContextTestCase):
             Location('repeating-group', 1, 'repeating-block-2')
         ]
 
-        navigation = Navigation(survey, AnswerStore(), metadata, completed_blocks=completed_blocks)
+        routing_path = [
+            Location('multiple-questions-group', 0, 'household-composition'),
+            Location('repeating-group', 0, 'repeating-block-1'),
+            Location('repeating-group', 0, 'repeating-block-2'),
+            Location('repeating-group', 1, 'repeating-block-1'),
+            Location('repeating-group', 1, 'repeating-block-2')
+        ]
+
+        navigation = Navigation(survey, AnswerStore(), metadata, completed_blocks, routing_path)
 
         navigation.answer_store.answers = [
             {
@@ -281,7 +293,12 @@ class TestNavigation(AppContextTestCase):
         answer_store.add(answer_2)
         answer_store.add(answer_3)
 
-        navigation = Navigation(survey, answer_store, metadata, completed_blocks)
+        routing_path = [
+            Location('multiple-questions-group', 0, 'household-composition'),
+            Location('extra-cover', 0, 'extra-cover-block')
+        ]
+
+        navigation = Navigation(survey, answer_store, metadata, completed_blocks, routing_path)
 
         user_navigation = [
             {
@@ -397,14 +414,21 @@ class TestNavigation(AppContextTestCase):
             answer_instance=0
         )
 
-
         answer_store.add(answer_1)
         answer_store.add(answer_2)
         answer_store.add(answer_3)
         answer_store.add(answer_4)
         answer_store.add(answer_5)
 
-        navigation = Navigation(survey, answer_store, metadata, completed_blocks=completed_blocks)
+        routing_path = [
+            Location('extra-cover', 0, 'extra-cover-block'),
+            Location('extra-cover-items-group', 0, 'extra-cover-items'),
+            Location('extra-cover-items-group', 0, 'extra-cover-items-radio'),
+            Location('extra-cover-items-group', 1, 'extra-cover-items'),
+            Location('extra-cover-items-group', 1, 'extra-cover-items-radio')
+        ]
+
+        navigation = Navigation(survey, answer_store, metadata, completed_blocks, routing_path)
 
         user_navigation = [
             {
@@ -497,7 +521,11 @@ class TestNavigation(AppContextTestCase):
         answer_store.add(answer_3)
         answer_store.add(answer_4)
 
-        navigation = Navigation(survey, answer_store, metadata, completed_blocks=completed_blocks)
+        routing_path = [
+            Location('multiple-questions-group', 0, 'household-composition')
+        ]
+
+        navigation = Navigation(survey, answer_store, metadata, completed_blocks, routing_path)
 
         user_navigation = [
             {
@@ -570,7 +598,7 @@ class TestNavigation(AppContextTestCase):
 
         answer_store.add(answer_1)
 
-        navigation = Navigation(survey, answer_store, metadata, completed_blocks=completed_blocks)
+        navigation = Navigation(survey, answer_store, metadata, completed_blocks, [])
         user_navigation = navigation.build_navigation('property-details', 0)
         link_names = [d['link_name'] for d in user_navigation]
         self.assertNotIn('Property Interstitial', link_names)
@@ -599,7 +627,7 @@ class TestNavigation(AppContextTestCase):
 
         answer_store.add(answer_1)
 
-        navigation = Navigation(survey, answer_store, metadata, completed_blocks=completed_blocks)
+        navigation = Navigation(survey, answer_store, metadata, completed_blocks, [])
 
         user_navigation = navigation.build_navigation('property-details', 0)
         link_names = [d['link_name'] for d in user_navigation]
@@ -628,7 +656,7 @@ class TestNavigation(AppContextTestCase):
         )
 
         answer_store.add(answer_1)
-        navigation = Navigation(survey, answer_store, metadata, completed_blocks=completed_blocks)
+        navigation = Navigation(survey, answer_store, metadata, completed_blocks, [])
 
         user_navigation = navigation.build_navigation('property-details', 0)
         link_names = [d['link_name'] for d in user_navigation]
@@ -655,7 +683,7 @@ class TestNavigation(AppContextTestCase):
         survey['navigation'] = {'visible': False}
         completed_blocks = []
         metadata = {}
-        navigation = Navigation(survey, AnswerStore(), metadata, completed_blocks)
+        navigation = Navigation(survey, AnswerStore(), metadata, completed_blocks, [])
 
         # When
         nav_menu = navigation.build_navigation('group-1', 'group-instance-1')
@@ -669,7 +697,7 @@ class TestNavigation(AppContextTestCase):
         del survey['navigation']
         completed_blocks = []
         metadata = {}
-        navigation = Navigation(survey, AnswerStore(), metadata, completed_blocks)
+        navigation = Navigation(survey, AnswerStore(), metadata, completed_blocks, [])
 
         # When
         nav_menu = navigation.build_navigation('group-1', 'group-instance-1')
@@ -687,7 +715,7 @@ class TestNavigation(AppContextTestCase):
             'collection_exercise_sid': '999',
             'form_type': 'some_form'
         }
-        navigation = Navigation(survey, AnswerStore(), metadata, completed_blocks)
+        navigation = Navigation(survey, AnswerStore(), metadata, completed_blocks, [])
 
         # When
         nav_menu = navigation.build_navigation('group-1', 'group-instance-1')
@@ -703,7 +731,7 @@ class TestNavigation(AppContextTestCase):
             'form_type': 'some_form'
         }
 
-        navigation = Navigation(survey, AnswerStore(), metadata)
+        navigation = Navigation(survey, AnswerStore(), metadata, [], [])
 
         confirmation_link = {
             'link_name': 'Summary',
@@ -731,7 +759,7 @@ class TestNavigation(AppContextTestCase):
             Location('multiple-questions-group', 0, 'household-composition'),
         ]
 
-        navigation = Navigation(survey, AnswerStore(), metadata, completed_blocks)
+        navigation = Navigation(survey, AnswerStore(), metadata, completed_blocks, [])
 
         confirmation_link = {
             'link_name': 'Summary',
@@ -827,7 +855,7 @@ class TestNavigation(AppContextTestCase):
             Location('extra-cover-items-group', 0, 'extra-cover-items'),
         ]
 
-        navigation = Navigation(survey, AnswerStore(), metadata, completed_blocks)
+        navigation = Navigation(survey, AnswerStore(), metadata, completed_blocks, [])
 
         confirmation_link = {
             'link_name': 'Submit answers',
@@ -849,7 +877,7 @@ class TestNavigation(AppContextTestCase):
             'form_type': 'some_form'
         }
 
-        navigation = Navigation(survey, AnswerStore(), metadata)
+        navigation = Navigation(survey, AnswerStore(), metadata, [], [])
 
         confirmation_link = {
             'link_name': 'Submit answers',
@@ -879,7 +907,7 @@ class TestNavigation(AppContextTestCase):
             Location('multiple-questions-group', 0, 'household-composition'),
         ]
 
-        navigation = Navigation(survey, AnswerStore(), metadata, completed_blocks)
+        navigation = Navigation(survey, AnswerStore(), metadata, completed_blocks, [])
 
         confirmation_link = {
             'link_name': 'Submit answers',
@@ -975,7 +1003,7 @@ class TestNavigation(AppContextTestCase):
             Location('extra-cover-items-group', 0, 'extra-cover-items'),
         ]
 
-        navigation = Navigation(survey, AnswerStore(), metadata, completed_blocks)
+        navigation = Navigation(survey, AnswerStore(), metadata, completed_blocks, [])
 
         confirmation_link = {
             'link_name': 'Summary',

--- a/tests/functional/pages/surveys/navigation/completeness/coffee.page.js
+++ b/tests/functional/pages/surveys/navigation/completeness/coffee.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../question.page');
+
+class CoffeePage extends QuestionPage {
+
+  constructor() {
+    super('coffee');
+  }
+
+  yes() {
+    return '#coffee-answer-0';
+  }
+
+  yesLabel() { return '#label-coffee-answer-0'; }
+
+  no() {
+    return '#coffee-answer-1';
+  }
+
+  noLabel() { return '#label-coffee-answer-1'; }
+
+}
+module.exports = new CoffeePage();

--- a/tests/functional/pages/surveys/navigation/completeness/response-no.page.js
+++ b/tests/functional/pages/surveys/navigation/completeness/response-no.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../question.page');
+
+class ResponseNoPage extends QuestionPage {
+
+  constructor() {
+    super('response-no');
+  }
+
+  answer() {
+    return '#response-no-number-of-cups';
+  }
+
+  answerLabel() { return '#label-response-no-number-of-cups'; }
+
+}
+module.exports = new ResponseNoPage();

--- a/tests/functional/pages/surveys/navigation/completeness/response-yes.page.js
+++ b/tests/functional/pages/surveys/navigation/completeness/response-yes.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../question.page');
+
+class ResponseYesPage extends QuestionPage {
+
+  constructor() {
+    super('response-yes');
+  }
+
+  answer() {
+    return '#response-yes-number-of-cups';
+  }
+
+  answerLabel() { return '#label-response-yes-number-of-cups'; }
+
+}
+module.exports = new ResponseYesPage();

--- a/tests/functional/pages/surveys/navigation/completeness/summary.page.js
+++ b/tests/functional/pages/surveys/navigation/completeness/summary.page.js
@@ -1,0 +1,27 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  coffeeAnswer() { return '#coffee-answer-answer'; }
+
+  coffeeAnswerEdit() { return '[data-qa="coffee-answer-edit"]'; }
+
+  responseYesNumberOfCups() { return '#response-yes-number-of-cups-answer'; }
+
+  responseYesNumberOfCupsEdit() { return '[data-qa="response-yes-number-of-cups-edit"]'; }
+
+  responseNoNumberOfCups() { return '#response-no-number-of-cups-answer'; }
+
+  responseNoNumberOfCupsEdit() { return '[data-qa="response-no-number-of-cups-edit"]'; }
+
+  toastAnswer() { return '#toast-answer-answer'; }
+
+  toastAnswerEdit() { return '[data-qa="toast-answer-edit"]'; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/pages/surveys/navigation/completeness/toast.page.js
+++ b/tests/functional/pages/surveys/navigation/completeness/toast.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../question.page');
+
+class ToastPage extends QuestionPage {
+
+  constructor() {
+    super('toast');
+  }
+
+  yes() {
+    return '#toast-answer-0';
+  }
+
+  yesLabel() { return '#label-toast-answer-0'; }
+
+  no() {
+    return '#toast-answer-1';
+  }
+
+  noLabel() { return '#label-toast-answer-1'; }
+
+}
+module.exports = new ToastPage();

--- a/tests/functional/spec/navigation.spec.js
+++ b/tests/functional/spec/navigation.spec.js
@@ -16,10 +16,12 @@ const SkipInterstitialPage = require('../pages/surveys/navigation/skip-interstit
 const SkipPaymentPage = require('../pages/surveys/navigation/skip-payment.page.js');
 const SummaryPage = require('../pages/surveys/navigation/summary.page.js');
 
+const CoffeePage = require('../pages/surveys/navigation/completeness/coffee.page.js');
+const ResponseYesPage = require('../pages/surveys/navigation/completeness/response-yes.page.js');
+const ResponseNoPage = require('../pages/surveys/navigation/completeness/response-no.page.js');
 
 
 describe('Navigation', function() {
-
 
   it('Given a page with navigation, a user should be able to see it', function() {
     return helpers.openQuestionnaire('test_navigation.json').then(() => {
@@ -196,5 +198,36 @@ describe('Navigation', function() {
     .click(SecurityCodeInterstitialPage.submit())
     .then(helpers.isSectionComplete('Payment Details')).should.eventually.be.true;
   }
+
+  describe('Completeness', function() {
+
+    before("Launch Survey", function () {
+      return helpers.openQuestionnaire('test_navigation_completeness.json');
+    });
+
+    it("When I complete a section then it should be marked complete", function () {
+      return browser
+        .click(CoffeePage.yes())
+        .click(CoffeePage.submit())
+        .setValue(ResponseYesPage.answer(), 2)
+        .click(ResponseYesPage.submit())
+        .then(helpers.isSectionComplete('Coffee')).should.eventually.be.true;
+    });
+
+    it("When I go back and change the routing path the section should be marked as incomplete", function () {
+      return browser
+        .click(helpers.navigationLink("Coffee"))
+        .click(CoffeePage.no())
+        .click(CoffeePage.submit())
+        .then(helpers.isSectionComplete('Coffee')).should.eventually.be.false;
+    });
+
+    it("When I complete the new path, then the section is marked as complete", function () {
+      return browser
+        .setValue(ResponseNoPage.answer(), 5)
+        .click(ResponseNoPage.submit())
+        .then(helpers.isSectionComplete('Coffee')).should.eventually.be.true;
+    });
+  });
 
 });


### PR DESCRIPTION
### What is the context of this PR?
This PR changes how Navigation sections are marked as completed by using the routing path to ensure that all blocks within the routing path for a navigation section are completed rather then just relying on the final block being complete.

This fixes issues with a scenario when their are multiple paths through a section and the route is modified which opens up new questions but the navigation does not then mark the section as incomplete.

This also removes the need to have a fixed end block to a section.

### How to review 
Test navigating around surveys opening and closing conditional routes and check that the section ticks on the navigation behave as expected.