### PR TITLE
Eq 1749 remove unnecessary use of escape sequences in survey json

### DIFF
--- a/data/en/1_0005.json
+++ b/data/en/1_0005.json
@@ -328,7 +328,7 @@
             "blocks": [{
                     "id": "weekly-pay-introduction",
                     "title": "Weekly Pay",
-                    "description": "<div class=\"panel panel--simple panel--info\"><div class=\"panel__body\"><h2 class=\"venus\">Important notice for December period</h2><p>We understand that many UK businesses have ‘holiday shutdowns’ in December. If this applies to your business, please share your weekly wage figures from a more representative week.</p></div></div><br/><p>The next section covers Weekly pay.</p><p>Please exclude the following from your figures for this section:</p><p><ul><li>trainees on government schemes</li><li>director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable)</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
+                    "description": "<div class=\"panel panel--simple panel--info\"><div class=\"panel__body\"><h2 class=\"venus\">Important notice for December period</h2><p>We understand that many UK businesses have ‘holiday shutdowns’ in December. If this applies to your business, please share your weekly wage figures from a more representative week.</p></div></div><br/><p>The next section covers Weekly pay.</p><p>Please exclude the following from your figures for this section:</p><p><ul><li>trainees on government schemes</li><li>director‘s fees</li><li>employer‘s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business‘s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable)</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
                     "type": "Interstitial"
                 },
                 {
@@ -353,7 +353,7 @@
                                     "title": "Exclude:",
                                     "list": [
                                         "trainees on government schemes",
-                                        "employees working abroad unless paid directly from this business\u2019s GB payroll",
+                                        "employees working abroad unless paid directly from this business‘s GB payroll",
                                         "employees in Northern Ireland"
                                     ]
                                 }
@@ -377,9 +377,9 @@
                                     "title": "Exclude:",
                                     "list": [
                                         "trainees on government schemes",
-                                        "director\u2019s fees",
-                                        "employer\u2019s NI and contribution to pension schemes",
-                                        "employees working abroad unless paid directly from this business\u2019s GB payroll",
+                                        "director‘s fees",
+                                        "employer‘s NI and contribution to pension schemes",
+                                        "employees working abroad unless paid directly from this business‘s GB payroll",
                                         "signing on fees (sporting professionals)",
                                         "payment in lieu of notice",
                                         "redundancy pay (taxable and non-taxable)",
@@ -480,9 +480,9 @@
                                             "title": "Exclude:",
                                             "list": [
                                                 "trainees on government schemes",
-                                                "director\u2019s fees",
-                                                "employer\u2019s NI and contribution to pension schemes",
-                                                "employees working abroad unless paid directly from this business\u2019s GB payroll",
+                                                "director‘s fees",
+                                                "employer‘s NI and contribution to pension schemes",
+                                                "employees working abroad unless paid directly from this business‘s GB payroll",
                                                 "signing on fees (sporting professionals)",
                                                 "payment in lieu of notice",
                                                 "redundancy pay (taxable and non-taxable)",
@@ -536,7 +536,7 @@
                             "q_code": "90w",
                             "type": "Radio"
                         }],
-                        "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                        "description": "<p>Please note: what constitutes a ‘significant change‘ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}‘s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                         "guidance": {
                             "content": [{
                                 "title": "Include:",
@@ -646,7 +646,7 @@
                             "q_code": "93w",
                             "type": "Radio"
                         }],
-                        "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                        "description": "<p>Please note: what constitutes a ‘significant change‘ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}‘s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                         "guidance": {
                             "content": [{
                                 "title": "Include:",
@@ -897,7 +897,7 @@
             "blocks": [{
                     "id": "fortnightly-pay-introduction",
                     "title": "Fortnightly Pay",
-                    "description": "<div class=\"panel panel--simple panel--info\"><div class=\"panel__body\"><h2 class=\"venus\">Important notice for December period</h2><p>We understand that many UK businesses have ‘holiday shutdowns’ in December. If this applies to your business, please share your weekly wage figures from a more representative week.</p></div></div><br/><p>The next section covers Fortnightly Pay.</p><p>Please exclude the following from your figures for this section:</p><p><ul><li>trainees on government schemes</li><li>director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
+                    "description": "<div class=\"panel panel--simple panel--info\"><div class=\"panel__body\"><h2 class=\"venus\">Important notice for December period</h2><p>We understand that many UK businesses have ‘holiday shutdowns’ in December. If this applies to your business, please share your weekly wage figures from a more representative week.</p></div></div><br/><p>The next section covers Fortnightly Pay.</p><p>Please exclude the following from your figures for this section:</p><p><ul><li>trainees on government schemes</li><li>director‘s fees</li><li>employer‘s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business‘s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
                     "type": "Interstitial"
                 },
                 {
@@ -922,7 +922,7 @@
                                     "title": "Exclude:",
                                     "list": [
                                         "trainees on government schemes",
-                                        "employees working abroad unless paid directly from this business\u2019s GB payroll",
+                                        "employees working abroad unless paid directly from this business‘s GB payroll",
                                         "employees in Northern Ireland"
                                     ]
                                 }
@@ -946,9 +946,9 @@
                                     "title": "Exclude:",
                                     "list": [
                                         "trainees on government schemes",
-                                        "director\u2019s fees",
-                                        "employer\u2019s NI and contribution to pension schemes",
-                                        "employees working abroad unless paid directly from this business\u2019s GB payroll",
+                                        "director‘s fees",
+                                        "employer‘s NI and contribution to pension schemes",
+                                        "employees working abroad unless paid directly from this business‘s GB payroll",
                                         "signing on fees (sporting professionals)",
                                         "payment in lieu of notice",
                                         "redundancy pay (taxable and non-taxable)",
@@ -1088,7 +1088,7 @@
                             "q_code": "90f",
                             "type": "Radio"
                         }],
-                        "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                        "description": "<p>Please note: what constitutes a ‘significant change‘ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}‘s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                         "guidance": {
                             "content": [{
                                 "title": "Include:",
@@ -1198,7 +1198,7 @@
                             "q_code": "93f",
                             "type": "Radio"
                         }],
-                        "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                        "description": "<p>Please note: what constitutes a ‘significant change‘ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}‘s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                         "guidance": {
                             "content": [{
                                 "title": "Include:",
@@ -1449,7 +1449,7 @@
             "blocks": [{
                     "id": "calendar-monthly-pay-introduction",
                     "title": "Calendar Monthly Pay",
-                    "description": "<p>The next section covers Calendar Monthly pay.</p><p>Please exclude the following from your figures for this section:</p><p><ul><li>trainees on government schemes</li><li>director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable)</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
+                    "description": "<p>The next section covers Calendar Monthly pay.</p><p>Please exclude the following from your figures for this section:</p><p><ul><li>trainees on government schemes</li><li>director‘s fees</li><li>employer‘s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business‘s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable)</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
                     "type": "Interstitial"
                 },
                 {
@@ -1474,7 +1474,7 @@
                                     "title": "Exclude:",
                                     "list": [
                                         "trainees on government schemes",
-                                        "employees working abroad unless paid directly from this business\u2019s GB payroll",
+                                        "employees working abroad unless paid directly from this business‘s GB payroll",
                                         "employees in Northern Ireland"
                                     ]
                                 }
@@ -1498,9 +1498,9 @@
                                     "title": "Exclude:",
                                     "list": [
                                         "trainees on government schemes",
-                                        "director\u2019s fees",
-                                        "employer\u2019s NI and contribution to pension schemes",
-                                        "employees working abroad unless paid directly from this business\u2019s GB payroll",
+                                        "director‘s fees",
+                                        "employer‘s NI and contribution to pension schemes",
+                                        "employees working abroad unless paid directly from this business‘s GB payroll",
                                         "signing on fees (sporting professionals)",
                                         "payment in lieu of notice",
                                         "redundancy pay (taxable and non-taxable)",
@@ -1622,7 +1622,7 @@
                             "q_code": "190m",
                             "type": "Radio"
                         }],
-                        "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                        "description": "<p>Please note: what constitutes a ‘significant change‘ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}‘s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                         "guidance": {
                             "content": [{
                                 "title": "Include:",
@@ -1732,7 +1732,7 @@
                             "q_code": "193m",
                             "type": "Radio"
                         }],
-                        "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                        "description": "<p>Please note: what constitutes a ‘significant change‘ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}‘s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                         "guidance": {
                             "content": [{
                                 "title": "Include:",
@@ -1983,7 +1983,7 @@
             "blocks": [{
                     "id": "four-weekly-pay-introduction",
                     "title": "Four Weekly Pay",
-                    "description": "<p>The next section covers Four Weekly pay.</p><p>Please exclude the following from your figures for this section:</p><p><ul><li>trainees on government schemes</li><li>director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
+                    "description": "<p>The next section covers Four Weekly pay.</p><p>Please exclude the following from your figures for this section:</p><p><ul><li>trainees on government schemes</li><li>director‘s fees</li><li>employer‘s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business‘s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
                     "type": "Interstitial"
                 },
                 {
@@ -2008,7 +2008,7 @@
                                     "title": "Exclude:",
                                     "list": [
                                         "trainees on government schemes",
-                                        "employees working abroad unless paid directly from this business\u2019s GB payroll",
+                                        "employees working abroad unless paid directly from this business‘s GB payroll",
                                         "employees in Northern Ireland"
                                     ]
                                 }
@@ -2031,9 +2031,9 @@
                                 "content": [{
                                     "title": "Exclude:",
                                     "list": [
-                                        "trainees on government schemes director\u2019s fees",
-                                        "employer\u2019s NI and contribution to pension schemes",
-                                        "employees working abroad unless paid directly from this business\u2019s GB payroll",
+                                        "trainees on government schemes director‘s fees",
+                                        "employer‘s NI and contribution to pension schemes",
+                                        "employees working abroad unless paid directly from this business‘s GB payroll",
                                         "signing on fees (sporting professionals)",
                                         "payment in lieu of notice",
                                         "redundancy pay (taxable and non-taxable)",
@@ -2155,7 +2155,7 @@
                             "q_code": "190w4",
                             "type": "Radio"
                         }],
-                        "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                        "description": "<p>Please note: what constitutes a ‘significant change‘ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}‘s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                         "guidance": {
                             "content": [{
                                 "title": "Include:",
@@ -2265,7 +2265,7 @@
                             "q_code": "193w4",
                             "type": "Radio"
                         }],
-                        "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                        "description": "<p>Please note: what constitutes a ‘significant change‘ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}‘s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                         "guidance": {
                             "content": [{
                                 "title": "Include:",
@@ -2516,7 +2516,7 @@
             "blocks": [{
                     "id": "five-weekly-pay-introduction",
                     "title": "Five Weekly Pay",
-                    "description": "<p>The next section covers Five Weekly Pay.</p><p>Please exclude the following from your figures for this section:</p><p><ul><li>trainees on government schemes</li><li>director\u2019s fees</li><li>employer\u2019s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business\u2019s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
+                    "description": "<p>The next section covers Five Weekly Pay.</p><p>Please exclude the following from your figures for this section:</p><p><ul><li>trainees on government schemes</li><li>director‘s fees</li><li>employer‘s NI and contribution to pension schemes</li><li>employees working abroad unless paid directly from this business‘s GB payroll</li><li>signing on fees (sporting professionals)</li><li>payment in lieu of notice</li><li>redundancy pay (taxable and non-taxable</li><li>accrued holiday pay</li><li>employees in Northern Ireland</li><li>benefits employees receive through pay, for example, family working tax credit</li><li>expenses payments for attending meetings, for example, councillors</li></ul></p>",
                     "type": "Interstitial"
                 },
                 {
@@ -2541,7 +2541,7 @@
                                     "title": "Exclude:",
                                     "list": [
                                         "trainees on government schemes",
-                                        "employees working abroad unless paid directly from this business\u2019s GB payroll",
+                                        "employees working abroad unless paid directly from this business‘s GB payroll",
                                         "employees in Northern Ireland"
                                     ]
                                 }
@@ -2565,9 +2565,9 @@
                                     "title": "Exclude:",
                                     "list": [
                                         "trainees on government schemes",
-                                        "director\u2019s fees",
-                                        "employer\u2019s NI and contribution to pension schemes",
-                                        "employees working abroad unless paid directly from this business\u2019s GB payroll",
+                                        "director‘s fees",
+                                        "employer‘s NI and contribution to pension schemes",
+                                        "employees working abroad unless paid directly from this business‘s GB payroll",
                                         "signing on fees (sporting professionals)",
                                         "payment in lieu of notice",
                                         "redundancy pay (taxable and non-taxable)",
@@ -2689,7 +2689,7 @@
                             "q_code": "190w5",
                             "type": "Radio"
                         }],
-                        "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                        "description": "<p>Please note: what constitutes a ‘significant change‘ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}‘s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                         "guidance": {
                             "content": [{
                                 "title": "Include:",
@@ -2799,7 +2799,7 @@
                             "q_code": "193w5",
                             "type": "Radio"
                         }],
-                        "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                        "description": "<p>Please note: what constitutes a ‘significant change‘ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}‘s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                         "guidance": {
                             "content": [{
                                 "title": "Include:",

--- a/data/en/1_0102.json
+++ b/data/en/1_0102.json
@@ -183,7 +183,7 @@
                         "decimal_places": 2
                     }],
                     "id": "total-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}\u2019s <em>total retail turnover</em>?",
+                    "title": "For the period {{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total retail turnover</em>?",
                     "type": "General"
                 }],
                 "title": "Retail Turnover"
@@ -262,7 +262,7 @@
                         "q_code": "146a",
                         "type": "Radio"
                     }],
-                    "description": "Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                    "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
                     "id": "significant-change-question",
                     "title": "Did any significant changes occur to the total retail turnover for {{respondent.trad_as_or_ru_name}}?",
                     "type": "General"
@@ -335,16 +335,16 @@
                                     "description": "Examples of commentary:"
                                 },
                                 {
-                                    "title": "\u2018In-store promotion\u2019",
-                                    "description": "\u201COffer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales.\u201D"
+                                    "title": "‘In-store promotion’",
+                                    "description": "“Offer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales.”"
                                 },
                                 {
-                                    "title": "\u2018Special events (for example, sporting events)\u2019",
-                                    "description": "\u201CThis was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online.\u201D"
+                                    "title": "‘Special events (for example, sporting events)’",
+                                    "description": "“This was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online.”"
                                 },
                                 {
-                                    "title": "\u2018Weather\u2019",
-                                    "description": "\u201CThe bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month.\u201D"
+                                    "title": "‘Weather’",
+                                    "description": "“The bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month.”"
                                 }
                             ]
                         },
@@ -354,7 +354,7 @@
                         "q_code": "146",
                         "type": "TextArea"
                     }],
-                    "description": "We rely on your commentary to \u2018tell the story\u2019 behind changes in figures. By commenting here it will reduce the need for us to call you.",
+                    "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
                     "id": "change-comment-question",
                     "title": "Please describe the changes in total retail turnover for {{respondent.trad_as_or_ru_name}} in more detail",
                     "type": "General"

--- a/data/en/1_0112.json
+++ b/data/en/1_0112.json
@@ -225,7 +225,7 @@
                         "decimal_places": 2
                     }],
                     "id": "total-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}\u2019s <em>total retail turnover</em>?",
