### PR TITLE
Add Exclusive Number Validation

### DIFF
--- a/app/validation/error_messages.py
+++ b/app/validation/error_messages.py
@@ -8,6 +8,8 @@ error_messages = {
     'MANDATORY_DATE': 'Enter a date to continue.',
     'NUMBER_TOO_SMALL': 'Enter a number more than or equal to %(min)s.',
     'NUMBER_TOO_LARGE': 'Enter a number less than or equal to %(max)s.',
+    'NUMBER_TOO_SMALL_EXCLUSIVE': 'Enter a number more than %(min)s.',
+    'NUMBER_TOO_LARGE_EXCLUSIVE': 'Enter a number less than %(max)s.',
     'INVALID_NUMBER': 'Enter a number.',
     'INVALID_INTEGER': 'Enter a whole number.',
     'INVALID_DECIMAL': 'Enter a number rounded to %(max)d decimal places.',

--- a/data/en/test_numbers.json
+++ b/data/en/test_numbers.json
@@ -19,7 +19,6 @@
                                 "description": "",
                                 "label": "Minimum Value",
                                 "mandatory": true,
-                                "options": [],
                                 "type": "Number",
                                 "decimal_places": 2
                             },
@@ -29,7 +28,6 @@
                                 "description": "",
                                 "label": "Maximum Value",
                                 "mandatory": true,
-                                "options": [],
                                 "type": "Number",
                                 "decimal_places": 2
                             }
