### PR TITLE
Add optional string description property to Option JSON schema.

### DIFF
--- a/data/schema/schema_v1.json
+++ b/data/schema/schema_v1.json
@@ -543,7 +543,11 @@
                                   "child_answer_id": {
                                     "type": "string",
                                     "description": "The id of an answer that should be treated as a child of this one, for example a text field answer can be the child of a radio option. The id must be of an answer in this list of answers."
-                                  }
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "description": "Descriptive text that appears below the option label"
+                                  },
                                 },
                                 "required": [
                                   "label",


### PR DESCRIPTION
### What is the context of this PR?
Whilst [fixing an issue on author](https://github.com/ONSdigital/eq-publisher/pull/30) I noticed that the survey runner schema does not contain the description property for option types.
The description property is used in survey runner as can be seen [here](https://github.com/ONSdigital/eq-survey-runner/blob/master/app/templates/partials/widgets/multiple_choice_widget.html#L34).
This PR adds an optional description string property to the `schema_v1.json` file.

### How to review 
All existing tests and checks should continue to pass.