+                    "title": "For the period {{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}'s <em>total retail turnover</em>?",
                     "type": "General"
                 }],
                 "title": "Retail Turnover"
@@ -289,7 +289,7 @@
                         "q_code": "146a",
                         "type": "Radio"
                     }],
-                    "description": "Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                    "description": "Please note: what constitutes a ‘significant change' is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}'s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
                     "id": "significant-change-question",
                     "title": "Did any significant changes occur to the total retail turnover for {{respondent.trad_as_or_ru_name}}?",
                     "type": "General"
@@ -375,16 +375,16 @@
                                     "description": "Examples of commentary:"
                                 },
                                 {
-                                    "title": "\u2018In-store promotion\u2019",
-                                    "description": "\u201COffer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales.\u201D"
+                                    "title": "‘In-store promotion'",
+                                    "description": "“Offer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales.”"
                                 },
                                 {
-                                    "title": "\u2018Special events (for example, sporting events)\u2019",
-                                    "description": "\u201CThis was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online.\u201D"
+                                    "title": "‘Special events (for example, sporting events)'",
+                                    "description": "“This was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online.”"
                                 },
                                 {
-                                    "title": "\u2018Weather\u2019",
-                                    "description": "\u201CThe bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month.\u201D"
+                                    "title": "‘Weather'",
+                                    "description": "“The bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month.”"
                                 }
                             ]
                         },
