### PR TITLE
Allow viewing of submitted answers

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -51,6 +51,8 @@ sdc-cryptography = "*"
 structlog = "*"
 ua-parser = "*"
 blinker = "*"
+"boto3" = "*"
+"humanize" = "*"
 
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "df9d93c03514e6508f8e8cbcce447a57d8f30c4bc181323ae3683fc04f4b0880"
+            "sha256": "26195491553a62cd38090bc06ecee93074cda9a303e827a8fb4bbb16053d1eda"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
@@ -9,9 +9,9 @@
             "os_name": "posix",
             "platform_machine": "x86_64",
             "platform_python_implementation": "CPython",
-            "platform_release": "17.2.0",
+            "platform_release": "17.3.0",
             "platform_system": "Darwin",
-            "platform_version": "Darwin Kernel Version 17.2.0: Fri Sep 29 18:27:05 PDT 2017; root:xnu-4570.20.62~3/RELEASE_X86_64",
+            "platform_version": "Darwin Kernel Version 17.3.0: Thu Nov  9 18:09:22 PST 2017; root:xnu-4570.31.3~1/RELEASE_X86_64",
             "python_full_version": "3.4.2",
             "python_version": "3.4",
             "sys_platform": "darwin"
@@ -38,10 +38,10 @@
         },
         "babel": {
             "hashes": [
-                "sha256:f20b2acd44f587988ff185d8949c3e208b4b3d5d20fcab7d91fe481ffa435528",
-                "sha256:6007daf714d0cd5524bbe436e2d42b3c20e68da66289559341e48d2cd6d25811"
+                "sha256:ad209a68d7162c4cff4b29cdebe3dec4cef75492df501b0049a9433c96ce6f80",
+                "sha256:8ce4cb6fdd4393edd323227cba3a077bceb2a6ce5201c902c65e730046f41f14"
             ],
-            "version": "==2.5.1"
+            "version": "==2.5.3"
         },
         "blinker": {
             "hashes": [
@@ -49,48 +49,58 @@
             ],
             "version": "==1.4"
         },
+        "boto3": {
+            "hashes": [
+                "sha256:24f8f919126b8a55ef3be6729243f71ffe4b927408e4a1be4e64671cdb011409",
+                "sha256:06614d6111c0bcc7e76ef699e4caec0de87217180486e43ec2c353d6f01a409d"
+            ],
+            "version": "==1.5.20"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:628994a88d09a1fe7d96e0c4b786302463bdfaff9f829d4a72ebe8d02e8160ba",
+                "sha256:b7c33d79fe4c6b8d15f4191aa6e60e3ac0f290b3ce3a8b4d831f79eddbca7115"
+            ],
+            "version": "==1.8.34"
+        },
         "certifi": {
             "hashes": [
-                "sha256:244be0d93b71e93fc0a0a479862051414d0e00e16435707e5bf5000f92e04694",
-                "sha256:5ec74291ca1136b40f0379e1128ff80e866597e4e2c1e755739a913bbc3613c0"
+                "sha256:14131608ad2fd56836d33a71ee60fa1c82bc9d2c8d98b7bdbc631fe1b3cd1296",
+                "sha256:edbc3f203427eef571f79a7692bb160a2b0f7ccaa31953e99bd17e307cf63f7d"
             ],
-            "version": "==2017.11.5"
+            "version": "==2018.1.18"
         },
         "cffi": {
             "hashes": [
-                "sha256:2c707e97ad7b0417713543be7cb87315c015bb5dd97903480168d60ebe3e313e",
-                "sha256:6d8c7e20eb90be9e1ccce8e8dd4ee5163b37289fc5708f9eeafc00adc07ba891",
-                "sha256:627298d788edcb317b6a01347428501e773f5e8f2988407231c07e50e3f6c1cf",
-                "sha256:bdd28cf8302eeca1b4c70ec727de384d4f6ea640b0e698934fd9b4c3bc88eeb1",
-                "sha256:248198cb714fe09f5c60b6acba3675d52199c6142641536796cdf89dd45e5590",
-                "sha256:c962cb68987cbfb70b034f153bfa467c615c0b55305d39b3237c4bdbdbc8b0f4",
-                "sha256:401ba2f6c1f1672b6c38670e1c00fa5f84f841edd30c32742dab5c7151cd89bf",
-                "sha256:1c103c0ee8235c47c4892288b2287014f33e7cb24b9d4a665be3aa744377dcb9",
-                "sha256:d7461ef8671ae40f991384bbc4a6b1b79f4e7175d8052584be44041996f46517",
-                "sha256:3ac9be5763238da1d6fa467c43e3f86472626837a478588c94165df09e62e120",
-                "sha256:d54a7c37f954fdbb971873c935a77ddc33690cec9b7ac254d9f948c43c32fa83",
-                "sha256:4d9bf1b23896bcd4d042e823f50ad36fb6d8e1e645a3dfb2fe2f070851489b92",
-                "sha256:61cf049b1c649d8eec360a1a1d09a61c37b9b2d542364506e8feb4afd232363d",
-                "sha256:ce3da410ae2ab8709565cc3b18fbe9a0eb96ea7b2189416098c48d839ecced84",
-                "sha256:e72d8b5056f967ecb57e166537408bc913f2f97dc568027fb6342fcfa9f81d64",
-                "sha256:11a8ba88ef6ae89110ef029dae7f1a293365e50bdd0c6ca973beed80cec95ae4",
-                "sha256:974f69112721ba2e8a6acd0f6b68a5e11432710a3eca4e4e6f4d7aaf99214ed1",
-                "sha256:062c66dabc3faf8e0db1ca09a6b8e308846e5d35f43bed1a68c492b0d96ac171",
-                "sha256:03a9b9efc280dbe6be149a7fa689f59a822df009eee633fdaf55a6f38795861f",
-                "sha256:8b3d6dc9981cedfb1ddcd4600ec0c7f5ac2c6ad2dc482011c7eecb4ae9c819e0",
-                "sha256:09b7d195d163b515ef7c2b2e26a689c9816c83d5319cceac6c36ffdab97ab048",
-                "sha256:943b94667749d1cfcd964e215a20b9c891deae913202ee8eacaf2b94164b155f",
-                "sha256:89829f5cfbcb5ad568a3d61bd23a8e33ad69b488d8f6a385e0097a4c20742a9b",
-                "sha256:ba78da7c940b041cdbb5aaff5afe11e8a8f25fe19564c12eefea5c5bd86930ca",
-                "sha256:a79b15b9bb4726672865cf5b0f63dee4835974a2b11b49652d70d49003f5d1f4",
-                "sha256:f6799913eb510b682de971ddef062bbb4a200f190e55cae81c413bc1fd4733c1",
-                "sha256:e7f5ad6b12f21b77d3a37d5c67260e464f4e9068eb0c0622f61d0e30390b31b6",
-                "sha256:5f96c92d5f5713ccb71e76dfa14cf819c59ecb9778e94bcb541e13e6d96d1ce5",
-                "sha256:5357b465e3d6b98972b7810f9969c913d365e75b09b7ba813f5f0577fe1ac9f4",
-                "sha256:75e1de9ba7c155d89bcf67d149b1c741df553c8158536e8d27e63167403159af",
-                "sha256:ab87dd91c0c4073758d07334c1e5f712ce8fe48f007b86f8238773963ee700a6"
+                "sha256:5d0d7023b72794ea847725680e2156d1d01bc698a9007fccce46d03c904fe093",
+                "sha256:86903c0afab4a3390170aca61f753f5adad8ffff947030719ee44dedc5b68403",
+                "sha256:7d35678a54da0d3f1bc30e3a58a232043753d57c691875b5a75e4e062793bc9a",
+                "sha256:824cac33906be5c8e976f0d950924d88ec058989ef9cd2f77f5cd53cec417635",
+                "sha256:6ca52651f6bd4b8647cb7dee15c82619de3e13490f8e0bc0620830a2245b51d1",
+                "sha256:a183959a4b1e01d6172aeed356e2523ec8682596075aa6cf0003fe08da959a49",
+                "sha256:9532c5bc0108bd0fe43c0eb3faa2ef98a2db60fc0d4019f106b88d46803dd663",
+                "sha256:96652215ef328262b5f1d5647632bd342ac6b31dfbc495b21f1ab27cb06d621d",
+                "sha256:6c99d19225e3135f6190a3bfce2a614cae8eaa5dcaf9e0705d4ccb79a3959a3f",
+                "sha256:12cbf4c04c1ad07124bfc9e928c01e282feac9ec7dd72a18042d4fc56456289a",
+                "sha256:69c37089ccf10692361c8d14dbf4138b00b46741ffe9628755054499f06ed548",
+                "sha256:b8d1454ef627098dc76ccfd6211a08065e6f84efe3754d8d112049fec3768e71",
+                "sha256:cd13f347235410c592f6e36395ee1c136a64b66534f10173bfa4df1dc88f47d0",
+                "sha256:0640f12f04f257c4467075a804a4920a5d07ef91e11c525fc65d715c08231c81",
+                "sha256:89a8d05b96bdeca8fdc89c5fa9469a357d30f6c066262e92c0c8d2e4d3c53cae",
+                "sha256:a67c430a9bde73ae85b0c885fcf41b556760e42ea74c16dc70431a349989b448",
+                "sha256:7a831170b621e98f45ed1d5758325be19619a593924127a0a47af9a72a117319",
+                "sha256:796d0379102e6da5215acfcd20e8e69cca9d97309215b4ce088fe175b1c2f586",
+                "sha256:0fe3b3d571543a4065059d1d3d6d39f4ca6da0f2207ad13547094522e32ead46",
+                "sha256:678135090c311780382b1dd3f828f715583ea8a69687ed053c047d3cec6625d6",
+                "sha256:f4992cd7b4c867f453d44c213ee29e8fd484cf81cfece4b6e836d0982b6fa1cf",
+                "sha256:6d191fb20138fe1948727b20e7b96582b7b7e676135eabf72d910e10bf7bfa65",
+                "sha256:ec208ca16e57904dd7f4c7568665f80b1f7eb7e3214be014560c28def219060d",
+                "sha256:b3653644d6411bf4bd64c1f2ca3cb1b093f98c68439ade5cef328609bbfabf8c",
+                "sha256:f4719d0bafc5f0a67b2ec432086d40f653840698d41fa6e9afa679403dea9d78",
+                "sha256:87f837459c3c78d75cb4f5aadf08a7104db15e8c7618a5c732e60f252279c7a6",
+                "sha256:df9083a992b17a28cd4251a3f5c879e0198bb26c9e808c4647e0a18739f1d11d"
             ],
-            "version": "==1.11.2"
+            "version": "==1.11.4"
         },
         "chardet": {
             "hashes": [
@@ -135,6 +145,14 @@
                 "sha256:5518337022718029e367d982642f3e3523541e098ad671672a90b82474c84882"
             ],
             "version": "==1.9"
+        },
+        "docutils": {
+            "hashes": [
+                "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6",
+                "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
+                "sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274"
+            ],
+            "version": "==0.14"
         },
         "flask": {
             "hashes": [
@@ -256,6 +274,12 @@
             ],
             "version": "==19.7.1"
         },
