### PR TITLE
Add Exclusive Number Validation to MWSS

### DIFF
--- a/data/en/1_0005.json
+++ b/data/en/1_0005.json
@@ -435,11 +435,12 @@
                                 "currency": "GBP",
                                 "decimal_places": 2,
                                 "max_value": {
-                                    "answer_id": "weekly-pay-gross-pay-answer"
+                                    "answer_id": "weekly-pay-gross-pay-answer",
+                                    "exclusive": true
                                 },
                                 "validation": {
                                     "messages": {
-                                        "NUMBER_TOO_LARGE": "Enter an amount less than or equal to %(max)s."
+                                        "NUMBER_TOO_LARGE_EXCLUSIVE": "Enter an amount less than %(max)s."
                                     }
                                 }
                             },
@@ -452,11 +453,12 @@
                                 "currency": "GBP",
                                 "decimal_places": 2,
                                 "max_value": {
-                                    "answer_id": "weekly-pay-gross-pay-answer"
+                                    "answer_id": "weekly-pay-gross-pay-answer",
+                                    "exclusive": true
                                 },
                                 "validation": {
                                     "messages": {
-                                        "NUMBER_TOO_LARGE": "Enter an amount less than or equal to %(max)s."
+                                        "NUMBER_TOO_LARGE_EXCLUSIVE": "Enter an amount less than %(max)s."
                                     }
                                 }
                             },
@@ -1002,11 +1004,12 @@
                                 "currency": "GBP",
                                 "decimal_places": 2,
                                 "max_value": {
-                                    "answer_id": "fortnightly-pay-gross-pay-answer"
+                                    "answer_id": "fortnightly-pay-gross-pay-answer",
+                                    "exclusive": true
                                 },
                                 "validation": {
                                     "messages": {
-                                        "NUMBER_TOO_LARGE": "Enter an amount less than or equal to %(max)s."
+                                        "NUMBER_TOO_LARGE_EXCLUSIVE": "Enter an amount less than %(max)s."
                                     }
                                 }
                             },
@@ -1019,11 +1022,12 @@
                                 "currency": "GBP",
                                 "decimal_places": 2,
                                 "max_value": {
-                                    "answer_id": "fortnightly-pay-gross-pay-answer"
+                                    "answer_id": "fortnightly-pay-gross-pay-answer",
+                                    "exclusive": true
                                 },
                                 "validation": {
                                     "messages": {
-                                        "NUMBER_TOO_LARGE": "Enter an amount less than or equal to %(max)s."
+                                        "NUMBER_TOO_LARGE_EXCLUSIVE": "Enter an amount less than %(max)s."
                                     }
                                 }
                             },
@@ -1551,11 +1555,12 @@
                                 "currency": "GBP",
                                 "decimal_places": 2,
                                 "max_value": {
-                                    "answer_id": "calendar-monthly-pay-gross-pay-answer"
+                                    "answer_id": "calendar-monthly-pay-gross-pay-answer",
+                                    "exclusive": true
                                 },
                                 "validation": {
                                     "messages": {
-                                        "NUMBER_TOO_LARGE": "Enter an amount less than or equal to %(max)s."
+                                        "NUMBER_TOO_LARGE_EXCLUSIVE": "Enter an amount less than %(max)s."
                                     }
                                 }
                             },
@@ -1580,11 +1585,12 @@
                                 "currency": "GBP",
                                 "decimal_places": 2,
                                 "max_value": {
-                                    "answer_id": "calendar-monthly-pay-gross-pay-answer"
+                                    "answer_id": "calendar-monthly-pay-gross-pay-answer",
+                                    "exclusive": true
                                 },
                                 "validation": {
                                     "messages": {
-                                        "NUMBER_TOO_LARGE": "Enter an amount less than or equal to %(max)s."
+                                        "NUMBER_TOO_LARGE_EXCLUSIVE": "Enter an amount less than %(max)s."
                                     }
                                 }
                             }
@@ -2082,11 +2088,12 @@
                                 "currency": "GBP",
                                 "decimal_places": 2,
                                 "max_value": {
-                                    "answer_id": "four-weekly-pay-gross-pay-answer"
+                                    "answer_id": "four-weekly-pay-gross-pay-answer",
+                                    "exclusive": true
                                 },
                                 "validation": {
                                     "messages": {
-                                        "NUMBER_TOO_LARGE": "Enter an amount less than or equal to %(max)s."
+                                        "NUMBER_TOO_LARGE_EXCLUSIVE": "Enter an amount less than %(max)s."
                                     }
                                 }
                             },