@@ -394,7 +394,7 @@
                         "q_code": "146",
                         "type": "TextArea"
                     }],
-                    "description": "We rely on your commentary to \u2018tell the story\u2019 behind changes in figures. By commenting here it will reduce the need for us to call you.",
+                    "description": "We rely on your commentary to ‘tell the story' behind changes in figures. By commenting here it will reduce the need for us to call you.",
                     "id": "change-comment-question",
                     "title": "Please describe the changes in total retail turnover for {{respondent.trad_as_or_ru_name}} in more detail",
                     "type": "General"
@@ -409,7 +409,7 @@
                         "content": [{
                                 "title": "Include",
                                 "list": [
-                                    "all workers paid directly from this business\u2019s payroll(s)",
+                                    "all workers paid directly from this business's payroll(s)",
                                     "those temporarily absent but still being paid, for example on maternity leave"
                                 ]
                             },
@@ -448,7 +448,7 @@
                         "content": [{
                                 "title": "Include",
                                 "list": [
-                                    "all workers paid directly from this business\u2019s payroll(s)",
+                                    "all workers paid directly from this business's payroll(s)",
                                     "those temporarily absent but still being paid, for example on maternity leave"
                                 ]
                             },

--- a/data/en/1_0203.json
+++ b/data/en/1_0203.json
@@ -275,7 +275,7 @@
                     }],
                     "description": "",
                     "id": "total-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}\u2019s <em>total retail turnover</em>?",