+        "humanize": {
+            "hashes": [
+                "sha256:a43f57115831ac7c70de098e6ac46ac13be00d69abbf60bdcac251344785bb19"
+            ],
+            "version": "==0.5.1"
+        },
         "idna": {
             "hashes": [
                 "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4",
@@ -276,6 +300,13 @@
             ],
             "version": "==2.10"
         },
+        "jmespath": {
+            "hashes": [
+                "sha256:f11b4461f425740a1d908e9a3f7365c3d2e569f6ca68a2ff8bc5bcd9676edd63",
+                "sha256:6a81d4c9aa62caf061cb517b4d9ad1dd300374cd4706997aff9cd6aedd61fc64"
+            ],
+            "version": "==0.9.3"
+        },
         "jwcrypto": {
             "hashes": [
                 "sha256:5b2565104caec6dbe612557ffbffc1489a7287d8ffed00e3a803b2bfdc5e063b",
@@ -291,9 +322,9 @@
         },
         "newrelic": {
             "hashes": [
-                "sha256:965214625392d41b9620c6928a6b10036bf1e2a2b797cdb6682650e95e1f616e"
+                "sha256:b75123173ac5e8a20aa9d8120e20a7bf45c38a5aa5a4672fac6ce4c3e0c8046e"
             ],
-            "version": "==2.98.0.81"
+            "version": "==2.100.0.84"
         },
         "pika": {
             "hashes": [
@@ -344,6 +375,13 @@
             ],
             "version": "==2.18"
         },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:95511bae634d69bc7329ba55e646499a842bc4ec342ad54a8cdb65645a0aad3c",
+                "sha256:891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca"
+            ],
+            "version": "==2.6.1"
+        },
         "pytz": {
             "hashes": [
                 "sha256:80af0f3008046b9975242012a985f04c5df1f01eed4ec1633d56cc47a75a6a48",
@@ -383,6 +421,13 @@
                 "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
             ],
             "version": "==2.18.4"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:23c156ca4d64b022476c92c44bf938bef71af9ce0dcd8fd6585e7bce52f66e47",
+                "sha256:10891b246296e0049071d56c32953af05cea614dca425a601e4c0be35990121e"
+            ],
+            "version": "==0.1.12"
         },
         "sdc-cryptography": {
             "hashes": [
@@ -426,9 +471,9 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:7dda3e0b1b12215e3bb05368d1abbf7d747112a43738e0a4e6deb466b83fd88e"
+                "sha256:9ede7070d6fd18f28058be88296ed67893e2637465516d6a596cd9afea97b154"
             ],
-            "version": "==1.2.0"
+            "version": "==1.2.1"
         },
         "structlog": {
             "hashes": [
@@ -489,10 +534,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:244be0d93b71e93fc0a0a479862051414d0e00e16435707e5bf5000f92e04694",
-                "sha256:5ec74291ca1136b40f0379e1128ff80e866597e4e2c1e755739a913bbc3613c0"
+                "sha256:14131608ad2fd56836d33a71ee60fa1c82bc9d2c8d98b7bdbc631fe1b3cd1296",
+                "sha256:edbc3f203427eef571f79a7692bb160a2b0f7ccaa31953e99bd17e307cf63f7d"
             ],
-            "version": "==2017.11.5"
+            "version": "==2018.1.18"
         },
         "chardet": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ Note, you will also need to run an upstream tool (eg, https://github.com/ONSDigi
 docker run -it -p 8000:8000 onsdigital/go-launch-a-survey:latest
 ```
 
+If you wish to view submitted data you will also need to run an additional upstream tool (eg, https://github.com/ONSDigital/eq-docker-dynamodb) to launch a dynamoDB container.
+ 
+```
+docker run -it -p 6060:8000 onsdigital/eq-docker-dynamodb:latest
+```
+
+
 This will generate a JWT for you to log into the application.
 
 ---

--- a/app/assets/styles/partials/components/_buttons.scss
+++ b/app/assets/styles/partials/components/_buttons.scss
@@ -43,12 +43,97 @@
   }
 }
 
+@mixin icon-bg-image ($name) {
+  background-image: url("https://cdn.ons.gov.uk/sdc/#{$cdn-version}/img/icons/icons--#{$name}.svg");
+}
+
+@mixin create-btn-icon-modifier ($defaultIconName, $hoverIconName, $focusIconName, $width) {
+  .btn__icon--#{$defaultIconName} {
+    width: $width;
+    @include icon-bg-image($defaultIconName);
+
+    &::before {
+      @include icon-bg-image($hoverIconName);
+    }
+
+    &::after {
+      @include icon-bg-image($focusIconName);
+    }
+  }
+}
+
 .btn {
   @include btn($color-primary, $color-white);
+
+  .btn__icon {
+    position: relative;
+    vertical-align: middle;
+    content: " ";
+    display: inline-block;
+    background-repeat: no-repeat;
+
+    &::after,
+    &::before {
+      width: inherit;
+      height: inherit;
+      content: " ";
+      vertical-align: inherit;
+      display: inherit;
+      background-repeat: inherit;
+      background-position: 0 0;
+      background-size: auto;
+      transition: opacity 0.3s ease-out;
+    }
+
+    &::before {
+      opacity: 0;
+    }
+
+    &::after {
+      position: absolute;
+      left: 0;
+      opacity: 0;
+    }
+  }
+
+  &:hover .btn__icon {
+    &::before {
+      opacity: 1;
+    }
+  }
+
+  &:focus .btn__icon {
+    &::after {
+      opacity: 1;
+    }
+  }
+
+  @include create-btn-icon-modifier(print-link, print-hover, print-focus, 1.3em);
+  // ...
 }
 
 .btn--secondary {
   @include btn($color-secondary, $color-white);
+}
+
+.btn--tertiary {
+  @include btn($color-white, $color-tertiary, $color-tertiary-dark);
+  padding: 0.3rem;
+  background-color: $color-white;
+  font-weight: 600;
+
+  &:hover {
+    background-color: $color-white;
+  }
+
+  &:focus {
+    color: $color-white;
+    background-color: $color-tertiary;
+  }
+
+  .btn__icon {
+    height: 1.4em;
+  }
 }
 
 .btn--neutral {
@@ -68,27 +153,30 @@
 }
 
 .btn--loader {
-  transition: all 300ms ease-out;
+  transition: color 300ms ease-out;
   position: relative;
-  &::before {
-    transition: all 300ms ease-out;
-    display: inline-block;
-    vertical-align: middle;
+  &::after {
+    display: block;
     content: "";
-    width: 1.2em;
-    height: 1.2em;
+    width: 2rem;
+    height: 2rem;
     opacity: 0;
-    margin-right: 0.5em;
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    margin: auto;
     background-image: url("/s/img/loader.svg");
     background-repeat: no-repeat;
     background-position: center center;
     background-size: 1.5rem;
+    transition: opacity 300ms ease-out 200ms;
     pointer-events: none;
-    margin-left: -1.8em;
-    margin-top: -0.2em;
   }
   &.is-loading {
-    &::before {
+    color: transparent;
+    &::after {
       opacity: 1;
     }
   }

--- a/app/assets/styles/partials/vars/_colors.scss
+++ b/app/assets/styles/partials/vars/_colors.scss
@@ -11,6 +11,8 @@ $color-lighter-grey: #f5f5f5;
 $color-primary: #0f8243;
 $color-primary-dark: #677424;
 $color-secondary: #033e58;
+$color-tertiary: #4263C2;
+$color-tertiary-dark: $color-secondary;
 
 $color-red: #d0021b;
 $color-light-red: #fbecec;

--- a/app/assets/styles/partials/vars/_vars.scss
+++ b/app/assets/styles/partials/vars/_vars.scss
@@ -1,1 +1,2 @@
 $s: "/s";
+$cdn-version: "adadf71"

--- a/app/authentication/authenticator.py
+++ b/app/authentication/authenticator.py
@@ -89,7 +89,9 @@ def _create_session_data_from_metadata(metadata):
         tx_id=metadata.get('tx_id'),
         eq_id=metadata.get('eq_id'),
         form_type=metadata.get('form_type'),
-        period_str=metadata.get('period_str')
+        period_str=metadata.get('period_str'),
+        ru_name=metadata.get('ru_name'),
+        ru_ref=metadata.get('ru_ref')
     )
     return session_data
 
@@ -115,7 +117,7 @@ def store_session(metadata):
     cookie_session[EQ_SESSION_ID] = eq_session_id
 
     session_data = _create_session_data_from_metadata(metadata)
-    create_session_store(eq_session_id, user_id, session_data)
+    create_session_store(eq_session_id, user_id, user_ik, session_data)
 
     questionnaire_store = get_questionnaire_store(user_id, user_ik)
     questionnaire_store.metadata = metadata

--- a/app/data_model/models.py
+++ b/app/data_model/models.py
@@ -31,10 +31,10 @@ class EQSession(db.Model):
     created_at = db.Column('created_at', db.DateTime, default=datetime.datetime.utcnow)
     updated_at = db.Column('updated_at', db.DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow)
 
-    def __init__(self, eq_session_id, user_id, session_data):
+    def __init__(self, eq_session_id, user_id):
         self.eq_session_id = eq_session_id
         self.user_id = user_id
-        self.session_data = session_data
+        self.session_data = None
 
 
 # pylint: disable=maybe-no-member

--- a/app/data_model/session_data.py
+++ b/app/data_model/session_data.py
@@ -1,8 +1,10 @@
 class SessionData(object):
 
-    def __init__(self, tx_id, eq_id, form_type, period_str, submitted_time=None):
+    def __init__(self, tx_id, eq_id, form_type, period_str, ru_name=None, ru_ref=None, submitted_time=None):
         self.tx_id = tx_id
         self.eq_id = eq_id
         self.form_type = form_type
         self.period_str = period_str
+        self.ru_name = ru_name
+        self.ru_ref = ru_ref
         self.submitted_time = submitted_time

--- a/app/data_model/submitted_responses.py
+++ b/app/data_model/submitted_responses.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+from botocore.exceptions import BotoCoreError, ConnectionError as BotoConnectionError
+from structlog import get_logger
+
+logger = get_logger()
+
+
+class SubmittedResponses(object):
+
+    def __init__(self, table):
+        self.table = table
+
+    def put_item(self, item):
+        """Insert an item to table"""
+        if item and item['valid_until']:
+            item['valid_until'] = int(item['valid_until'].strftime('%s'))  # convert to epoch
+
+        try:
+            response = self.table.put_item(Item=item)['ResponseMetadata']['HTTPStatusCode']
+            return response == 200
+
+        except (BotoCoreError, BotoConnectionError, ConnectionError):
+            logger.warn('Could not load data into DynamoDB')
+            return False
+
+    def get_item(self, tx_id):
+        """ Get an item given its key """
+        try:
+            response = self.table.get_item(Key={'tx_id': tx_id})
+            item = response.get('Item', None)
+            if item:
+                item['valid_until'] = datetime.utcfromtimestamp(item['valid_until'])
+            return item
+
+        except (BotoCoreError, BotoConnectionError, ConnectionError):
+            logger.warn('Could not get data from DynamoDB')
+            return None

--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -77,6 +77,11 @@ def format_month_year_date(value, date_format='%B %Y'):
 
 
 @blueprint.app_template_filter()
+def format_datetime(value, date_format='%d %B %Y at %H:%M'):
+    return "<span class='date'>{date}</span>".format(date=datetime.strptime(value, '%Y-%m-%dT%H:%M:%S.%f').strftime(date_format))
+
+
+@blueprint.app_template_filter()
 def format_conditional_date(date1=None, date2=None):
     """
     This function format_conditional_date accepts two dates, a user submitted date and a metadata date

--- a/app/libs/utils.py
+++ b/app/libs/utils.py
@@ -2,6 +2,11 @@ import uuid
 
 
 def convert_tx_id(tx_id):
+    # converts the guid tx_id to string of 16 characters with a dash between every 4 characters
+    return (tx_id[:4] + '-' + tx_id[4:])[:19]
+
+
+def convert_tx_id_for_boxes(tx_id):
     # converts the guid tx_id to string of 16 characters with a space between every 4 characters
     tx_id = uuid.UUID(tx_id)
     tx_id = tx_id.hex

--- a/app/settings.py
+++ b/app/settings.py
@@ -65,6 +65,11 @@ EQ_SERVER_SIDE_STORAGE_DATABASE_NAME = os.getenv('EQ_SERVER_SIDE_STORAGE_DATABAS
 EQ_SERVER_SIDE_STORAGE_USER_ID_ITERATIONS = ensure_min(os.getenv('EQ_SERVER_SIDE_STORAGE_USER_ID_ITERATIONS', 10000),
                                                        1000)
 
+EQ_DYNAMODB_ENABLED = parse_mode(os.getenv('EQ_DYNAMODB_ENABLED', 'True'))
+if EQ_DYNAMODB_ENABLED:
+    EQ_DYNAMODB_ENDPOINT = os.getenv('EQ_DYNAMODB_ENDPOINT')
+    EQ_SUBMITTED_RESPONSES_TABLE_NAME = get_env_or_fail('EQ_SUBMITTED_RESPONSES_TABLE_NAME')
+
 RESPONDENT_ACCOUNT_URL = os.getenv('RESPONDENT_ACCOUNT_URL', 'https://survey.ons.gov.uk/')
 
 EQ_DEV_MODE = parse_mode(os.getenv('EQ_DEV_MODE', 'False'))

--- a/app/storage/encrypted_questionnaire_storage.py
+++ b/app/storage/encrypted_questionnaire_storage.py
@@ -1,14 +1,9 @@
-import hashlib
 import simplejson as json
 
-from jwcrypto import jwe, jwk
-from jwcrypto.common import base64url_encode, base64url_decode
 from structlog import get_logger
 
+from app.storage.storage_encryption import StorageEncryption
 from app.data_model.models import QuestionnaireState, db
-from app.utilities.strings import to_bytes
-from app.utilities.strings import to_str
-
 logger = get_logger()
 
 
@@ -17,15 +12,12 @@ class EncryptedQuestionnaireStorage:
     def __init__(self, user_id, user_ik, pepper):
         if user_id is None:
             raise ValueError('User id must be set')
-        if user_ik is None:
-            raise ValueError('User ik must be set')
-        if pepper is None:
-            raise ValueError('Pepper must be set')
+
         self._user_id = user_id
-        self._cek = self._generate_key(user_id, user_ik, pepper)
+        self.encrypter = StorageEncryption(user_id, user_ik, pepper)
 
     def add_or_update(self, data, version):
-        encrypted_data = self._encrypt_data(data)
+        encrypted_data = self.encrypter.encrypt_data(data)
         encrypted_data_json = json.dumps({'data': encrypted_data})
         questionnaire_state = self._find_questionnaire_state()
         if questionnaire_state:
@@ -48,7 +40,7 @@ class EncryptedQuestionnaireStorage:
             version = questionnaire_state.version or 0
 
             if 'data' in data:
-                decrypted_data = self._decrypt_data(data['data'])
+                decrypted_data = self.encrypter.decrypt_data(data['data'])
                 return decrypted_data, version
 
         return None, None
@@ -62,50 +54,8 @@ class EncryptedQuestionnaireStorage:
             db.session.delete(questionnaire_state)
             db.session.commit()
 
-    @staticmethod
-    def _generate_key(user_id, user_ik, pepper):
-        sha256 = hashlib.sha256()
-        sha256.update(to_str(user_id).encode('utf-8'))
-        sha256.update(to_str(user_ik).encode('utf-8'))
-        sha256.update(to_str(pepper).encode('utf-8'))
-
-        # we only need the first 32 characters for the CEK
-        return to_bytes(sha256.hexdigest()[:32])
-
-    def _encrypt_data(self, data):
-        protected_header = {
-            'alg': 'dir',
-            'enc': 'A256GCM',
-            'kid': '1,1',
-        }
-        jwe_token = jwe.JWE(plaintext=base64url_encode(data), protected=protected_header)
-
-        key = self.generate_jwk_from_cek(self._cek)
-
-        jwe_token.add_recipient(key)
-
-        return jwe_token.serialize(compact=True)
-
-    def _decrypt_data(self, encrypted_token):
-
-        key = self.generate_jwk_from_cek(self._cek)
-
-        jwe_token = jwe.JWE(algs=['dir', 'A256GCM'])
-        jwe_token.deserialize(encrypted_token, key)
-
-        return base64url_decode(jwe_token.payload.decode()).decode()
-
     def _find_questionnaire_state(self):
         logger.debug('getting questionnaire data', user_id=self._user_id)
         # pylint: disable=maybe-no-member
         # SQLAlchemy doing declarative magic which makes session scope query property available
         return QuestionnaireState.query.filter(QuestionnaireState.user_id == self._user_id).first()
-
-    @staticmethod
-    def generate_jwk_from_cek(cek):
-        password = {
-            'kty': 'oct',
-            'k': base64url_encode(cek),
-        }
-
-        return jwk.JWK(**password)

--- a/app/storage/storage_encryption.py
+++ b/app/storage/storage_encryption.py
@@ -1,0 +1,64 @@
+import hashlib
+
+from jwcrypto import jwe, jwk
+from jwcrypto.common import base64url_encode, base64url_decode
+from structlog import get_logger
+
+from app.utilities.strings import to_bytes
+from app.utilities.strings import to_str
+import simplejson as json
+
+logger = get_logger()
+
+
+class StorageEncryption:
+
+    def __init__(self, user_id, user_ik, pepper):
+        if user_id is None:
+            raise ValueError('User id must be set')
+        if user_ik is None:
+            raise ValueError('User ik must be set')
+        if pepper is None:
+            raise ValueError('Pepper must be set')
+
+        self.key = self._generate_key(user_id, user_ik, pepper)
+
+    @staticmethod
+    def _generate_key(user_id, user_ik, pepper):
+        sha256 = hashlib.sha256()
+        sha256.update(to_str(user_id).encode('utf-8'))
+        sha256.update(to_str(user_ik).encode('utf-8'))
+        sha256.update(to_str(pepper).encode('utf-8'))
+
+        # we only need the first 32 characters for the CEK
+        cek = to_bytes(sha256.hexdigest()[:32])
+
+        password = {
+            'kty': 'oct',
+            'k': base64url_encode(cek),
+        }
+
+        return jwk.JWK(**password)
+
+    def encrypt_data(self, data):
+        if not isinstance(data, str):
+            data = json.dumps(data)
+
+        protected_header = {
+            'alg': 'dir',
+            'enc': 'A256GCM',
+            'kid': '1,1',
+        }
+
+        jwe_token = jwe.JWE(plaintext=base64url_encode(data), protected=protected_header)
+
+        jwe_token.add_recipient(self.key)
+
+        return jwe_token.serialize(compact=True)
+
+    def decrypt_data(self, encrypted_token):
+
+        jwe_token = jwe.JWE(algs=['dir', 'A256GCM'])
+        jwe_token.deserialize(encrypted_token, self.key)
+
+        return base64url_decode(jwe_token.payload.decode()).decode()

--- a/app/templates/partials/footer2.html
+++ b/app/templates/partials/footer2.html
@@ -1,4 +1,4 @@
-<footer class="footer2 page__footer2">
+<footer class="footer2 page__footer2 print__hidden">
     <div class="footer2-nav container" role="contentinfo">
 
         <div class="grid container">

--- a/app/templates/partials/summary/summary.html
+++ b/app/templates/partials/summary/summary.html
@@ -1,0 +1,53 @@
+{% set not_answered = 'No answer provided' %}
+
+<div>
+  <div class="summary">
+
+    {% for group in content.summary %}
+
+      <h2 class="summary__title saturn" id="{{group.id}}">{{group.title}}</h2>
+
+      <div class="summary__block">
+
+        {% for block in group.blocks %}
+
+          <div class="summary__items">
+
+            {% for question in block.questions %}
+
+              <div class="summary__question" id="{{question.id}}">
+                {{question.number or ''}} {{question.title|striptags}}
+              </div>
+
+              {% for answer in question.answers %}
+                {% if question.answers|length > 1 and answer.label %}
+                  <div class="summary__question summary__question--sub">
+                    {{answer.label|striptags}}
+                  </div>
+                {% endif %}
+
+                <div class="summary__answer">
+                  <div class="summary__answer-text" id="{{answer.id}}-answer" data-qa="{{answer.id}}-answer">
+                    {%- if answer.value is none or answer.value == '' -%}
+                      {{not_answered}}
+                    {%- else -%}
+                      {% include theme(['partials/summary/' ~ answer.type ~ '.html', 'partials/summary/default.html']) %}
+                     {%- endif -%}
+                   </div>
+
+                  {% if content.answers_are_editable %}
+                    <div class="summary__edit">
+                      <a href="{{ block.link }}#{{answer.id}}" class="summary__edit-link" aria-describedby="{{answer.id}} {{answer.id}}-answer" data-qa="{{answer.id}}-edit" {{helpers.track('click', 'Summary', 'Edit click')}}>Edit <span class="u-vh">your answer</span></a>
+                    </div>
+                  {% endif %}
+                </div>
+              {% endfor %}
+            {% endfor %}
+
+          </div>
+
+        {% endfor %}
+      </div>
+    {% endfor %}
+  </div>
+</div>

--- a/app/templates/summary.html
+++ b/app/templates/summary.html
@@ -4,8 +4,6 @@
 
 {% block page_title -%}{{_("Summary")}} - {{survey_title}}{% endblock -%}
 
-{% set not_answered = 'No answer provided' %}
-
 {% block sidebar %}
   {% if navigation %}
     {% include theme('partials/navigation.html') %}
@@ -20,65 +18,22 @@
 {% block inline_feedback %}{{ super() }}{% endblock %}
 
 <div>
-  <h1 class="saturn">Your responses</h1>
+  <h1 class="saturn">Your answers</h1>
   <div class="print__message panel panel--simple panel--error">
-    <h2 class="saturn">Please remember to submit these responses.</h2>
+    <h2 class="saturn">Please remember to submit these answers.</h2>
   </div>
   <div class="print__hidden panel panel--simple panel--warn">
-    <h2 class="neptune">Please check your responses carefully before submitting.</h2>
+    <h2 class="neptune">Please check your answers carefully before submitting.</h2>
   </div>
 </div>
 
-<div>
-  <div class="summary">
+{% include theme('partials/summary/summary.html') %}
 
-  {% for group in content.summary %}
-
-      <h2 class="summary__title saturn" id="{{group.id}}">{{group.title}}</h2>
-
-      <div class="summary__block">
-
-     {% for block in group.blocks %}
-
-        <div class="summary__items">
-
-            {% for question in block.questions %}
-
-                <div class="summary__question" id="{{question.id}}">
-                  {{question.number or ''}} {{question.title|striptags}}
-                </div>
-
-                {% for answer in question.answers %}
-                      {% if question.answers|length > 1 and answer.label %}
-                        <div class="summary__question summary__question--sub">
-                          {{answer.label|striptags}}
-                        </div>
-                      {% endif %}
-
-                      <div class="summary__answer">
-                        <div class="summary__answer-text" id="{{answer.id}}-answer" data-qa="{{answer.id}}-answer">
-                          {%- if answer.value is none or answer.value == '' -%}
-                            {{not_answered}}
-                          {%- else -%}
-                            {% include theme(['partials/summary/' ~ answer.type ~ '.html', 'partials/summary/default.html']) %}
-                          {%- endif -%}
-                        </div>
-                        <div class="summary__edit">
-                          <a href="{{ block.link }}#{{answer.id}}" class="summary__edit-link" aria-describedby="{{answer.id}} {{answer.id}}-answer" data-qa="{{answer.id}}-edit" {{helpers.track('click', 'Summary', 'Edit click')}}>Edit <span class="u-vh">your answer</span></a>
-                        </div>
-                      </div>
-                {% endfor %}
-
-            {% endfor %}
-
-        </div>
-
-     {% endfor %}
-
-     </div>
-  {% endfor %}
+{% if content.is_view_submission_response_enabled %}
+  <div class="u-mb-s u-mb-m@s">
+    <div class="venus">You will have the opportunity to view and print a copy of your answers after submitting this questionnaire</div>
   </div>
-</div>
+{% endif %}
 
 {{super()}}
 

--- a/app/templates/thank-you.html
+++ b/app/templates/thank-you.html
@@ -6,25 +6,41 @@
 
 <div class="u-mb-s">
     <h1 class="saturn">Submission Successful</h1>
-    <p>Thank you for submitting the {{ survey_title }}, your responses have been successfully received.</p>
 </div>
 
-<div class="panel panel--simple panel--success panel--spacious">
-    <p class="mars">Transaction ID (Please quote this reference for any support queries)</p>
-    {% if meta.respondent %}
-    <ul class="list list--boxes">
-        {%for id_part in meta.respondent.tx_id%}<li class="list__item">{{id_part}}</li>{% endfor %}
-    </ul>
+<div class="u-mb-s">
+    <div class="panel panel--simple panel--success panel--spacious">
+        <p class="mars">Your answers were submitted for <b>{{meta.respondent.ru_name}}</b> on {{meta.survey.submitted_time|format_datetime}}</p>
+        <p class="mars">Transaction ID: <b>{{meta.respondent.tx_id}}</b></p>
+    </div>
+</div>
+
+<div class="u-mb-s">
+    <p>Your answers will be processed in the next few weeks.
+        We may contact you to query your answers via phone or secure message.</p>
+</div>
+
+{% block view_submission %}
+{% if is_view_submitted_response_enabled %}
+    <div class="u-mb-s">
+    {% if view_submission_url %}
+        <p class="u-mb-m@s mars" data-qa="view-submission"><a href={{view_submission_url}}>View and print a copy of your answers</a></p>
+        <p class="u-mb-s mars">Your answers will only be available for <b>{{view_submission_duration}}</b> to keep them secure.</p>
+    {% else %}
+        <div class="panel panel--simple panel--info" data-qa="view-submission-expired">
+            <div class="panel__body">
+                <p>You are no longer able to view and print your answers.</p>
+                <p>The link expires to maintain the security of your information.</p>
+            </div>
+        </div>
     {% endif %}
-    <p class="u-mb-no mars">You may wish to save or print this page for your records.</p>
-</div>
+    </div>
+{% endif %}
+{% endblock %}
 
-{{answer_guidance}}
-
-<div class="u-mt-s">
+<div class="u-mb-s">
     <div class="mars">For more information on how we use this data.</div>
     <p class="u-mb-m@s mars"><a href="https://www.ons.gov.uk/surveys">https://www.ons.gov.uk/surveys</a></p>
-    <p class="mars">It is now safe to close this window.</p>
 </div>
 
 {% endblock %}

--- a/app/templates/view-submission.html
+++ b/app/templates/view-submission.html
@@ -1,0 +1,23 @@
+{% extends theme('layouts/_twocol.html') %}
+{% import 'macros/helpers.html' as helpers %}
+
+{% block page_title -%}{{_("Submission")}} - {{survey_title}}{% endblock -%}
+
+{% block main -%}
+
+<div>
+  <h1 class="saturn">Submitted answers</h1>
+</div>
+
+<div class="u-mb-s">
+    <div class="panel panel--simple panel--success panel--spacious">
+        <p class="mars">Your answers were submitted for <b>{{meta.respondent.ru_name}}</b> on {{meta.survey.submitted_time|format_datetime}}</p>
+        <p class="mars">Transaction ID: <b>{{meta.respondent.tx_id}}</b></p>
+    </div>
+</div>
+
+<button class="btn btn--tertiary print__hidden u-no-js-hide" onclick="window.print()">Print this page <span class="btn__icon btn__icon--print-link"></span></button>
+
+{% include theme('partials/summary/summary.html') %}
+
+{% endblock -%}

--- a/app/templating/metadata_context.py
+++ b/app/templating/metadata_context.py
@@ -47,12 +47,15 @@ def _build_survey_meta(metadata):
     }
 
 
-def build_metadata_context_for_survey_completed(survey_completed_metadata):
+def build_metadata_context_for_survey_completed(session_data):
     return {
         'survey': {
-            'period_str': survey_completed_metadata['period_str'],
+            'period_str': session_data.period_str,
+            'submitted_time': session_data.submitted_time
         },
         'respondent': {
-            'tx_id': convert_tx_id(survey_completed_metadata['tx_id']),
+            'tx_id': convert_tx_id(session_data.tx_id),
+            'ru_name': session_data.ru_name,
+            'ru_ref': session_data.ru_ref,
         },
     }

--- a/app/views/errors.py
+++ b/app/views/errors.py
@@ -9,7 +9,7 @@ from ua_parser import user_agent_parser
 
 from app.authentication.no_token_exception import NoTokenException
 from app.globals import get_metadata
-from app.libs.utils import convert_tx_id
+from app.libs.utils import convert_tx_id_for_boxes
 from app.submitter.submission_failed import SubmissionFailedException
 from app.templating.template_renderer import TemplateRenderer
 
@@ -91,7 +91,7 @@ def get_tx_id():
     tx_id = None
     metadata = get_metadata(current_user)
     if metadata:
-        tx_id = convert_tx_id(metadata['tx_id'])
+        tx_id = convert_tx_id_for_boxes(metadata['tx_id'])
     return tx_id
 
 

--- a/data/en/test_view_submitted_response.json
+++ b/data/en/test_view_submitted_response.json
@@ -1,0 +1,113 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "0",
+    "title": "Test Submitted Answers Survey",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "description": "A questionnaire to demo radio field Other input.",
+    "view_submitted_response": {
+        "enabled": true,
+        "duration": 5
+    },
+    "groups": [{
+        "blocks": [{
+                "type": "Question",
+                "id": "radio",
+                "description": "",
+                "questions": [{
+                    "answers": [{
+                            "id": "radio-answer",
+                            "label": "What is your favourite breakfast food?",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "None",
+                                    "value": "None"
+                                },
+                                {
+                                    "label": "Bacon",
+                                    "value": "Bacon"
+                                },
+                                {
+                                    "label": "Eggs",
+                                    "value": "Eggs"
+                                },
+                                {
+                                    "label": "Sausage",
+                                    "value": "Sausage"
+                                },
+                                {
+                                    "label": "Other",
+                                    "description": "An answer is required.",
+                                    "value": "Other",
+                                    "child_answer_id": "other-answer-mandatory"
+                                }
+                            ],
+                            "q_code": "20",
+                            "type": "Radio"
+                        },
+                        {
+                            "parent_answer_id": "radio-answer",
+                            "alias": "othervalue",
+                            "mandatory": false,
+                            "id": "other-answer-mandatory",
+                            "label": "Please specify other",
+                            "q_code": "20",
+                            "type": "TextField"
+                        }
+                    ],
+                    "description": "",
+                    "id": "radio-question",
+                    "title": "",
+                    "type": "General"
+                }],
+                "title": "What is your favourite breakfast food"
+            },
+            {
+                "type": "Question",
+                "id": "test-number-block",
+                "description": "",
+                "questions": [{
+                    "answers": [{
+                            "id": "test-currency",
+                            "description": "",
+                            "label": "Currency Test",
+                            "mandatory": false,
+                            "type": "Currency",
+                            "currency": "GBP",
+                            "decimal_places": 2
+                        },
+                        {
+                            "id": "square-kilometres",
+                            "description": "",
+                            "label": "Kilometres Square",
+                            "mandatory": false,
+                            "type": "Unit",
+                            "unit": "area-square-kilometer"
+                        },
+                        {
+                            "id": "test-decimal",
+                            "description": "",
+                            "label": "Decimal test to 2 decimal places",
+                            "mandatory": false,
+                            "type": "Number",
+                            "decimal_places": 2
+                        }
+                    ],
+                    "description": "",
+                    "id": "test-number-range-question",
+                    "title": "Please enter test values (none mandatory)",
+                    "type": "General"
+                }],
+                "title": ""
+            },
+            {
+                "type": "Summary",
+                "id": "summary"
+            }
+        ],
+        "id": "summary-group",
+        "title": "View Submission Test"
+    }]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 
 services:
 
@@ -25,7 +25,7 @@ services:
       - eq-env
 
   eq-survey-register:
-    image: onsdigital/eq-survey-register:simple-rest-api
+    image: onsdigital/eq-survey-register:latest
     restart: always
     networks:
       - eq-env
@@ -44,10 +44,15 @@ services:
       EQ_RABBITMQ_HOST_SECONDARY: rabbit
       EQ_SECRETS_FILE: docker-secrets.yml
       EQ_KEYS_FILE: docker-keys.yml
+      EQ_SUBMITTED_RESPONSES_TABLE_NAME: dev-submitted-responses
+      EQ_DYNAMODB_ENDPOINT: http://eq-docker-dynamodb:8000
+      AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID:-dummy}"
+      AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY:-dummy}"
     restart: always
     depends_on:
       - db
       - rabbit
+      - eq-docker-dynamodb
     networks:
       - eq-env
     ports:
@@ -65,6 +70,15 @@ services:
       - eq-env
     ports:
       - "8000:8000"
+
+
+  eq-docker-dynamodb:
+    image: onsdigital/eq-docker-dynamodb:latest
+    restart: always
+    networks:
+      - eq-env
+    ports:
+      - "6060:8000"
 
 
 networks:

--- a/scripts/dev_settings.sh
+++ b/scripts/dev_settings.sh
@@ -24,6 +24,18 @@ if [ -z "$SQLALCHEMY_DATABASE_URI" ]; then
   export SQLALCHEMY_DATABASE_URI="sqlite:////tmp/questionnaire.db"
 fi
 
+if [ -z "$EQ_SUBMITTED_RESPONSES_TABLE_NAME" ]; then
+  export EQ_SUBMITTED_RESPONSES_TABLE_NAME="dev-submitted-responses"
+fi
+
+if [ -z "$EQ_DYNAMODB_ENABLED" ]; then
+  export EQ_DYNAMODB_ENABLED=False
+fi
+
+if [ -z "$EQ_DYNAMODB_ENDPOINT" ]; then
+  export EQ_DYNAMODB_ENDPOINT="http://localhost:6060"
+fi
+
 export FLASK_DEBUG=1
 
 python scripts/generate_secrets.py jwt-test-secrets/

--- a/tests/app/app_context_test_case.py
+++ b/tests/app/app_context_test_case.py
@@ -13,10 +13,11 @@ class AppContextTestCase(unittest.TestCase):
     def setUp(self):
         setting_overrides = {
             'SQLALCHEMY_DATABASE_URI': 'sqlite://',
-            'LOGIN_DISABLED': self.LOGIN_DISABLED
+            'LOGIN_DISABLED': self.LOGIN_DISABLED,
+            'EQ_DYNAMODB_ENABLED': False
         }
-
         self._app = create_app(setting_overrides)
+
         self._app.config['SERVER_NAME'] = 'test'
         self._app_context = self._app.app_context()
         self._app_context.push()

--- a/tests/app/authentication/test_authenticator.py
+++ b/tests/app/authentication/test_authenticator.py
@@ -16,9 +16,11 @@ class TestAuthenticator(AppContextTestCase): # pylint: disable=too-many-public-m
             tx_id='tx_id',
             eq_id='eq_id',
             form_type='form_type',
-            period_str='period_str'
+            period_str='period_str',
+            ru_name='ru_name',
+            ru_ref='ru_ref',
         )
-        self.session_store = SessionStore('eq_session_id')
+        self.session_store = SessionStore('user_ik', 'pepper', 'eq_session_id')
 
     def test_check_session_with_user_id_in_session(self):
         with self.test_request_context('/status'):

--- a/tests/app/data_model/test_session_store.py
+++ b/tests/app/data_model/test_session_store.py
@@ -10,12 +10,14 @@ class SessionStoreTest(AppContextTestCase):
     def setUp(self):
         super().setUp()
         self._app.permanent_session_lifetime = timedelta(seconds=1)
-        self.session_store = SessionStore()
+        self.session_store = SessionStore('user_ik', 'pepper')
         self.session_data = SessionData(
             tx_id='tx_id',
             eq_id='eq_id',
             form_type='form_type',
-            period_str='period_str'
+            period_str='period_str',
+            ru_name='ru_name',
+            ru_ref='ru_ref'
         )
 
     def test_no_session(self):
@@ -33,7 +35,7 @@ class SessionStoreTest(AppContextTestCase):
     def test_save(self):
         with self._app.test_request_context():
             self.session_store.create('eq_session_id', 'test', self.session_data).save()
-            session_store = SessionStore('eq_session_id')
+            session_store = SessionStore('user_ik', 'pepper', 'eq_session_id')
             self.assertEqual(session_store.session_data.tx_id, 'tx_id')
 
     def test_delete(self):
@@ -50,7 +52,7 @@ class SessionStoreTest(AppContextTestCase):
             self.session_store.session_data.submitted_time = current_time
             self.session_store.save()
 
-            session_store = SessionStore('eq_session_id')
+            session_store = SessionStore('user_ik', 'pepper', 'eq_session_id')
             self.assertEqual(session_store.session_data.submitted_time, current_time)
 
     def test_should_not_delete_when_no_session(self):

--- a/tests/app/data_model/test_submitted_responses.py
+++ b/tests/app/data_model/test_submitted_responses.py
@@ -1,0 +1,55 @@
+import unittest
+
+from datetime import datetime, timedelta
+from mock import Mock
+from botocore.exceptions import BotoCoreError, ConnectionError as BotoConnectionError
+from app.data_model.submitted_responses import SubmittedResponses
+
+
+class SubmittedResponsesTest(unittest.TestCase):
+
+    def setUp(self):
+        self.table = Mock()
+        self.submitted_responses = SubmittedResponses(self.table)
+
+        valid_until = datetime.utcnow() + timedelta(seconds=10)
+
+        self.item = {
+            'tx_id': 'test_tx_id',
+            'data': 'test_data',
+            'valid_until': valid_until
+        }
+
+
+    def test_put_item(self):
+        self.table.put_item = Mock(return_value={'ResponseMetadata': {'HTTPStatusCode': 200}})
+        valid_until = self.item['valid_until']
+        response = self.submitted_responses.put_item(self.item)
+
+        self.assertTrue(response)
+        item = self.table.put_item.call_args[1]['Item']
+        self.assertEqual(item.get('tx_id'), self.item['tx_id'])
+        self.assertEqual(item.get('data'), self.item['data'])
+        self.assertEqual(item.get('valid_until'), int(valid_until.strftime('%s')))
+
+
+    def test_get_item(self):
+        item_in = self.item
+        item_in['valid_until'] = int(item_in['valid_until'].strftime('%s'))
+
+        self.table.get_item = Mock(return_value={'Item': item_in})
+        item_out = self.submitted_responses.get_item('test_tx_id')
+
+        self.assertEqual(item_out.get('tx_id'), self.item['tx_id'])
+        self.assertEqual(item_out.get('data'), self.item['data'])
+        self.assertEqual(item_out.get('valid_until'), self.item['valid_until'])
+
+
+    def test_exceptions(self):
+        self.table.put_item = Mock(side_effect=BotoCoreError)
+        response = self.submitted_responses.put_item(self.item)
+        self.assertFalse(response)
+
+        self.table.get_item = Mock(side_effect=BotoConnectionError)
+        item = self.submitted_responses.get_item('test_tx_id')
+        self.assertIsNone(item)

--- a/tests/app/storage/test_encrypted_questionnaire_storage.py
+++ b/tests/app/storage/test_encrypted_questionnaire_storage.py
@@ -2,9 +2,6 @@ import unittest
 
 from app.data_model.questionnaire_store import QuestionnaireStore
 from app.storage.encrypted_questionnaire_storage import EncryptedQuestionnaireStorage
-
-
-# pylint: disable=W0212
 from tests.app.app_context_test_case import AppContextTestCase
 
 
@@ -21,39 +18,6 @@ class TestEncryptedQuestionnaireStorage(AppContextTestCase):
     def test_encrypted_storage_requires_user_ik(self):
         with self.assertRaises(ValueError):
             EncryptedQuestionnaireStorage('1', None, 'pepper')
-
-    def test_encrypted_storage_requires_pepper(self):
-        with self.assertRaises(ValueError):
-            EncryptedQuestionnaireStorage('1', 'key', None)
-
-    def test_generate_cek(self):
-        cek1 = EncryptedQuestionnaireStorage('user1', 'user_ik_1', 'pepper')._cek
-        cek2 = EncryptedQuestionnaireStorage('user1', 'user_ik_1', 'pepper')._cek
-        cek3 = EncryptedQuestionnaireStorage('user2', 'user_ik_2', 'pepper')._cek
-        self.assertEqual(cek1, cek2)
-        self.assertNotEqual(cek1, cek3)
-        self.assertNotEqual(cek2, cek3)
-
-    def test_generate_cek_different_user_ids(self):
-        cek1 = EncryptedQuestionnaireStorage('user1', 'user_ik_1', 'pepper')._cek
-        cek2 = EncryptedQuestionnaireStorage('user1', 'user_ik_1', 'pepper')._cek
-        cek3 = EncryptedQuestionnaireStorage('user2', 'user_ik_1', 'pepper')._cek
-        self.assertEqual(cek1, cek2)
-        self.assertNotEqual(cek1, cek3)
-        self.assertNotEqual(cek2, cek3)
-
-    def test_generate_cek_different_user_iks(self):
-        cek1 = EncryptedQuestionnaireStorage('user1', 'user_ik_1', 'pepper')._cek
-        cek2 = EncryptedQuestionnaireStorage('user1', 'user_ik_1', 'pepper')._cek
-        cek3 = EncryptedQuestionnaireStorage('user1', 'user_ik_2', 'pepper')._cek
-        self.assertEqual(cek1, cek2)
-        self.assertNotEqual(cek1, cek3)
-        self.assertNotEqual(cek2, cek3)
-
-    def test_generate_cek_different_pepper(self):
-        cek1 = EncryptedQuestionnaireStorage('user1', 'user_ik_1', 'pepper')._cek
-        cek2 = EncryptedQuestionnaireStorage('user1', 'user_ik_1', 'test')._cek
-        self.assertNotEqual(cek1, cek2)
 
     def test_store_and_get(self):
         user_id = '1'

--- a/tests/app/storage/test_storage_encryption.py
+++ b/tests/app/storage/test_storage_encryption.py
@@ -1,0 +1,60 @@
+import unittest
+import simplejson as json
+
+from app.storage.storage_encryption import StorageEncryption
+from tests.app.app_context_test_case import AppContextTestCase
+
+# pylint: disable=W0212
+class TestStorageEncryption(AppContextTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.encrypter = StorageEncryption('user_id', 'user_ik', 'pepper')
+
+    def test_encrypted_storage_requires_user_id(self):
+        with self.assertRaises(ValueError):
+            StorageEncryption(None, 'key', 'pepper')
+
+    def test_encrypted_storage_requires_user_ik(self):
+        with self.assertRaises(ValueError):
+            StorageEncryption('1', None, 'pepper')
+
+    def test_generate_key(self):
+        key1 = StorageEncryption('user1', 'user_ik_1', 'pepper').key._key['k']
+        key2 = StorageEncryption('user1', 'user_ik_1', 'pepper').key._key['k']
+        key3 = StorageEncryption('user2', 'user_ik_2', 'pepper').key._key['k']
+        self.assertEqual(key1, key2)
+        self.assertNotEqual(key1, key3)
+        self.assertNotEqual(key2, key3)
+
+    def test_generate_key_different_user_ids(self):
+        key1 = StorageEncryption('user1', 'user_ik_1', 'pepper').key._key['k']
+        key2 = StorageEncryption('user1', 'user_ik_1', 'pepper').key._key['k']
+        key3 = StorageEncryption('user2', 'user_ik_1', 'pepper').key._key['k']
+        self.assertEqual(key1, key2)
+        self.assertNotEqual(key1, key3)
+        self.assertNotEqual(key2, key3)
+
+    def test_generate_key_different_user_iks(self):
+        key1 = StorageEncryption('user1', 'user_ik_1', 'pepper').key._key['k']
+        key2 = StorageEncryption('user1', 'user_ik_1', 'pepper').key._key['k']
+        key3 = StorageEncryption('user1', 'user_ik_2', 'pepper').key._key['k']
+        self.assertEqual(key1, key2)
+        self.assertNotEqual(key1, key3)
+        self.assertNotEqual(key2, key3)
+
+    def test_encryption_decryption(self):
+        data = {
+            'data1': 'Test Data One',
+            'data2': 'Test Data Two'
+        }
+        encrypted_data = self.encrypter.encrypt_data(data)
+        self.assertNotEqual(encrypted_data, data)
+        self.assertIsInstance(encrypted_data, str)
+
+        decrypted_data = self.encrypter.decrypt_data(encrypted_data)
+        decrypted_data = json.loads(decrypted_data)
+        self.assertEqual(data, decrypted_data)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/functional/pages/features/submitted_responses/radio.page.js
+++ b/tests/functional/pages/features/submitted_responses/radio.page.js
@@ -1,0 +1,45 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class RadioPage extends QuestionPage {
+
+  constructor() {
+    super('radio');
+  }
+
+  none() {
+    return '#radio-answer-0';
+  }
+
+  noneLabel() { return '#label-radio-answer-0'; }
+
+  bacon() {
+    return '#radio-answer-1';
+  }
+
+  baconLabel() { return '#label-radio-answer-1'; }
+
+  eggs() {
+    return '#radio-answer-2';
+  }
+
+  eggsLabel() { return '#label-radio-answer-2'; }
+
+  sausage() {
+    return '#radio-answer-3';
+  }
+
+  sausageLabel() { return '#label-radio-answer-3'; }
+
+  other() {
+    return '#radio-answer-4';
+  }
+
+  otherLabel() { return '#label-radio-answer-4'; }
+
+  otherText() {
+    return '#other-answer-mandatory';
+  }
+
+}
+module.exports = new RadioPage();

--- a/tests/functional/pages/features/submitted_responses/submission.page.js
+++ b/tests/functional/pages/features/submitted_responses/submission.page.js
@@ -1,0 +1,31 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  radioAnswer() { return '#radio-answer-answer'; }
+
+  radioAnswerEdit() { return '[data-qa="radio-answer-edit"]'; }
+
+  otherAnswerMandatory() { return '#other-answer-mandatory-answer'; }
+
+  otherAnswerMandatoryEdit() { return '[data-qa="other-answer-mandatory-edit"]'; }
+
+  testCurrency() { return '#test-currency-answer'; }
+
+  testCurrencyEdit() { return '[data-qa="test-currency-edit"]'; }
+
+  squareKilometres() { return '#square-kilometres-answer'; }
+
+  squareKilometresEdit() { return '[data-qa="square-kilometres-edit"]'; }
+
+  testDecimal() { return '#test-decimal-answer'; }
+
+  testDecimalEdit() { return '[data-qa="test-decimal-edit"]'; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/pages/features/submitted_responses/test-number-block.page.js
+++ b/tests/functional/pages/features/submitted_responses/test-number-block.page.js
@@ -1,0 +1,29 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class TestNumberBlockPage extends QuestionPage {
+
+  constructor() {
+    super('test-number-block');
+  }
+
+  testCurrency() {
+    return '#test-currency';
+  }
+
+  testCurrencyLabel() { return '#label-test-currency'; }
+
+  squareKilometres() {
+    return '#square-kilometres';
+  }
+
+  squareKilometresLabel() { return '#label-square-kilometres'; }
+
+  testDecimal() {
+    return '#test-decimal';
+  }
+
+  testDecimalLabel() { return '#label-test-decimal'; }
+
+}
+module.exports = new TestNumberBlockPage();

--- a/tests/functional/pages/thank-you.page.js
+++ b/tests/functional/pages/thank-you.page.js
@@ -1,3 +1,18 @@
 const QuestionPage = require('./surveys/question.page');
 
-module.exports = new QuestionPage('thank-you');
+class ThankYouPage extends QuestionPage {
+
+  constructor() {
+    super('thank-you');
+  }
+
+  viewSubmitted() {
+    return '[data-qa="view-submission"]';
+  }
+
+  viewSubmissionExpired() {
+    return '[data-qa="view-submission-expired"]';
+  }
+
+}
+module.exports = new ThankYouPage();

--- a/tests/functional/spec/features/submitted_responses.spec.js
+++ b/tests/functional/spec/features/submitted_responses.spec.js
@@ -1,0 +1,66 @@
+const helpers = require('../../helpers');
+
+const RadioPage = require('../../pages/features/submitted_responses/radio.page.js');
+const NumberBlockPage = require('../../pages/features/submitted_responses/test-number-block.page.js');
+const SummaryPage = require('../../pages/summary.page.js');
+const ThankYouPage = require('../../pages/thank-you.page.js');
+const SubmissionPage = require('../../pages/features/submitted_responses/submission.page.js');
+
+
+describe('Feature: Submitted Responses', function() {
+
+  beforeEach(function() {
+    return helpers.openQuestionnaire('test_view_submitted_response.json').then(() => {
+        return browser
+          .click(RadioPage.bacon())
+          .click(RadioPage.submit())
+          .setValue(NumberBlockPage.testCurrency(), 123.45)
+          .click(NumberBlockPage.submit())
+          .click(SummaryPage.submit());
+
+    });
+  });
+
+  describe('Check submitted responses', function() {
+    it('Given I complete to Thank-You page, When I click the submitted answers link, Then I should be able to view my submitted answers', function() {
+        return browser
+          .click(ThankYouPage.viewSubmitted())
+          .getUrl().should.eventually.contain('view-submission')
+          .getText(SubmissionPage.radioAnswer()).should.eventually.contain('Bacon')
+          .getText(SubmissionPage.testCurrency()).should.eventually.contain('123.45');
+    });
+
+    it('Given I am viewing my submitted answers, When I click refresh after the timeout period, Then I should be routed back to Thank You page', function() {
+        return browser
+          .waitUntil(function () {
+            return browser
+              .refresh()
+              .isVisible(ThankYouPage.viewSubmissionExpired());
+          }, 6000, 'Can still view submission after timeout');
+    });
+  });
+
+  describe('Try to click view submission link after timeout', function() {
+    it('Given I complete to Thank-You page, When I click the submitted answers link after the timeout period, Then I should not be able to view my submitted answers', function() {
+        return browser
+          .isVisible(ThankYouPage.viewSubmitted())
+          .pause(5000)
+          .click(ThankYouPage.viewSubmitted())
+          .isVisible(ThankYouPage.viewSubmissionExpired());
+    });
+  });
+
+  describe('Check view submission link has expired after timeout', function() {
+    it('Given I complete to Thank-You page, When I refresh after the timeout period, Then I should not be able to view my submitted answers', function() {
+        return browser
+          .isVisible(ThankYouPage.viewSubmitted())
+          .waitUntil(function () {
+            return browser
+              .refresh()
+              .isVisible(ThankYouPage.viewSubmissionExpired());
+          }, 6000, 'Can still view submission after timeout');
+    });
+  });
+
+});
+

--- a/tests/integration/mci/test_empty_comments.py
+++ b/tests/integration/mci/test_empty_comments.py
@@ -43,8 +43,8 @@ class TestEmptyComments(IntegrationTestCase):
 
         # We are on the review answers page
         self.assertInPage('>Monthly Business Survey - Retail Sales Index</')
-        self.assertInPage('>Your responses<')
-        self.assertInPage('Please check your responses carefully before submitting')
+        self.assertInPage('>Your answers<')
+        self.assertInPage('Please check your answers carefully before submitting')
         self.assertInPage('>Submit answers<')
 
         # We submit our answers

--- a/tests/integration/mci/test_empty_submission.py
+++ b/tests/integration/mci/test_empty_submission.py
@@ -63,8 +63,8 @@ class TestEmptySubmission(IntegrationTestCase):
         self.assertInUrl(mci_test_urls.MCI_0205_SUMMARY)
 
         # We are on the review answers page
-        self.assertInPage('>Your responses<')
-        self.assertInPage('Please check your responses carefully before submitting')
+        self.assertInPage('>Your answers<')
+        self.assertInPage('Please check your answers carefully before submitting')
         self.assertInPage('>Submit answers<')
 
         # We submit our answers

--- a/tests/integration/mci/test_happy_path.py
+++ b/tests/integration/mci/test_happy_path.py
@@ -49,8 +49,8 @@ class TestHappyPath(IntegrationTestCase):
 
         # We are on the review answers page
         self.assertInPage('>Monthly Business Survey - Retail Sales Index</')
-        self.assertInPage('>Your responses<')
-        self.assertInPage('Please check your responses carefully before submitting.')
+        self.assertInPage('>Your answers<')
+        self.assertInPage('Please check your answers carefully before submitting.')
         self.assertInPage('>Submit answers<')
 
         # Submit answers

--- a/tests/integration/mci/test_invalid_dates_numbers.py
+++ b/tests/integration/mci/test_invalid_dates_numbers.py
@@ -52,8 +52,8 @@ class TestInvalidDateNumber(IntegrationTestCase):
         self.assertInUrl(mci_test_urls.MCI_0205_SUMMARY)
 
         # We are on the review answers page
-        self.assertInPage('>Your responses<')
-        self.assertInPage('Please check your responses carefully before submitting')
+        self.assertInPage('>Your answers<')
+        self.assertInPage('Please check your answers carefully before submitting')
         self.assertInPage('>Submit answers<')
 
         # We submit our answers

--- a/tests/integration/mci/test_mci_submission_data.py
+++ b/tests/integration/mci/test_mci_submission_data.py
@@ -44,8 +44,8 @@ class TestMciSubmissionData(IntegrationTestCase):
         # There are no validation errors (we're on the summary screen)
         self.assertInUrl('summary')
         self.assertInPage('>Monthly Business Survey - Retail Sales Index</')
-        self.assertInPage('>Your responses<')
-        self.assertInPage('Please check your responses carefully before submitting')
+        self.assertInPage('>Your answers<')
+        self.assertInPage('Please check your answers carefully before submitting')
         self.assertInPage('>Submit answers<')
 
         actual = self.dumpSubmission()

--- a/tests/integration/qbs/test_qbs_submission_data.py
+++ b/tests/integration/qbs/test_qbs_submission_data.py
@@ -30,8 +30,8 @@ class TestQbsSubmissionData(IntegrationTestCase):
         # There are no validation errors (we're on the summary screen)
         self.assertInUrl('summary')
         self.assertInPage('>Quarterly Business Survey</')
-        self.assertInPage('>Your responses<')
-        self.assertInPage('Please check your responses carefully before submitting')
+        self.assertInPage('>Your answers<')
+        self.assertInPage('Please check your answers carefully before submitting')
         self.assertInPage('>Submit answers<')
 
         # And the JSON response contains the data I submitted

--- a/tests/integration/rsi/test_rsi_submission_data.py
+++ b/tests/integration/rsi/test_rsi_submission_data.py
@@ -38,8 +38,8 @@ class TestRsiSubmissionData(IntegrationTestCase):
         # There are no validation errors (we're on the summary screen)
         self.assertInUrl('summary')
         self.assertInPage('>Monthly Business Survey - Retail Sales Index</')
-        self.assertInPage('>Your responses<')
-        self.assertInPage('Please check your responses carefully before submitting')
+        self.assertInPage('>Your answers<')
+        self.assertInPage('Please check your answers carefully before submitting')
         self.assertInPage('>Submit answers<')
 
         # And the JSON response contains the data I submitted
@@ -126,8 +126,8 @@ class TestRsiSubmissionData(IntegrationTestCase):
         # There are no validation errors (we're on the summary screen)
         self.assertInUrl('summary')
         self.assertInPage('>Monthly Business Survey - Retail Sales Index</')
-        self.assertInPage('>Your responses<')
-        self.assertInPage('Please check your responses carefully before submitting')
+        self.assertInPage('>Your answers<')
+        self.assertInPage('Please check your answers carefully before submitting')
         self.assertInPage('>Submit answers<')
 
         # And the JSON response contains the data I submitted

--- a/tests/integration/star_wars/test_conditional_display.py
+++ b/tests/integration/star_wars/test_conditional_display.py
@@ -43,7 +43,7 @@ class TestConditionalDisplay(StarWarsTestCase):
 
         # We are on the summary page
         self.assertInPage('>Star Wars</')
-        self.assertInPage('>Your responses<')
+        self.assertInPage('>Your answers<')
         self.assertInPage('What is the name of Jar Jar Binks')
 
     def test_conditional_display_questions_non_present(self):
@@ -81,5 +81,5 @@ class TestConditionalDisplay(StarWarsTestCase):
 
         # We are on the review answers page
         self.assertInPage('>Star Wars</')
-        self.assertInPage('>Your responses<')
+        self.assertInPage('>Your answers<')
         self.assertNotInPage('What is the name of Jar Jar Binks')

--- a/tests/integration/star_wars/test_confirmation_page.py
+++ b/tests/integration/star_wars/test_confirmation_page.py
@@ -57,4 +57,4 @@ class TestConfirmationPage(IntegrationTestCase):
 
     def rogue_one_check_confirmation_page(self):
         self.assertInPage('Summary')
-        self.assertInPage('Please check your responses carefully before submitting')
+        self.assertInPage('Please check your answers carefully before submitting')

--- a/tests/integration/star_wars/test_empty_submission_fails.py
+++ b/tests/integration/star_wars/test_empty_submission_fails.py
@@ -42,7 +42,7 @@ class TestEmptySubmissionFails(StarWarsTestCase):
 
         # We are on the review answers page
         self.assertInPage('>Star Wars</')
-        self.assertInPage('>Your responses<')
+        self.assertInPage('>Your answers<')
         self.assertRegexPage('(?s)How old is Chewy?.*?234')
         self.assertRegexPage('(?s)How many Octillions do Nasa reckon it would cost to build a death star?.*?£40')
         self.assertRegexPage('(?s)How hot is a lightsaber in degrees C?.*?1,370')
@@ -57,7 +57,7 @@ class TestEmptySubmissionFails(StarWarsTestCase):
         self.assertRegexPage('(?s)What was the total number of Ewoks?.*?')
         self.assertRegexPage("(?s)Why doesn't Chewbacca receive a medal at the end of A New Hope?.*?"
                              'Wookiees don’t place value in material rewards and refused the medal initially')
-        self.assertInPage('>Please check your responses carefully before submitting.<')
+        self.assertInPage('>Please check your answers carefully before submitting.<')
         self.assertInPage('>Submit answers<')
 
         # Submit answers

--- a/tests/integration/star_wars/test_light_side_path.py
+++ b/tests/integration/star_wars/test_light_side_path.py
@@ -37,7 +37,7 @@ class TestLightSidePath(StarWarsTestCase):
 
         # We are on the review answers page
         self.assertInPage('>Star Wars</')
-        self.assertInPage('>Your responses<')
+        self.assertInPage('>Your answers<')
         self.assertRegexPage('(?s)How old is Chewy?.*?234')
         self.assertRegexPage('(?s)How many Octillions do Nasa reckon it would cost to build a death star?.*?£40')
         self.assertRegexPage('(?s)How hot is a lightsaber in degrees C?.*?1,370')
@@ -51,7 +51,7 @@ class TestLightSidePath(StarWarsTestCase):
         self.assertRegexPage('(?s)What was the total number of Ewoks?.*?')
         self.assertRegexPage("(?s)Why doesn't Chewbacca receive a medal at the end of A New Hope?.*?"
                              'Wookiees don’t place value in material rewards and refused the medal initially')
-        self.assertInPage('Please check your responses carefully before submitting')
+        self.assertInPage('Please check your answers carefully before submitting')
         self.assertInPage('>Submit answers<')
 
         # Post answers

--- a/tests/integration/star_wars/test_navigation.py
+++ b/tests/integration/star_wars/test_navigation.py
@@ -47,7 +47,7 @@ class TestNavigation(StarWarsTestCase):
 
         # We are on the review answers page
         self.assertInPage('>Star Wars</')
-        self.assertInPage('>Your responses<')
+        self.assertInPage('>Your answers<')
         self.assertRegexPage('(?s)How old is Chewy?.*?234')
         self.assertRegexPage('(?s)How many Octillions do Nasa reckon it would cost to build a death star?.*?£40')
         self.assertRegexPage('(?s)How hot is a lightsaber in degrees C?.*?1,370')
@@ -60,7 +60,7 @@ class TestNavigation(StarWarsTestCase):
         self.assertRegexPage('(?s)What was the total number of Ewoks?.*?')
         self.assertRegexPage("(?s)Why doesn't Chewbacca receive a medal at the end of A New Hope?.*?"
                              'Wookiees don’t place value in material rewards and refused the medal initially')  # NOQA
-        self.assertInPage('>Please check your responses carefully before submitting.<')
+        self.assertInPage('>Please check your answers carefully before submitting.<')
         self.assertInPage('>Submit answers<')
 
         # Submit answers

--- a/tests/integration/test_app_create.py
+++ b/tests/integration/test_app_create.py
@@ -13,7 +13,8 @@ from app.submitter.submitter import LogSubmitter, RabbitMQSubmitter
 class TestCreateApp(unittest.TestCase):
     def setUp(self):
         self._setting_overrides = {
-            'SQLALCHEMY_DATABASE_URI': 'sqlite:////tmp/questionnaire.db'
+            'SQLALCHEMY_DATABASE_URI': 'sqlite:////tmp/questionnaire.db',
+            'EQ_DYNAMODB_ENABLED': False
         }
 
     def test_returns_application(self):

--- a/tests/integration/views/test_view_submission.py
+++ b/tests/integration/views/test_view_submission.py
@@ -1,0 +1,105 @@
+from tests.integration.integration_test_case import IntegrationTestCase
+from mock import Mock
+from flask import current_app
+
+class TestViewSubmission(IntegrationTestCase):
+
+    def setUp(self):
+        super().SetUpWithDynamoDB()
+
+        with self._application.app_context():
+            self.table = current_app.eq['submitted_responses'].table
+
+    def test_view_submission(self):
+        self.launchSurvey('test', 'view_submitted_response')
+
+        # check we're on first page
+        self.assertInPage('What is your favourite breakfast food')
+
+        # We fill in our answer
+        form_data = {
+            # Food choice
+            'radio-answer': 'Bacon',
+        }
+
+        # We submit the form
+        self.post(form_data)
+
+        # check we're on second page
+        self.assertInPage('Please enter test values (none mandatory)')
+
+        # We fill in our answers
+        form_data = {
+            # Food choice
+            'test-currency': '12',
+            'square-kilometres': '345',
+            'test-decimal': '67.89',
+        }
+
+        # We submit the form
+        self.post(form_data)
+
+        # There are no validation errors
+        self.assertInUrl('summary')
+
+        # check we're on the review answers page
+        self.assertInPage('Please check your answers carefully before submitting.')
+
+        # Submit answers
+        self.table.put_item = Mock(return_value={'ResponseMetadata': {'HTTPStatusCode': 200}})
+        self.post(action=None)
+
+        item = self.table.put_item.call_args[1]
+
+        # check we're on the thank you page and view submission link is available
+        self.assertInUrl('thank-you')
+        self.assertInPage('View and print a copy of your answers')
+
+        # go to the view submission page
+        self.table.get_item = Mock(return_value=item)
+        self.get('questionnaire/test/view_submitted_response/view-submission')
+
+        # check we're on the view submission page
+        self.assertInUrl('view-submission')
+        self.assertInPage('Submitted answers')
+
+        # check answers are on page
+        self.assertInPage('Bacon')
+        self.assertInPage('12')
+        self.assertInPage('345')
+        self.assertInPage('67.89')
+
+
+    def test_try_view_submission_when_not_available(self):
+        self.launchSurvey('test', 'currency')
+
+        # check we're on first page
+        self.assertInPage('Currency Input Test')
+
+        # We fill in our answers
+        form_data = {
+            # Food choice
+            'answer': '12',
+            'answer-usd': '345',
+            'answer-eur': '67.89',
+            'answer-jpy': '0',
+        }
+
+        # We submit the form
+        self.post(form_data)
+
+        # There are no validation errors
+        self.assertInUrl('summary')
+
+        # Submit answers
+        self.post(action=None)
+
+        # check we're on the thank you page and view submission link is not available
+        self.assertInUrl('thank-you')
+        self.assertNotInPage('View and print a copy of your answers')
+
+        # try go to the view submission page anyway
+        self.get('questionnaire/test/currency/view-submission')
+
+        # check we're redirected back to thank you page
+        self.assertInUrl('thank-you')


### PR DESCRIPTION
### What is the context of this PR?
**As a** respondent, 
**I need** to access my responses to questions 
**so that** I can refer to them if my data is queried by ONS at a later date or used as a reference for next time I complete the same survey

### How to review 
Easiest to test using docker (`docker-compose up -d`) to ensure the dynamoDb container is created.

Use `test_submitted_responses.json` schema which allows answers to be viewed for 45 seconds.
