### PR TITLE
Remove period from RSI QBS Banners

### DIFF
--- a/data/en/1_0112.json
+++ b/data/en/1_0112.json
@@ -7,9 +7,6 @@
     "description": "RSI Description",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
-    "variables": {
-        "period": "{{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}"
-    },
     "groups": [{
         "blocks": [{
                 "type": "Introduction",

--- a/data/en/1_0213.json
+++ b/data/en/1_0213.json
@@ -7,9 +7,6 @@
     "description": "MCI Description",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
-    "variables": {
-        "period": "{{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}"
-    },
     "groups": [{
         "blocks": [{
                 "type": "Introduction",

--- a/data/en/1_0215.json
+++ b/data/en/1_0215.json
@@ -7,9 +7,6 @@
     "description": "MCI Description",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
-    "variables": {
-        "period": "{{ format_conditional_date(answers.period_from, exercise.start_date) }} to {{ format_conditional_date(answers.period_to, exercise.end_date) }}"
-    },
     "groups": [{
         "blocks": [{
                 "type": "Introduction",

--- a/data/en/2_0001.json
+++ b/data/en/2_0001.json
@@ -133,8 +133,5 @@
     "schema_version": "0.0.1",
     "survey_id": "139",
     "theme": "default",
-    "title": "Quarterly Business Survey",
-    "variables": {
-        "period": "{{ format_start_end_date(exercise.start_date, exercise.end_date) }}"
-    }
+    "title": "Quarterly Business Survey"
 }


### PR DESCRIPTION
### What is the context of this PR?
Due to a missed requirement the period which has been added to the banner doesn't apply to employment questions within surveys so the employment area would like us to take it out of the banner for those surveys affected until we have done user research.

### How to review 
Check surveys 1_0112, 1_0213, 1_0215 and 2_0001 no longer have period information in their banners.