+                    "title": "For the period {{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total retail turnover</em>?",
                     "type": "General"
                 }],
                 "title": "Retail Turnover"
@@ -327,7 +327,7 @@
                             "list": [
                                 "alcoholic drink",
                                 "chocolate and sugar confectionery",
-                                "tobacco and smokers\u2019 requisites"
+                                "tobacco and smokers’ requisites"
                             ]
                         }]
                     },
@@ -399,7 +399,7 @@
                                     "lighting and minor electrical supplies",
                                     "records, compact discs, audio and video tapes",
                                     "musical instruments and goods",
-                                    "decorators\u2019 and DIY supplies",
+                                    "decorators’ and DIY supplies",
                                     "lawn-mowers",
                                     "hardware",
                                     "china, glassware and cutlery",
@@ -445,7 +445,7 @@
                                         "jewellery",
                                         "silverware and plate, clocks and watches",
                                         "household cleaning products and kitchen paper products",
-                                        "pets, pets\u2019 requisites and pet foods",
+                                        "pets, pets’ requisites and pet foods",
                                         "cut flowers, plants, seeds and other garden sundries",
                                         "other new and second hand goods",
                                         "Mobile phones"
@@ -554,7 +554,7 @@
                         "q_code": "146a",
                         "type": "Radio"
                     }],
