### PR TITLE
Removed `-U` from pip install as they contradict the locked versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.4
 
-RUN pip install -U pipenv==8.2.7 \
-  && pip install -U awscli==1.11.174
+RUN pip install pipenv==8.2.7 \
+  && pip install awscli==1.11.174
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
The `-U` means Upgrade all specified packages to the newest available version. This contradicts with specifying the version we want.