@@ -49,9 +47,8 @@
                         "answers": [{
                                 "id": "test-range",
                                 "description": "",
-                                "label": "Range Test {{answers.min_value|format_number}} to {{answers.max_value|format_number}}",
+                                "label": "Range Test ({{answers.min_value|format_number}} to {{answers.max_value|format_number}})",
                                 "mandatory": false,
-                                "options": [],
                                 "type": "Number",
                                 "decimal_places": 2,
                                 "max_value": {
@@ -62,11 +59,26 @@
                                 }
                             },
                             {
+                                "id": "test-range-exclusive",
+                                "description": "",
+                                "label": "Range Exclusive Test ({{answers.min_value|format_number}} to {{answers.max_value|format_number}} Exclusive)",
+                                "mandatory": false,
+                                "type": "Number",
+                                "decimal_places": 2,
+                                "max_value": {
+                                    "answer_id": "set-maximum",
+                                    "exclusive": true
+                                },
+                                "min_value": {
+                                    "answer_id": "set-minimum",
+                                    "exclusive": true
+                                }
+                            },
+                            {
                                 "id": "test-min",
                                 "description": "",
                                 "label": "Min Test (123 to 9,999,999,999)",
                                 "mandatory": false,
-                                "options": [],
                                 "type": "Number",
                                 "min_value": {
                                     "value": 123
@@ -77,10 +89,31 @@
                                 "description": "",
                                 "label": "Max Test (0 to 1,234)",
                                 "mandatory": false,
-                                "options": [],
                                 "type": "Number",
                                 "max_value": {
                                     "value": 1234
+                                }
+                            },
+                            {
+                                "id": "test-min-exclusive",
+                                "description": "",
+                                "label": "Min Exclusive Test (124 to 9,999,999,999 - 123 Exclusive)",
+                                "mandatory": false,
+                                "type": "Number",
+                                "min_value": {
+                                    "value": 123,
+                                    "exclusive": true
+                                }
+                            },
+                            {
+                                "id": "test-max-exclusive",
+                                "description": "",
+                                "label": "Max Exclusive Test (0 to 1,233 - 1,234 Exclusive)",
+                                "mandatory": false,
+                                "type": "Number",
+                                "max_value": {
+                                    "value": 1234,
+                                    "exclusive": true
                                 }
                             },
                             {
@@ -88,7 +121,6 @@
                                 "description": "",
                                 "label": "Percent Test (0 to 100)",
                                 "mandatory": false,
-                                "options": [],
                                 "type": "Percentage",
                                 "max_value": {
                                     "value": 100
@@ -99,7 +131,6 @@
                                 "description": "",
                                 "label": "Decimal test to 2 decimal places between {{answers.min_value|format_number}} to {{answers.max_value|format_number}}",
                                 "mandatory": false,
-                                "options": [],
                                 "type": "Currency",
                                 "currency": "GBP",
                                 "decimal_places": 2,

--- a/data/schema/schema_v1.json
+++ b/data/schema/schema_v1.json
@@ -575,6 +575,10 @@
                                 "answer_id": {
                                   "type": "string",
                                   "description": "The id of an answer from which to obtain the max_value"
+                                },
+                                "exclusive": {
+                                  "type": "boolean",
+                                  "description": "Whether validation is exclusive of value or not"
                                 }
                               },
                               "oneOf": [
@@ -600,6 +604,10 @@
                                 "answer_id": {
                                   "type": "string",
                                   "description": "The id of an answer from which to obtain the min_value"
+                                },
+                                "exclusive": {
+                                  "type": "boolean",
+                                  "description": "Whether validation is exclusive of value or not"
                                 }
                               },
                               "oneOf": [

--- a/tests/app/validation/test_number_range_validator.py
+++ b/tests/app/validation/test_number_range_validator.py
@@ -509,3 +509,93 @@ class TestNumberRangeValidator(unittest.TestCase):
 
         self.assertEqual(str(ite.exception),
                          'answer: set-maximum-cat value: cat for answer id: test-range is not a valid number')
+
+    def test_manual_min_exclusive(self):
+        answer = { 'min_value': {
+                        "value": 10,
+                        "exclusive": True
+                    },
+                   'label': 'Min Test',
+                   'guidance': '',
+                   'options': [],
+                   'mandatory': False,
+                   'validation':
+                      {'messages':
+                           {
+                            'INVALID_NUMBER': 'Please only enter whole numbers into the field.',
+                            'NUMBER_TOO_SMALL_EXCLUSIVE': 'The minimum value allowed is 10. Please correct your answer.'
+                           }
+                      },
+                   'description': '',
+                   'id': 'test-range',
+                   'type': 'Currency'
+                  }
+        label = answer['label']
+        error_messages = answer['validation']['messages']
+
+        integer_field = get_number_field(answer, label, '', error_messages, self.store)
+
+        self.assertTrue(integer_field.field_class == CustomIntegerField)
+
+        for validator in integer_field.kwargs['validators']:
+            if isinstance(validator, NumberRange):
+                test_validator = validator
+
+        mock_form = Mock()
+        integer_field.data = 10
+
+        with self.assertRaises(ValidationError) as ite:
+            test_validator(mock_form, integer_field)
+
+        self.assertEqual(str(ite.exception), error_messages['NUMBER_TOO_SMALL_EXCLUSIVE'])
+
+        try:
+            integer_field.data = 11
+            test_validator(mock_form, integer_field)
+        except ValidationError:
+            self.fail("Valid integer raised ValidationError")
+
+    def test_manual_max_exclusive(self):
+        answer = { 'max_value': {
+                        "value": 20,
+                        "exclusive": True
+                    },
+                   'label': 'Max Test',
+                   'guidance': '',
+                   'options': [],
+                   'mandatory': False,
+                   'validation':
+                      {'messages':
+                           {
+                            'INVALID_NUMBER': 'Please only enter whole numbers into the field.',
+                            'NUMBER_TOO_LARGE_EXCLUSIVE': 'The maximum value allowed is 20. Please correct your answer.'
+                           }
+                      },
+                   'description': '',
+                   'id': 'test-range',
+                   'type': 'Currency'
+                  }
+        label = answer['label']
+        error_messages = answer['validation']['messages']
+
+        integer_field = get_number_field(answer, label, '', error_messages, self.store)
+
+        self.assertTrue(integer_field.field_class == CustomIntegerField)
+
+        for validator in integer_field.kwargs['validators']:
+            if isinstance(validator, NumberRange):
+                test_validator = validator
+
+        mock_form = Mock()
+        integer_field.data = 20
+
+        with self.assertRaises(ValidationError) as ite:
+            test_validator(mock_form, integer_field)
+
+        self.assertEqual(str(ite.exception), error_messages['NUMBER_TOO_LARGE_EXCLUSIVE'])
+
+        try:
+            integer_field.data = 19
+            test_validator(mock_form, integer_field)
+        except ValidationError:
+            self.fail("Valid integer raised ValidationError")

--- a/tests/functional/pages/surveys/numbers/test-min-max-block.page.js
+++ b/tests/functional/pages/surveys/numbers/test-min-max-block.page.js
@@ -13,6 +13,13 @@ class TestMinMaxBlockPage extends QuestionPage {
 
   testRangeLabel() { return '#label-test-range'; }
 
+  testRangeExclusive() {
+    return '#test-range-exclusive';
+  }
+
+  testRangeLabelExclusive() { return '#label-test-range-exclusive'; }
+
+
   testMin() {
     return '#test-min';
   }
@@ -24,6 +31,19 @@ class TestMinMaxBlockPage extends QuestionPage {
   }
 
   testMaxLabel() { return '#label-test-max'; }
+
+  testMinExclusive() {
+    return '#test-min-exclusive';
+  }
+
+  testMinLabelExclusive() { return '#label-test-min-exclusive'; }
+
+  testMaxExclusive() {
+    return '#test-max-exclusive';
+  }
+
+  testMaxLabelExclusive() { return '#label-test-max-exclusive'; }
+
 
   testPercent() {
     return '#test-percent';

--- a/tests/functional/spec/numbers.spec.js
+++ b/tests/functional/spec/numbers.spec.js
@@ -31,16 +31,22 @@ describe('NumericRange', function() {
           .setValue(SetMinMax.setMaximum(), '20')
           .click(SetMinMax.submit())
           .setValue(TestMinMax.testRange(), '9')
+          .setValue(TestMinMax.testRangeExclusive(), '10')
           .setValue(TestMinMax.testMin(), '0')
           .setValue(TestMinMax.testMax(), '12345')
+          .setValue(TestMinMax.testMinExclusive(), '123')
+          .setValue(TestMinMax.testMaxExclusive(), '1234')
           .setValue(TestMinMax.testPercent(), '101')
           .setValue(TestMinMax.testDecimal(), '5.4')
           .click(TestMinMax.submit())
           .getText(TestMinMax.errorNumber(1)).should.eventually.contain("Enter a number more than or equal to 10.")
-          .getText(TestMinMax.errorNumber(2)).should.eventually.contain("Enter a number more than or equal to 123.")
-          .getText(TestMinMax.errorNumber(3)).should.eventually.contain("Enter a number less than or equal to 1,234.")
-          .getText(TestMinMax.errorNumber(4)).should.eventually.contain("Enter a number less than or equal to 100.")
-          .getText(TestMinMax.errorNumber(5)).should.eventually.contain("Enter a number more than or equal to £10.00.");
+          .getText(TestMinMax.errorNumber(2)).should.eventually.contain("Enter a number more than 10.")
+          .getText(TestMinMax.errorNumber(3)).should.eventually.contain("Enter a number more than or equal to 123.")
+          .getText(TestMinMax.errorNumber(4)).should.eventually.contain("Enter a number less than or equal to 1,234.")
+          .getText(TestMinMax.errorNumber(5)).should.eventually.contain("Enter a number more than 123.")
+          .getText(TestMinMax.errorNumber(6)).should.eventually.contain("Enter a number less than 1,234.")
+          .getText(TestMinMax.errorNumber(7)).should.eventually.contain("Enter a number less than or equal to 100.")
+          .getText(TestMinMax.errorNumber(8)).should.eventually.contain("Enter a number more than or equal to £10.00.");
       });
   });
 


### PR DESCRIPTION
### What is the context of this PR?
Allow for you to specify in Maximum and Minimum definitions if validation is exclusive or not of the value specified.  

### How to review 
test_numbers.json has additional questions where it will validate answers and do not allow them to equal the specified maximum or minimum.

New schema definition includes:
"min_value": {
   "answer_id": "set-minimum",
   **"exclusive": true**
}