-                    "description": "Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                    "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
                     "id": "significant-change-question",
                     "title": "Did any significant changes occur to the total retail turnover for {{respondent.trad_as_or_ru_name}}?",
                     "type": "General"
@@ -629,16 +629,16 @@
                                     "description": "Examples of commentary:"
                                 },
                                 {
-                                    "title": "\u2018In-store promotion\u2019",
-                                    "description": "\u201COffer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales.\u201D"
+                                    "title": "‘In-store promotion’",
+                                    "description": "“Offer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales.”"
                                 },
                                 {
-                                    "title": "\u2018Special events (for example, sporting events)\u2019",
-                                    "description": "\u201CThis was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online.\u201D"
+                                    "title": "‘Special events (for example, sporting events)’",
+                                    "description": "“This was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online.”"
                                 },
                                 {
-                                    "title": "\u2018Weather\u2019",
-                                    "description": "\u201CThe bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month.\u201D"
+                                    "title": "‘Weather’",
+                                    "description": "“The bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month.”"
                                 }
                             ]
                         },
@@ -648,7 +648,7 @@
                         "q_code": "146",
                         "type": "TextArea"
                     }],
-                    "description": "We rely on your commentary to \u2018tell the story\u2019 behind changes in figures. By commenting here it will reduce the need for us to call you.",
+                    "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
                     "id": "change-comment-question",
                     "title": "Please describe the changes in total retail turnover for {{respondent.trad_as_or_ru_name}} in more detail",
                     "type": "General"

--- a/data/en/1_0205.json
+++ b/data/en/1_0205.json
@@ -292,7 +292,7 @@
                     }],
                     "description": "",
                     "id": "total-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}\u2019s <em>total retail turnover</em>?",
+                    "title": "For the period {{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total retail turnover</em>?",
                     "type": "General"
                 }],
                 "title": "Retail Turnover"
@@ -343,7 +343,7 @@
                             "list": [
                                 "alcoholic drink",
                                 "chocolate and sugar confectionery",
-                                "tobacco and smokers\u2019 requisites"
+                                "tobacco and smokers’ requisites"
                             ]
                         }]
                     },
@@ -414,7 +414,7 @@
                                     "lighting and minor electrical supplies",
                                     "records, compact discs, audio and video tapes",
                                     "musical instruments and goods",
-                                    "decorators\u2019 and DIY supplies",
+                                    "decorators’ and DIY supplies",
                                     "lawn-mowers",
                                     "hardware",
                                     "china, glassware and cutlery",
@@ -459,7 +459,7 @@
                                         "jewellery",
                                         "silverware and plate, clocks and watches",
                                         "household cleaning products and kitchen paper products",
-                                        "pets, pets\u2019 requisites and pet foods",
+                                        "pets, pets’ requisites and pet foods",
                                         "cut flowers, plants, seeds and other garden sundries",
                                         "other new and second hand goods",
                                         "Mobile phones"
@@ -604,7 +604,7 @@
                         "q_code": "146a",
                         "type": "Radio"
                     }],
