### PR TITLE
Correct datetime column to TIMESTAMP for postgres

### DIFF
--- a/database-scripts/pr-1347-apply.sql
+++ b/database-scripts/pr-1347-apply.sql
@@ -1,8 +1,8 @@
 ALTER TABLE questionnaire_state
-  ADD COLUMN created_at DATETIME;
+  ADD COLUMN created_at TIMESTAMP;
 
 ALTER TABLE questionnaire_state
-  ADD COLUMN updated_at DATETIME;
+  ADD COLUMN updated_at TIMESTAMP;
 
 ALTER TABLE questionnaire_state
   ADD COLUMN version INT;


### PR DESCRIPTION
### What is the context of this PR?
Postgres does not support a column type of DATETIME so this has been updated to be TIMESTAMP

### How to review 
Apply the sql patch to Postgres