@@ -2111,11 +2118,12 @@
                                 "currency": "GBP",
                                 "decimal_places": 2,
                                 "max_value": {
-                                    "answer_id": "four-weekly-pay-gross-pay-answer"
+                                    "answer_id": "four-weekly-pay-gross-pay-answer",
+                                    "exclusive": true
                                 },
                                 "validation": {
                                     "messages": {
-                                        "NUMBER_TOO_LARGE": "Enter an amount less than or equal to %(max)s."
+                                        "NUMBER_TOO_LARGE_EXCLUSIVE": "Enter an amount less than %(max)s."
                                     }
                                 }
                             }
@@ -2614,11 +2622,12 @@
                                 "currency": "GBP",
                                 "decimal_places": 2,
                                 "max_value": {
-                                    "answer_id": "five-weekly-pay-gross-pay-answer"
+                                    "answer_id": "five-weekly-pay-gross-pay-answer",
+                                    "exclusive": true
                                 },
                                 "validation": {
                                     "messages": {
-                                        "NUMBER_TOO_LARGE": "Enter an amount less than or equal to %(max)s."
+                                        "NUMBER_TOO_LARGE_EXCLUSIVE": "Enter an amount less than %(max)s."
                                     }
                                 }
                             },
@@ -2643,11 +2652,12 @@
                                 "currency": "GBP",
                                 "decimal_places": 2,
                                 "max_value": {
-                                    "answer_id": "five-weekly-pay-gross-pay-answer"
+                                    "answer_id": "five-weekly-pay-gross-pay-answer",
+                                    "exclusive": true
                                 },
                                 "validation": {
                                     "messages": {
-                                        "NUMBER_TOO_LARGE": "Enter an amount less than or equal to %(max)s."
+                                        "NUMBER_TOO_LARGE_EXCLUSIVE": "Enter an amount less than %(max)s."
                                     }
                                 }
                             }

--- a/data/schema/schema_v1.json
+++ b/data/schema/schema_v1.json
@@ -141,6 +141,13 @@
         "NUMBER_TOO_LARGE": {
           "type": "string"
         },
+        "NUMBER_TOO_SMALL_EXCLUSIVE": {
+          "type": "string"
+        },
+        "NUMBER_TOO_LARGE_EXCLUSIVE": {
+          "type": "string"
+        },
+
         "INVALID_NUMBER": {
           "type": "string"
         },

--- a/tests/integration/mwss/test_mwss_submission_data.py
+++ b/tests/integration/mwss/test_mwss_submission_data.py
@@ -36,8 +36,8 @@ class TestMwssSubmissionData(IntegrationTestCase):
                 "data": {
                     "40": "50",
                     "50": "20",
-                    "60": "20",
-                    "70": "20",
+                    "60": "19",
+                    "70": "19",
                     "80": "10",
                     "100": "50.58",
                     "110": "01/04/2016",
@@ -163,8 +163,8 @@ class TestMwssSubmissionData(IntegrationTestCase):
         self.post(post_data={'weekly-pay-paid-employees-answer': '50'})
         self.post(post_data={'weekly-pay-gross-pay-answer': '20'})
 
-        self.post(post_data={'weekly-pay-breakdown-holiday-answer': '20',
-                             'weekly-pay-breakdown-arrears-answer': '20',
+        self.post(post_data={'weekly-pay-breakdown-holiday-answer': '19',
+                             'weekly-pay-breakdown-arrears-answer': '19',
                              'weekly-pay-breakdown-prp-answer': '10'})
 
         self.post(post_data={'weekly-pay-significant-changes-paid-employees-answer': ['Yes']})


### PR DESCRIPTION
### What is the context of this PR?
Missing requirements around the pay patterns we have applied to MWSS, we were asked for each of the 'of which' on every pay pattern to add "less than or equal to", this isn't quite right. In some instances it is less than only.

### How to review 
Run MWSS and check following changes:

- Holiday pay  -  weekly/fortnightly - 'less than'
- Arrears  - weekly/fortnightly/monthly/4 weekly & 5 weekly -  'less than' 
- Bonus/commission - calendar monthly, 4 weekly, 5 weekly - 'less than'