-                    "description": "Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                    "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
                     "id": "significant-change-question",
                     "title": "Did any significant changes occur to the total retail turnover for {{respondent.trad_as_or_ru_name}}?",
                     "type": "General"
@@ -678,16 +678,16 @@
                                     "description": "Examples of commentary:"
                                 },
                                 {
-                                    "title": "\u2018In-store promotion\u2019",
-                                    "description": "\u201COffer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales.\u201D"
+                                    "title": "‘In-store promotion’",
+                                    "description": "“Offer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales.”"
                                 },
                                 {
-                                    "title": "\u2018Special events (for example, sporting events)\u2019",
-                                    "description": "\u201CThis was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online.\u201D"
+                                    "title": "‘Special events (for example, sporting events)’",
+                                    "description": "“This was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online.”"
                                 },
                                 {
-                                    "title": "\u2018Weather\u2019",
-                                    "description": "\u201CThe bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month.\u201D"
+                                    "title": "‘Weather’",
+                                    "description": "“The bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month.”"
                                 }
                             ]
                         },
@@ -697,7 +697,7 @@
                         "q_code": "146",
                         "type": "TextArea"
                     }],
-                    "description": "We rely on your commentary to \u2018tell the story\u2019 behind changes in figures. By commenting here it will reduce the need for us to call you.",
+                    "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
                     "id": "change-comment-question",
                     "title": "Please describe the changes in total retail turnover for {{respondent.trad_as_or_ru_name}} in more detail",
                     "type": "General"

--- a/data/en/1_0213.json
+++ b/data/en/1_0213.json
@@ -317,7 +317,7 @@
                         "decimal_places": 2
                     }],
                     "id": "total-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}\u2019s <em>total retail turnover</em>?",
+                    "title": "For the period {{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total retail turnover</em>?",
                     "type": "General"
                 }],
                 "title": "Retail Turnover"
@@ -368,7 +368,7 @@
                             "list": [
                                 "alcoholic drink",
                                 "chocolate and sugar confectionery",
-                                "tobacco and smokers\u2019 requisites"
+                                "tobacco and smokers’ requisites"
                             ]
                         }]
                     },
@@ -438,7 +438,7 @@
                                     "lighting and minor electrical supplies",
                                     "records, compact discs, audio and video tapes",
                                     "musical instruments and goods",
-                                    "decorators\u2019 and DIY supplies",
+                                    "decorators’ and DIY supplies",
                                     "lawn-mowers",
                                     "hardware",
                                     "china, glassware and cutlery",
@@ -483,7 +483,7 @@
                                         "jewellery",
                                         "silverware and plate, clocks and watches",
                                         "household cleaning products and kitchen paper products",
-                                        "pets, pets\u2019 requisites and pet foods",
+                                        "pets, pets’ requisites and pet foods",
                                         "cut flowers, plants, seeds and other garden sundries",
                                         "other new and second hand goods",
                                         "Mobile phones"
@@ -572,7 +572,7 @@
                         "q_code": "146a",
                         "type": "Radio"
                     }],
-                    "description": "Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                    "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
                     "id": "significant-change-question",
                     "title": "Did any significant changes occur to the total retail turnover for {{respondent.trad_as_or_ru_name}}?",
                     "type": "General"
@@ -660,16 +660,16 @@
                                     "description": "Examples of commentary:"
                                 },
                                 {
-                                    "title": "\u2018In-store promotion\u2019",
-                                    "description": "\u201COffer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales.\u201D"
+                                    "title": "‘In-store promotion’",
+                                    "description": "“Offer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales.”"
                                 },
                                 {
-                                    "title": "\u2018Special events (for example, sporting events)\u2019",
-                                    "description": "\u201CThis was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online.\u201D"
+                                    "title": "‘Special events (for example, sporting events)’",
+                                    "description": "“This was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online.”"
                                 },
                                 {
-                                    "title": "\u2018Weather\u2019",
-                                    "description": "\u201CThe bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month.\u201D"
+                                    "title": "‘Weather’",
+                                    "description": "“The bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month.”"
                                 }
                             ]
                         },
@@ -679,7 +679,7 @@
                         "q_code": "146",
                         "type": "TextArea"
                     }],
-                    "description": "We rely on your commentary to \u2018tell the story\u2019 behind changes in figures. By commenting here it will reduce the need for us to call you.",
+                    "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
                     "id": "change-comment-question",
                     "title": "Please describe the changes in total retail turnover for {{respondent.trad_as_or_ru_name}} in more detail",
                     "type": "General"
