### PR TITLE
Fix Travis pipenv performance issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,8 @@ cache:
     - yarn
     - pip
     - directories:
-        - /home/travis/.pyenv/versions/
+        - /opt/python/
+        - /home/travis/.local/share/
 script:
     - set -e
     - yarn compile


### PR DESCRIPTION
By caching the Python versions that we use the we remove a 3(ish) minute build step that sets up the build.