@@ -694,7 +694,7 @@
                         "content": [{
                                 "title": "Include",
                                 "list": [
-                                    "all workers paid directly from this business\u2019s payroll(s)",
+                                    "all workers paid directly from this business’s payroll(s)",
                                     "those temporarily absent but still being paid, for example on maternity leave"
                                 ]
                             },
@@ -733,7 +733,7 @@
                         "content": [{
                                 "title": "Include",
                                 "list": [
-                                    "all workers paid directly from this business\u2019s payroll(s)",
+                                    "all workers paid directly from this business’s payroll(s)",
                                     "those temporarily absent but still being paid, for example on maternity leave"
                                 ]
                             },

--- a/data/en/1_0215.json
+++ b/data/en/1_0215.json
@@ -336,7 +336,7 @@
                         "decimal_places": 2
                     }],
                     "id": "total-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}\u2019s <em>total retail turnover</em>?",
+                    "title": "For the period {{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total retail turnover</em>?",
                     "type": "General"
                 }],
                 "title": "Retail Turnover"
@@ -387,7 +387,7 @@
                             "list": [
                                 "alcoholic drink",
                                 "chocolate and sugar confectionery",
-                                "tobacco and smokers\u2019 requisites"
+                                "tobacco and smokers’ requisites"
                             ]
                         }]
                     },
@@ -459,7 +459,7 @@
                                         "lighting and minor electrical supplies",
                                         "records, compact discs, audio and video tapes",
                                         "musical instruments and goods",
-                                        "decorators\u2019 and DIY supplies",
+                                        "decorators’ and DIY supplies",
                                         "lawn-mowers",
                                         "hardware",
                                         "china, glassware and cutlery",
@@ -507,7 +507,7 @@
                                         "jewellery",
                                         "silverware and plate, clocks and watches",
                                         "household cleaning products and kitchen paper products",
-                                        "pets, pets\u2019 requisites and pet foods",
+                                        "pets, pets’ requisites and pet foods",
                                         "cut flowers, plants, seeds and other garden sundries",
                                         "other new and second hand goods",
                                         "Mobile phones"
@@ -652,7 +652,7 @@
                         "q_code": "146a",
                         "type": "Radio"
                     }],
-                    "description": "Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}\u2019s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                    "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
                     "id": "significant-change-question",
                     "title": "Did any significant changes occur to the total retail turnover for {{respondent.trad_as_or_ru_name}}?",
                     "type": "General"
@@ -726,22 +726,22 @@
                                     "description": "Examples of commentary:"
                                 },
                                 {
-                                    "title": "\u2018In-store promotion\u2019"
+                                    "title": "‘In-store promotion’"
                                 },
                                 {
-                                    "description": "\u201COffer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales.\u201D"
+                                    "description": "“Offer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales.”"
                                 },
                                 {
-                                    "title": "\u2018Special events (for example, sporting events)\u2019"
+                                    "title": "‘Special events (for example, sporting events)’"
                                 },
                                 {
-                                    "description": "\u201CThis was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online.\u201D"
+                                    "description": "“This was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online.”"
                                 },
                                 {
-                                    "title": "\u2018Weather\u2019"
+                                    "title": "‘Weather’"
                                 },
                                 {
-                                    "description": "\u201CThe bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month.\u201D"
+                                    "description": "“The bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month.”"
                                 }
                             ]
                         },
@@ -751,7 +751,7 @@
                         "q_code": "146",
                         "type": "TextArea"
                     }],
-                    "description": "We rely on your commentary to \u2018tell the story\u2019 behind changes in figures. By commenting here it will reduce the need for us to call you.",
+                    "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
                     "id": "change-comment-question",
                     "title": "Please describe the changes in total retail turnover for {{respondent.trad_as_or_ru_name}} in more detail",
                     "type": "General"
@@ -766,7 +766,7 @@
                         "content": [{
                                 "title": "Include",
                                 "list": [
-                                    "all workers paid directly from this business\u2019s payroll(s)",
+                                    "all workers paid directly from this business’s payroll(s)",
                                     "those temporarily absent but still being paid, for example on maternity leave"
                                 ]
                             },
@@ -805,7 +805,7 @@
                         "content": [{
                                 "title": "Include",
                                 "list": [
-                                    "all workers paid directly from this business\u2019s payroll(s)",
+                                    "all workers paid directly from this business’s payroll(s)",
                                     "those temporarily absent but still being paid, for example on maternity leave"
                                 ]
                             },

--- a/data/en/test_0203.json
+++ b/data/en/test_0203.json
@@ -175,7 +175,7 @@
                                         "lighting and minor electrical supplies",
                                         "records, compact discs, audio and video tapes",
                                         "musical instruments and goods",
-                                        "decorators\u2019 and DIY supplies",
+                                        "decorators’ and DIY supplies",
                                         "lawn-mowers",
                                         "hardware",
                                         "china, glassware and cutlery",
@@ -216,7 +216,7 @@
                                             "jewellery",
                                             "silverware and plate, clocks and watches",
                                             "household cleaning products and kitchen paper products",
-                                            "pets, pets\u2019 requisites and pet foods",
+                                            "pets, pets’ requisites and pet foods",
                                             "cut flowers, plants, seeds and other garden sundries",
                                             "other new and second hand goods",
                                             "Mobile phones"
@@ -234,7 +234,7 @@
                                 ]
                             },
                             "id": "total-sales-other-goods",
-                            "label": "What was the value of the business\u2019s total sales of other goods?",
+                            "label": "What was the value of the business’s total sales of other goods?",
                             "mandatory": false,
                             "q_code": "26",
                             "type": "Currency",
@@ -272,7 +272,7 @@
                                 ]
                             },
                             "id": "total-retail-turnover",
-                            "label": "What was the value of the business\u2019s total retail turnover?",
+                            "label": "What was the value of the business’s total retail turnover?",
                             "mandatory": true,
                             "q_code": "20",
                             "type": "Currency",

--- a/data/en/test_0205.json
+++ b/data/en/test_0205.json
@@ -181,7 +181,7 @@
                                         "lighting and minor electrical supplies",
                                         "records, compact discs, audio and video tapes",
                                         "musical instruments and goods",
-                                        "decorators\u2019 and DIY supplies",
+                                        "decorators’ and DIY supplies",
                                         "lawn-mowers",
                                         "hardware",
                                         "china, glassware and cutlery",
@@ -221,7 +221,7 @@
                                             "jewellery",
                                             "silverware and plate, clocks and watches",
                                             "household cleaning products and kitchen paper products",
-                                            "pets, pets\u2019 requisites and pet foods",
+                                            "pets, pets’ requisites and pet foods",
                                             "cut flowers, plants, seeds and other garden sundries",
                                             "other new and second hand goods",
                                             "Mobile phones"

--- a/data/en/test_0213.json
+++ b/data/en/test_0213.json
@@ -109,7 +109,7 @@
                                     "list": [
                                         "alcoholic drink",
                                         "chocolate and sugar confectionery",
-                                        "tobacco and smokers\u2019 requisites"
+                                        "tobacco and smokers’ requisites"
                                     ]
                                 }]
                             },
@@ -171,7 +171,7 @@
                                         "lighting and minor electrical supplies",
                                         "records, compact discs, audio and video tapes",
                                         "musical instruments and goods",
-                                        "decorators\u2019 and DIY supplies",
+                                        "decorators’ and DIY supplies",
                                         "lawn-mowers",
                                         "hardware",
                                         "china, glassware and cutlery",
@@ -211,7 +211,7 @@
                                             "jewellery",
                                             "silverware and plate, clocks and watches",
                                             "household cleaning products and kitchen paper products",
-                                            "pets, pets\u2019 requisites and pet foods",
+                                            "pets, pets’ requisites and pet foods",
                                             "cut flowers, plants, seeds and other garden sundries",
                                             "other new and second hand goods",
                                             "Mobile phones"
@@ -229,7 +229,7 @@
                                 ]
                             },
                             "id": "total-sales-other-goods",
-                            "label": "What was the value of the business\u2019s total sales of other goods?",
+                            "label": "What was the value of the business’s total sales of other goods?",
                             "mandatory": false,
                             "q_code": "26",
                             "type": "Currency",
@@ -266,7 +266,7 @@
                                 ]
                             },
                             "id": "total-retail-turnover",
-                            "label": "What was the value of the business\u2019s total retail turnover?",
+                            "label": "What was the value of the business’s total retail turnover?",
                             "mandatory": true,
                             "q_code": "20",
                             "type": "Currency",
@@ -327,7 +327,7 @@
                             "content": [{
                                     "title": "Include",
                                     "list": [
-                                        "all workers paid directly from this business\u2019s payroll(s)",
+                                        "all workers paid directly from this business’s payroll(s)",
                                         "those temporarily absent but still being paid, for example on maternity leave"
                                     ]
                                 },


### PR DESCRIPTION
### What is the context of this PR?
Throughout the survey JSON escape sequences are used for non-standard characters like quotes a currency symbols. This makes them hard to read and author. All occurrences of these escape sequences should be replaced with the real characters.

### How to review 
Check all of the unnecessary escape sequences are escaped as well as the ones in the tests.
