### PR TITLE
Make "Select all that apply" label on checkbox fieldsets consistent

### DIFF
--- a/app/assets/styles/partials/components/_field.scss
+++ b/app/assets/styles/partials/components/_field.scss
@@ -2,6 +2,10 @@
   background: none;
 }
 
+.field__label {
+  margin-bottom: 0.5rem;
+}
+
 .field__legend {
   font-size: 1rem;
   font-weight: $font-weight-bold;

--- a/app/templates/partials/widgets/multiple_choice_widget.html
+++ b/app/templates/partials/widgets/multiple_choice_widget.html
@@ -10,6 +10,10 @@
     {%- endif -%}
   </legend>
 
+  {% if widget_type == "checkbox" %}
+    <div class="field__label mars">Select all that apply:</div>
+  {% endif %}
+
   {% for option in form[answer.id] %}
     {% set input = {
       "class": "input input--" ~ widget_type ~ " js-focusable",
@@ -26,7 +30,8 @@
       "for": option.id,
       "id": "label-" ~ option.id
     } %}
-
+    
+    
     <div class="field__item js-focusable-box">
       <input {{input|xmlattr}}>
       <label {{label|xmlattr}}>

--- a/data/en/1_0005.json
+++ b/data/en/1_0005.json
@@ -191,7 +191,6 @@
                     "questions": [{
                         "answers": [{
                             "id": "pay-pattern-frequency-answer",
-                            "label": "Please select all that apply",
                             "alias": "pay_pattern",
                             "mandatory": true,
                             "options": [{

--- a/data/en/1_0102.json
+++ b/data/en/1_0102.json
@@ -1,375 +1,435 @@
 {
-    "mime_type": "application/json/ons/eq",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.1",
-    "survey_id": "023",
-    "title": "Monthly Business Survey - Retail Sales Index",
-    "description": "RSI Description",
-    "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
-    "variables": {
-        "period": "{{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}"
-    },
-    "groups": [{
-        "blocks": [{
-                "type": "Introduction",
-                "id": "introduction",
-                "primary_content": [{
-                    "id": "get-started",
-                    "content": [{
-                        "list": [
-                            "On average it takes 10 minutes to complete this survey once you’ve collected the information.",
-                            "Data should relate to all sites in England, Scotland and Wales.",
-                            "You can provide informed estimates if actual figures aren't available.",
-                            "We will treat your data securely and confidentially."
-                        ]
-                    }]
-                }],
-                "preview_content": {
-                    "id": "preview",
-                    "title": "Information you need",
-                    "content": [{
-                        "title": "",
-                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
-                    }],
-                    "questions": [{
-                        "question": "Total retail turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "VAT",
-                                "internet sales",
-                                "retail sales from outlets in Great Britain to customers abroad"
-                            ]
-                        }, {
-                            "description": "Exclude:",
-                            "list": [
-                                "revenue from mobile phone network commission and top-up",
-                                "sales from catering facilities used by customers",
-                                "lottery sales and commission from lottery sales",
-                                "sales of car accessories and motor vehicles",
-                                "NHS receipts"
-                            ]
-                        }]
-                    }, {
-                        "question": "Internet sales",
-                        "content": [{
-                            "description": "Include: VAT"
-                        }]
-                    }, {
-                        "question": "Significant changes to the total retail turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": [
-                                "in-store / online promotions",
-                                "special events (e.g.  sporting events)",
-                                "calendar events (e.g.  Christmas, Easter, Bank Holiday)",
-                                "weather",
-                                "store closures/openings"
-                            ]
-                        }]
-                    }]
-                },
-                "secondary_content": [{
-                    "id": "how-we-use-your-data",
-                    "title": "How we use your data",
-                    "content": [{
-                        "list": [
-                            "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
-                            "The information you supply is used to produce monthly estimates of the total retail sales in Great Britain. It is also used to help estimate consumer spending on retail goods and the output of the retail sector, both of which feed into the compilation of the UK National Accounts."
-                        ]
-                    }]
-                }]
-            },
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.1",
+  "survey_id": "023",
+  "title": "Monthly Business Survey - Retail Sales Index",
+  "description": "RSI Description",
+  "theme": "default",
+  "legal_basis": "StatisticsOfTradeAct",
+  "variables": {
+    "period": "{{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}"
+  },
+  "groups": [
+    {
+      "blocks": [
+        {
+          "type": "Introduction",
+          "id": "introduction",
+          "primary_content": [
             {
-                "questions": [{
-                    "type": "General",
-                    "answers": [{
-                        "type": "Radio",
-                        "id": "reporting-period-choice-answer",
-                        "options": [{
-                                "label": "Yes",
-                                "value": "Yes"
-                            },
-                            {
-                                "label": "No",
-                                "value": "No"
-                            }
-                        ],
-                        "mandatory": true
-                    }],
-                    "id": "reporting-period-choice-question",
-                    "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
-                }],
-                "type": "Question",
-                "title": "Reporting period",
-                "id": "reporting-period-choice",
-                "routing_rules": [{
-                        "goto": {
-                            "when": [{
-                                "value": "Yes",
-                                "id": "reporting-period-choice-answer",
-                                "condition": "equals"
-                            }],
-                            "block": "total-retail-turnover-block"
-                        }
-                    },
-                    {
-                        "goto": {
-                            "block": "reporting-period"
-                        }
-                    }
-                ]
-            },
-            {
-                "type": "Question",
-                "questions": [{
-                    "type": "DateRange",
-                    "answers": [{
-                            "label": "From",
-                            "type": "Date",
-                            "id": "period-from",
-                            "q_code": "11",
-                            "mandatory": true,
-                            "alias": "period_from"
-                        },
-                        {
-                            "label": "To",
-                            "type": "Date",
-                            "id": "period-to",
-                            "q_code": "12",
-                            "mandatory": true,
-                            "alias": "period_to"
-                        }
-                    ],
-                    "id": "reporting-period-question",
-                    "title": "What are the dates of the period that you will be reporting for?"
-                }],
-                "id": "reporting-period",
-                "title": "Reporting period"
-            },
-            {
-                "type": "Question",
-                "id": "total-retail-turnover-block",
-                "questions": [{
-                    "guidance": {
-                        "content": [{
-                                "title": "Include",
-                                "list": [
-                                    "VAT",
-                                    "internet sales"
-                                ]
-                            },
-                            {
-                                "title": "Exclude",
-                                "list": [
-                                    "revenue from mobile phone network commission and top-up",
-                                    "sales from catering facilities used by customers",
-                                    "lottery sales and commission from lottery sales",
-                                    "sales of car accessories and motor vehicles",
-                                    "NHS receipts"
-                                ]
-                            }
-                        ]
-                    },
-                    "answers": [{
-                        "id": "total-retail-turnover-answer",
-                        "alias": "total_turnover",
-                        "label": "Total retail turnover",
-                        "mandatory": true,
-                        "q_code": "20",
-                        "type": "Currency",
-                        "currency": "GBP",
-                        "decimal_places": 2
-                    }],
-                    "id": "total-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total retail turnover</em>?",
-                    "type": "General"
-                }],
-                "title": "Retail Turnover"
-            },
-            {
-                "type": "Question",
-                "id": "total-internet-sales",
-                "questions": [{
-                    "guidance": {
-                        "content": [{
-                            "title": "Include",
-                            "list": [
-                                "VAT",
-                                "sales from orders received over the internet, irrespective of the payment or delivery method"
-                            ]
-                        }]
-                    },
-                    "answers": [{
-                        "id": "internet-sales-answer",
-                        "label": "Internet sales",
-                        "mandatory": true,
-                        "q_code": "21",
-                        "type": "Currency",
-                        "currency": "GBP",
-                        "decimal_places": 2,
-                        "max_value": {
-                            "answer_id": "total-retail-turnover-answer"
-                        }
-                    }],
-                    "id": "internet-sales-question",
-                    "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>internet</em> sales?",
-                    "type": "General"
-                }],
-                "title": "Retail turnover"
-            },
-            {
-                "id": "significant-change",
-                "routing_rules": [{
-                        "goto": {
-                            "block": "reason-for-change",
-                            "when": [{
-                                "id": "significant-change-established-answer",
-                                "condition": "equals",
-                                "value": "Yes"
-                            }]
-                        }
-                    },
-                    {
-                        "goto": {
-                            "block": "summary"
-                        }
-                    }
-                ],
-                "questions": [{
-                    "guidance": {
-                        "content": [{
-                            "title": "Include",
-                            "list": [
-                                "in-store / online promotions",
-                                "special events (e.g. sporting events)",
-                                "calendar events (e.g. Christmas, Easter, Bank Holiday)",
-                                "weather",
-                                "store closures/openings"
-                            ]
-                        }]
-                    },
-                    "answers": [{
-                        "id": "significant-change-established-answer",
-                        "mandatory": true,
-                        "options": [{
-                                "label": "Yes",
-                                "value": "Yes"
-                            },
-                            {
-                                "label": "No",
-                                "value": "No"
-                            }
-                        ],
-                        "q_code": "146a",
-                        "type": "Radio"
-                    }],
-                    "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
-                    "id": "significant-change-question",
-                    "title": "Did any significant changes occur to the total retail turnover for {{respondent.trad_as_or_ru_name}}?",
-                    "type": "General"
-                }],
-                "title": "Changes in total retail turnover",
-                "type": "Question"
-            },
-            {
-                "type": "Question",
-                "id": "reason-for-change",
-                "questions": [{
-                    "answers": [{
-                        "id": "reason-for-change-answer",
-                        "mandatory": true,
-                        "options": [{
-                                "label": "In-store / online promotions",
-                                "q_code": "146b",
-                                "value": "In-store / online promotions"
-                            },
-                            {
-                                "label": "Special events (e.g. sporting events)",
-                                "q_code": "146c",
-                                "value": "Special events (e.g. sporting events)"
-                            },
-                            {
-                                "label": "Calendar events (e.g. Christmas, Easter, Bank Holiday)",
-                                "q_code": "146d",
-                                "value": "Calendar events (e.g. Christmas, Easter, Bank Holiday)"
-                            },
-                            {
-                                "label": "Weather",
-                                "q_code": "146e",
-                                "value": "Weather"
-                            },
-                            {
-                                "label": "Store closures",
-                                "q_code": "146f",
-                                "value": "Store closures"
-                            },
-                            {
-                                "label": "Store openings",
-                                "q_code": "146g",
-                                "value": "Store openings"
-                            },
-                            {
-                                "label": "Other",
-                                "q_code": "146h",
-                                "value": "Other"
-                            }
-                        ],
-                        "type": "Checkbox"
-                    }],
-
-                    "description": "Select all that apply",
-                    "id": "reason-for-change-question",
-                    "title": "Please indicate the reasons for any changes in the total retail turnover for {{respondent.trad_as_or_ru_name}}",
-                    "type": "General"
-                }],
-                "title": "Changes in total retail turnover"
-            },
-            {
-                "type": "Question",
-                "id": "change-comment-block",
-                "questions": [{
-                    "answers": [{
-                        "guidance": {
-                            "show_guidance": "Show examples of commentary on changes to total retail turnover",
-                            "hide_guidance": "Hide examples of commentary on changes to total retail turnover",
-                            "content": [{
-                                    "description": "Examples of commentary:"
-                                },
-                                {
-                                    "title": "‘In-store promotion’",
-                                    "description": "“Offer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales.”"
-                                },
-                                {
-                                    "title": "‘Special events (for example, sporting events)’",
-                                    "description": "“This was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online.”"
-                                },
-                                {
-                                    "title": "‘Weather’",
-                                    "description": "“The bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month.”"
-                                }
-                            ]
-                        },
-                        "id": "change-comment",
-                        "label": "Comments",
-                        "mandatory": true,
-                        "q_code": "146",
-                        "type": "TextArea"
-                    }],
-                    "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
-                    "id": "change-comment-question",
-                    "title": "Please describe the changes in total retail turnover for {{respondent.trad_as_or_ru_name}} in more detail",
-                    "type": "General"
-                }],
-                "title": "Changes in total retail turnover"
-            },
-            {
-                "type": "Summary",
-                "id": "summary"
+              "id": "get-started",
+              "content": [
+                {
+                  "list": [
+                    "On average it takes 10 minutes to complete this survey once you’ve collected the information.",
+                    "Data should relate to all sites in England, Scotland and Wales.",
+                    "You can provide informed estimates if actual figures aren't available.",
+                    "We will treat your data securely and confidentially."
+                  ]
+                }
+              ]
             }
-        ],
-        "id": "rsi",
-        "title": ""
-    }]
+          ],
+          "preview_content": {
+            "id": "preview",
+            "title": "Information you need",
+            "content": [
+              {
+                "title": "",
+                "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+              }
+            ],
+            "questions": [
+              {
+                "question": "Total retail turnover",
+                "content": [
+                  {
+                    "description": "Include:",
+                    "list": ["VAT", "internet sales", "retail sales from outlets in Great Britain to customers abroad"]
+                  },
+                  {
+                    "description": "Exclude:",
+                    "list": [
+                      "revenue from mobile phone network commission and top-up",
+                      "sales from catering facilities used by customers",
+                      "lottery sales and commission from lottery sales",
+                      "sales of car accessories and motor vehicles",
+                      "NHS receipts"
+                    ]
+                  }
+                ]
+              },
+              {
+                "question": "Internet sales",
+                "content": [
+                  {
+                    "description": "Include: VAT"
+                  }
+                ]
+              },
+              {
+                "question": "Significant changes to the total retail turnover",
+                "content": [
+                  {
+                    "description": "Include:",
+                    "list": [
+                      "in-store / online promotions",
+                      "special events (e.g.  sporting events)",
+                      "calendar events (e.g.  Christmas, Easter, Bank Holiday)",
+                      "weather",
+                      "store closures/openings"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "secondary_content": [
+            {
+              "id": "how-we-use-your-data",
+              "title": "How we use your data",
+              "content": [
+                {
+                  "list": [
+                    "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                    "The information you supply is used to produce monthly estimates of the total retail sales in Great Britain. It is also used to help estimate consumer spending on retail goods and the output of the retail sector, both of which feed into the compilation of the UK National Accounts."
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "questions": [
+            {
+              "type": "General",
+              "answers": [
+                {
+                  "type": "Radio",
+                  "id": "reporting-period-choice-answer",
+                  "options": [
+                    {
+                      "label": "Yes",
+                      "value": "Yes"
+                    },
+                    {
+                      "label": "No",
+                      "value": "No"
+                    }
+                  ],
+                  "mandatory": true
+                }
+              ],
+              "id": "reporting-period-choice-question",
+              "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
+            }
+          ],
+          "type": "Question",
+          "title": "Reporting period",
+          "id": "reporting-period-choice",
+          "routing_rules": [
+            {
+              "goto": {
+                "when": [
+                  {
+                    "value": "Yes",
+                    "id": "reporting-period-choice-answer",
+                    "condition": "equals"
+                  }
+                ],
+                "block": "total-retail-turnover-block"
+              }
+            },
+            {
+              "goto": {
+                "block": "reporting-period"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "questions": [
+            {
+              "type": "DateRange",
+              "answers": [
+                {
+                  "label": "From",
+                  "type": "Date",
+                  "id": "period-from",
+                  "q_code": "11",
+                  "mandatory": true,
+                  "alias": "period_from"
+                },
+                {
+                  "label": "To",
+                  "type": "Date",
+                  "id": "period-to",
+                  "q_code": "12",
+                  "mandatory": true,
+                  "alias": "period_to"
+                }
+              ],
+              "id": "reporting-period-question",
+              "title": "What are the dates of the period that you will be reporting for?"
+            }
+          ],
+          "id": "reporting-period",
+          "title": "Reporting period"
+        },
+        {
+          "type": "Question",
+          "id": "total-retail-turnover-block",
+          "questions": [
+            {
+              "guidance": {
+                "content": [
+                  {
+                    "title": "Include",
+                    "list": ["VAT", "internet sales"]
+                  },
+                  {
+                    "title": "Exclude",
+                    "list": [
+                      "revenue from mobile phone network commission and top-up",
+                      "sales from catering facilities used by customers",
+                      "lottery sales and commission from lottery sales",
+                      "sales of car accessories and motor vehicles",
+                      "NHS receipts"
+                    ]
+                  }
+                ]
+              },
+              "answers": [
+                {
+                  "id": "total-retail-turnover-answer",
+                  "alias": "total_turnover",
+                  "label": "Total retail turnover",
+                  "mandatory": true,
+                  "q_code": "20",
+                  "type": "Currency",
+                  "currency": "GBP",
+                  "decimal_places": 2
+                }
+              ],
+              "id": "total-turnover-question",
+              "title":
+                "For the period {{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total retail turnover</em>?",
+              "type": "General"
+            }
+          ],
+          "title": "Retail Turnover"
+        },
+        {
+          "type": "Question",
+          "id": "total-internet-sales",
+          "questions": [
+            {
+              "guidance": {
+                "content": [
+                  {
+                    "title": "Include",
+                    "list": ["VAT", "sales from orders received over the internet, irrespective of the payment or delivery method"]
+                  }
+                ]
+              },
+              "answers": [
+                {
+                  "id": "internet-sales-answer",
+                  "label": "Internet sales",
+                  "mandatory": true,
+                  "q_code": "21",
+                  "type": "Currency",
+                  "currency": "GBP",
+                  "decimal_places": 2,
+                  "max_value": {
+                    "answer_id": "total-retail-turnover-answer"
+                  }
+                }
+              ],
+              "id": "internet-sales-question",
+              "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>internet</em> sales?",
+              "type": "General"
+            }
+          ],
+          "title": "Retail turnover"
+        },
+        {
+          "id": "significant-change",
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "reason-for-change",
+                "when": [
+                  {
+                    "id": "significant-change-established-answer",
+                    "condition": "equals",
+                    "value": "Yes"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "summary"
+              }
+            }
+          ],
+          "questions": [
+            {
+              "guidance": {
+                "content": [
+                  {
+                    "title": "Include",
+                    "list": [
+                      "in-store / online promotions",
+                      "special events (e.g. sporting events)",
+                      "calendar events (e.g. Christmas, Easter, Bank Holiday)",
+                      "weather",
+                      "store closures/openings"
+                    ]
+                  }
+                ]
+              },
+              "answers": [
+                {
+                  "id": "significant-change-established-answer",
+                  "mandatory": true,
+                  "options": [
+                    {
+                      "label": "Yes",
+                      "value": "Yes"
+                    },
+                    {
+                      "label": "No",
+                      "value": "No"
+                    }
+                  ],
+                  "q_code": "146a",
+                  "type": "Radio"
+                }
+              ],
+              "description":
+                "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+              "id": "significant-change-question",
+              "title": "Did any significant changes occur to the total retail turnover for {{respondent.trad_as_or_ru_name}}?",
+              "type": "General"
+            }
+          ],
+          "title": "Changes in total retail turnover",
+          "type": "Question"
+        },
+        {
+          "type": "Question",
+          "id": "reason-for-change",
+          "questions": [
+            {
+              "answers": [
+                {
+                  "id": "reason-for-change-answer",
+                  "mandatory": true,
+                  "options": [
+                    {
+                      "label": "In-store / online promotions",
+                      "q_code": "146b",
+                      "value": "In-store / online promotions"
+                    },
+                    {
+                      "label": "Special events (e.g. sporting events)",
+                      "q_code": "146c",
+                      "value": "Special events (e.g. sporting events)"
+                    },
+                    {
+                      "label": "Calendar events (e.g. Christmas, Easter, Bank Holiday)",
+                      "q_code": "146d",
+                      "value": "Calendar events (e.g. Christmas, Easter, Bank Holiday)"
+                    },
+                    {
+                      "label": "Weather",
+                      "q_code": "146e",
+                      "value": "Weather"
+                    },
+                    {
+                      "label": "Store closures",
+                      "q_code": "146f",
+                      "value": "Store closures"
+                    },
+                    {
+                      "label": "Store openings",
+                      "q_code": "146g",
+                      "value": "Store openings"
+                    },
+                    {
+                      "label": "Other",
+                      "q_code": "146h",
+                      "value": "Other"
+                    }
+                  ],
+                  "type": "Checkbox"
+                }
+              ],
+              "id": "reason-for-change-question",
+              "title": "Please indicate the reasons for any changes in the total retail turnover for {{respondent.trad_as_or_ru_name}}",
+              "type": "General"
+            }
+          ],
+          "title": "Changes in total retail turnover"
+        },
+        {
+          "type": "Question",
+          "id": "change-comment-block",
+          "questions": [
+            {
+              "answers": [
+                {
+                  "guidance": {
+                    "show_guidance": "Show examples of commentary on changes to total retail turnover",
+                    "hide_guidance": "Hide examples of commentary on changes to total retail turnover",
+                    "content": [
+                      {
+                        "description": "Examples of commentary:"
+                      },
+                      {
+                        "title": "‘In-store promotion’",
+                        "description":
+                          "“Offer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales.”"
+                      },
+                      {
+                        "title": "‘Special events (for example, sporting events)’",
+                        "description":
+                          "“This was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online.”"
+                      },
+                      {
+                        "title": "‘Weather’",
+                        "description":
+                          "“The bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month.”"
+                      }
+                    ]
+                  },
+                  "id": "change-comment",
+                  "label": "Comments",
+                  "mandatory": true,
+                  "q_code": "146",
+                  "type": "TextArea"
+                }
+              ],
+              "description":
+                "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
+              "id": "change-comment-question",
+              "title": "Please describe the changes in total retail turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+              "type": "General"
+            }
+          ],
+          "title": "Changes in total retail turnover"
+        },
+        {
+          "type": "Summary",
+          "id": "summary"
+        }
+      ],
+      "id": "rsi",
+      "title": ""
+    }
+  ]
 }

--- a/data/en/1_0102.json
+++ b/data/en/1_0102.json
@@ -1,435 +1,368 @@
 {
-  "mime_type": "application/json/ons/eq",
-  "schema_version": "0.0.1",
-  "data_version": "0.0.1",
-  "survey_id": "023",
-  "title": "Monthly Business Survey - Retail Sales Index",
-  "description": "RSI Description",
-  "theme": "default",
-  "legal_basis": "StatisticsOfTradeAct",
-  "variables": {
-    "period": "{{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}"
-  },
-  "groups": [
-    {
-      "blocks": [
-        {
-          "type": "Introduction",
-          "id": "introduction",
-          "primary_content": [
-            {
-              "id": "get-started",
-              "content": [
-                {
-                  "list": [
-                    "On average it takes 10 minutes to complete this survey once you’ve collected the information.",
-                    "Data should relate to all sites in England, Scotland and Wales.",
-                    "You can provide informed estimates if actual figures aren't available.",
-                    "We will treat your data securely and confidentially."
-                  ]
-                }
-              ]
-            }
-          ],
-          "preview_content": {
-            "id": "preview",
-            "title": "Information you need",
-            "content": [
-              {
-                "title": "",
-                "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
-              }
-            ],
-            "questions": [
-              {
-                "question": "Total retail turnover",
-                "content": [
-                  {
-                    "description": "Include:",
-                    "list": ["VAT", "internet sales", "retail sales from outlets in Great Britain to customers abroad"]
-                  },
-                  {
-                    "description": "Exclude:",
-                    "list": [
-                      "revenue from mobile phone network commission and top-up",
-                      "sales from catering facilities used by customers",
-                      "lottery sales and commission from lottery sales",
-                      "sales of car accessories and motor vehicles",
-                      "NHS receipts"
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "survey_id": "023",
+    "title": "Monthly Business Survey - Retail Sales Index",
+    "description": "RSI Description",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "variables": {
+        "period": "{{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}"
+    },
+    "groups": [{
+        "blocks": [{
+                "type": "Introduction",
+                "id": "introduction",
+                "primary_content": [{
+                    "id": "get-started",
+                    "content": [{
+                        "list": [
+                            "On average it takes 10 minutes to complete this survey once you’ve collected the information.",
+                            "Data should relate to all sites in England, Scotland and Wales.",
+                            "You can provide informed estimates if actual figures aren't available.",
+                            "We will treat your data securely and confidentially."
+                        ]
+                    }]
+                }],
+                "preview_content": {
+                    "id": "preview",
+                    "title": "Information you need",
+                    "content": [{
+                        "title": "",
+                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                    }],
+                    "questions": [{
+                            "question": "Total retail turnover",
+                            "content": [{
+                                    "description": "Include:",
+                                    "list": ["VAT", "internet sales", "retail sales from outlets in Great Britain to customers abroad"]
+                                },
+                                {
+                                    "description": "Exclude:",
+                                    "list": [
+                                        "revenue from mobile phone network commission and top-up",
+                                        "sales from catering facilities used by customers",
+                                        "lottery sales and commission from lottery sales",
+                                        "sales of car accessories and motor vehicles",
+                                        "NHS receipts"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "question": "Internet sales",
+                            "content": [{
+                                "description": "Include: VAT"
+                            }]
+                        },
+                        {
+                            "question": "Significant changes to the total retail turnover",
+                            "content": [{
+                                "description": "Include:",
+                                "list": [
+                                    "in-store / online promotions",
+                                    "special events (e.g.  sporting events)",
+                                    "calendar events (e.g.  Christmas, Easter, Bank Holiday)",
+                                    "weather",
+                                    "store closures/openings"
+                                ]
+                            }]
+                        }
                     ]
-                  }
-                ]
-              },
-              {
-                "question": "Internet sales",
-                "content": [
-                  {
-                    "description": "Include: VAT"
-                  }
-                ]
-              },
-              {
-                "question": "Significant changes to the total retail turnover",
-                "content": [
-                  {
-                    "description": "Include:",
-                    "list": [
-                      "in-store / online promotions",
-                      "special events (e.g.  sporting events)",
-                      "calendar events (e.g.  Christmas, Easter, Bank Holiday)",
-                      "weather",
-                      "store closures/openings"
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          "secondary_content": [
-            {
-              "id": "how-we-use-your-data",
-              "title": "How we use your data",
-              "content": [
-                {
-                  "list": [
-                    "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
-                    "The information you supply is used to produce monthly estimates of the total retail sales in Great Britain. It is also used to help estimate consumer spending on retail goods and the output of the retail sector, both of which feed into the compilation of the UK National Accounts."
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "questions": [
-            {
-              "type": "General",
-              "answers": [
-                {
-                  "type": "Radio",
-                  "id": "reporting-period-choice-answer",
-                  "options": [
-                    {
-                      "label": "Yes",
-                      "value": "Yes"
-                    },
-                    {
-                      "label": "No",
-                      "value": "No"
-                    }
-                  ],
-                  "mandatory": true
-                }
-              ],
-              "id": "reporting-period-choice-question",
-              "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
-            }
-          ],
-          "type": "Question",
-          "title": "Reporting period",
-          "id": "reporting-period-choice",
-          "routing_rules": [
-            {
-              "goto": {
-                "when": [
-                  {
-                    "value": "Yes",
-                    "id": "reporting-period-choice-answer",
-                    "condition": "equals"
-                  }
-                ],
-                "block": "total-retail-turnover-block"
-              }
-            },
-            {
-              "goto": {
-                "block": "reporting-period"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "questions": [
-            {
-              "type": "DateRange",
-              "answers": [
-                {
-                  "label": "From",
-                  "type": "Date",
-                  "id": "period-from",
-                  "q_code": "11",
-                  "mandatory": true,
-                  "alias": "period_from"
                 },
-                {
-                  "label": "To",
-                  "type": "Date",
-                  "id": "period-to",
-                  "q_code": "12",
-                  "mandatory": true,
-                  "alias": "period_to"
-                }
-              ],
-              "id": "reporting-period-question",
-              "title": "What are the dates of the period that you will be reporting for?"
-            }
-          ],
-          "id": "reporting-period",
-          "title": "Reporting period"
-        },
-        {
-          "type": "Question",
-          "id": "total-retail-turnover-block",
-          "questions": [
-            {
-              "guidance": {
-                "content": [
-                  {
-                    "title": "Include",
-                    "list": ["VAT", "internet sales"]
-                  },
-                  {
-                    "title": "Exclude",
-                    "list": [
-                      "revenue from mobile phone network commission and top-up",
-                      "sales from catering facilities used by customers",
-                      "lottery sales and commission from lottery sales",
-                      "sales of car accessories and motor vehicles",
-                      "NHS receipts"
-                    ]
-                  }
-                ]
-              },
-              "answers": [
-                {
-                  "id": "total-retail-turnover-answer",
-                  "alias": "total_turnover",
-                  "label": "Total retail turnover",
-                  "mandatory": true,
-                  "q_code": "20",
-                  "type": "Currency",
-                  "currency": "GBP",
-                  "decimal_places": 2
-                }
-              ],
-              "id": "total-turnover-question",
-              "title":
-                "For the period {{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total retail turnover</em>?",
-              "type": "General"
-            }
-          ],
-          "title": "Retail Turnover"
-        },
-        {
-          "type": "Question",
-          "id": "total-internet-sales",
-          "questions": [
-            {
-              "guidance": {
-                "content": [
-                  {
-                    "title": "Include",
-                    "list": ["VAT", "sales from orders received over the internet, irrespective of the payment or delivery method"]
-                  }
-                ]
-              },
-              "answers": [
-                {
-                  "id": "internet-sales-answer",
-                  "label": "Internet sales",
-                  "mandatory": true,
-                  "q_code": "21",
-                  "type": "Currency",
-                  "currency": "GBP",
-                  "decimal_places": 2,
-                  "max_value": {
-                    "answer_id": "total-retail-turnover-answer"
-                  }
-                }
-              ],
-              "id": "internet-sales-question",
-              "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>internet</em> sales?",
-              "type": "General"
-            }
-          ],
-          "title": "Retail turnover"
-        },
-        {
-          "id": "significant-change",
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "reason-for-change",
-                "when": [
-                  {
-                    "id": "significant-change-established-answer",
-                    "condition": "equals",
-                    "value": "Yes"
-                  }
-                ]
-              }
+                "secondary_content": [{
+                    "id": "how-we-use-your-data",
+                    "title": "How we use your data",
+                    "content": [{
+                        "list": [
+                            "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                            "The information you supply is used to produce monthly estimates of the total retail sales in Great Britain. It is also used to help estimate consumer spending on retail goods and the output of the retail sector, both of which feed into the compilation of the UK National Accounts."
+                        ]
+                    }]
+                }]
             },
             {
-              "goto": {
-                "block": "summary"
-              }
-            }
-          ],
-          "questions": [
-            {
-              "guidance": {
-                "content": [
-                  {
-                    "title": "Include",
-                    "list": [
-                      "in-store / online promotions",
-                      "special events (e.g. sporting events)",
-                      "calendar events (e.g. Christmas, Easter, Bank Holiday)",
-                      "weather",
-                      "store closures/openings"
-                    ]
-                  }
+                "questions": [{
+                    "type": "General",
+                    "answers": [{
+                        "type": "Radio",
+                        "id": "reporting-period-choice-answer",
+                        "options": [{
+                                "label": "Yes",
+                                "value": "Yes"
+                            },
+                            {
+                                "label": "No",
+                                "value": "No"
+                            }
+                        ],
+                        "mandatory": true
+                    }],
+                    "id": "reporting-period-choice-question",
+                    "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
+                }],
+                "type": "Question",
+                "title": "Reporting period",
+                "id": "reporting-period-choice",
+                "routing_rules": [{
+                        "goto": {
+                            "when": [{
+                                "value": "Yes",
+                                "id": "reporting-period-choice-answer",
+                                "condition": "equals"
+                            }],
+                            "block": "total-retail-turnover-block"
+                        }
+                    },
+                    {
+                        "goto": {
+                            "block": "reporting-period"
+                        }
+                    }
                 ]
-              },
-              "answers": [
-                {
-                  "id": "significant-change-established-answer",
-                  "mandatory": true,
-                  "options": [
-                    {
-                      "label": "Yes",
-                      "value": "Yes"
-                    },
-                    {
-                      "label": "No",
-                      "value": "No"
-                    }
-                  ],
-                  "q_code": "146a",
-                  "type": "Radio"
-                }
-              ],
-              "description":
-                "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
-              "id": "significant-change-question",
-              "title": "Did any significant changes occur to the total retail turnover for {{respondent.trad_as_or_ru_name}}?",
-              "type": "General"
-            }
-          ],
-          "title": "Changes in total retail turnover",
-          "type": "Question"
-        },
-        {
-          "type": "Question",
-          "id": "reason-for-change",
-          "questions": [
+            },
             {
-              "answers": [
-                {
-                  "id": "reason-for-change-answer",
-                  "mandatory": true,
-                  "options": [
-                    {
-                      "label": "In-store / online promotions",
-                      "q_code": "146b",
-                      "value": "In-store / online promotions"
-                    },
-                    {
-                      "label": "Special events (e.g. sporting events)",
-                      "q_code": "146c",
-                      "value": "Special events (e.g. sporting events)"
-                    },
-                    {
-                      "label": "Calendar events (e.g. Christmas, Easter, Bank Holiday)",
-                      "q_code": "146d",
-                      "value": "Calendar events (e.g. Christmas, Easter, Bank Holiday)"
-                    },
-                    {
-                      "label": "Weather",
-                      "q_code": "146e",
-                      "value": "Weather"
-                    },
-                    {
-                      "label": "Store closures",
-                      "q_code": "146f",
-                      "value": "Store closures"
-                    },
-                    {
-                      "label": "Store openings",
-                      "q_code": "146g",
-                      "value": "Store openings"
-                    },
-                    {
-                      "label": "Other",
-                      "q_code": "146h",
-                      "value": "Other"
-                    }
-                  ],
-                  "type": "Checkbox"
-                }
-              ],
-              "id": "reason-for-change-question",
-              "title": "Please indicate the reasons for any changes in the total retail turnover for {{respondent.trad_as_or_ru_name}}",
-              "type": "General"
-            }
-          ],
-          "title": "Changes in total retail turnover"
-        },
-        {
-          "type": "Question",
-          "id": "change-comment-block",
-          "questions": [
+                "type": "Question",
+                "questions": [{
+                    "type": "DateRange",
+                    "answers": [{
+                            "label": "From",
+                            "type": "Date",
+                            "id": "period-from",
+                            "q_code": "11",
+                            "mandatory": true,
+                            "alias": "period_from"
+                        },
+                        {
+                            "label": "To",
+                            "type": "Date",
+                            "id": "period-to",
+                            "q_code": "12",
+                            "mandatory": true,
+                            "alias": "period_to"
+                        }
+                    ],
+                    "id": "reporting-period-question",
+                    "title": "What are the dates of the period that you will be reporting for?"
+                }],
+                "id": "reporting-period",
+                "title": "Reporting period"
+            },
             {
-              "answers": [
-                {
-                  "guidance": {
-                    "show_guidance": "Show examples of commentary on changes to total retail turnover",
-                    "hide_guidance": "Hide examples of commentary on changes to total retail turnover",
-                    "content": [
-                      {
-                        "description": "Examples of commentary:"
-                      },
-                      {
-                        "title": "‘In-store promotion’",
-                        "description":
-                          "“Offer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales.”"
-                      },
-                      {
-                        "title": "‘Special events (for example, sporting events)’",
-                        "description":
-                          "“This was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online.”"
-                      },
-                      {
-                        "title": "‘Weather’",
-                        "description":
-                          "“The bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month.”"
-                      }
-                    ]
-                  },
-                  "id": "change-comment",
-                  "label": "Comments",
-                  "mandatory": true,
-                  "q_code": "146",
-                  "type": "TextArea"
-                }
-              ],
-              "description":
-                "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
-              "id": "change-comment-question",
-              "title": "Please describe the changes in total retail turnover for {{respondent.trad_as_or_ru_name}} in more detail",
-              "type": "General"
+                "type": "Question",
+                "id": "total-retail-turnover-block",
+                "questions": [{
+                    "guidance": {
+                        "content": [{
+                                "title": "Include",
+                                "list": ["VAT", "internet sales"]
+                            },
+                            {
+                                "title": "Exclude",
+                                "list": [
+                                    "revenue from mobile phone network commission and top-up",
+                                    "sales from catering facilities used by customers",
+                                    "lottery sales and commission from lottery sales",
+                                    "sales of car accessories and motor vehicles",
+                                    "NHS receipts"
+                                ]
+                            }
+                        ]
+                    },
+                    "answers": [{
+                        "id": "total-retail-turnover-answer",
+                        "alias": "total_turnover",
+                        "label": "Total retail turnover",
+                        "mandatory": true,
+                        "q_code": "20",
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2
+                    }],
+                    "id": "total-turnover-question",
+                    "title": "For the period {{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total retail turnover</em>?",
+                    "type": "General"
+                }],
+                "title": "Retail Turnover"
+            },
+            {
+                "type": "Question",
+                "id": "total-internet-sales",
+                "questions": [{
+                    "guidance": {
+                        "content": [{
+                            "title": "Include",
+                            "list": ["VAT", "sales from orders received over the internet, irrespective of the payment or delivery method"]
+                        }]
+                    },
+                    "answers": [{
+                        "id": "internet-sales-answer",
+                        "label": "Internet sales",
+                        "mandatory": true,
+                        "q_code": "21",
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2,
+                        "max_value": {
+                            "answer_id": "total-retail-turnover-answer"
+                        }
+                    }],
+                    "id": "internet-sales-question",
+                    "title": "Of the <em>{{answers.total_turnover|format_currency}}</em> total retail turnover, what was the value of <em>internet</em> sales?",
+                    "type": "General"
+                }],
+                "title": "Retail turnover"
+            },
+            {
+                "id": "significant-change",
+                "routing_rules": [{
+                        "goto": {
+                            "block": "reason-for-change",
+                            "when": [{
+                                "id": "significant-change-established-answer",
+                                "condition": "equals",
+                                "value": "Yes"
+                            }]
+                        }
+                    },
+                    {
+                        "goto": {
+                            "block": "summary"
+                        }
+                    }
+                ],
+                "questions": [{
+                    "guidance": {
+                        "content": [{
+                            "title": "Include",
+                            "list": [
+                                "in-store / online promotions",
+                                "special events (e.g. sporting events)",
+                                "calendar events (e.g. Christmas, Easter, Bank Holiday)",
+                                "weather",
+                                "store closures/openings"
+                            ]
+                        }]
+                    },
+                    "answers": [{
+                        "id": "significant-change-established-answer",
+                        "mandatory": true,
+                        "options": [{
+                                "label": "Yes",
+                                "value": "Yes"
+                            },
+                            {
+                                "label": "No",
+                                "value": "No"
+                            }
+                        ],
+                        "q_code": "146a",
+                        "type": "Radio"
+                    }],
+                    "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                    "id": "significant-change-question",
+                    "title": "Did any significant changes occur to the total retail turnover for {{respondent.trad_as_or_ru_name}}?",
+                    "type": "General"
+                }],
+                "title": "Changes in total retail turnover",
+                "type": "Question"
+            },
+            {
+                "type": "Question",
+                "id": "reason-for-change",
+                "questions": [{
+                    "answers": [{
+                        "id": "reason-for-change-answer",
+                        "mandatory": true,
+                        "options": [{
+                                "label": "In-store / online promotions",
+                                "q_code": "146b",
+                                "value": "In-store / online promotions"
+                            },
+                            {
+                                "label": "Special events (e.g. sporting events)",
+                                "q_code": "146c",
+                                "value": "Special events (e.g. sporting events)"
+                            },
+                            {
+                                "label": "Calendar events (e.g. Christmas, Easter, Bank Holiday)",
+                                "q_code": "146d",
+                                "value": "Calendar events (e.g. Christmas, Easter, Bank Holiday)"
+                            },
+                            {
+                                "label": "Weather",
+                                "q_code": "146e",
+                                "value": "Weather"
+                            },
+                            {
+                                "label": "Store closures",
+                                "q_code": "146f",
+                                "value": "Store closures"
+                            },
+                            {
+                                "label": "Store openings",
+                                "q_code": "146g",
+                                "value": "Store openings"
+                            },
+                            {
+                                "label": "Other",
+                                "q_code": "146h",
+                                "value": "Other"
+                            }
+                        ],
+                        "type": "Checkbox"
+                    }],
+                    "id": "reason-for-change-question",
+                    "title": "Please indicate the reasons for any changes in the total retail turnover for {{respondent.trad_as_or_ru_name}}",
+                    "type": "General"
+                }],
+                "title": "Changes in total retail turnover"
+            },
+            {
+                "type": "Question",
+                "id": "change-comment-block",
+                "questions": [{
+                    "answers": [{
+                        "guidance": {
+                            "show_guidance": "Show examples of commentary on changes to total retail turnover",
+                            "hide_guidance": "Hide examples of commentary on changes to total retail turnover",
+                            "content": [{
+                                    "description": "Examples of commentary:"
+                                },
+                                {
+                                    "title": "‘In-store promotion’",
+                                    "description": "“Offer on wine for the whole month (save 25% when you buy 6 bottles). The promotion was available in-store and online, contributing to an increase in both total retail turnover and internet sales.”"
+                                },
+                                {
+                                    "title": "‘Special events (for example, sporting events)’",
+                                    "description": "“This was the month before the start of Euro 2016 (football), we recorded an increase in sales of audio-visual equipment (for example, televisions and audio equipment). This led to an increase in sales both in-store and online.”"
+                                },
+                                {
+                                    "title": "‘Weather’",
+                                    "description": "“The bad weather has decreased our sales of summer clothing. This has led to a reduction in total retail turnover and internet sales this month.”"
+                                }
+                            ]
+                        },
+                        "id": "change-comment",
+                        "label": "Comments",
+                        "mandatory": true,
+                        "q_code": "146",
+                        "type": "TextArea"
+                    }],
+                    "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
+                    "id": "change-comment-question",
+                    "title": "Please describe the changes in total retail turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+                    "type": "General"
+                }],
+                "title": "Changes in total retail turnover"
+            },
+            {
+                "type": "Summary",
+                "id": "summary"
             }
-          ],
-          "title": "Changes in total retail turnover"
-        },
-        {
-          "type": "Summary",
-          "id": "summary"
-        }
-      ],
-      "id": "rsi",
-      "title": ""
-    }
-  ]
+        ],
+        "id": "rsi",
+        "title": ""
+    }]
 }

--- a/data/en/1_0112.json
+++ b/data/en/1_0112.json
@@ -351,8 +351,6 @@
                         ],
                         "type": "Checkbox"
                     }],
-
-                    "description": "Select all that apply",
                     "id": "reason-for-change-question",
                     "title": "Please indicate the reasons for any changes in the total retail turnover for {{respondent.trad_as_or_ru_name}}",
                     "type": "General"

--- a/data/en/1_0203.json
+++ b/data/en/1_0203.json
@@ -627,8 +627,6 @@
                         ],
                         "type": "Checkbox"
                     }],
-
-                    "description": "Select all that apply",
                     "id": "reason-for-change-question",
                     "title": "Please indicate the reasons for any changes in the total retail turnover for {{respondent.trad_as_or_ru_name}}",
                     "type": "General"

--- a/data/en/1_0205.json
+++ b/data/en/1_0205.json
@@ -676,8 +676,6 @@
                         ],
                         "type": "Checkbox"
                     }],
-
-                    "description": "Select all that apply",
                     "id": "reason-for-change-question",
                     "title": "Please indicate the reasons for any changes in the total retail turnover for {{respondent.trad_as_or_ru_name}}",
                     "type": "General"

--- a/data/en/1_0213.json
+++ b/data/en/1_0213.json
@@ -651,8 +651,6 @@
                         ],
                         "type": "Checkbox"
                     }],
-
-                    "description": "Select all that apply",
                     "id": "reason-for-change-question",
                     "title": "Please indicate the reasons for any changes in the total retail turnover for {{respondent.trad_as_or_ru_name}}",
                     "type": "General"

--- a/data/en/1_0215.json
+++ b/data/en/1_0215.json
@@ -724,8 +724,6 @@
                         ],
                         "type": "Checkbox"
                     }],
-
-                    "description": "Select all that apply",
                     "id": "reason-for-change-question",
                     "title": "Please indicate the reasons for any changes in the total retail turnover for {{respondent.trad_as_or_ru_name}}",
                     "type": "General"

--- a/data/en/census_communal.json
+++ b/data/en/census_communal.json
@@ -164,7 +164,6 @@
                 "questions": [{
                     "id": "describe-residents-question",
                     "title": "How would you describe your usual residents?",
-                    "description": "Select all that apply",
                     "type": "General",
                     "answers": [{
                             "id": "describe-residents-answer",
@@ -261,7 +260,6 @@
                 "questions": [{
                     "id": "why-paper-individual-question",
                     "title": "Why do you think they would choose to do it on paper?",
-                    "description": "Select all that apply",
                     "type": "General",
                     "answers": [{
                             "id": "why-paper-individual-answer",
@@ -348,7 +346,6 @@
                 "questions": [{
                     "id": "why-paper-establishment-question",
                     "title": "Why would you choose to do it on paper?",
-                    "description": "Select all that apply",
                     "type": "General",
                     "answers": [{
                             "id": "why-paper-establishment-answer",

--- a/data/en/census_household.json
+++ b/data/en/census_household.json
@@ -1,4572 +1,3894 @@
 {
-  "mime_type": "application/json/ons/eq",
-  "schema_version": "0.0.1",
-  "data_version": "0.0.2",
-  "survey_id": "census",
-  "title": "2017 Census Test",
-  "description": "Census England Household Schema",
-  "theme": "census",
-  "legal_basis": "Voluntary",
-  "navigation": {
-    "visible": true,
-    "sections": [
-      {
-        "title": "Who lives here?",
-        "group_order": ["who-lives-here", "who-lives-here-relationship", "who-lives-here-interstitial"]
-      },
-      {
-        "title": "Household and Accommodation",
-        "group_order": ["household-and-accommodation"]
-      },
-      {
-        "title_from_answers": ["first-name", "last-name"],
-        "group_order": ["household-member"]
-      },
-      {
-        "title": "Visitors",
-        "group_order": ["visitors-begin", "visitors", "visitors-interstitial"]
-      },
-      {
-        "title": "Submit answers",
-        "group_order": ["questionnaire-completed"]
-      }
-    ]
-  },
-  "groups": [
-    {
-      "id": "what-is-your-address-group",
-      "title": "What is your address?",
-      "blocks": [
-        {
-          "type": "Introduction",
-          "id": "introduction"
-        },
-        {
-          "type": "Question",
-          "id": "what-is-your-address",
-          "questions": [
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "census",
+    "title": "2017 Census Test",
+    "description": "Census England Household Schema",
+    "theme": "census",
+    "legal_basis": "Voluntary",
+    "navigation": {
+        "visible": true,
+        "sections": [{
+                "title": "Who lives here?",
+                "group_order": ["who-lives-here", "who-lives-here-relationship", "who-lives-here-interstitial"]
+            },
             {
-              "id": "what-is-your-address-question",
-              "title": "What is your address?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "address-line-1",
-                  "label": "Address Line 1 (Including your house name or number)",
-                  "mandatory": true,
-                  "type": "TextField",
-                  "alias": "address_line_1",
-                  "validation": {
-                    "messages": {
-                      "MANDATORY_TEXTFIELD": "Enter an address to continue"
-                    }
-                  }
-                },
-                {
-                  "id": "address-line-2",
-                  "label": "Address Line 2",
-                  "mandatory": false,
-                  "type": "TextField"
-                },
-                {
-                  "id": "address-line-3",
-                  "label": "Address Line 3",
-                  "mandatory": false,
-                  "type": "TextField"
-                },
-                {
-                  "id": "town-city",
-                  "label": "Town/City",
-                  "mandatory": false,
-                  "type": "TextField"
-                },
-                {
-                  "id": "county",
-                  "label": "County",
-                  "mandatory": false,
-                  "type": "TextField"
-                },
-                {
-                  "id": "postcode",
-                  "label": "Postcode",
-                  "mandatory": false,
-                  "type": "TextField"
-                },
-                {
-                  "id": "country",
-                  "label": "Country",
-                  "mandatory": false,
-                  "type": "TextField"
-                }
-              ]
+                "title": "Household and Accommodation",
+                "group_order": ["household-and-accommodation"]
+            },
+            {
+                "title_from_answers": ["first-name", "last-name"],
+                "group_order": ["household-member"]
+            },
+            {
+                "title": "Visitors",
+                "group_order": ["visitors-begin", "visitors", "visitors-interstitial"]
+            },
+            {
+                "title": "Submit answers",
+                "group_order": ["questionnaire-completed"]
             }
-          ]
-        }
-      ]
+        ]
     },
-    {
-      "id": "who-lives-here",
-      "title": "Who lives here?",
-      "blocks": [
-        {
-          "type": "Interstitial",
-          "id": "who-lives-here-section",
-          "title": "People who live in the household",
-          "description": "In this section, we’re going to ask you about the people that live at <em>{{answers.address_line_1}}</em>.",
-          "content": [
-            {
-              "title": "Information you need",
-              "list": [
-                "Names of the people living in household and how they are related",
-                "The number of visitors staying in the household on 29 November 2017"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "permanent-or-family-home",
-          "questions": [
-            {
-              "id": "permanent-or-family-home-question",
-              "title": "Does anyone live at <em>{{answers.address_line_1}}</em> as their permanent or family home?",
-              "guidance": {
-                "content": [
-                  {
-                    "title": "Include",
-                    "list": [
-                      "yourself, if this is your permanent or family home",
-                      "family members including partners, children and babies born on or before 9 April 2017",
-                      "students and, or school children who live away from home during term time",
-                      "housemates tenants or lodgers"
-                    ]
-                  }
-                ]
-              },
-              "type": "General",
-              "answers": [
-                {
-                  "id": "permanent-or-family-home-answer",
-                  "mandatory": true,
-                  "guidance": {
-                    "show_guidance": "Show further guidance",
-                    "hide_guidance": "Hide further guidance",
-                    "content": [
-                      {
-                        "description": "For most people, their permanent home will be the address where they spend the most time."
-                      }
-                    ]
-                  },
-                  "options": [
-                    {
-                      "label": "Yes",
-                      "value": "Yes"
-                    },
-                    {
-                      "label": "No",
-                      "value": "No",
-                      "description": "For example this is a second address or holiday home"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "household-composition",
-                "when": [
-                  {
-                    "id": "permanent-or-family-home-answer",
-                    "condition": "equals",
-                    "value": "Yes"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "else-permanent-or-family-home",
-                "when": [
-                  {
-                    "id": "permanent-or-family-home-answer",
-                    "condition": "equals",
-                    "value": "No"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "else-permanent-or-family-home",
-          "questions": [
-            {
-              "id": "else-permanent-or-family-home-question",
-              "title": "Can you confirm no one lives here as their permanent or family home?",
-              "guidance": {
-                "content": [
-                  {
-                    "title": "This could be:",
-                    "list": [
-                      "people who usually live outside the UK who are staying in the UK for <b>three months or more</b>",
-                      "people who work away from home within the UK if this is their permanent or family home",
-                      "members of the Armed Forces if this is their permanent or family home",
-                      "people who are temporarily outside the UK for <b>less than 12 months</b>",
-                      "people staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends",
-                      "other people who usually live here, including anyone temporarily away from home "
-                    ]
-                  }
-                ]
-              },
-              "type": "General",
-              "answers": [
-                {
-                  "id": "else-permanent-or-family-home-answer",
-                  "mandatory": true,
-                  "options": [
-                    {
-                      "label": "Someone lives here as their permanent home",
-                      "value": "Someone lives here as their permanent home"
-                    },
-                    {
-                      "label": "No one lives here as their permanent home",
-                      "value": "No one lives here as their permanent home"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "household-composition",
-                "when": [
-                  {
-                    "id": "else-permanent-or-family-home-answer",
-                    "condition": "equals",
-                    "value": "Someone lives here as their permanent home"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "overnight-visitors",
-                "when": [
-                  {
-                    "id": "else-permanent-or-family-home-answer",
-                    "condition": "equals",
-                    "value": "No one lives here as their permanent home"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "household-composition",
-          "questions": [
-            {
-              "id": "household-composition-question",
-              "title": "What are the names of everyone who live at <em>{{answers.address_line_1}}</em>?",
-              "guidance": {
-                "content": [
-                  {
-                    "title": "Include",
-                    "list": [
-                      "Yourself, if this is your permanent or family home",
-                      "Family members including partners, children and babies born on or before 9 April 2017",
-                      "Students and, or school children who live away from home during term time",
-                      "Housemates tenants or lodgers",
-                      "Household members who have requested a personal form"
-                    ]
-                  }
-                ]
-              },
-              "type": "RepeatingAnswer",
-              "answers": [
-                {
-                  "alias": "first_name",
-                  "id": "first-name",
-                  "label": "First name",
-                  "mandatory": true,
-                  "type": "TextField",
-                  "validation": {
-                    "messages": {
-                      "MANDATORY_TEXTFIELD": "Please enter a name or remove the person to continue"
-                    }
-                  }
+    "groups": [{
+            "id": "what-is-your-address-group",
+            "title": "What is your address?",
+            "blocks": [{
+                    "type": "Introduction",
+                    "id": "introduction"
                 },
                 {
-                  "alias": "middle_names",
-                  "id": "middle-names",
-                  "label": "Middle names",
-                  "mandatory": false,
-                  "type": "TextField"
-                },
-                {
-                  "alias": "last_name",
-                  "id": "last-name",
-                  "label": "Last name",
-                  "mandatory": false,
-                  "guidance": {
-                    "show_guidance": "Show further guidance",
-                    "hide_guidance": "Hide further guidance",
-                    "content": [
-                      {
-                        "description": "Enter the current first, middle and last names of all the people who usually live here."
-                      },
-                      {
-                        "description":
-                          "If you have not yet named your newborn, please enter ‘Baby’ for their first name and then enter their last name (surname)."
-                      },
-                      {
-                        "description": "Please also include household members who have requested a personal form."
-                      },
-                      {
-                        "description":
-                          "Please also include the names of people staying with you temporarily who don’t have a usual address in the UK. This is so that we make sure we count everyone."
-                      },
-                      {
-                        "title": "Include",
-                        "list": [
-                          "people who usually live outside the UK who are staying in the UK for <strong>three months or more</strong>",
-                          "people who work away from home within the UK  if this is their permanent or family home",
-                          "members of the Armed Forces if this is their permanent or family home",
-                          "people who are temporarily outside the UK for <strong>less than 12 months</strong>",
-                          "people staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends"
+                    "type": "Question",
+                    "id": "what-is-your-address",
+                    "questions": [{
+                        "id": "what-is-your-address-question",
+                        "title": "What is your address?",
+                        "type": "General",
+                        "answers": [{
+                                "id": "address-line-1",
+                                "label": "Address Line 1 (Including your house name or number)",
+                                "mandatory": true,
+                                "type": "TextField",
+                                "alias": "address_line_1",
+                                "validation": {
+                                    "messages": {
+                                        "MANDATORY_TEXTFIELD": "Enter an address to continue"
+                                    }
+                                }
+                            },
+                            {
+                                "id": "address-line-2",
+                                "label": "Address Line 2",
+                                "mandatory": false,
+                                "type": "TextField"
+                            },
+                            {
+                                "id": "address-line-3",
+                                "label": "Address Line 3",
+                                "mandatory": false,
+                                "type": "TextField"
+                            },
+                            {
+                                "id": "town-city",
+                                "label": "Town/City",
+                                "mandatory": false,
+                                "type": "TextField"
+                            },
+                            {
+                                "id": "county",
+                                "label": "County",
+                                "mandatory": false,
+                                "type": "TextField"
+                            },
+                            {
+                                "id": "postcode",
+                                "label": "Postcode",
+                                "mandatory": false,
+                                "type": "TextField"
+                            },
+                            {
+                                "id": "country",
+                                "label": "Country",
+                                "mandatory": false,
+                                "type": "TextField"
+                            }
                         ]
-                      }
-                    ]
-                  },
-                  "type": "TextField"
+                    }]
                 }
-              ]
-            }
-          ]
+            ]
         },
         {
-          "type": "Question",
-          "id": "everyone-at-address-confirmation",
-          "description":
-            "<h2 class='neptune'>Your household includes:</h2> {{ [answers.first_name, answers.middle_names, answers.last_name]|format_household_summary }}",
-          "questions": [
-            {
-              "id": "everyone-at-address-confirmation-question",
-              "title": "Is this everyone for whom this is their permanent or family home?",
-              "description": "Please note that you will need to ensure that everyone is included because you will be unable to make changes later",
-              "guidance": {
-                "content": [
-                  {
-                    "title": "Include",
-                    "list": [
-                      "people who usually live outside the UK who are staying in the UK for <b>three months or more</b>",
-                      "people who work away from home within the UK  if this is their permanent or family home",
-                      "members of the Armed Forces if this is their permanent or family home",
-                      "people who are temporarily outside the UK for <b>less than 12 months</b>",
-                      "people staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends",
-                      "other people who usually live here, including anyone temporarily away from home"
-                    ]
-                  }
-                ]
-              },
-              "type": "General",
-              "answers": [
-                {
-                  "id": "everyone-at-address-confirmation-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Yes",
-                      "value": "Yes"
-                    },
-                    {
-                      "label": "No, I need to add another person",
-                      "value": "No, I need to add another person"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "household-composition",
-                "when": [
-                  {
-                    "id": "everyone-at-address-confirmation-answer",
-                    "condition": "equals",
-                    "value": "No, I need to add another person"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "overnight-visitors"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "overnight-visitors",
-          "questions": [
-            {
-              "id": "overnight-visitors-question",
-              "title": "How many visitors are staying overnight at <em>{{answers.address_line_1}}</em> on 9th April 2017?",
-              "guidance": {
-                "content": [
-                  {
-                    "title": "Include",
-                    "list": [
-                      "people who usually live somewhere else in the UK. For example, friends or relatives",
-                      "people staying here because it is their second address, for example, for work. Their permanent or family home is elsewhere",
-                      "people who usually live outside the UK who are visiting the UK for less than three months",
-                      "people here on holiday"
-                    ]
-                  }
-                ]
-              },
-              "type": "General",
-              "answers": [
-                {
-                  "id": "overnight-visitors-answer",
-                  "label": "Number of visitors (enter 0 if no visitors)",
-                  "mandatory": true,
-                  "type": "Number"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "who-lives-here-relationship",
-      "title": "Relationships",
-      "hide_in_navigation": true,
-      "routing_rules": [
-        {
-          "repeat": {
-            "type": "answer_count_minus_one",
-            "answer_id": "first-name"
-          }
-        }
-      ],
-      "blocks": [
-        {
-          "type": "Question",
-          "id": "household-relationships",
-          "questions": [
-            {
-              "id": "household-relationships-question",
-              "title":
-                "How is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> related to the people below?",
-              "description":
-                "If members are not related, select the ‘unrelated’ option.</br>If you are the parents of adopted children, select the ‘Mother or father’ option to show your relationship to them.</br>If you have foster children living with you, select the ‘Unrelated’ option.</br>Include half-brothers and half-sisters in the ‘Step-brother or step-sister’ category.</br>Same-sex civil partner is used to describe the relationship between two people who have legally registered a civil partnership.</br>If none of the options fully reflects your relationship, please select the one which you feel best describes your situation.",
-              "type": "Relationship",
-              "answers": [
-                {
-                  "id": "household-relationships-answer",
-                  "label": "%(current_person)s is %(other_person)s",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Husband or wife",
-                      "value": "Husband or wife"
-                    },
-                    {
-                      "label": "Same-sex civil partner",
-                      "value": "Same-sex civil partner"
-                    },
-                    {
-                      "label": "Partner",
-                      "value": "Partner"
-                    },
-                    {
-                      "label": "Grandparent",
-                      "value": "Grandparent"
-                    },
-                    {
-                      "label": "Mother or father",
-                      "value": "Mother or father"
-                    },
-                    {
-                      "label": "Step-mother or step-father",
-                      "value": "Step-mother or step-father"
-                    },
-                    {
-                      "label": "Son or daughter",
-                      "value": "Son or daughter"
-                    },
-                    {
-                      "label": "Step-child",
-                      "value": "Step-child"
-                    },
-                    {
-                      "label": "Brother or sister",
-                      "value": "Brother or sister"
-                    },
-                    {
-                      "label": "Step–brother or step–sister",
-                      "value": "Step–brother or step–sister"
-                    },
-                    {
-                      "label": "Grandchild",
-                      "value": "Grandchild"
-                    },
-                    {
-                      "label": "Relation - other",
-                      "value": "Relation - other"
-                    },
-                    {
-                      "label": "Unrelated (including foster child)",
-                      "value": "Unrelated (including foster child)"
-                    }
-                  ],
-                  "type": "Relationship"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "who-lives-here-interstitial",
-      "title": "Who lives here?",
-      "hide_in_navigation": true,
-      "blocks": [
-        {
-          "id": "who-lives-here-completed",
-          "title": "You have successfully completed the ‘Who lives here?’ section",
-          "description": "In the next section we are going to ask you about the household and accommodation you live in.",
-          "type": "Interstitial"
-        }
-      ]
-    },
-    {
-      "id": "household-and-accommodation",
-      "title": "Household and Accommodation",
-      "blocks": [
-        {
-          "type": "Interstitial",
-          "id": "household-and-accommodation-section",
-          "title": "Household and accommodation",
-          "description": "In this section, we’re going to ask you about the household and accommodation you live in.",
-          "content": [
-            {
-              "title": "Information you need",
-              "list": ["Type of property, and if it’s owned or rented", "Type of landlord, if the property is rented", "Number of cars or vans"]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "type-of-accommodation",
-          "questions": [
-            {
-              "id": "type-of-accommodation-question",
-              "title": "What type of accommodation is <em>{{answers.address_line_1}}</em>?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "type-of-accommodation-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Whole house or bungalow",
-                      "value": "Whole house or bungalow"
-                    },
-                    {
-                      "label": "Flat, maisonette or apartment (including bedsits)",
-                      "value": "Flat, maisonette or apartment (including bedsits)"
-                    },
-                    {
-                      "label": "Caravan or other mobile or temporary structure",
-                      "value": "Caravan or other mobile or temporary structure"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "type-of-house",
-                "when": [
-                  {
-                    "id": "type-of-accommodation-answer",
-                    "condition": "equals",
-                    "value": "Whole house or bungalow"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "type-of-flat",
-                "when": [
-                  {
-                    "id": "type-of-accommodation-answer",
-                    "condition": "equals",
-                    "value": "Flat, maisonette or apartment (including bedsits)"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "self-contained-accommodation"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "type-of-house",
-          "questions": [
-            {
-              "id": "type-of-house-question",
-              "title": "Is your house or bungalow:",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "type-of-house-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Detached",
-                      "value": "Detached"
-                    },
-                    {
-                      "label": "Semi-detached",
-                      "value": "Semi-detached"
-                    },
-                    {
-                      "label": "Terraced (including end-terrace)",
-                      "value": "Terraced"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "self-contained-accommodation"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "type-of-flat",
-          "questions": [
-            {
-              "id": "type-of-flat-question",
-              "title": "Is your flat, maisonette or apartment:",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "type-of-flat-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "In a purpose-built block of flats or tenement",
-                      "value": "In a purpose-built block of flats or tenement"
-                    },
-                    {
-                      "label": "Part of a converted or shared house (including bedsits)",
-                      "value": "Part of a converted or shared house (including bedsits)"
-                    },
-                    {
-                      "label": "In a commercial building (for example, in an office building, hotel, or over a  shop).",
-                      "value": "In a commercial building (for example, in an office building, hotel, or over a  shop)."
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "self-contained-accommodation",
-          "questions": [
-            {
-              "id": "self-contained-accommodation-question",
-              "title": "Is the accommodation of <em>{{answers.address_line_1}}</em> self-contained?",
-              "description": "This means that all the rooms, including the kitchen, bathroom and toilet, are behind a door that only this household can use",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "self-contained-accommodation-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Yes, all the rooms are behind a door that only this household can use",
-                      "value": "Yes, all the rooms are behind a door that only this household can use"
-                    },
-                    {
-                      "label": "No",
-                      "value": "No"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "number-of-bedrooms",
-          "questions": [
-            {
-              "id": "number-of-bedrooms-question",
-              "title": "How many bedrooms are at <em>{{answers.address_line_1}}</em>?",
-              "guidance": {
-                "content": [
-                  {
-                    "description": "Include all rooms built or converted for use as bedrooms, even if they’re not currently used as bedrooms"
-                  }
-                ]
-              },
-              "type": "General",
-              "answers": [
-                {
-                  "id": "number-of-bedrooms-answer",
-                  "label": "Number of bedrooms",
-                  "mandatory": false,
-                  "type": "Number"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "central-heating",
-          "questions": [
-            {
-              "id": "central-heating-question",
-              "title": "What type of central heating does <em>{{answers.address_line_1}}</em> have?",
-              "description":
-                "<p>Central heating is a central system that generates heat for multiple rooms.</p><p>Select all that apply, whether or not you use it.</p>",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "central-heating-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Gas",
-                      "value": "Gas"
-                    },
-                    {
-                      "label": "Electric (include storage heaters)",
-                      "value": "Electric (include storage heaters)"
-                    },
-                    {
-                      "label": "Oil",
-                      "value": "Oil"
-                    },
-                    {
-                      "label": "Solid fuel (for example wood, coal)",
-                      "value": "Solid fuel (for example wood, coal)"
-                    },
-                    {
-                      "label": "Renewable (for example solar panels)",
-                      "value": "Renewable (for example solar panels)"
-                    },
-                    {
-                      "label": "Other central heating",
-                      "value": "Other central heating"
-                    },
-                    {
-                      "label": "No central heating",
-                      "value": "No central heating"
-                    }
-                  ],
-                  "type": "Checkbox"
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "own-or-rent",
-                "when": [
-                  {
-                    "id": "permanent-or-family-home-answer",
-                    "condition": "equals",
-                    "value": "Yes"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "own-or-rent",
-                "when": [
-                  {
-                    "id": "else-permanent-or-family-home-answer",
-                    "condition": "equals",
-                    "value": "Someone lives here as their permanent home"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "household-and-accommodation-completed"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "own-or-rent",
-          "questions": [
-            {
-              "id": "own-or-rent-question",
-              "title": "Does your household own or rent <em>{{answers.address_line_1}}</em>?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "own-or-rent-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Owns outright",
-                      "value": "Owns outright"
-                    },
-                    {
-                      "label": "Owns with a mortgage or loan",
-                      "value": "Owns with a mortgage or loan"
-                    },
-                    {
-                      "label": "Part owns and part rents (shared ownership)",
-                      "value": "Part owns and part rents (shared ownership)"
-                    },
-                    {
-                      "label": "Rents (with or without housing benefit)",
-                      "value": "Rents (with or without housing benefit)"
-                    },
-                    {
-                      "label": "Lives here rent free",
-                      "value": "Lives here rent free"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "number-of-vehicles",
-                "when": [
-                  {
-                    "id": "own-or-rent-answer",
-                    "condition": "equals",
-                    "value": "Owns outright"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "number-of-vehicles",
-                "when": [
-                  {
-                    "id": "own-or-rent-answer",
-                    "condition": "equals",
-                    "value": "Owns with a mortgage or loan"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "landlord"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "landlord",
-          "questions": [
-            {
-              "id": "landlord-question",
-              "title": "Who is your landlord?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "landlord-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Housing association, housing co-operative, charitable trust, registered social landlord",
-                      "value": "Housing association, housing co-operative, charitable trust, registered social landlord"
-                    },
-                    {
-                      "label": "Council (local authority)",
-                      "value": "Council (local authority)"
-                    },
-                    {
-                      "label": "Private landlord or letting agency",
-                      "value": "Private landlord or letting agency"
-                    },
-                    {
-                      "label": "Employer of a household member",
-                      "value": "Employer of a household member"
-                    },
-                    {
-                      "label": "Relative or friend of a household member",
-                      "value": "Relative or friend of a household member"
-                    },
-                    {
-                      "label": "Other",
-                      "value": "Other"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "number-of-vehicles",
-          "questions": [
-            {
-              "id": "number-of-vehicles-question",
-              "title": "How many cars or vans are owned, or available for use, by members of this household?",
-              "guidance": {
-                "content": [
-                  {
-                    "description": "Include any company cars or vans available for private use"
-                  }
-                ]
-              },
-              "type": "General",
-              "answers": [
-                {
-                  "id": "number-of-vehicles-answer",
-                  "label": "Number of cars or vans",
-                  "mandatory": false,
-                  "type": "Number"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "id": "household-and-accommodation-completed",
-          "title": "You have successfully completed the ‘Household and Accommodation’ section",
-          "description": "",
-          "type": "Interstitial"
-        }
-      ]
-    },
-    {
-      "id": "household-member",
-      "title": "Household Member Details",
-      "routing_rules": [
-        {
-          "repeat": {
-            "type": "answer_count",
-            "answer_id": "first-name"
-          }
-        }
-      ],
-      "blocks": [
-        {
-          "type": "Interstitial",
-          "id": "household-member-begin-section",
-          "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}",
-          "description":
-            "In this section, we’re going to ask you questions about <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em>.",
-          "content": [
-            {
-              "title": "Information you need",
-              "list": [
-                "Personal details such as date of birth, country of birth, religion etc.",
-                "Education and qualifications",
-                "Employment and travel to work",
-                "Second or holiday homes",
-                "Unpaid care, health and well-being",
-                "Languages"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "details-correct",
-          "questions": [
-            {
-              "id": "details-correct-question",
-              "title":
-                "Is the name {{ [answers.first_name[group_instance], answers.middle_names[group_instance], answers.last_name[group_instance]] | format_household_name }} correct, including any middle name(s)?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "details-correct-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Yes, this is my full name",
-                      "value": "Yes, this is my full name"
-                    },
-                    {
-                      "label": "No, I need to change my name",
-                      "value": "No, I need to change my name"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "correct-name",
-                "when": [
-                  {
-                    "id": "details-correct-answer",
-                    "condition": "equals",
-                    "value": "No, I need to change my name"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "over-16"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "correct-name",
-          "questions": [
-            {
-              "id": "correct-name-question",
-              "title": "What is your correct name?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "correct-first-name",
-                  "label": "First name",
-                  "mandatory": false,
-                  "type": "TextField"
+            "id": "who-lives-here",
+            "title": "Who lives here?",
+            "blocks": [{
+                    "type": "Interstitial",
+                    "id": "who-lives-here-section",
+                    "title": "People who live in the household",
+                    "description": "In this section, we’re going to ask you about the people that live at <em>{{answers.address_line_1}}</em>.",
+                    "content": [{
+                        "title": "Information you need",
+                        "list": [
+                            "Names of the people living in household and how they are related",
+                            "The number of visitors staying in the household on 29 November 2017"
+                        ]
+                    }]
                 },
                 {
-                  "id": "correct-middle-names",
-                  "label": "Middle names",
-                  "mandatory": false,
-                  "type": "TextField"
+                    "type": "Question",
+                    "id": "permanent-or-family-home",
+                    "questions": [{
+                        "id": "permanent-or-family-home-question",
+                        "title": "Does anyone live at <em>{{answers.address_line_1}}</em> as their permanent or family home?",
+                        "guidance": {
+                            "content": [{
+                                "title": "Include",
+                                "list": [
+                                    "yourself, if this is your permanent or family home",
+                                    "family members including partners, children and babies born on or before 9 April 2017",
+                                    "students and, or school children who live away from home during term time",
+                                    "housemates tenants or lodgers"
+                                ]
+                            }]
+                        },
+                        "type": "General",
+                        "answers": [{
+                            "id": "permanent-or-family-home-answer",
+                            "mandatory": true,
+                            "guidance": {
+                                "show_guidance": "Show further guidance",
+                                "hide_guidance": "Hide further guidance",
+                                "content": [{
+                                    "description": "For most people, their permanent home will be the address where they spend the most time."
+                                }]
+                            },
+                            "options": [{
+                                    "label": "Yes",
+                                    "value": "Yes"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "No",
+                                    "description": "For example this is a second address or holiday home"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "household-composition",
+                                "when": [{
+                                    "id": "permanent-or-family-home-answer",
+                                    "condition": "equals",
+                                    "value": "Yes"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "else-permanent-or-family-home",
+                                "when": [{
+                                    "id": "permanent-or-family-home-answer",
+                                    "condition": "equals",
+                                    "value": "No"
+                                }]
+                            }
+                        }
+                    ]
                 },
                 {
-                  "id": "correct-last-name",
-                  "label": "Last name",
-                  "mandatory": false,
-                  "type": "TextField"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "over-16",
-          "questions": [
-            {
-              "id": "over-16-question",
-              "title": "Are you aged 16 or over?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "over-16-answer",
-                  "mandatory": true,
-                  "options": [
-                    {
-                      "label": "Yes",
-                      "value": "Yes"
-                    },
-                    {
-                      "label": "No",
-                      "value": "No"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "private-response",
-                "when": [
-                  {
-                    "id": "over-16-answer",
-                    "condition": "equals",
-                    "value": "Yes"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "sex"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "private-response",
-          "questions": [
-            {
-              "id": "private-response-question",
-              "title": "Do you want to request a personal form?",
-              "description": "Anyone aged 16 or over who would like to keep their answers private can request a personal and confidential form.",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "private-response-answer",
-                  "mandatory": false,
-                  "guidance": {
-                    "show_guidance": "Show further guidance",
-                    "hide_guidance": "Hide further guidance",
-                    "content": [
-                      {
-                        "description":
-                          "If you request a personal or confidential form we will send you a unique access code that will allow you to complete the individual questions for yourself. No-one else will be able to see the answers you provide."
-                      }
+                    "type": "Question",
+                    "id": "else-permanent-or-family-home",
+                    "questions": [{
+                        "id": "else-permanent-or-family-home-question",
+                        "title": "Can you confirm no one lives here as their permanent or family home?",
+                        "guidance": {
+                            "content": [{
+                                "title": "This could be:",
+                                "list": [
+                                    "people who usually live outside the UK who are staying in the UK for <b>three months or more</b>",
+                                    "people who work away from home within the UK if this is their permanent or family home",
+                                    "members of the Armed Forces if this is their permanent or family home",
+                                    "people who are temporarily outside the UK for <b>less than 12 months</b>",
+                                    "people staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends",
+                                    "other people who usually live here, including anyone temporarily away from home "
+                                ]
+                            }]
+                        },
+                        "type": "General",
+                        "answers": [{
+                            "id": "else-permanent-or-family-home-answer",
+                            "mandatory": true,
+                            "options": [{
+                                    "label": "Someone lives here as their permanent home",
+                                    "value": "Someone lives here as their permanent home"
+                                },
+                                {
+                                    "label": "No one lives here as their permanent home",
+                                    "value": "No one lives here as their permanent home"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "household-composition",
+                                "when": [{
+                                    "id": "else-permanent-or-family-home-answer",
+                                    "condition": "equals",
+                                    "value": "Someone lives here as their permanent home"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "overnight-visitors",
+                                "when": [{
+                                    "id": "else-permanent-or-family-home-answer",
+                                    "condition": "equals",
+                                    "value": "No one lives here as their permanent home"
+                                }]
+                            }
+                        }
                     ]
-                  },
-                  "options": [
-                    {
-                      "label": "No, I do not want to request a personal form",
-                      "value": "No, I do not want to request a personal form"
-                    },
-                    {
-                      "label": "Yes, I want to request a personal form",
-                      "value": "Yes, I want to request a personal form"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "request-private-response",
-                "when": [
-                  {
-                    "id": "private-response-answer",
-                    "condition": "equals",
-                    "value": "Yes, I want to request a personal form"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "sex"
-              }
-            }
-          ]
-        },
-        {
-          "id": "request-private-response",
-          "title": "Request for personal and confidential form",
-          "description":
-            "<p>You can <a rel='noopener noreferrer' target='_blank' href='https://census.gov.uk/individualquestionnaire'>request a personal and confidential form online</a>.</p> <p>Alternatively, call <a href='tel:03000683001'>0300 068 3001</a>.</p>",
-          "type": "Interstitial",
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "household-member-completed"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "sex",
-          "questions": [
-            {
-              "id": "sex-question",
-              "title": "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> sex?",
-              "type": "General",
-              "answers": [
+                },
                 {
-                  "id": "sex-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Male",
-                      "value": "Male"
-                    },
-                    {
-                      "label": "Female",
-                      "value": "Female"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "date-of-birth",
-          "questions": [
-            {
-              "id": "date-of-birth-question",
-              "title":
-                "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive }}</em> date of birth?",
-              "description": "For example 20 March 1980",
-              "type": "General",
-              "answers": [
+                    "type": "Question",
+                    "id": "household-composition",
+                    "questions": [{
+                        "id": "household-composition-question",
+                        "title": "What are the names of everyone who live at <em>{{answers.address_line_1}}</em>?",
+                        "guidance": {
+                            "content": [{
+                                "title": "Include",
+                                "list": [
+                                    "Yourself, if this is your permanent or family home",
+                                    "Family members including partners, children and babies born on or before 9 April 2017",
+                                    "Students and, or school children who live away from home during term time",
+                                    "Housemates tenants or lodgers",
+                                    "Household members who have requested a personal form"
+                                ]
+                            }]
+                        },
+                        "type": "RepeatingAnswer",
+                        "answers": [{
+                                "alias": "first_name",
+                                "id": "first-name",
+                                "label": "First name",
+                                "mandatory": true,
+                                "type": "TextField",
+                                "validation": {
+                                    "messages": {
+                                        "MANDATORY_TEXTFIELD": "Please enter a name or remove the person to continue"
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "middle_names",
+                                "id": "middle-names",
+                                "label": "Middle names",
+                                "mandatory": false,
+                                "type": "TextField"
+                            },
+                            {
+                                "alias": "last_name",
+                                "id": "last-name",
+                                "label": "Last name",
+                                "mandatory": false,
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                            "description": "Enter the current first, middle and last names of all the people who usually live here."
+                                        },
+                                        {
+                                            "description": "If you have not yet named your newborn, please enter ‘Baby’ for their first name and then enter their last name (surname)."
+                                        },
+                                        {
+                                            "description": "Please also include household members who have requested a personal form."
+                                        },
+                                        {
+                                            "description": "Please also include the names of people staying with you temporarily who don’t have a usual address in the UK. This is so that we make sure we count everyone."
+                                        },
+                                        {
+                                            "title": "Include",
+                                            "list": [
+                                                "people who usually live outside the UK who are staying in the UK for <strong>three months or more</strong>",
+                                                "people who work away from home within the UK  if this is their permanent or family home",
+                                                "members of the Armed Forces if this is their permanent or family home",
+                                                "people who are temporarily outside the UK for <strong>less than 12 months</strong>",
+                                                "people staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "TextField"
+                            }
+                        ]
+                    }]
+                },
                 {
-                  "id": "date-of-birth-answer",
-                  "mandatory": false,
-                  "type": "Date"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "marital-status",
-          "questions": [
-            {
-              "id": "marital-status-question",
-              "title":
-                "On 9 April 2017, what is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive }}</em> legal marital or same-sex civil partnership status?",
-              "description":
-                "If you were married (or formed a registered same-sex partnership) abroad, and this enables you to be recognised as married or civil partnered in the UK, complete the question reflecting that legal partnership.",
-              "type": "General",
-              "answers": [
+                    "type": "Question",
+                    "id": "everyone-at-address-confirmation",
+                    "description": "<h2 class='neptune'>Your household includes:</h2> {{ [answers.first_name, answers.middle_names, answers.last_name]|format_household_summary }}",
+                    "questions": [{
+                        "id": "everyone-at-address-confirmation-question",
+                        "title": "Is this everyone for whom this is their permanent or family home?",
+                        "description": "Please note that you will need to ensure that everyone is included because you will be unable to make changes later",
+                        "guidance": {
+                            "content": [{
+                                "title": "Include",
+                                "list": [
+                                    "people who usually live outside the UK who are staying in the UK for <b>three months or more</b>",
+                                    "people who work away from home within the UK  if this is their permanent or family home",
+                                    "members of the Armed Forces if this is their permanent or family home",
+                                    "people who are temporarily outside the UK for <b>less than 12 months</b>",
+                                    "people staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends",
+                                    "other people who usually live here, including anyone temporarily away from home"
+                                ]
+                            }]
+                        },
+                        "type": "General",
+                        "answers": [{
+                            "id": "everyone-at-address-confirmation-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Yes",
+                                    "value": "Yes"
+                                },
+                                {
+                                    "label": "No, I need to add another person",
+                                    "value": "No, I need to add another person"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "household-composition",
+                                "when": [{
+                                    "id": "everyone-at-address-confirmation-answer",
+                                    "condition": "equals",
+                                    "value": "No, I need to add another person"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "overnight-visitors"
+                            }
+                        }
+                    ]
+                },
                 {
-                  "id": "marital-status-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Never married and never registered a same-sex civil partnership",
-                      "value": "Never married and never registered a same-sex civil partnership"
-                    },
-                    {
-                      "label": "Married",
-                      "value": "Married"
-                    },
-                    {
-                      "label": "In a registered same-sex civil partnership",
-                      "value": "In a registered same-sex civil partnership"
-                    },
-                    {
-                      "label": "Separated, but still legally married",
-                      "value": "Separated, but still legally married"
-                    },
-                    {
-                      "label": "Separated, but still legally in a same-sex civil partnership",
-                      "value": "Separated, but still legally in a same-sex civil partnership"
-                    },
-                    {
-                      "label": "Divorced",
-                      "value": "Divorced"
-                    },
-                    {
-                      "label": "Formerly in a same-sex civil partnership which is now legally dissolved",
-                      "value": "Formerly in a same-sex civil partnership which is now legally dissolved"
-                    },
-                    {
-                      "label": "Widowed",
-                      "value": "Widowed"
-                    },
-                    {
-                      "label": "Surviving partner from a same-sex civil partnership",
-                      "value": "Surviving partner from a same-sex civil partnership"
-                    }
-                  ],
-                  "type": "Radio"
+                    "type": "Question",
+                    "id": "overnight-visitors",
+                    "questions": [{
+                        "id": "overnight-visitors-question",
+                        "title": "How many visitors are staying overnight at <em>{{answers.address_line_1}}</em> on 9th April 2017?",
+                        "guidance": {
+                            "content": [{
+                                "title": "Include",
+                                "list": [
+                                    "people who usually live somewhere else in the UK. For example, friends or relatives",
+                                    "people staying here because it is their second address, for example, for work. Their permanent or family home is elsewhere",
+                                    "people who usually live outside the UK who are visiting the UK for less than three months",
+                                    "people here on holiday"
+                                ]
+                            }]
+                        },
+                        "type": "General",
+                        "answers": [{
+                            "id": "overnight-visitors-answer",
+                            "label": "Number of visitors (enter 0 if no visitors)",
+                            "mandatory": true,
+                            "type": "Number"
+                        }]
+                    }]
                 }
-              ]
-            }
-          ]
+            ]
         },
         {
-          "type": "Question",
-          "id": "another-address",
-          "questions": [
-            {
-              "id": "another-address-question",
-              "title":
-                "Does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> stay at another address for more than 30 days a year?",
-              "type": "General",
-              "guidance": {
-                "content": [
-                  {
-                    "title": "Include:",
-                    "list": [
-                      "another parent’s address, an armed forces base, a holiday home, or term-time address.",
-                      "the days you stay at the address do not have to be in a row. They can be at any time during the year."
+            "id": "who-lives-here-relationship",
+            "title": "Relationships",
+            "hide_in_navigation": true,
+            "routing_rules": [{
+                "repeat": {
+                    "type": "answer_count_minus_one",
+                    "answer_id": "first-name"
+                }
+            }],
+            "blocks": [{
+                "type": "Question",
+                "id": "household-relationships",
+                "questions": [{
+                    "id": "household-relationships-question",
+                    "title": "How is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> related to the people below?",
+                    "description": "If members are not related, select the ‘unrelated’ option.</br>If you are the parents of adopted children, select the ‘Mother or father’ option to show your relationship to them.</br>If you have foster children living with you, select the ‘Unrelated’ option.</br>Include half-brothers and half-sisters in the ‘Step-brother or step-sister’ category.</br>Same-sex civil partner is used to describe the relationship between two people who have legally registered a civil partnership.</br>If none of the options fully reflects your relationship, please select the one which you feel best describes your situation.",
+                    "type": "Relationship",
+                    "answers": [{
+                        "id": "household-relationships-answer",
+                        "label": "%(current_person)s is %(other_person)s",
+                        "mandatory": false,
+                        "options": [{
+                                "label": "Husband or wife",
+                                "value": "Husband or wife"
+                            },
+                            {
+                                "label": "Same-sex civil partner",
+                                "value": "Same-sex civil partner"
+                            },
+                            {
+                                "label": "Partner",
+                                "value": "Partner"
+                            },
+                            {
+                                "label": "Grandparent",
+                                "value": "Grandparent"
+                            },
+                            {
+                                "label": "Mother or father",
+                                "value": "Mother or father"
+                            },
+                            {
+                                "label": "Step-mother or step-father",
+                                "value": "Step-mother or step-father"
+                            },
+                            {
+                                "label": "Son or daughter",
+                                "value": "Son or daughter"
+                            },
+                            {
+                                "label": "Step-child",
+                                "value": "Step-child"
+                            },
+                            {
+                                "label": "Brother or sister",
+                                "value": "Brother or sister"
+                            },
+                            {
+                                "label": "Step–brother or step–sister",
+                                "value": "Step–brother or step–sister"
+                            },
+                            {
+                                "label": "Grandchild",
+                                "value": "Grandchild"
+                            },
+                            {
+                                "label": "Relation - other",
+                                "value": "Relation - other"
+                            },
+                            {
+                                "label": "Unrelated (including foster child)",
+                                "value": "Unrelated (including foster child)"
+                            }
+                        ],
+                        "type": "Relationship"
+                    }]
+                }]
+            }]
+        },
+        {
+            "id": "who-lives-here-interstitial",
+            "title": "Who lives here?",
+            "hide_in_navigation": true,
+            "blocks": [{
+                "id": "who-lives-here-completed",
+                "title": "You have successfully completed the ‘Who lives here?’ section",
+                "description": "In the next section we are going to ask you about the household and accommodation you live in.",
+                "type": "Interstitial"
+            }]
+        },
+        {
+            "id": "household-and-accommodation",
+            "title": "Household and Accommodation",
+            "blocks": [{
+                    "type": "Interstitial",
+                    "id": "household-and-accommodation-section",
+                    "title": "Household and accommodation",
+                    "description": "In this section, we’re going to ask you about the household and accommodation you live in.",
+                    "content": [{
+                        "title": "Information you need",
+                        "list": ["Type of property, and if it’s owned or rented", "Type of landlord, if the property is rented", "Number of cars or vans"]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "type-of-accommodation",
+                    "questions": [{
+                        "id": "type-of-accommodation-question",
+                        "title": "What type of accommodation is <em>{{answers.address_line_1}}</em>?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "type-of-accommodation-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Whole house or bungalow",
+                                    "value": "Whole house or bungalow"
+                                },
+                                {
+                                    "label": "Flat, maisonette or apartment (including bedsits)",
+                                    "value": "Flat, maisonette or apartment (including bedsits)"
+                                },
+                                {
+                                    "label": "Caravan or other mobile or temporary structure",
+                                    "value": "Caravan or other mobile or temporary structure"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "type-of-house",
+                                "when": [{
+                                    "id": "type-of-accommodation-answer",
+                                    "condition": "equals",
+                                    "value": "Whole house or bungalow"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "type-of-flat",
+                                "when": [{
+                                    "id": "type-of-accommodation-answer",
+                                    "condition": "equals",
+                                    "value": "Flat, maisonette or apartment (including bedsits)"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "self-contained-accommodation"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Question",
+                    "id": "type-of-house",
+                    "questions": [{
+                        "id": "type-of-house-question",
+                        "title": "Is your house or bungalow:",
+                        "type": "General",
+                        "answers": [{
+                            "id": "type-of-house-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Detached",
+                                    "value": "Detached"
+                                },
+                                {
+                                    "label": "Semi-detached",
+                                    "value": "Semi-detached"
+                                },
+                                {
+                                    "label": "Terraced (including end-terrace)",
+                                    "value": "Terraced"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }],
+                    "routing_rules": [{
+                        "goto": {
+                            "block": "self-contained-accommodation"
+                        }
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "type-of-flat",
+                    "questions": [{
+                        "id": "type-of-flat-question",
+                        "title": "Is your flat, maisonette or apartment:",
+                        "type": "General",
+                        "answers": [{
+                            "id": "type-of-flat-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "In a purpose-built block of flats or tenement",
+                                    "value": "In a purpose-built block of flats or tenement"
+                                },
+                                {
+                                    "label": "Part of a converted or shared house (including bedsits)",
+                                    "value": "Part of a converted or shared house (including bedsits)"
+                                },
+                                {
+                                    "label": "In a commercial building (for example, in an office building, hotel, or over a  shop).",
+                                    "value": "In a commercial building (for example, in an office building, hotel, or over a  shop)."
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "self-contained-accommodation",
+                    "questions": [{
+                        "id": "self-contained-accommodation-question",
+                        "title": "Is the accommodation of <em>{{answers.address_line_1}}</em> self-contained?",
+                        "description": "This means that all the rooms, including the kitchen, bathroom and toilet, are behind a door that only this household can use",
+                        "type": "General",
+                        "answers": [{
+                            "id": "self-contained-accommodation-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Yes, all the rooms are behind a door that only this household can use",
+                                    "value": "Yes, all the rooms are behind a door that only this household can use"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "No"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "number-of-bedrooms",
+                    "questions": [{
+                        "id": "number-of-bedrooms-question",
+                        "title": "How many bedrooms are at <em>{{answers.address_line_1}}</em>?",
+                        "guidance": {
+                            "content": [{
+                                "description": "Include all rooms built or converted for use as bedrooms, even if they’re not currently used as bedrooms"
+                            }]
+                        },
+                        "type": "General",
+                        "answers": [{
+                            "id": "number-of-bedrooms-answer",
+                            "label": "Number of bedrooms",
+                            "mandatory": false,
+                            "type": "Number"
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "central-heating",
+                    "questions": [{
+                        "id": "central-heating-question",
+                        "title": "What type of central heating does <em>{{answers.address_line_1}}</em> have?",
+                        "description": "<p>Central heating is a central system that generates heat for multiple rooms.</p><p>Select all that apply, whether or not you use it.</p>",
+                        "type": "General",
+                        "answers": [{
+                            "id": "central-heating-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Gas",
+                                    "value": "Gas"
+                                },
+                                {
+                                    "label": "Electric (include storage heaters)",
+                                    "value": "Electric (include storage heaters)"
+                                },
+                                {
+                                    "label": "Oil",
+                                    "value": "Oil"
+                                },
+                                {
+                                    "label": "Solid fuel (for example wood, coal)",
+                                    "value": "Solid fuel (for example wood, coal)"
+                                },
+                                {
+                                    "label": "Renewable (for example solar panels)",
+                                    "value": "Renewable (for example solar panels)"
+                                },
+                                {
+                                    "label": "Other central heating",
+                                    "value": "Other central heating"
+                                },
+                                {
+                                    "label": "No central heating",
+                                    "value": "No central heating"
+                                }
+                            ],
+                            "type": "Checkbox"
+                        }]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "own-or-rent",
+                                "when": [{
+                                    "id": "permanent-or-family-home-answer",
+                                    "condition": "equals",
+                                    "value": "Yes"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "own-or-rent",
+                                "when": [{
+                                    "id": "else-permanent-or-family-home-answer",
+                                    "condition": "equals",
+                                    "value": "Someone lives here as their permanent home"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "household-and-accommodation-completed"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Question",
+                    "id": "own-or-rent",
+                    "questions": [{
+                        "id": "own-or-rent-question",
+                        "title": "Does your household own or rent <em>{{answers.address_line_1}}</em>?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "own-or-rent-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Owns outright",
+                                    "value": "Owns outright"
+                                },
+                                {
+                                    "label": "Owns with a mortgage or loan",
+                                    "value": "Owns with a mortgage or loan"
+                                },
+                                {
+                                    "label": "Part owns and part rents (shared ownership)",
+                                    "value": "Part owns and part rents (shared ownership)"
+                                },
+                                {
+                                    "label": "Rents (with or without housing benefit)",
+                                    "value": "Rents (with or without housing benefit)"
+                                },
+                                {
+                                    "label": "Lives here rent free",
+                                    "value": "Lives here rent free"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "number-of-vehicles",
+                                "when": [{
+                                    "id": "own-or-rent-answer",
+                                    "condition": "equals",
+                                    "value": "Owns outright"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "number-of-vehicles",
+                                "when": [{
+                                    "id": "own-or-rent-answer",
+                                    "condition": "equals",
+                                    "value": "Owns with a mortgage or loan"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "landlord"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Question",
+                    "id": "landlord",
+                    "questions": [{
+                        "id": "landlord-question",
+                        "title": "Who is your landlord?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "landlord-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Housing association, housing co-operative, charitable trust, registered social landlord",
+                                    "value": "Housing association, housing co-operative, charitable trust, registered social landlord"
+                                },
+                                {
+                                    "label": "Council (local authority)",
+                                    "value": "Council (local authority)"
+                                },
+                                {
+                                    "label": "Private landlord or letting agency",
+                                    "value": "Private landlord or letting agency"
+                                },
+                                {
+                                    "label": "Employer of a household member",
+                                    "value": "Employer of a household member"
+                                },
+                                {
+                                    "label": "Relative or friend of a household member",
+                                    "value": "Relative or friend of a household member"
+                                },
+                                {
+                                    "label": "Other",
+                                    "value": "Other"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "number-of-vehicles",
+                    "questions": [{
+                        "id": "number-of-vehicles-question",
+                        "title": "How many cars or vans are owned, or available for use, by members of this household?",
+                        "guidance": {
+                            "content": [{
+                                "description": "Include any company cars or vans available for private use"
+                            }]
+                        },
+                        "type": "General",
+                        "answers": [{
+                            "id": "number-of-vehicles-answer",
+                            "label": "Number of cars or vans",
+                            "mandatory": false,
+                            "type": "Number"
+                        }]
+                    }]
+                },
+                {
+                    "id": "household-and-accommodation-completed",
+                    "title": "You have successfully completed the ‘Household and Accommodation’ section",
+                    "description": "",
+                    "type": "Interstitial"
+                }
+            ]
+        },
+        {
+            "id": "household-member",
+            "title": "Household Member Details",
+            "routing_rules": [{
+                "repeat": {
+                    "type": "answer_count",
+                    "answer_id": "first-name"
+                }
+            }],
+            "blocks": [{
+                    "type": "Interstitial",
+                    "id": "household-member-begin-section",
+                    "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}",
+                    "description": "In this section, we’re going to ask you questions about <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em>.",
+                    "content": [{
+                        "title": "Information you need",
+                        "list": [
+                            "Personal details such as date of birth, country of birth, religion etc.",
+                            "Education and qualifications",
+                            "Employment and travel to work",
+                            "Second or holiday homes",
+                            "Unpaid care, health and well-being",
+                            "Languages"
+                        ]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "details-correct",
+                    "questions": [{
+                        "id": "details-correct-question",
+                        "title": "Is the name {{ [answers.first_name[group_instance], answers.middle_names[group_instance], answers.last_name[group_instance]] | format_household_name }} correct, including any middle name(s)?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "details-correct-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Yes, this is my full name",
+                                    "value": "Yes, this is my full name"
+                                },
+                                {
+                                    "label": "No, I need to change my name",
+                                    "value": "No, I need to change my name"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "correct-name",
+                                "when": [{
+                                    "id": "details-correct-answer",
+                                    "condition": "equals",
+                                    "value": "No, I need to change my name"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "over-16"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Question",
+                    "id": "correct-name",
+                    "questions": [{
+                        "id": "correct-name-question",
+                        "title": "What is your correct name?",
+                        "type": "General",
+                        "answers": [{
+                                "id": "correct-first-name",
+                                "label": "First name",
+                                "mandatory": false,
+                                "type": "TextField"
+                            },
+                            {
+                                "id": "correct-middle-names",
+                                "label": "Middle names",
+                                "mandatory": false,
+                                "type": "TextField"
+                            },
+                            {
+                                "id": "correct-last-name",
+                                "label": "Last name",
+                                "mandatory": false,
+                                "type": "TextField"
+                            }
+                        ]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "over-16",
+                    "questions": [{
+                        "id": "over-16-question",
+                        "title": "Are you aged 16 or over?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "over-16-answer",
+                            "mandatory": true,
+                            "options": [{
+                                    "label": "Yes",
+                                    "value": "Yes"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "No"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "private-response",
+                                "when": [{
+                                    "id": "over-16-answer",
+                                    "condition": "equals",
+                                    "value": "Yes"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "sex"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Question",
+                    "id": "private-response",
+                    "questions": [{
+                        "id": "private-response-question",
+                        "title": "Do you want to request a personal form?",
+                        "description": "Anyone aged 16 or over who would like to keep their answers private can request a personal and confidential form.",
+                        "type": "General",
+                        "answers": [{
+                            "id": "private-response-answer",
+                            "mandatory": false,
+                            "guidance": {
+                                "show_guidance": "Show further guidance",
+                                "hide_guidance": "Hide further guidance",
+                                "content": [{
+                                    "description": "If you request a personal or confidential form we will send you a unique access code that will allow you to complete the individual questions for yourself. No-one else will be able to see the answers you provide."
+                                }]
+                            },
+                            "options": [{
+                                    "label": "No, I do not want to request a personal form",
+                                    "value": "No, I do not want to request a personal form"
+                                },
+                                {
+                                    "label": "Yes, I want to request a personal form",
+                                    "value": "Yes, I want to request a personal form"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "request-private-response",
+                                "when": [{
+                                    "id": "private-response-answer",
+                                    "condition": "equals",
+                                    "value": "Yes, I want to request a personal form"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "sex"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "request-private-response",
+                    "title": "Request for personal and confidential form",
+                    "description": "<p>You can <a rel='noopener noreferrer' target='_blank' href='https://census.gov.uk/individualquestionnaire'>request a personal and confidential form online</a>.</p> <p>Alternatively, call <a href='tel:03000683001'>0300 068 3001</a>.</p>",
+                    "type": "Interstitial",
+                    "routing_rules": [{
+                        "goto": {
+                            "block": "household-member-completed"
+                        }
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "sex",
+                    "questions": [{
+                        "id": "sex-question",
+                        "title": "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> sex?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "sex-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Male",
+                                    "value": "Male"
+                                },
+                                {
+                                    "label": "Female",
+                                    "value": "Female"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "date-of-birth",
+                    "questions": [{
+                        "id": "date-of-birth-question",
+                        "title": "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive }}</em> date of birth?",
+                        "description": "For example 20 March 1980",
+                        "type": "General",
+                        "answers": [{
+                            "id": "date-of-birth-answer",
+                            "mandatory": false,
+                            "type": "Date"
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "marital-status",
+                    "questions": [{
+                        "id": "marital-status-question",
+                        "title": "On 9 April 2017, what is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive }}</em> legal marital or same-sex civil partnership status?",
+                        "description": "If you were married (or formed a registered same-sex partnership) abroad, and this enables you to be recognised as married or civil partnered in the UK, complete the question reflecting that legal partnership.",
+                        "type": "General",
+                        "answers": [{
+                            "id": "marital-status-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Never married and never registered a same-sex civil partnership",
+                                    "value": "Never married and never registered a same-sex civil partnership"
+                                },
+                                {
+                                    "label": "Married",
+                                    "value": "Married"
+                                },
+                                {
+                                    "label": "In a registered same-sex civil partnership",
+                                    "value": "In a registered same-sex civil partnership"
+                                },
+                                {
+                                    "label": "Separated, but still legally married",
+                                    "value": "Separated, but still legally married"
+                                },
+                                {
+                                    "label": "Separated, but still legally in a same-sex civil partnership",
+                                    "value": "Separated, but still legally in a same-sex civil partnership"
+                                },
+                                {
+                                    "label": "Divorced",
+                                    "value": "Divorced"
+                                },
+                                {
+                                    "label": "Formerly in a same-sex civil partnership which is now legally dissolved",
+                                    "value": "Formerly in a same-sex civil partnership which is now legally dissolved"
+                                },
+                                {
+                                    "label": "Widowed",
+                                    "value": "Widowed"
+                                },
+                                {
+                                    "label": "Surviving partner from a same-sex civil partnership",
+                                    "value": "Surviving partner from a same-sex civil partnership"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "another-address",
+                    "questions": [{
+                        "id": "another-address-question",
+                        "title": "Does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> stay at another address for more than 30 days a year?",
+                        "type": "General",
+                        "guidance": {
+                            "content": [{
+                                "title": "Include:",
+                                "list": [
+                                    "another parent’s address, an armed forces base, a holiday home, or term-time address.",
+                                    "the days you stay at the address do not have to be in a row. They can be at any time during the year."
+                                ],
+                                "description": ""
+                            }]
+                        },
+                        "answers": [{
+                                "id": "another-address-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "No",
+                                        "value": "No"
+                                    },
+                                    {
+                                        "label": "Yes, an address within the UK",
+                                        "value": "Yes, an address within the UK"
+                                    },
+                                    {
+                                        "label": "Yes, an address outside the UK",
+                                        "value": "Other",
+                                        "child_answer_id": "another-address-answer-other"
+                                    }
+                                ],
+                                "type": "Radio"
+                            },
+                            {
+                                "id": "another-address-answer-other",
+                                "parent_answer_id": "another-address-answer",
+                                "type": "TextField",
+                                "mandatory": false,
+                                "label": "Please specify a country"
+                            }
+                        ]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "in-education",
+                                "when": [{
+                                    "id": "another-address-answer",
+                                    "condition": "equals",
+                                    "value": "No"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "other-address",
+                                "when": [{
+                                    "id": "another-address-answer",
+                                    "condition": "equals",
+                                    "value": "Yes, an address within the UK"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "address-type",
+                                "when": [{
+                                    "id": "another-address-answer",
+                                    "condition": "equals",
+                                    "value": "Other"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "in-education",
+                                "when": [{
+                                    "id": "another-address-answer",
+                                    "condition": "not set"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "address-type",
+                                "when": [{
+                                    "id": "another-address-answer",
+                                    "condition": "not equals",
+                                    "value": "Other"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "in-education"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Question",
+                    "id": "other-address",
+                    "questions": [{
+                        "id": "other-address-question",
+                        "title": "Enter details of the other UK address where <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> stay more than 30 days a year",
+                        "type": "General",
+                        "answers": [{
+                                "id": "other-address-answer-building",
+                                "label": "Building",
+                                "mandatory": false,
+                                "type": "TextField"
+                            },
+                            {
+                                "id": "other-address-answer-street",
+                                "label": "Street",
+                                "mandatory": false,
+                                "type": "TextField"
+                            },
+                            {
+                                "id": "other-address-answer-city",
+                                "label": "Town or city",
+                                "mandatory": false,
+                                "type": "TextField"
+                            },
+                            {
+                                "id": "other-address-answer-county",
+                                "label": "County (optional)",
+                                "mandatory": false,
+                                "type": "TextField"
+                            },
+                            {
+                                "id": "other-address-answer-postcode",
+                                "label": "Postcode",
+                                "mandatory": false,
+                                "type": "TextField"
+                            }
+                        ]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "address-type",
+                    "questions": [{
+                        "id": "address-type-question",
+                        "title": "What is that address?",
+                        "type": "General",
+                        "answers": [{
+                                "id": "address-type-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Armed forces base address",
+                                        "value": "Armed forces base address"
+                                    },
+                                    {
+                                        "label": "Another address when working away from home",
+                                        "value": "Another address when working away from home"
+                                    },
+                                    {
+                                        "label": "Student’s home address",
+                                        "value": "Student’s home address"
+                                    },
+                                    {
+                                        "label": "Student’s term time address",
+                                        "value": "Student’s term time address"
+                                    },
+                                    {
+                                        "label": "Another parent or guardian’s address",
+                                        "value": "Another parent or guardian’s address"
+                                    },
+                                    {
+                                        "label": "Holiday home",
+                                        "value": "Holiday home"
+                                    },
+                                    {
+                                        "label": "Other (please specify)",
+                                        "value": "Other",
+                                        "child_answer_id": "address-type-answer-other"
+                                    }
+                                ],
+                                "type": "Radio"
+                            },
+                            {
+                                "id": "address-type-answer-other",
+                                "parent_answer_id": "address-type-answer",
+                                "type": "TextField",
+                                "mandatory": false,
+                                "label": "Please specify type of address"
+                            }
+                        ]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "in-education",
+                    "questions": [{
+                        "id": "in-education-question",
+                        "title": "Is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> in full-time education?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "in-education-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Yes",
+                                    "value": "Yes"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "No"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "term-time-location",
+                                "when": [{
+                                    "id": "in-education-answer",
+                                    "condition": "equals",
+                                    "value": "Yes"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "country-of-birth"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Question",
+                    "id": "term-time-location",
+                    "questions": [{
+                        "id": "term-time-location-question",
+                        "title": "During term time, does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> live at <em>{{answers.address_line_1}}</em> ?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "term-time-location-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Yes",
+                                    "value": "Yes"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "No"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "household-member-completed",
+                                "when": [{
+                                    "id": "term-time-location-answer",
+                                    "condition": "equals",
+                                    "value": "No"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "country-of-birth"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Question",
+                    "id": "country-of-birth",
+                    "questions": [{
+                            "id": "country-of-birth-england-question",
+                            "title": "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> country of birth?",
+                            "type": "General",
+                            "answers": [{
+                                    "id": "country-of-birth-england-answer",
+                                    "mandatory": false,
+                                    "options": [{
+                                            "label": "England",
+                                            "value": "England"
+                                        },
+                                        {
+                                            "label": "Wales",
+                                            "value": "Wales"
+                                        },
+                                        {
+                                            "label": "Scotland",
+                                            "value": "Scotland"
+                                        },
+                                        {
+                                            "label": "Northern Ireland",
+                                            "value": "Northern Ireland"
+                                        },
+                                        {
+                                            "label": "Republic of Ireland",
+                                            "value": "Republic of Ireland"
+                                        },
+                                        {
+                                            "label": "Elsewhere",
+                                            "value": "Other",
+                                            "child_answer_id": "country-of-birth-england-answer-other"
+                                        }
+                                    ],
+                                    "type": "Radio"
+                                },
+                                {
+                                    "id": "country-of-birth-england-answer-other",
+                                    "parent_answer_id": "country-of-birth-england-answer",
+                                    "type": "TextField",
+                                    "mandatory": false,
+                                    "label": "Please specify current name of country"
+                                }
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "meta": "region_code",
+                                    "condition": "equals",
+                                    "value": "GB-WLS"
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "country-of-birth-wales-question",
+                            "title": "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> country of birth?",
+                            "type": "General",
+                            "answers": [{
+                                    "id": "country-of-birth-wales-answer",
+                                    "mandatory": false,
+                                    "options": [{
+                                            "label": "Wales",
+                                            "value": "Wales"
+                                        },
+                                        {
+                                            "label": "England",
+                                            "value": "England"
+                                        },
+                                        {
+                                            "label": "Scotland",
+                                            "value": "Scotland"
+                                        },
+                                        {
+                                            "label": "Northern Ireland",
+                                            "value": "Northern Ireland"
+                                        },
+                                        {
+                                            "label": "Republic of Ireland",
+                                            "value": "Republic of Ireland"
+                                        },
+                                        {
+                                            "label": "Elsewhere",
+                                            "value": "Other",
+                                            "child_answer_id": "country-of-birth-wales-answer-other"
+                                        }
+                                    ],
+                                    "type": "Radio"
+                                },
+                                {
+                                    "id": "country-of-birth-wales-answer-other",
+                                    "parent_answer_id": "country-of-birth-wales-answer",
+                                    "type": "TextField",
+                                    "mandatory": false,
+                                    "label": "Please specify current name of country"
+                                }
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "meta": "region_code",
+                                    "condition": "not equals",
+                                    "value": "GB-WLS"
+                                }]
+                            }]
+                        }
                     ],
-                    "description": ""
-                  }
-                ]
-              },
-              "answers": [
-                {
-                  "id": "another-address-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "No",
-                      "value": "No"
-                    },
-                    {
-                      "label": "Yes, an address within the UK",
-                      "value": "Yes, an address within the UK"
-                    },
-                    {
-                      "label": "Yes, an address outside the UK",
-                      "value": "Other",
-                      "child_answer_id": "another-address-answer-other"
-                    }
-                  ],
-                  "type": "Radio"
-                },
-                {
-                  "id": "another-address-answer-other",
-                  "parent_answer_id": "another-address-answer",
-                  "type": "TextField",
-                  "mandatory": false,
-                  "label": "Please specify a country"
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "in-education",
-                "when": [
-                  {
-                    "id": "another-address-answer",
-                    "condition": "equals",
-                    "value": "No"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "other-address",
-                "when": [
-                  {
-                    "id": "another-address-answer",
-                    "condition": "equals",
-                    "value": "Yes, an address within the UK"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "address-type",
-                "when": [
-                  {
-                    "id": "another-address-answer",
-                    "condition": "equals",
-                    "value": "Other"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "in-education",
-                "when": [
-                  {
-                    "id": "another-address-answer",
-                    "condition": "not set"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "address-type",
-                "when": [
-                  {
-                    "id": "another-address-answer",
-                    "condition": "not equals",
-                    "value": "Other"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "in-education"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "other-address",
-          "questions": [
-            {
-              "id": "other-address-question",
-              "title":
-                "Enter details of the other UK address where <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> stay more than 30 days a year",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "other-address-answer-building",
-                  "label": "Building",
-                  "mandatory": false,
-                  "type": "TextField"
-                },
-                {
-                  "id": "other-address-answer-street",
-                  "label": "Street",
-                  "mandatory": false,
-                  "type": "TextField"
-                },
-                {
-                  "id": "other-address-answer-city",
-                  "label": "Town or city",
-                  "mandatory": false,
-                  "type": "TextField"
-                },
-                {
-                  "id": "other-address-answer-county",
-                  "label": "County (optional)",
-                  "mandatory": false,
-                  "type": "TextField"
-                },
-                {
-                  "id": "other-address-answer-postcode",
-                  "label": "Postcode",
-                  "mandatory": false,
-                  "type": "TextField"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "address-type",
-          "questions": [
-            {
-              "id": "address-type-question",
-              "title": "What is that address?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "address-type-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Armed forces base address",
-                      "value": "Armed forces base address"
-                    },
-                    {
-                      "label": "Another address when working away from home",
-                      "value": "Another address when working away from home"
-                    },
-                    {
-                      "label": "Student’s home address",
-                      "value": "Student’s home address"
-                    },
-                    {
-                      "label": "Student’s term time address",
-                      "value": "Student’s term time address"
-                    },
-                    {
-                      "label": "Another parent or guardian’s address",
-                      "value": "Another parent or guardian’s address"
-                    },
-                    {
-                      "label": "Holiday home",
-                      "value": "Holiday home"
-                    },
-                    {
-                      "label": "Other (please specify)",
-                      "value": "Other",
-                      "child_answer_id": "address-type-answer-other"
-                    }
-                  ],
-                  "type": "Radio"
-                },
-                {
-                  "id": "address-type-answer-other",
-                  "parent_answer_id": "address-type-answer",
-                  "type": "TextField",
-                  "mandatory": false,
-                  "label": "Please specify type of address"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "in-education",
-          "questions": [
-            {
-              "id": "in-education-question",
-              "title":
-                "Is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> in full-time education?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "in-education-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Yes",
-                      "value": "Yes"
-                    },
-                    {
-                      "label": "No",
-                      "value": "No"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "term-time-location",
-                "when": [
-                  {
-                    "id": "in-education-answer",
-                    "condition": "equals",
-                    "value": "Yes"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "country-of-birth"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "term-time-location",
-          "questions": [
-            {
-              "id": "term-time-location-question",
-              "title":
-                "During term time, does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> live at <em>{{answers.address_line_1}}</em> ?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "term-time-location-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Yes",
-                      "value": "Yes"
-                    },
-                    {
-                      "label": "No",
-                      "value": "No"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "household-member-completed",
-                "when": [
-                  {
-                    "id": "term-time-location-answer",
-                    "condition": "equals",
-                    "value": "No"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "country-of-birth"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "country-of-birth",
-          "questions": [
-            {
-              "id": "country-of-birth-england-question",
-              "title":
-                "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> country of birth?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "country-of-birth-england-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "England",
-                      "value": "England"
-                    },
-                    {
-                      "label": "Wales",
-                      "value": "Wales"
-                    },
-                    {
-                      "label": "Scotland",
-                      "value": "Scotland"
-                    },
-                    {
-                      "label": "Northern Ireland",
-                      "value": "Northern Ireland"
-                    },
-                    {
-                      "label": "Republic of Ireland",
-                      "value": "Republic of Ireland"
-                    },
-                    {
-                      "label": "Elsewhere",
-                      "value": "Other",
-                      "child_answer_id": "country-of-birth-england-answer-other"
-                    }
-                  ],
-                  "type": "Radio"
-                },
-                {
-                  "id": "country-of-birth-england-answer-other",
-                  "parent_answer_id": "country-of-birth-england-answer",
-                  "type": "TextField",
-                  "mandatory": false,
-                  "label": "Please specify current name of country"
-                }
-              ],
-              "skip_conditions": [
-                {
-                  "when": [
-                    {
-                      "meta": "region_code",
-                      "condition": "equals",
-                      "value": "GB-WLS"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "country-of-birth-wales-question",
-              "title":
-                "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> country of birth?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "country-of-birth-wales-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Wales",
-                      "value": "Wales"
-                    },
-                    {
-                      "label": "England",
-                      "value": "England"
-                    },
-                    {
-                      "label": "Scotland",
-                      "value": "Scotland"
-                    },
-                    {
-                      "label": "Northern Ireland",
-                      "value": "Northern Ireland"
-                    },
-                    {
-                      "label": "Republic of Ireland",
-                      "value": "Republic of Ireland"
-                    },
-                    {
-                      "label": "Elsewhere",
-                      "value": "Other",
-                      "child_answer_id": "country-of-birth-wales-answer-other"
-                    }
-                  ],
-                  "type": "Radio"
-                },
-                {
-                  "id": "country-of-birth-wales-answer-other",
-                  "parent_answer_id": "country-of-birth-wales-answer",
-                  "type": "TextField",
-                  "mandatory": false,
-                  "label": "Please specify current name of country"
-                }
-              ],
-              "skip_conditions": [
-                {
-                  "when": [
-                    {
-                      "meta": "region_code",
-                      "condition": "not equals",
-                      "value": "GB-WLS"
-                    }
-                  ]
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "carer",
-                "when": [
-                  {
-                    "id": "country-of-birth-england-answer",
-                    "condition": "equals",
-                    "value": "England"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "carer",
-                "when": [
-                  {
-                    "id": "country-of-birth-england-answer",
-                    "condition": "equals",
-                    "value": "Wales"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "carer",
-                "when": [
-                  {
-                    "id": "country-of-birth-england-answer",
-                    "condition": "equals",
-                    "value": "Scotland"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "carer",
-                "when": [
-                  {
-                    "id": "country-of-birth-england-answer",
-                    "condition": "equals",
-                    "value": "Northern Ireland"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "carer",
-                "when": [
-                  {
-                    "id": "country-of-birth-wales-answer",
-                    "condition": "equals",
-                    "value": "Wales"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "carer",
-                "when": [
-                  {
-                    "id": "country-of-birth-wales-answer",
-                    "condition": "equals",
-                    "value": "England"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "carer",
-                "when": [
-                  {
-                    "id": "country-of-birth-wales-answer",
-                    "condition": "equals",
-                    "value": "Scotland"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "carer",
-                "when": [
-                  {
-                    "id": "country-of-birth-wales-answer",
-                    "condition": "equals",
-                    "value": "Northern Ireland"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "arrive-in-uk"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "arrive-in-uk",
-          "questions": [
-            {
-              "id": "arrive-in-uk-question",
-              "title":
-                "If you were not born in the United Kingdom, when did <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> most recently arrive to live here?",
-              "guidance": {
-                "content": [
-                  {
-                    "description": "Exclude short visits away from the UK"
-                  }
-                ]
-              },
-              "type": "General",
-              "answers": [
-                {
-                  "id": "arrive-in-uk-answer",
-                  "mandatory": false,
-                  "type": "MonthYearDate"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "length-of-stay",
-          "questions": [
-            {
-              "id": "length-of-stay-question",
-              "title":
-                "Including the time already spent here, how long does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> intend to stay in the United Kingdom?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "length-of-stay-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Less than 12 months",
-                      "value": "Less than 12 months"
-                    },
-                    {
-                      "label": "12 months or more",
-                      "value": "12 months or more"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "health",
-          "questions": [
-            {
-              "id": "health-question",
-              "title":
-                "How is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> health in general?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "health-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Very good",
-                      "value": "Very good"
-                    },
-                    {
-                      "label": "Good",
-                      "value": "Good"
-                    },
-                    {
-                      "label": "Fair",
-                      "value": "Fair"
-                    },
-                    {
-                      "label": "Bad",
-                      "value": "Bad"
-                    },
-                    {
-                      "label": "Very bad",
-                      "value": "Very bad"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "carer",
-          "questions": [
-            {
-              "id": "carer-question",
-              "title":
-                "Does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> look after, or give any help or support to family members, friends, neighbours or others?",
-              "description": "",
-              "guidance": {
-                "content": [
-                  {
-                    "title": "Include",
-                    "list": ["long-term physical or mental ill-health/disability", "problems related to old age"]
-                  },
-                  {
-                    "title": "Exclude",
-                    "list": ["anything you do as part of your paid employment"]
-                  }
-                ]
-              },
-              "type": "General",
-              "answers": [
-                {
-                  "id": "carer-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "No",
-                      "value": "No"
-                    },
-                    {
-                      "label": "Yes, 1 -19 hours a week",
-                      "value": "Yes, 1 -19 hours a week"
-                    },
-                    {
-                      "label": "Yes, 20 - 49 hours a week",
-                      "value": "Yes, 20 - 49 hours a week"
-                    },
-                    {
-                      "label": "Yes, 50 or more hours a week",
-                      "value": "Yes, 50 or more hours a week"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "national-identity",
-          "questions": [
-            {
-              "id": "national-identity-england-question",
-              "title":
-                "How would you describe <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> national identity?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "national-identity-england-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "English",
-                      "value": "English"
-                    },
-                    {
-                      "label": "Welsh",
-                      "value": "Welsh"
-                    },
-                    {
-                      "label": "Scottish",
-                      "value": "Scottish"
-                    },
-                    {
-                      "label": "Northern Irish",
-                      "value": "Northern Irish"
-                    },
-                    {
-                      "label": "British",
-                      "value": "British"
-                    },
-                    {
-                      "label": "Other",
-                      "value": "Other",
-                      "child_answer_id": "national-identity-england-answer-other"
-                    }
-                  ],
-                  "type": "Checkbox"
-                },
-                {
-                  "id": "national-identity-england-answer-other",
-                  "parent_answer_id": "national-identity-england-answer",
-                  "type": "TextField",
-                  "mandatory": false,
-                  "label": "Please describe your national identity"
-                }
-              ],
-              "skip_conditions": [
-                {
-                  "when": [
-                    {
-                      "meta": "region_code",
-                      "condition": "equals",
-                      "value": "GB-WLS"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "national-identity-wales-question",
-              "title":
-                "How would you describe <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> national identity?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "national-identity-wales-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Welsh",
-                      "value": "Welsh"
-                    },
-                    {
-                      "label": "English",
-                      "value": "English"
-                    },
-                    {
-                      "label": "Scottish",
-                      "value": "Scottish"
-                    },
-                    {
-                      "label": "Northern Irish",
-                      "value": "Northern Irish"
-                    },
-                    {
-                      "label": "British",
-                      "value": "British"
-                    },
-                    {
-                      "label": "Other",
-                      "value": "Other",
-                      "child_answer_id": "national-identity-wales-answer-other"
-                    }
-                  ],
-                  "type": "Checkbox"
-                },
-                {
-                  "id": "national-identity-wales-answer-other",
-                  "parent_answer_id": "national-identity-wales-answer",
-                  "type": "TextField",
-                  "mandatory": false,
-                  "label": "Please describe your national identity"
-                }
-              ],
-              "skip_conditions": [
-                {
-                  "when": [
-                    {
-                      "meta": "region_code",
-                      "condition": "not equals",
-                      "value": "GB-WLS"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "ethnic-group",
-          "questions": [
-            {
-              "id": "ethnic-group-england-question",
-              "title":
-                "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> ethnic group?",
-              "description":
-                "It is for you to choose your ethnic group. For example this could be your family or cultural background, or it could be how you would describe yourself.",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "ethnic-group-england-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "White",
-                      "value": "White",
-                      "description": "Including English, Welsh, Scottish, Northern Irish, British, Irish, Gypsy, Irish Traveller or any other White background"
-                    },
-                    {
-                      "label": "Mixed or multiple ethnic groups",
-                      "value": "Mixed or multiple ethnic groups",
-                      "description":
-                        "Including White and Black Caribbean, White and Black African, White and Asian or any other Mixed or multiple ethnic background"
-                    },
-                    {
-                      "label": "Asian or Asian British",
-                      "value": "Asian or Asian British",
-                      "description": "Including Indian, Pakistani, Bangladeshi, Chinese or any other Asian background"
-                    },
-                    {
-                      "label": "Black, African, Caribbean or Black British",
-                      "value": "Black, African, Caribbean or Black British",
-                      "description": "Including African, Caribbean or any other Black, African or Caribbean background"
-                    },
-                    {
-                      "label": "Other ethnic group",
-                      "value": "Other ethnic group",
-                      "description": "Including Arab or any other ethnic group"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ],
-              "skip_conditions": [
-                {
-                  "when": [
-                    {
-                      "meta": "region_code",
-                      "condition": "equals",
-                      "value": "GB-WLS"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "ethnic-group-wales-question",
-              "title":
-                "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> ethnic group?",
-              "description":
-                "It is for you to choose your ethnic group. For example this could be your family or cultural background, or it could be how you would describe yourself.",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "ethnic-group-wales-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "White",
-                      "value": "White",
-                      "description": "Including Welsh, English, Scottish, Northern Irish, British, Irish, Gypsy, Irish Traveller or any other White background"
-                    },
-                    {
-                      "label": "Mixed or multiple ethnic groups",
-                      "value": "Mixed or multiple ethnic groups",
-                      "description":
-                        "Including White and Black Caribbean, White and Black African, White and Asian or any other Mixed or multiple ethnic background"
-                    },
-                    {
-                      "label": "Asian or Asian British",
-                      "value": "Asian or Asian British",
-                      "description": "Including Indian, Pakistani, Bangladeshi, Chinese or any other Asian background"
-                    },
-                    {
-                      "label": "Black, African, Caribbean or Black British",
-                      "value": "Black, African, Caribbean or Black British",
-                      "description": "Including African, Caribbean or any other Black, African or Caribbean background"
-                    },
-                    {
-                      "label": "Other ethnic group",
-                      "value": "Other ethnic group",
-                      "description": "Including Arab or any other ethnic group"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ],
-              "skip_conditions": [
-                {
-                  "when": [
-                    {
-                      "meta": "region_code",
-                      "condition": "not equals",
-                      "value": "GB-WLS"
-                    }
-                  ]
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "white-ethnic-group",
-                "when": [
-                  {
-                    "id": "ethnic-group-england-answer",
-                    "condition": "equals",
-                    "value": "White"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "mixed-ethnic-group",
-                "when": [
-                  {
-                    "id": "ethnic-group-england-answer",
-                    "condition": "equals",
-                    "value": "Mixed or multiple ethnic groups"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "asian-ethnic-group",
-                "when": [
-                  {
-                    "id": "ethnic-group-england-answer",
-                    "condition": "equals",
-                    "value": "Asian or Asian British"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "black-ethnic-group",
-                "when": [
-                  {
-                    "id": "ethnic-group-england-answer",
-                    "condition": "equals",
-                    "value": "Black, African, Caribbean or Black British"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "other-ethnic-group",
-                "when": [
-                  {
-                    "id": "ethnic-group-england-answer",
-                    "condition": "equals",
-                    "value": "Other ethnic group"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "white-ethnic-group",
-                "when": [
-                  {
-                    "id": "ethnic-group-wales-answer",
-                    "condition": "equals",
-                    "value": "White"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "mixed-ethnic-group",
-                "when": [
-                  {
-                    "id": "ethnic-group-wales-answer",
-                    "condition": "equals",
-                    "value": "Mixed or multiple ethnic groups"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "asian-ethnic-group",
-                "when": [
-                  {
-                    "id": "ethnic-group-wales-answer",
-                    "condition": "equals",
-                    "value": "Asian or Asian British"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "black-ethnic-group",
-                "when": [
-                  {
-                    "id": "ethnic-group-wales-answer",
-                    "condition": "equals",
-                    "value": "Black, African, Caribbean or Black British"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "other-ethnic-group",
-                "when": [
-                  {
-                    "id": "ethnic-group-wales-answer",
-                    "condition": "equals",
-                    "value": "Other ethnic group"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "sexual-identity",
-                "when": [
-                  {
-                    "id": "over-16-answer",
-                    "condition": "equals",
-                    "value": "Yes"
-                  },
-                  {
-                    "meta": "variant_flags.sexual_identity",
-                    "condition": "equals",
-                    "value": true
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "understand-welsh",
-                "when": [
-                  {
-                    "meta": "region_code",
-                    "condition": "equals",
-                    "value": "GB-WLS"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "language"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "white-ethnic-group",
-          "questions": [
-            {
-              "id": "white-ethnic-group-england-question",
-              "title":
-                "Which one best describes <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> White ethnic group or background?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "white-ethnic-group-england-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "English, Welsh, Scottish, Northern Irish or British",
-                      "value": "English, Welsh, Scottish, Northern Irish or British"
-                    },
-                    {
-                      "label": "Irish",
-                      "value": "Irish"
-                    },
-                    {
-                      "label": "Gypsy or Irish Traveller",
-                      "value": "Gypsy or Irish Traveller"
-                    },
-                    {
-                      "label": "Any other White background",
-                      "value": "Other",
-                      "child_answer_id": "white-ethnic-group-england-answer-other"
-                    }
-                  ],
-                  "type": "Radio"
-                },
-                {
-                  "id": "white-ethnic-group-england-answer-other",
-                  "parent_answer_id": "white-ethnic-group-england-answer",
-                  "type": "TextField",
-                  "mandatory": false,
-                  "label": "Please specify other White background"
-                }
-              ],
-              "skip_conditions": [
-                {
-                  "when": [
-                    {
-                      "meta": "region_code",
-                      "condition": "equals",
-                      "value": "GB-WLS"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "white-ethnic-group-wales-question",
-              "title":
-                "Which one best describes <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> White ethnic group or background?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "white-ethnic-group-wales-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Welsh, English, Scottish, Northern Irish or British",
-                      "value": "Welsh, English, Scottish, Northern Irish or British"
-                    },
-                    {
-                      "label": "Irish",
-                      "value": "Irish"
-                    },
-                    {
-                      "label": "Gypsy or Irish Traveller",
-                      "value": "Gypsy or Irish Traveller"
-                    },
-                    {
-                      "label": "Any other White background",
-                      "value": "Other",
-                      "child_answer_id": "white-ethnic-group-wales-question-other"
-                    }
-                  ],
-                  "type": "Radio"
-                },
-                {
-                  "id": "white-ethnic-group-wales-question-other",
-                  "parent_answer_id": "white-ethnic-group-wales-answer",
-                  "type": "TextField",
-                  "mandatory": false,
-                  "label": "Please specify other White background"
-                }
-              ],
-              "skip_conditions": [
-                {
-                  "when": [
-                    {
-                      "meta": "region_code",
-                      "condition": "not equals",
-                      "value": "GB-WLS"
-                    }
-                  ]
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "sexual-identity",
-                "when": [
-                  {
-                    "id": "over-16-answer",
-                    "condition": "equals",
-                    "value": "Yes"
-                  },
-                  {
-                    "meta": "variant_flags.sexual_identity",
-                    "condition": "equals",
-                    "value": true
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "understand-welsh",
-                "when": [
-                  {
-                    "meta": "region_code",
-                    "condition": "equals",
-                    "value": "GB-WLS"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "language"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "mixed-ethnic-group",
-          "questions": [
-            {
-              "id": "mixed-ethnic-group-question",
-              "title":
-                "Which one best describes <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> Mixed, multiple ethnic group or background?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "mixed-ethnic-group-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "White and Black Caribbean",
-                      "value": "White and Black Caribbean"
-                    },
-                    {
-                      "label": "White and Black African",
-                      "value": "White and Black African"
-                    },
-                    {
-                      "label": "White and Asian",
-                      "value": "White and Asian"
-                    },
-                    {
-                      "label": "Any other Mixed or multiple ethnic background",
-                      "value": "Other",
-                      "child_answer_id": "mixed-ethnic-group-answer-other"
-                    }
-                  ],
-                  "type": "Radio"
-                },
-                {
-                  "id": "mixed-ethnic-group-answer-other",
-                  "parent_answer_id": "mixed-ethnic-group-answer",
-                  "type": "TextField",
-                  "mandatory": false,
-                  "label": "Please specify other Mixed or multiple ethnic background"
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "sexual-identity",
-                "when": [
-                  {
-                    "id": "over-16-answer",
-                    "condition": "equals",
-                    "value": "Yes"
-                  },
-                  {
-                    "meta": "variant_flags.sexual_identity",
-                    "condition": "equals",
-                    "value": true
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "understand-welsh",
-                "when": [
-                  {
-                    "meta": "region_code",
-                    "condition": "equals",
-                    "value": "GB-WLS"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "language"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "asian-ethnic-group",
-          "questions": [
-            {
-              "id": "asian-ethnic-group-question",
-              "title":
-                "Which one best describes <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> Asian, Asian British ethnic group or background?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "asian-ethnic-group-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Indian",
-                      "value": "Indian"
-                    },
-                    {
-                      "label": "Pakistani",
-                      "value": "Pakistani"
-                    },
-                    {
-                      "label": "Bangladeshi",
-                      "value": "Bangladeshi"
-                    },
-                    {
-                      "label": "Chinese",
-                      "value": "Chinese"
-                    },
-                    {
-                      "label": "Any other Asian background",
-                      "value": "Other",
-                      "child_answer_id": "asian-ethnic-group-answer-other"
-                    }
-                  ],
-                  "type": "Radio"
-                },
-                {
-                  "id": "asian-ethnic-group-answer-other",
-                  "parent_answer_id": "asian-ethnic-group-answer",
-                  "type": "TextField",
-                  "mandatory": false,
-                  "label": "Please specify other Asian background"
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "sexual-identity",
-                "when": [
-                  {
-                    "id": "over-16-answer",
-                    "condition": "equals",
-                    "value": "Yes"
-                  },
-                  {
-                    "meta": "variant_flags.sexual_identity",
-                    "condition": "equals",
-                    "value": true
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "understand-welsh",
-                "when": [
-                  {
-                    "meta": "region_code",
-                    "condition": "equals",
-                    "value": "GB-WLS"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "language"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "black-ethnic-group",
-          "questions": [
-            {
-              "id": "black-ethnic-group-question",
-              "title":
-                "Which one best describes <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> Black, African, Caribbean, Black British ethnic group or background?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "black-ethnic-group-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "African",
-                      "value": "African"
-                    },
-                    {
-                      "label": "Caribbean",
-                      "value": "Caribbean"
-                    },
-                    {
-                      "label": "Any other Black, African or Caribbean background",
-                      "value": "Other",
-                      "child_answer_id": "black-ethnic-group-answer-other"
-                    }
-                  ],
-                  "type": "Radio"
-                },
-                {
-                  "id": "black-ethnic-group-answer-other",
-                  "parent_answer_id": "black-ethnic-group-answer",
-                  "type": "TextField",
-                  "mandatory": false,
-                  "label": "Please specify other Black, African or Caribbean background"
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "sexual-identity",
-                "when": [
-                  {
-                    "id": "over-16-answer",
-                    "condition": "equals",
-                    "value": "Yes"
-                  },
-                  {
-                    "meta": "variant_flags.sexual_identity",
-                    "condition": "equals",
-                    "value": true
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "understand-welsh",
-                "when": [
-                  {
-                    "meta": "region_code",
-                    "condition": "equals",
-                    "value": "GB-WLS"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "language"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "other-ethnic-group",
-          "questions": [
-            {
-              "id": "other-ethnic-group-question",
-              "title":
-                "Which one best describes <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> Other ethnic group or background?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "other-ethnic-group-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Arab",
-                      "value": "Arab"
-                    },
-                    {
-                      "label": "Any other ethnic group",
-                      "value": "Other",
-                      "child_answer_id": "other-ethnic-group-answer-other"
-                    }
-                  ],
-                  "type": "Radio"
-                },
-                {
-                  "id": "other-ethnic-group-answer-other",
-                  "parent_answer_id": "other-ethnic-group-answer",
-                  "type": "TextField",
-                  "mandatory": false,
-                  "label": "Please specify Other ethnic group"
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "sexual-identity",
-                "when": [
-                  {
-                    "id": "over-16-answer",
-                    "condition": "equals",
-                    "value": "Yes"
-                  },
-                  {
-                    "meta": "variant_flags.sexual_identity",
-                    "condition": "equals",
-                    "value": true
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "understand-welsh",
-                "when": [
-                  {
-                    "meta": "region_code",
-                    "condition": "equals",
-                    "value": "GB-WLS"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "language"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "sexual-identity",
-          "questions": [
-            {
-              "id": "sexual-identity-question",
-              "title":
-                "Which of the following options best describes how <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> thinks of themselves?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "sexual-identity-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Heterosexual or Straight",
-                      "value": "Heterosexual or Straight"
-                    },
-                    {
-                      "label": "Gay or Lesbian",
-                      "value": "Gay or Lesbian"
-                    },
-                    {
-                      "label": "Bisexual",
-                      "value": "Bisexual"
-                    },
-                    {
-                      "label": "Other",
-                      "value": "Other",
-                      "child_answer_id": "sexual-identity-answer-other"
-                    },
-                    {
-                      "label": "Prefer not to say",
-                      "value": "Prefer not to say"
-                    }
-                  ],
-                  "type": "Checkbox"
-                },
-                {
-                  "id": "sexual-identity-answer-other",
-                  "parent_answer_id": "sexual-identity-answer",
-                  "type": "TextField",
-                  "mandatory": false,
-                  "label": "Please specify"
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "understand-welsh",
-                "when": [
-                  {
-                    "meta": "region_code",
-                    "condition": "equals",
-                    "value": "GB-WLS"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "language"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "understand-welsh",
-          "questions": [
-            {
-              "id": "understand-welsh-question",
-              "title":
-                "Can <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> understand, speak, read or write Welsh",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "understand-welsh-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Understand spoken Welsh",
-                      "value": "Understand spoken Welsh"
-                    },
-                    {
-                      "label": "Speak Welsh",
-                      "value": "Speak Welsh"
-                    },
-                    {
-                      "label": "Read Welsh",
-                      "value": "Read Welsh"
-                    },
-                    {
-                      "label": "Write Welsh",
-                      "value": "Write Welsh"
-                    },
-                    {
-                      "label": "None of the above",
-                      "value": "None of the above"
-                    }
-                  ],
-                  "type": "Checkbox"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "language",
-          "questions": [
-            {
-              "id": "language-england-question",
-              "title":
-                "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> main language?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "language-england-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "English",
-                      "value": "English"
-                    },
-                    {
-                      "label": "Other",
-                      "value": "Other",
-                      "description": "Including British Sign Language",
-                      "child_answer_id": "language-england-answer-other"
-                    }
-                  ],
-                  "type": "Radio"
-                },
-                {
-                  "id": "language-england-answer-other",
-                  "parent_answer_id": "language-england-answer",
-                  "type": "TextField",
-                  "mandatory": false,
-                  "label": "Please specify main language"
-                }
-              ],
-              "skip_conditions": [
-                {
-                  "when": [
-                    {
-                      "meta": "region_code",
-                      "condition": "equals",
-                      "value": "GB-WLS"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "language-welsh-question",
-              "title":
-                "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> main language?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "language-welsh-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "English or Welsh",
-                      "value": "English or Welsh"
-                    },
-                    {
-                      "label": "Other",
-                      "value": "Other",
-                      "description": "Including British Sign Language",
-                      "child_answer_id": "language-welsh-answer-other"
-                    }
-                  ],
-                  "type": "Radio"
-                },
-                {
-                  "id": "language-welsh-answer-other",
-                  "parent_answer_id": "language-welsh-answer",
-                  "type": "TextField",
-                  "mandatory": false,
-                  "label": "Please specify main language"
-                }
-              ],
-              "skip_conditions": [
-                {
-                  "when": [
-                    {
-                      "meta": "region_code",
-                      "condition": "not equals",
-                      "value": "GB-WLS"
-                    }
-                  ]
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "religion",
-                "when": [
-                  {
-                    "id": "language-england-answer",
-                    "condition": "equals",
-                    "value": "English"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "religion",
-                "when": [
-                  {
-                    "id": "language-welsh-answer",
-                    "condition": "equals",
-                    "value": "English or Welsh"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "english"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "english",
-          "questions": [
-            {
-              "id": "english-question",
-              "title":
-                "How well can <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> speak English?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "english-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Very well",
-                      "value": "Very well"
-                    },
-                    {
-                      "label": "Well",
-                      "value": "Well"
-                    },
-                    {
-                      "label": "Not well",
-                      "value": "Not well"
-                    },
-                    {
-                      "label": "Not at all",
-                      "value": "Not at all"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "religion",
-          "questions": [
-            {
-              "id": "religion-question",
-              "title":
-                "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> religion?",
-              "description": "This question is voluntary",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "religion-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "No religion",
-                      "value": "No religion"
-                    },
-                    {
-                      "label": "Christianity",
-                      "value": "Christianity"
-                    },
-                    {
-                      "label": "Buddhism",
-                      "value": "Buddhism"
-                    },
-                    {
-                      "label": "Hinduism",
-                      "value": "Hinduism"
-                    },
-                    {
-                      "label": "Judaism",
-                      "value": "Judaism"
-                    },
-                    {
-                      "label": "Islam",
-                      "value": "Islam"
-                    },
-                    {
-                      "label": "Sikhism",
-                      "value": "Sikhism"
-                    },
-                    {
-                      "label": "Any other religion",
-                      "value": "Other",
-                      "child_answer_id": "religion-answer-other"
-                    }
-                  ],
-                  "type": "Checkbox"
-                },
-                {
-                  "id": "religion-answer-other",
-                  "parent_answer_id": "religion-answer",
-                  "type": "TextField",
-                  "mandatory": false,
-                  "label": "Please specify other religion"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "past-usual-address",
-          "questions": [
-            {
-              "id": "past-usual-address-question",
-              "title": "One year ago, what was your usual address?",
-              "description": "If you had no usual address one year ago, state the address where you were staying",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "past-usual-address-answer",
-                  "mandatory": false,
-                  "guidance": {
-                    "show_guidance": "Show further guidance",
-                    "hide_guidance": "Hide further guidance",
-                    "content": [
-                      {
-                        "description": "In most cases your usual address will be the permanent or family home that you were living in."
-                      }
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "carer",
+                                "when": [{
+                                    "id": "country-of-birth-england-answer",
+                                    "condition": "equals",
+                                    "value": "England"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "carer",
+                                "when": [{
+                                    "id": "country-of-birth-england-answer",
+                                    "condition": "equals",
+                                    "value": "Wales"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "carer",
+                                "when": [{
+                                    "id": "country-of-birth-england-answer",
+                                    "condition": "equals",
+                                    "value": "Scotland"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "carer",
+                                "when": [{
+                                    "id": "country-of-birth-england-answer",
+                                    "condition": "equals",
+                                    "value": "Northern Ireland"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "carer",
+                                "when": [{
+                                    "id": "country-of-birth-wales-answer",
+                                    "condition": "equals",
+                                    "value": "Wales"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "carer",
+                                "when": [{
+                                    "id": "country-of-birth-wales-answer",
+                                    "condition": "equals",
+                                    "value": "England"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "carer",
+                                "when": [{
+                                    "id": "country-of-birth-wales-answer",
+                                    "condition": "equals",
+                                    "value": "Scotland"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "carer",
+                                "when": [{
+                                    "id": "country-of-birth-wales-answer",
+                                    "condition": "equals",
+                                    "value": "Northern Ireland"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "arrive-in-uk"
+                            }
+                        }
                     ]
-                  },
-                  "options": [
-                    {
-                      "label": "This address",
-                      "value": "This address"
-                    },
-                    {
-                      "label": "Student term time or boarding school address in the UK",
-                      "value": "Student term time or boarding school address in the UK"
-                    },
-                    {
-                      "label": "Another address in the UK",
-                      "value": "Another address in the UK"
-                    },
-                    {
-                      "label": "An address outside the UK",
-                      "value": "Other",
-                      "child_answer_id": "past-usual-address-answer-other"
-                    }
-                  ],
-                  "type": "Radio"
                 },
                 {
-                  "id": "past-usual-address-answer-other",
-                  "parent_answer_id": "past-usual-address-answer",
-                  "type": "TextField",
-                  "mandatory": false,
-                  "label": "Please enter the country"
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "last-year-address",
-                "when": [
-                  {
-                    "id": "past-usual-address-answer",
-                    "condition": "equals",
-                    "value": "Student term time or boarding school address in the UK"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "last-year-address",
-                "when": [
-                  {
-                    "id": "past-usual-address-answer",
-                    "condition": "equals",
-                    "value": "Another address in the UK"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "passports"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "last-year-address",
-          "questions": [
-            {
-              "id": "last-year-address-question",
-              "title": "Enter details of your address one year ago",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "last-year-address-answer-building",
-                  "label": "Building",
-                  "mandatory": false,
-                  "type": "TextField"
+                    "type": "Question",
+                    "id": "arrive-in-uk",
+                    "questions": [{
+                        "id": "arrive-in-uk-question",
+                        "title": "If you were not born in the United Kingdom, when did <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> most recently arrive to live here?",
+                        "guidance": {
+                            "content": [{
+                                "description": "Exclude short visits away from the UK"
+                            }]
+                        },
+                        "type": "General",
+                        "answers": [{
+                            "id": "arrive-in-uk-answer",
+                            "mandatory": false,
+                            "type": "MonthYearDate"
+                        }]
+                    }]
                 },
                 {
-                  "id": "last-year-address-answer-street",
-                  "label": "Street",
-                  "mandatory": false,
-                  "type": "TextField"
+                    "type": "Question",
+                    "id": "length-of-stay",
+                    "questions": [{
+                        "id": "length-of-stay-question",
+                        "title": "Including the time already spent here, how long does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> intend to stay in the United Kingdom?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "length-of-stay-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Less than 12 months",
+                                    "value": "Less than 12 months"
+                                },
+                                {
+                                    "label": "12 months or more",
+                                    "value": "12 months or more"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }]
                 },
                 {
-                  "id": "last-year-address-answer-city",
-                  "label": "Town or city",
-                  "mandatory": false,
-                  "type": "TextField"
+                    "type": "Question",
+                    "id": "health",
+                    "questions": [{
+                        "id": "health-question",
+                        "title": "How is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> health in general?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "health-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Very good",
+                                    "value": "Very good"
+                                },
+                                {
+                                    "label": "Good",
+                                    "value": "Good"
+                                },
+                                {
+                                    "label": "Fair",
+                                    "value": "Fair"
+                                },
+                                {
+                                    "label": "Bad",
+                                    "value": "Bad"
+                                },
+                                {
+                                    "label": "Very bad",
+                                    "value": "Very bad"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }]
                 },
                 {
-                  "id": "last-year-address-answer-county",
-                  "label": "County (optional)",
-                  "mandatory": false,
-                  "type": "TextField"
+                    "type": "Question",
+                    "id": "carer",
+                    "questions": [{
+                        "id": "carer-question",
+                        "title": "Does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> look after, or give any help or support to family members, friends, neighbours or others?",
+                        "description": "",
+                        "guidance": {
+                            "content": [{
+                                    "title": "Include",
+                                    "list": ["long-term physical or mental ill-health/disability", "problems related to old age"]
+                                },
+                                {
+                                    "title": "Exclude",
+                                    "list": ["anything you do as part of your paid employment"]
+                                }
+                            ]
+                        },
+                        "type": "General",
+                        "answers": [{
+                            "id": "carer-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "No",
+                                    "value": "No"
+                                },
+                                {
+                                    "label": "Yes, 1 -19 hours a week",
+                                    "value": "Yes, 1 -19 hours a week"
+                                },
+                                {
+                                    "label": "Yes, 20 - 49 hours a week",
+                                    "value": "Yes, 20 - 49 hours a week"
+                                },
+                                {
+                                    "label": "Yes, 50 or more hours a week",
+                                    "value": "Yes, 50 or more hours a week"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }]
                 },
                 {
-                  "id": "last-year-address-answer-postcode",
-                  "label": "Postcode",
-                  "mandatory": false,
-                  "type": "TextField"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "passports",
-          "questions": [
-            {
-              "id": "passports-question",
-              "title": "What passports do you hold?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "passports-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "United Kingdom",
-                      "value": "United Kingdom"
-                    },
-                    {
-                      "label": "Irish",
-                      "value": "Irish"
-                    },
-                    {
-                      "label": "Other",
-                      "value": "Other"
-                    },
-                    {
-                      "label": "None",
-                      "value": "None"
-                    }
-                  ],
-                  "type": "Checkbox"
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "other-passports",
-                "when": [
-                  {
-                    "id": "passports-answer",
-                    "condition": "contains",
-                    "value": "Other"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "disability"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "other-passports",
-          "questions": [
-            {
-              "id": "other-passports-question",
-              "title": "Please specify other passports held",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "other-passports-answer",
-                  "label": "Passports held",
-                  "mandatory": false,
-                  "type": "TextField"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "disability",
-          "questions": [
-            {
-              "id": "disability-question",
-              "title":
-                "Are <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> day-to-day activities limited because of a health problem or disability which has lasted, or is expected to last, at least 12 months?",
-              "guidance": {
-                "content": [
-                  {
-                    "description": "<strong>Include</strong> problems related to old age"
-                  }
-                ]
-              },
-              "type": "General",
-              "answers": [
-                {
-                  "id": "disability-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Yes, limited a lot",
-                      "value": "Yes, limited a lot"
-                    },
-                    {
-                      "label": "Yes, limited a little",
-                      "value": "Yes, limited a little"
-                    },
-                    {
-                      "label": "No",
-                      "value": "No"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "household-member-completed",
-                "when": [
-                  {
-                    "id": "over-16-answer",
-                    "condition": "equals",
-                    "value": "No"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "qualifications"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "qualifications",
-          "questions": [
-            {
-              "id": "qualifications-england-question",
-              "title":
-                "Thinking of any studies, exams or qualifications, which of the following does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> have?",
-              "description": "Select every option that applies (whether UK or foreign equivalent) if you have any of the qualifications listed",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "qualifications-england-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label":
-                        "5 or more  GCSEs (grades A-Star to C) or O-Levels (passes) or CSEs (grade 1), School Certificate, One A-Level, 2 to 3 AS-Levels or VCEs, Higher Diploma",
-                      "value":
-                        "5 or more  GCSEs (grades A-Star to C) or O-Levels (passes) or CSEs (grade 1), School Certificate, One A-Level, 2 to 3 AS-Levels or VCEs, Higher Diploma"
-                    },
-                    {
-                      "label": "1 to 4 GCSEs or O-Levels or CSEs (any grades), Entry level, Foundation Diploma",
-                      "value": "1 to 4 GCSEs or O-Levels or CSEs (any grades), Entry level, Foundation Diploma"
-                    },
-                    {
-                      "label": "2 or more  A-Levels, 4 or more  AS-levels or VCEs, Higher School Certificate, Advanced Diploma",
-                      "value": "2 or more  A-Levels, 4 or more  AS-levels or VCEs, Higher School Certificate, Advanced Diploma"
-                    },
-                    {
-                      "label": "Apprenticeship (trade, advanced, foundation or modern)",
-                      "value": "Apprenticeship (trade, advanced, foundation or modern)"
-                    },
-                    {
-                      "label": "NVQ level one, Foundation GNVQ, Basic Skills",
-                      "value": "NVQ level one, Foundation GNVQ, Basic Skills"
-                    },
-                    {
-                      "label": "NVQ level two, Intermediate GNVQ, City and Guilds Craft, BTEC First, RSA Diploma",
-                      "value": "NVQ level two, Intermediate GNVQ, City and Guilds Craft, BTEC First, RSA Diploma"
-                    },
-                    {
-                      "label": "NVQ Level three, Advanced GNVQ, City and Guilds Advanced Craft, ONC, OND, BTEC National, RSA Advanced Diploma",
-                      "value": "NVQ Level three, Advanced GNVQ, City and Guilds Advanced Craft, ONC, OND, BTEC National, RSA Advanced Diploma"
-                    },
-                    {
-                      "label": "NVQ Level four to five, HNC, HND, RSA Higher Diploma, BTEC Higher, Foundation degree",
-                      "value": "NVQ Level four to five, HNC, HND, RSA Higher Diploma, BTEC Higher, Foundation degree"
-                    },
-                    {
-                      "label": "Other vocational or work-related qualifications",
-                      "value": "Other vocational or work-related qualifications"
-                    },
-                    {
-                      "label": "Undergraduate Degree",
-                      "value": "Undergraduate Degree"
-                    },
-                    {
-                      "label": "Postgraduate Certificate / Diploma",
-                      "value": "Postgraduate Certificate / Diploma"
-                    },
-                    {
-                      "label": "Masters Degree",
-                      "value": "Masters Degree"
-                    },
-                    {
-                      "label": "Doctorate Degree (for example PhD)",
-                      "value": "Doctorate Degree (for example PhD)"
-                    },
-                    {
-                      "label": "Professional qualification (for example teaching, nursing, accountancy)",
-                      "value": "Professional qualification (for example teaching, nursing, accountancy)"
-                    },
-                    {
-                      "label": "Foreign qualifications (UK equivalent not known)",
-                      "value": "Foreign qualifications (UK equivalent not known)"
-                    },
-                    {
-                      "label": "No qualifications",
-                      "value": "No qualifications"
-                    }
-                  ],
-                  "type": "Checkbox"
-                }
-              ],
-              "skip_conditions": [
-                {
-                  "when": [
-                    {
-                      "meta": "region_code",
-                      "condition": "equals",
-                      "value": "GB-WLS"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "qualifications-welsh-question",
-              "title":
-                "Thinking of any studies, exams or qualifications, which of the following does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> have?",
-              "description": "Select every option that applies (whether UK or foreign equivalent) if you have any of the qualifications listed",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "qualifications-welsh-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label":
-                        "5 or more GCSEs (grades A-Star to C) or O Levels (passes) or CSEs (grade 1), School Certificate, One A-Level, 2 to 3 AS-Levels or VCEs,  Intermediate or National Welsh Baccalaureate (Level two)",
-                      "value":
-                        "5 or more GCSEs (grades A-Star to C) or O Levels (passes) or CSEs (grade 1), School Certificate, One A-Level, 2 to 3 AS-Levels or VCEs,  Intermediate or National Welsh Baccalaureate (Level two)"
-                    },
-                    {
-                      "label": "1 to 4  GCSEs or O Levels or CSEs (any grades), Entry level, Foundation Welsh Baccalaureate (level one)",
-                      "value": "1 to 4  GCSEs or O Levels or CSEs (any grades), Entry level, Foundation Welsh Baccalaureate (level one)"
-                    },
-                    {
-                      "label": "More than 2 A-Levels, more than 4 AS-levels or VCEs, Higher School Certificate, Advanced Welsh Baccalaureate (level three)",
-                      "value": "More than 2 A-Levels, more than 4 AS-levels or VCEs, Higher School Certificate, Advanced Welsh Baccalaureate (level three)"
-                    },
-                    {
-                      "label": "Apprenticeship (foundation, modern or higher)",
-                      "value": "Apprenticeship (foundation, modern or higher)"
-                    },
-                    {
-                      "label": "NVQ level one, Foundation GNVQ, Essential or Key  Skills",
-                      "value": "NVQ level one, Foundation GNVQ, Essential or Key  Skills"
-                    },
-                    {
-                      "label": "NVQ level two, Intermediate GNVQ, City and Guilds Craft, BTEC First, RSA Diploma",
-                      "value": "NVQ level two, Intermediate GNVQ, City and Guilds Craft, BTEC First, RSA Diploma"
-                    },
-                    {
-                      "label": "NVQ Level three, Advanced GNVQ, City and Guilds Advanced Craft, ONC, OND, BTEC National, RSA Advanced Diploma",
-                      "value": "NVQ Level three, Advanced GNVQ, City and Guilds Advanced Craft, ONC, OND, BTEC National, RSA Advanced Diploma"
-                    },
-                    {
-                      "label": "NVQ Level four to five, HNC, HND, RSA Higher Diploma, BTEC Higher",
-                      "value": "NVQ Level four to five, HNC, HND, RSA Higher Diploma, BTEC Higher"
-                    },
-                    {
-                      "label": "Other vocational or work-related qualifications",
-                      "value": "Other vocational or work-related qualifications"
-                    },
-                    {
-                      "label": "Undergraduate Degree",
-                      "value": "Undergraduate Degree"
-                    },
-                    {
-                      "label": "Postgraduate Certificate / Diploma",
-                      "value": "Postgraduate Certificate / Diploma"
-                    },
-                    {
-                      "label": "Masters Degree",
-                      "value": "Masters Degree"
-                    },
-                    {
-                      "label": "Doctorate Degree (for example PhD)",
-                      "value": "Doctorate Degree (for example PhD)"
-                    },
-                    {
-                      "label": "Professional qualification (for example teaching, nursing, accountancy)",
-                      "value": "Professional qualification (for example teaching, nursing, accountancy)"
-                    },
-                    {
-                      "label": "Foreign qualifications (UK equivalent not known)",
-                      "value": "Foreign qualifications (UK equivalent not known)"
-                    },
-                    {
-                      "label": "No qualifications",
-                      "value": "No qualifications"
-                    }
-                  ],
-                  "type": "Checkbox"
-                }
-              ],
-              "skip_conditions": [
-                {
-                  "when": [
-                    {
-                      "meta": "region_code",
-                      "condition": "not equals",
-                      "value": "GB-WLS"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "employment-type",
-          "questions": [
-            {
-              "id": "employment-type-question",
-              "title":
-                "Which of the following best describes what <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> was doing last week?",
-              "guidance": {
-                "content": [
-                  {
-                    "description": "<strong>Include</strong> any paid work, including casual or temporary work, even if only for one hour"
-                  }
-                ]
-              },
-              "type": "General",
-              "answers": [
-                {
-                  "id": "employment-type-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "working as an employee",
-                      "value": "working as an employee"
-                    },
-                    {
-                      "label": "on a government sponsored training scheme",
-                      "value": "on a government sponsored training scheme"
-                    },
-                    {
-                      "label": "self-employed or freelance",
-                      "value": "self-employed or freelance"
-                    },
-                    {
-                      "label": "working paid or unpaid for you own or your family’s business",
-                      "value": "working paid or unpaid for you own or your family’s business"
-                    },
-                    {
-                      "label": "away from work ill, on maternity leave, on holiday or temporarily laid off",
-                      "value": "away from work ill, on maternity leave, on holiday or temporarily laid off"
-                    },
-                    {
-                      "label": "doing any other kind of paid work",
-                      "value": "doing any other kind of paid work"
-                    },
-                    {
-                      "label": "none of the above",
-                      "value": "none of the above"
-                    }
-                  ],
-                  "type": "Checkbox"
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "main-job",
-                "when": [
-                  {
-                    "id": "employment-type-answer",
-                    "condition": "contains",
-                    "value": "working as an employee"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "main-job",
-                "when": [
-                  {
-                    "id": "employment-type-answer",
-                    "condition": "contains",
-                    "value": "on a government sponsored training scheme"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "main-job",
-                "when": [
-                  {
-                    "id": "employment-type-answer",
-                    "condition": "contains",
-                    "value": "self-employed or freelance"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "main-job",
-                "when": [
-                  {
-                    "id": "employment-type-answer",
-                    "condition": "contains",
-                    "value": "working paid or unpaid for you own or your family’s business"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "main-job",
-                "when": [
-                  {
-                    "id": "employment-type-answer",
-                    "condition": "contains",
-                    "value": "away from work ill, on maternity leave, on holiday or temporarily laid off"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "main-job",
-                "when": [
-                  {
-                    "id": "employment-type-answer",
-                    "condition": "contains",
-                    "value": "doing any other kind of paid work"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "jobseeker"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "jobseeker",
-          "questions": [
-            {
-              "id": "jobseeker-question",
-              "title":
-                "Was <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> actively looking for any kind of paid work during the last four weeks?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "jobseeker-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Yes",
-                      "value": "Yes"
-                    },
-                    {
-                      "label": "No",
-                      "value": "No"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "job-availability",
-          "questions": [
-            {
-              "id": "job-availability-question",
-              "title":
-                "If a job had been offered to <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> last week, could they have started it within 2 weeks?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "job-availability-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Yes",
-                      "value": "Yes"
-                    },
-                    {
-                      "label": "No",
-                      "value": "No"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "job-pending",
-          "questions": [
-            {
-              "id": "job-pending-question",
-              "title":
-                "Last week, was <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> waiting to start a job already accepted?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "job-pending-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Yes",
-                      "value": "Yes"
-                    },
-                    {
-                      "label": "No",
-                      "value": "No"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "occupation",
-          "questions": [
-            {
-              "id": "occupation-question",
-              "title":
-                "Which of the following best describes what <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> was doing last week?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "occupation-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "retired (whether receiving a pension or not)",
-                      "value": "retired (whether receiving a pension or not)"
-                    },
-                    {
-                      "label": "a student",
-                      "value": "a student"
-                    },
-                    {
-                      "label": "looking after home or family",
-                      "value": "looking after home or family"
-                    },
-                    {
-                      "label": "long-term sick or disabled",
-                      "value": "long-term sick or disabled"
-                    },
-                    {
-                      "label": "other",
-                      "value": "other"
-                    }
-                  ],
-                  "type": "Checkbox"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "ever-worked",
-          "questions": [
-            {
-              "id": "ever-worked-question",
-              "title": "Has <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> ever worked?",
-              "type": "General",
-              "guidance": {
-                "content": [
-                  {
-                    "title": "Include:",
-                    "list": ["work outside of the United Kingdom.", "even if you are now retired."]
-                  }
-                ]
-              },
-              "answers": [
-                {
-                  "id": "ever-worked-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Yes",
-                      "value": "Yes"
-                    },
-                    {
-                      "label": "No",
-                      "value": "No"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "household-member-completed",
-                "when": [
-                  {
-                    "id": "ever-worked-answer",
-                    "condition": "equals",
-                    "value": "No"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "household-member-completed",
-                "when": [
-                  {
-                    "id": "ever-worked-answer",
-                    "condition": "not set"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "main-job"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "main-job",
-          "questions": [
-            {
-              "id": "main-job-question",
-              "title":
-                "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive }}</em> employment status?",
-              "guidance": {
-                "content": [
-                  {
-                    "description":
-                      "<p>If you are not working answer the remaining questions about your last main job.</p><p>Your main job is the job which you usually work (worked) the most hours</p>"
-                  }
-                ]
-              },
-              "type": "General",
-              "answers": [
-                {
-                  "id": "main-job-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "an employee",
-                      "value": "an employee"
-                    },
-                    {
-                      "label": "self-employed or freelance without employees",
-                      "value": "self-employed or freelance without employees"
-                    },
-                    {
-                      "label": "self-employed with employees",
-                      "value": "self-employed with employees"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "hours-worked",
-          "description": "",
-          "questions": [
-            {
-              "title":
-                "In <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive }}</em> main job, how many hours a week do they usually work?",
-              "guidance": {
-                "content": [
-                  {
-                    "description": "Include paid and unpaid overtime"
-                  }
-                ]
-              },
-              "id": "hours-worked-question",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "hours-worked-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "15 or less",
-                      "value": "15 or less"
-                    },
-                    {
-                      "label": "16 - 30",
-                      "value": "16 - 30"
-                    },
-                    {
-                      "label": "31 - 48",
-                      "value": "31 - 48"
-                    },
-                    {
-                      "label": "49 or more",
-                      "value": "49 or more "
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "work-travel",
-          "description": "",
-          "questions": [
-            {
-              "title":
-                "How does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> usually travel to work?",
-              "description":
-                "Select the option for the longest part, in distance, of your journey. For example, you travel by bus and by car. Your bus journey is 5 miles, and the car journey is 8 miles. You should select car as your answer.",
-              "id": "work-travel-question",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "work-travel-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Work mainly at or from home",
-                      "value": "Work mainly at or from home"
-                    },
-                    {
-                      "label": "Underground, metro, light rail or tram",
-                      "value": "Underground, metro, light rail or tram"
-                    },
-                    {
-                      "label": "Train",
-                      "value": "Train"
-                    },
-                    {
-                      "label": "Bus, minibus or coach",
-                      "value": "Bus, minibus or coach "
-                    },
-                    {
-                      "label": "Taxi",
-                      "value": "Taxi "
-                    },
-                    {
-                      "label": "Motorcycle, scooter or moped",
-                      "value": "Motorcycle, scooter or moped"
-                    },
-                    {
-                      "label": "Driving a car or van",
-                      "value": "Driving a car or van"
-                    },
-                    {
-                      "label": "Passenger in a car or van",
-                      "value": "Passenger in a car or van"
-                    },
-                    {
-                      "label": "Bicycle",
-                      "value": "Bicycle"
-                    },
-                    {
-                      "label": "On foot",
-                      "value": "On foot"
-                    },
-                    {
-                      "label": "Other",
-                      "value": "Other"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "job-title",
-          "questions": [
-            {
-              "id": "job-title-question",
-              "title":
-                "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive }}</em> full job title?",
-              "description":
-                "<p>For example, <b>primary school teacher, car mechanic, district nurse, structural engineer</b></p><p>Do not state your grade or pay band</p><p>Please enter your job title in the space provided.</p><p>Do not state your grade or pay band.</p><p>If you are not sure of your job title please give the best information you can.</p>",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "job-title-answer",
-                  "label": "Job title",
-                  "mandatory": false,
-                  "type": "TextField"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "job-description",
-          "questions": [
-            {
-              "id": "job-description-question",
-              "title":
-                "What <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> does in their main job?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "job-description-answer",
-                  "label": "Description",
-                  "mandatory": false,
-                  "type": "TextArea"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "main-job-type",
-          "questions": [
-            {
-              "id": "main-job-type-question",
-              "title":
-                "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> employment status?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "main-job-type-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Employed by an organisation or business",
-                      "value": "Employed by an organisation or business"
-                    },
-                    {
-                      "label": "Self-employed in your own organisation or business",
-                      "value": "Self-employed in your own organisation or business"
-                    },
-                    {
-                      "label": "Not working for an organisation or business",
-                      "value": "Not working for an organisation or business",
-                      "description": "For example self-employed freelance or work (worked) for a private individual"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "household-member-completed",
-                "when": [
-                  {
-                    "id": "main-job-type-answer",
-                    "condition": "equals",
-                    "value": "Not working for an organisation or business"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "business-name"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "business-name",
-          "questions": [
-            {
-              "id": "business-name-question",
-              "title":
-                "What is the name of the organisation of business that <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> work for?",
-              "description":
-                "<p>If you were self-employed in your own organisation or business, enter the name</p><p>This question is asking for the name of the organisation or business that you work (or worked) for in your main job.</p><p>If you can’t remember the name of the organisation, please give the best information you can.</p><p>If you are employed through an agency please enter the name of the business you are working for, not the agency.</p>",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "business-name-answer",
-                  "label": "Organisation or business name",
-                  "mandatory": false,
-                  "type": "TextField",
-                  "alias": "company_name"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "employers-business",
-          "questions": [
-            {
-              "id": "employers-business-question",
-              "title": "What is the main activity of <em>{{answers.company_name}}</em>?",
-              "description":
-                "<p>Enter the main activity of your employer or business.</p><p>Another way of describing main activity is the industry that your employer or business works in.</p><p>If you are not sure of the main activity of your employer or business please give the best information you can.</p><p>If you are employed through an agency please enter the main activity of the business you are working for, not the agency.</p><p>For example, <b>primary education, repairing cars, contract catering, computer servicing</b></p>",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "employers-business-answer",
-                  "label": "Description",
-                  "mandatory": false,
-                  "type": "TextArea"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "id": "household-member-completed",
-          "title": "There are no more questions for {{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
-          "description": "",
-          "type": "Interstitial"
-        }
-      ]
-    },
-    {
-      "id": "visitors-begin",
-      "title": "VisitorsBegin",
-      "skip_conditions": [
-        {
-          "when": [
-            {
-              "id": "overnight-visitors-answer",
-              "condition": "equals",
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "when": [
-            {
-              "id": "overnight-visitors-answer",
-              "condition": "not set"
-            }
-          ]
-        }
-      ],
-      "blocks": [
-        {
-          "type": "Interstitial",
-          "id": "visitor-begin-section",
-          "title": "Visitors",
-          "description":
-            "In this section, we’re going to ask you about any visitors that were staying overnight at <em>{{answers.address_line_1}}</em> on 29 November 2017.",
-          "content": [
-            {
-              "title": "Information you need",
-              "list": ["Name of visitor", "Gender of visitor", "Date of birth of visitor", "Address of visitor"]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "visitors",
-      "title": "Visitors",
-      "routing_rules": [
-        {
-          "repeat": {
-            "type": "answer_value",
-            "answer_id": "overnight-visitors-answer"
-          }
-        }
-      ],
-      "blocks": [
-        {
-          "type": "Question",
-          "id": "visitor-name",
-          "questions": [
-            {
-              "id": "visitor-name-question",
-              "title": "What is the name of visitor {{group_instance + 1}}?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "visitor-first-name",
-                  "label": "First name",
-                  "mandatory": false,
-                  "type": "TextField"
-                },
-                {
-                  "id": "visitor-last-name",
-                  "label": "Last name",
-                  "mandatory": false,
-                  "type": "TextField"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "visitor-sex",
-          "questions": [
-            {
-              "id": "visitor-sex-question",
-              "title": "What is this person’s sex?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "visitor-sex-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Male",
-                      "value": "Male"
-                    },
-                    {
-                      "label": "Female",
-                      "value": "Female"
-                    }
-                  ],
-                  "type": "Radio"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "visitor-date-of-birth",
-          "questions": [
-            {
-              "id": "visitor-date-of-birth-question",
-              "title": "What is this person’s date of birth?",
-              "description": "For example 20 March 1980",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "visitor-date-of-birth-answer",
-                  "mandatory": false,
-                  "type": "Date"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "visitor-uk-resident",
-          "questions": [
-            {
-              "id": "visitor-uk-resident-question",
-              "title": "Does this person usually live in the United Kingdom?",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "visitor-uk-resident-answer",
-                  "mandatory": false,
-                  "options": [
-                    {
-                      "label": "Yes, usually lives in the United Kingdom",
-                      "value": "Yes, usually lives in the United Kingdom"
-                    },
-                    {
-                      "label": "No, usually lives outside the United Kingdom (please specify)",
-                      "value": "Other",
-                      "child_answer_id": "visitor-uk-resident-answer-other"
-                    }
-                  ],
-                  "type": "Radio"
-                },
-                {
-                  "id": "visitor-uk-resident-answer-other",
-                  "parent_answer_id": "visitor-uk-resident-answer",
-                  "type": "TextField",
-                  "mandatory": false,
-                  "label": "Please specify country"
-                }
-              ]
-            }
-          ],
-          "routing_rules": [
-            {
-              "goto": {
-                "block": "visitor-address",
-                "when": [
-                  {
-                    "id": "visitor-uk-resident-answer",
-                    "condition": "equals",
-                    "value": "Yes, usually lives in the United Kingdom"
-                  }
-                ]
-              }
-            },
-            {
-              "goto": {
-                "block": "visitor-completed"
-              }
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "visitor-address",
-          "questions": [
-            {
-              "id": "visitor-address-question",
-              "title": "Enter details of this person’s usual UK address",
-              "type": "General",
-              "answers": [
-                {
-                  "id": "visitor-address-answer-building",
-                  "label": "Building",
-                  "mandatory": false,
-                  "type": "TextField"
-                },
-                {
-                  "id": "visitor-address-answer-street",
-                  "label": "Street",
-                  "mandatory": false,
-                  "type": "TextField"
-                },
-                {
-                  "id": "visitor-address-answer-city",
-                  "label": "Town or city",
-                  "mandatory": false,
-                  "type": "TextField"
-                },
-                {
-                  "id": "visitor-address-answer-county",
-                  "label": "County (optional)",
-                  "mandatory": false,
-                  "type": "TextField"
-                },
-                {
-                  "id": "visitor-address-answer-postcode",
-                  "label": "Postcode",
-                  "mandatory": false,
-                  "type": "TextField"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "id": "visitor-completed",
-          "title": "You have completed all questions for Visitor {{group_instance + 1}}",
-          "description": "",
-          "type": "Interstitial"
-        }
-      ]
-    },
-    {
-      "id": "visitors-interstitial",
-      "title": "Visitors",
-      "skip_conditions": [
-        {
-          "when": [
-            {
-              "id": "overnight-visitors-answer",
-              "condition": "equals",
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "when": [
-            {
-              "id": "overnight-visitors-answer",
-              "condition": "not set"
-            }
-          ]
-        }
-      ],
-      "blocks": [
-        {
-          "id": "visitors-completed",
-          "type": "Interstitial",
-          "title": "You have successfully completed the ‘Visitors’ section",
-          "description": ""
-        }
-      ]
-    },
-    {
-      "id": "questionnaire-completed",
-      "title": "Submit answers",
-      "blocks": [
-        {
-          "type": "Confirmation",
-          "id": "confirmation",
-          "title": "You’re ready to submit your 2017 Census Test",
-          "description": "<p>Thank you for taking part in the 2017 Census Test.</p>",
-          "questions": [
-            {
-              "answers": [],
-              "id": "questionnaire-completed-question",
-              "title": "",
-              "type": "General",
-              "guidance": {
-                "content": [
-                  {
-                    "title": "Please note:",
-                    "list": [
-                      "by submitting your responses, you are declaring that you have completed to the best of your knowledge and belief.",
-                      "if you do not submit, your responses will be automatically submitted when the Census 2017 Test closes.",
-                      "after submission you will have an opportunity to provide feedback on your experience."
+                    "type": "Question",
+                    "id": "national-identity",
+                    "questions": [{
+                            "id": "national-identity-england-question",
+                            "title": "How would you describe <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> national identity?",
+                            "type": "General",
+                            "answers": [{
+                                    "id": "national-identity-england-answer",
+                                    "mandatory": false,
+                                    "options": [{
+                                            "label": "English",
+                                            "value": "English"
+                                        },
+                                        {
+                                            "label": "Welsh",
+                                            "value": "Welsh"
+                                        },
+                                        {
+                                            "label": "Scottish",
+                                            "value": "Scottish"
+                                        },
+                                        {
+                                            "label": "Northern Irish",
+                                            "value": "Northern Irish"
+                                        },
+                                        {
+                                            "label": "British",
+                                            "value": "British"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "child_answer_id": "national-identity-england-answer-other"
+                                        }
+                                    ],
+                                    "type": "Checkbox"
+                                },
+                                {
+                                    "id": "national-identity-england-answer-other",
+                                    "parent_answer_id": "national-identity-england-answer",
+                                    "type": "TextField",
+                                    "mandatory": false,
+                                    "label": "Please describe your national identity"
+                                }
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "meta": "region_code",
+                                    "condition": "equals",
+                                    "value": "GB-WLS"
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "national-identity-wales-question",
+                            "title": "How would you describe <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> national identity?",
+                            "type": "General",
+                            "answers": [{
+                                    "id": "national-identity-wales-answer",
+                                    "mandatory": false,
+                                    "options": [{
+                                            "label": "Welsh",
+                                            "value": "Welsh"
+                                        },
+                                        {
+                                            "label": "English",
+                                            "value": "English"
+                                        },
+                                        {
+                                            "label": "Scottish",
+                                            "value": "Scottish"
+                                        },
+                                        {
+                                            "label": "Northern Irish",
+                                            "value": "Northern Irish"
+                                        },
+                                        {
+                                            "label": "British",
+                                            "value": "British"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "child_answer_id": "national-identity-wales-answer-other"
+                                        }
+                                    ],
+                                    "type": "Checkbox"
+                                },
+                                {
+                                    "id": "national-identity-wales-answer-other",
+                                    "parent_answer_id": "national-identity-wales-answer",
+                                    "type": "TextField",
+                                    "mandatory": false,
+                                    "label": "Please describe your national identity"
+                                }
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "meta": "region_code",
+                                    "condition": "not equals",
+                                    "value": "GB-WLS"
+                                }]
+                            }]
+                        }
                     ]
-                  }
-                ]
-              }
-            }
-          ]
+                },
+                {
+                    "type": "Question",
+                    "id": "ethnic-group",
+                    "questions": [{
+                            "id": "ethnic-group-england-question",
+                            "title": "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> ethnic group?",
+                            "description": "It is for you to choose your ethnic group. For example this could be your family or cultural background, or it could be how you would describe yourself.",
+                            "type": "General",
+                            "answers": [{
+                                "id": "ethnic-group-england-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "White",
+                                        "value": "White",
+                                        "description": "Including English, Welsh, Scottish, Northern Irish, British, Irish, Gypsy, Irish Traveller or any other White background"
+                                    },
+                                    {
+                                        "label": "Mixed or multiple ethnic groups",
+                                        "value": "Mixed or multiple ethnic groups",
+                                        "description": "Including White and Black Caribbean, White and Black African, White and Asian or any other Mixed or multiple ethnic background"
+                                    },
+                                    {
+                                        "label": "Asian or Asian British",
+                                        "value": "Asian or Asian British",
+                                        "description": "Including Indian, Pakistani, Bangladeshi, Chinese or any other Asian background"
+                                    },
+                                    {
+                                        "label": "Black, African, Caribbean or Black British",
+                                        "value": "Black, African, Caribbean or Black British",
+                                        "description": "Including African, Caribbean or any other Black, African or Caribbean background"
+                                    },
+                                    {
+                                        "label": "Other ethnic group",
+                                        "value": "Other ethnic group",
+                                        "description": "Including Arab or any other ethnic group"
+                                    }
+                                ],
+                                "type": "Radio"
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "meta": "region_code",
+                                    "condition": "equals",
+                                    "value": "GB-WLS"
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "ethnic-group-wales-question",
+                            "title": "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> ethnic group?",
+                            "description": "It is for you to choose your ethnic group. For example this could be your family or cultural background, or it could be how you would describe yourself.",
+                            "type": "General",
+                            "answers": [{
+                                "id": "ethnic-group-wales-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "White",
+                                        "value": "White",
+                                        "description": "Including Welsh, English, Scottish, Northern Irish, British, Irish, Gypsy, Irish Traveller or any other White background"
+                                    },
+                                    {
+                                        "label": "Mixed or multiple ethnic groups",
+                                        "value": "Mixed or multiple ethnic groups",
+                                        "description": "Including White and Black Caribbean, White and Black African, White and Asian or any other Mixed or multiple ethnic background"
+                                    },
+                                    {
+                                        "label": "Asian or Asian British",
+                                        "value": "Asian or Asian British",
+                                        "description": "Including Indian, Pakistani, Bangladeshi, Chinese or any other Asian background"
+                                    },
+                                    {
+                                        "label": "Black, African, Caribbean or Black British",
+                                        "value": "Black, African, Caribbean or Black British",
+                                        "description": "Including African, Caribbean or any other Black, African or Caribbean background"
+                                    },
+                                    {
+                                        "label": "Other ethnic group",
+                                        "value": "Other ethnic group",
+                                        "description": "Including Arab or any other ethnic group"
+                                    }
+                                ],
+                                "type": "Radio"
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "meta": "region_code",
+                                    "condition": "not equals",
+                                    "value": "GB-WLS"
+                                }]
+                            }]
+                        }
+                    ],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "white-ethnic-group",
+                                "when": [{
+                                    "id": "ethnic-group-england-answer",
+                                    "condition": "equals",
+                                    "value": "White"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "mixed-ethnic-group",
+                                "when": [{
+                                    "id": "ethnic-group-england-answer",
+                                    "condition": "equals",
+                                    "value": "Mixed or multiple ethnic groups"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "asian-ethnic-group",
+                                "when": [{
+                                    "id": "ethnic-group-england-answer",
+                                    "condition": "equals",
+                                    "value": "Asian or Asian British"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "black-ethnic-group",
+                                "when": [{
+                                    "id": "ethnic-group-england-answer",
+                                    "condition": "equals",
+                                    "value": "Black, African, Caribbean or Black British"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "other-ethnic-group",
+                                "when": [{
+                                    "id": "ethnic-group-england-answer",
+                                    "condition": "equals",
+                                    "value": "Other ethnic group"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "white-ethnic-group",
+                                "when": [{
+                                    "id": "ethnic-group-wales-answer",
+                                    "condition": "equals",
+                                    "value": "White"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "mixed-ethnic-group",
+                                "when": [{
+                                    "id": "ethnic-group-wales-answer",
+                                    "condition": "equals",
+                                    "value": "Mixed or multiple ethnic groups"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "asian-ethnic-group",
+                                "when": [{
+                                    "id": "ethnic-group-wales-answer",
+                                    "condition": "equals",
+                                    "value": "Asian or Asian British"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "black-ethnic-group",
+                                "when": [{
+                                    "id": "ethnic-group-wales-answer",
+                                    "condition": "equals",
+                                    "value": "Black, African, Caribbean or Black British"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "other-ethnic-group",
+                                "when": [{
+                                    "id": "ethnic-group-wales-answer",
+                                    "condition": "equals",
+                                    "value": "Other ethnic group"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "sexual-identity",
+                                "when": [{
+                                        "id": "over-16-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "meta": "variant_flags.sexual_identity",
+                                        "condition": "equals",
+                                        "value": true
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "understand-welsh",
+                                "when": [{
+                                    "meta": "region_code",
+                                    "condition": "equals",
+                                    "value": "GB-WLS"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "language"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Question",
+                    "id": "white-ethnic-group",
+                    "questions": [{
+                            "id": "white-ethnic-group-england-question",
+                            "title": "Which one best describes <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> White ethnic group or background?",
+                            "type": "General",
+                            "answers": [{
+                                    "id": "white-ethnic-group-england-answer",
+                                    "mandatory": false,
+                                    "options": [{
+                                            "label": "English, Welsh, Scottish, Northern Irish or British",
+                                            "value": "English, Welsh, Scottish, Northern Irish or British"
+                                        },
+                                        {
+                                            "label": "Irish",
+                                            "value": "Irish"
+                                        },
+                                        {
+                                            "label": "Gypsy or Irish Traveller",
+                                            "value": "Gypsy or Irish Traveller"
+                                        },
+                                        {
+                                            "label": "Any other White background",
+                                            "value": "Other",
+                                            "child_answer_id": "white-ethnic-group-england-answer-other"
+                                        }
+                                    ],
+                                    "type": "Radio"
+                                },
+                                {
+                                    "id": "white-ethnic-group-england-answer-other",
+                                    "parent_answer_id": "white-ethnic-group-england-answer",
+                                    "type": "TextField",
+                                    "mandatory": false,
+                                    "label": "Please specify other White background"
+                                }
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "meta": "region_code",
+                                    "condition": "equals",
+                                    "value": "GB-WLS"
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "white-ethnic-group-wales-question",
+                            "title": "Which one best describes <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> White ethnic group or background?",
+                            "type": "General",
+                            "answers": [{
+                                    "id": "white-ethnic-group-wales-answer",
+                                    "mandatory": false,
+                                    "options": [{
+                                            "label": "Welsh, English, Scottish, Northern Irish or British",
+                                            "value": "Welsh, English, Scottish, Northern Irish or British"
+                                        },
+                                        {
+                                            "label": "Irish",
+                                            "value": "Irish"
+                                        },
+                                        {
+                                            "label": "Gypsy or Irish Traveller",
+                                            "value": "Gypsy or Irish Traveller"
+                                        },
+                                        {
+                                            "label": "Any other White background",
+                                            "value": "Other",
+                                            "child_answer_id": "white-ethnic-group-wales-question-other"
+                                        }
+                                    ],
+                                    "type": "Radio"
+                                },
+                                {
+                                    "id": "white-ethnic-group-wales-question-other",
+                                    "parent_answer_id": "white-ethnic-group-wales-answer",
+                                    "type": "TextField",
+                                    "mandatory": false,
+                                    "label": "Please specify other White background"
+                                }
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "meta": "region_code",
+                                    "condition": "not equals",
+                                    "value": "GB-WLS"
+                                }]
+                            }]
+                        }
+                    ],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "sexual-identity",
+                                "when": [{
+                                        "id": "over-16-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "meta": "variant_flags.sexual_identity",
+                                        "condition": "equals",
+                                        "value": true
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "understand-welsh",
+                                "when": [{
+                                    "meta": "region_code",
+                                    "condition": "equals",
+                                    "value": "GB-WLS"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "language"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Question",
+                    "id": "mixed-ethnic-group",
+                    "questions": [{
+                        "id": "mixed-ethnic-group-question",
+                        "title": "Which one best describes <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> Mixed, multiple ethnic group or background?",
+                        "type": "General",
+                        "answers": [{
+                                "id": "mixed-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "White and Black Caribbean",
+                                        "value": "White and Black Caribbean"
+                                    },
+                                    {
+                                        "label": "White and Black African",
+                                        "value": "White and Black African"
+                                    },
+                                    {
+                                        "label": "White and Asian",
+                                        "value": "White and Asian"
+                                    },
+                                    {
+                                        "label": "Any other Mixed or multiple ethnic background",
+                                        "value": "Other",
+                                        "child_answer_id": "mixed-ethnic-group-answer-other"
+                                    }
+                                ],
+                                "type": "Radio"
+                            },
+                            {
+                                "id": "mixed-ethnic-group-answer-other",
+                                "parent_answer_id": "mixed-ethnic-group-answer",
+                                "type": "TextField",
+                                "mandatory": false,
+                                "label": "Please specify other Mixed or multiple ethnic background"
+                            }
+                        ]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "sexual-identity",
+                                "when": [{
+                                        "id": "over-16-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "meta": "variant_flags.sexual_identity",
+                                        "condition": "equals",
+                                        "value": true
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "understand-welsh",
+                                "when": [{
+                                    "meta": "region_code",
+                                    "condition": "equals",
+                                    "value": "GB-WLS"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "language"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Question",
+                    "id": "asian-ethnic-group",
+                    "questions": [{
+                        "id": "asian-ethnic-group-question",
+                        "title": "Which one best describes <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> Asian, Asian British ethnic group or background?",
+                        "type": "General",
+                        "answers": [{
+                                "id": "asian-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Indian",
+                                        "value": "Indian"
+                                    },
+                                    {
+                                        "label": "Pakistani",
+                                        "value": "Pakistani"
+                                    },
+                                    {
+                                        "label": "Bangladeshi",
+                                        "value": "Bangladeshi"
+                                    },
+                                    {
+                                        "label": "Chinese",
+                                        "value": "Chinese"
+                                    },
+                                    {
+                                        "label": "Any other Asian background",
+                                        "value": "Other",
+                                        "child_answer_id": "asian-ethnic-group-answer-other"
+                                    }
+                                ],
+                                "type": "Radio"
+                            },
+                            {
+                                "id": "asian-ethnic-group-answer-other",
+                                "parent_answer_id": "asian-ethnic-group-answer",
+                                "type": "TextField",
+                                "mandatory": false,
+                                "label": "Please specify other Asian background"
+                            }
+                        ]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "sexual-identity",
+                                "when": [{
+                                        "id": "over-16-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "meta": "variant_flags.sexual_identity",
+                                        "condition": "equals",
+                                        "value": true
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "understand-welsh",
+                                "when": [{
+                                    "meta": "region_code",
+                                    "condition": "equals",
+                                    "value": "GB-WLS"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "language"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Question",
+                    "id": "black-ethnic-group",
+                    "questions": [{
+                        "id": "black-ethnic-group-question",
+                        "title": "Which one best describes <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> Black, African, Caribbean, Black British ethnic group or background?",
+                        "type": "General",
+                        "answers": [{
+                                "id": "black-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "African",
+                                        "value": "African"
+                                    },
+                                    {
+                                        "label": "Caribbean",
+                                        "value": "Caribbean"
+                                    },
+                                    {
+                                        "label": "Any other Black, African or Caribbean background",
+                                        "value": "Other",
+                                        "child_answer_id": "black-ethnic-group-answer-other"
+                                    }
+                                ],
+                                "type": "Radio"
+                            },
+                            {
+                                "id": "black-ethnic-group-answer-other",
+                                "parent_answer_id": "black-ethnic-group-answer",
+                                "type": "TextField",
+                                "mandatory": false,
+                                "label": "Please specify other Black, African or Caribbean background"
+                            }
+                        ]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "sexual-identity",
+                                "when": [{
+                                        "id": "over-16-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "meta": "variant_flags.sexual_identity",
+                                        "condition": "equals",
+                                        "value": true
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "understand-welsh",
+                                "when": [{
+                                    "meta": "region_code",
+                                    "condition": "equals",
+                                    "value": "GB-WLS"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "language"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Question",
+                    "id": "other-ethnic-group",
+                    "questions": [{
+                        "id": "other-ethnic-group-question",
+                        "title": "Which one best describes <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> Other ethnic group or background?",
+                        "type": "General",
+                        "answers": [{
+                                "id": "other-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Arab",
+                                        "value": "Arab"
+                                    },
+                                    {
+                                        "label": "Any other ethnic group",
+                                        "value": "Other",
+                                        "child_answer_id": "other-ethnic-group-answer-other"
+                                    }
+                                ],
+                                "type": "Radio"
+                            },
+                            {
+                                "id": "other-ethnic-group-answer-other",
+                                "parent_answer_id": "other-ethnic-group-answer",
+                                "type": "TextField",
+                                "mandatory": false,
+                                "label": "Please specify Other ethnic group"
+                            }
+                        ]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "sexual-identity",
+                                "when": [{
+                                        "id": "over-16-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "meta": "variant_flags.sexual_identity",
+                                        "condition": "equals",
+                                        "value": true
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "understand-welsh",
+                                "when": [{
+                                    "meta": "region_code",
+                                    "condition": "equals",
+                                    "value": "GB-WLS"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "language"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Question",
+                    "id": "sexual-identity",
+                    "questions": [{
+                        "id": "sexual-identity-question",
+                        "title": "Which of the following options best describes how <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> thinks of themselves?",
+                        "type": "General",
+                        "answers": [{
+                                "id": "sexual-identity-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Heterosexual or Straight",
+                                        "value": "Heterosexual or Straight"
+                                    },
+                                    {
+                                        "label": "Gay or Lesbian",
+                                        "value": "Gay or Lesbian"
+                                    },
+                                    {
+                                        "label": "Bisexual",
+                                        "value": "Bisexual"
+                                    },
+                                    {
+                                        "label": "Other",
+                                        "value": "Other",
+                                        "child_answer_id": "sexual-identity-answer-other"
+                                    },
+                                    {
+                                        "label": "Prefer not to say",
+                                        "value": "Prefer not to say"
+                                    }
+                                ],
+                                "type": "Checkbox"
+                            },
+                            {
+                                "id": "sexual-identity-answer-other",
+                                "parent_answer_id": "sexual-identity-answer",
+                                "type": "TextField",
+                                "mandatory": false,
+                                "label": "Please specify"
+                            }
+                        ]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "understand-welsh",
+                                "when": [{
+                                    "meta": "region_code",
+                                    "condition": "equals",
+                                    "value": "GB-WLS"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "language"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Question",
+                    "id": "understand-welsh",
+                    "questions": [{
+                        "id": "understand-welsh-question",
+                        "title": "Can <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> understand, speak, read or write Welsh",
+                        "type": "General",
+                        "answers": [{
+                            "id": "understand-welsh-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Understand spoken Welsh",
+                                    "value": "Understand spoken Welsh"
+                                },
+                                {
+                                    "label": "Speak Welsh",
+                                    "value": "Speak Welsh"
+                                },
+                                {
+                                    "label": "Read Welsh",
+                                    "value": "Read Welsh"
+                                },
+                                {
+                                    "label": "Write Welsh",
+                                    "value": "Write Welsh"
+                                },
+                                {
+                                    "label": "None of the above",
+                                    "value": "None of the above"
+                                }
+                            ],
+                            "type": "Checkbox"
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "language",
+                    "questions": [{
+                            "id": "language-england-question",
+                            "title": "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> main language?",
+                            "type": "General",
+                            "answers": [{
+                                    "id": "language-england-answer",
+                                    "mandatory": false,
+                                    "options": [{
+                                            "label": "English",
+                                            "value": "English"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "description": "Including British Sign Language",
+                                            "child_answer_id": "language-england-answer-other"
+                                        }
+                                    ],
+                                    "type": "Radio"
+                                },
+                                {
+                                    "id": "language-england-answer-other",
+                                    "parent_answer_id": "language-england-answer",
+                                    "type": "TextField",
+                                    "mandatory": false,
+                                    "label": "Please specify main language"
+                                }
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "meta": "region_code",
+                                    "condition": "equals",
+                                    "value": "GB-WLS"
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "language-welsh-question",
+                            "title": "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> main language?",
+                            "type": "General",
+                            "answers": [{
+                                    "id": "language-welsh-answer",
+                                    "mandatory": false,
+                                    "options": [{
+                                            "label": "English or Welsh",
+                                            "value": "English or Welsh"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "description": "Including British Sign Language",
+                                            "child_answer_id": "language-welsh-answer-other"
+                                        }
+                                    ],
+                                    "type": "Radio"
+                                },
+                                {
+                                    "id": "language-welsh-answer-other",
+                                    "parent_answer_id": "language-welsh-answer",
+                                    "type": "TextField",
+                                    "mandatory": false,
+                                    "label": "Please specify main language"
+                                }
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "meta": "region_code",
+                                    "condition": "not equals",
+                                    "value": "GB-WLS"
+                                }]
+                            }]
+                        }
+                    ],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "religion",
+                                "when": [{
+                                    "id": "language-england-answer",
+                                    "condition": "equals",
+                                    "value": "English"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "religion",
+                                "when": [{
+                                    "id": "language-welsh-answer",
+                                    "condition": "equals",
+                                    "value": "English or Welsh"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "english"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Question",
+                    "id": "english",
+                    "questions": [{
+                        "id": "english-question",
+                        "title": "How well can <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> speak English?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "english-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Very well",
+                                    "value": "Very well"
+                                },
+                                {
+                                    "label": "Well",
+                                    "value": "Well"
+                                },
+                                {
+                                    "label": "Not well",
+                                    "value": "Not well"
+                                },
+                                {
+                                    "label": "Not at all",
+                                    "value": "Not at all"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "religion",
+                    "questions": [{
+                        "id": "religion-question",
+                        "title": "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> religion?",
+                        "description": "This question is voluntary",
+                        "type": "General",
+                        "answers": [{
+                                "id": "religion-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "No religion",
+                                        "value": "No religion"
+                                    },
+                                    {
+                                        "label": "Christianity",
+                                        "value": "Christianity"
+                                    },
+                                    {
+                                        "label": "Buddhism",
+                                        "value": "Buddhism"
+                                    },
+                                    {
+                                        "label": "Hinduism",
+                                        "value": "Hinduism"
+                                    },
+                                    {
+                                        "label": "Judaism",
+                                        "value": "Judaism"
+                                    },
+                                    {
+                                        "label": "Islam",
+                                        "value": "Islam"
+                                    },
+                                    {
+                                        "label": "Sikhism",
+                                        "value": "Sikhism"
+                                    },
+                                    {
+                                        "label": "Any other religion",
+                                        "value": "Other",
+                                        "child_answer_id": "religion-answer-other"
+                                    }
+                                ],
+                                "type": "Checkbox"
+                            },
+                            {
+                                "id": "religion-answer-other",
+                                "parent_answer_id": "religion-answer",
+                                "type": "TextField",
+                                "mandatory": false,
+                                "label": "Please specify other religion"
+                            }
+                        ]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "past-usual-address",
+                    "questions": [{
+                        "id": "past-usual-address-question",
+                        "title": "One year ago, what was your usual address?",
+                        "description": "If you had no usual address one year ago, state the address where you were staying",
+                        "type": "General",
+                        "answers": [{
+                                "id": "past-usual-address-answer",
+                                "mandatory": false,
+                                "guidance": {
+                                    "show_guidance": "Show further guidance",
+                                    "hide_guidance": "Hide further guidance",
+                                    "content": [{
+                                        "description": "In most cases your usual address will be the permanent or family home that you were living in."
+                                    }]
+                                },
+                                "options": [{
+                                        "label": "This address",
+                                        "value": "This address"
+                                    },
+                                    {
+                                        "label": "Student term time or boarding school address in the UK",
+                                        "value": "Student term time or boarding school address in the UK"
+                                    },
+                                    {
+                                        "label": "Another address in the UK",
+                                        "value": "Another address in the UK"
+                                    },
+                                    {
+                                        "label": "An address outside the UK",
+                                        "value": "Other",
+                                        "child_answer_id": "past-usual-address-answer-other"
+                                    }
+                                ],
+                                "type": "Radio"
+                            },
+                            {
+                                "id": "past-usual-address-answer-other",
+                                "parent_answer_id": "past-usual-address-answer",
+                                "type": "TextField",
+                                "mandatory": false,
+                                "label": "Please enter the country"
+                            }
+                        ]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "last-year-address",
+                                "when": [{
+                                    "id": "past-usual-address-answer",
+                                    "condition": "equals",
+                                    "value": "Student term time or boarding school address in the UK"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "last-year-address",
+                                "when": [{
+                                    "id": "past-usual-address-answer",
+                                    "condition": "equals",
+                                    "value": "Another address in the UK"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "passports"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Question",
+                    "id": "last-year-address",
+                    "questions": [{
+                        "id": "last-year-address-question",
+                        "title": "Enter details of your address one year ago",
+                        "type": "General",
+                        "answers": [{
+                                "id": "last-year-address-answer-building",
+                                "label": "Building",
+                                "mandatory": false,
+                                "type": "TextField"
+                            },
+                            {
+                                "id": "last-year-address-answer-street",
+                                "label": "Street",
+                                "mandatory": false,
+                                "type": "TextField"
+                            },
+                            {
+                                "id": "last-year-address-answer-city",
+                                "label": "Town or city",
+                                "mandatory": false,
+                                "type": "TextField"
+                            },
+                            {
+                                "id": "last-year-address-answer-county",
+                                "label": "County (optional)",
+                                "mandatory": false,
+                                "type": "TextField"
+                            },
+                            {
+                                "id": "last-year-address-answer-postcode",
+                                "label": "Postcode",
+                                "mandatory": false,
+                                "type": "TextField"
+                            }
+                        ]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "passports",
+                    "questions": [{
+                        "id": "passports-question",
+                        "title": "What passports do you hold?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "passports-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "United Kingdom",
+                                    "value": "United Kingdom"
+                                },
+                                {
+                                    "label": "Irish",
+                                    "value": "Irish"
+                                },
+                                {
+                                    "label": "Other",
+                                    "value": "Other"
+                                },
+                                {
+                                    "label": "None",
+                                    "value": "None"
+                                }
+                            ],
+                            "type": "Checkbox"
+                        }]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "other-passports",
+                                "when": [{
+                                    "id": "passports-answer",
+                                    "condition": "contains",
+                                    "value": "Other"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "disability"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Question",
+                    "id": "other-passports",
+                    "questions": [{
+                        "id": "other-passports-question",
+                        "title": "Please specify other passports held",
+                        "type": "General",
+                        "answers": [{
+                            "id": "other-passports-answer",
+                            "label": "Passports held",
+                            "mandatory": false,
+                            "type": "TextField"
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "disability",
+                    "questions": [{
+                        "id": "disability-question",
+                        "title": "Are <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> day-to-day activities limited because of a health problem or disability which has lasted, or is expected to last, at least 12 months?",
+                        "guidance": {
+                            "content": [{
+                                "description": "<strong>Include</strong> problems related to old age"
+                            }]
+                        },
+                        "type": "General",
+                        "answers": [{
+                            "id": "disability-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Yes, limited a lot",
+                                    "value": "Yes, limited a lot"
+                                },
+                                {
+                                    "label": "Yes, limited a little",
+                                    "value": "Yes, limited a little"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "No"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "household-member-completed",
+                                "when": [{
+                                    "id": "over-16-answer",
+                                    "condition": "equals",
+                                    "value": "No"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "qualifications"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Question",
+                    "id": "qualifications",
+                    "questions": [{
+                            "id": "qualifications-england-question",
+                            "title": "Thinking of any studies, exams or qualifications, which of the following does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> have?",
+                            "description": "Select every option that applies (whether UK or foreign equivalent) if you have any of the qualifications listed",
+                            "type": "General",
+                            "answers": [{
+                                "id": "qualifications-england-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "5 or more  GCSEs (grades A-Star to C) or O-Levels (passes) or CSEs (grade 1), School Certificate, One A-Level, 2 to 3 AS-Levels or VCEs, Higher Diploma",
+                                        "value": "5 or more  GCSEs (grades A-Star to C) or O-Levels (passes) or CSEs (grade 1), School Certificate, One A-Level, 2 to 3 AS-Levels or VCEs, Higher Diploma"
+                                    },
+                                    {
+                                        "label": "1 to 4 GCSEs or O-Levels or CSEs (any grades), Entry level, Foundation Diploma",
+                                        "value": "1 to 4 GCSEs or O-Levels or CSEs (any grades), Entry level, Foundation Diploma"
+                                    },
+                                    {
+                                        "label": "2 or more  A-Levels, 4 or more  AS-levels or VCEs, Higher School Certificate, Advanced Diploma",
+                                        "value": "2 or more  A-Levels, 4 or more  AS-levels or VCEs, Higher School Certificate, Advanced Diploma"
+                                    },
+                                    {
+                                        "label": "Apprenticeship (trade, advanced, foundation or modern)",
+                                        "value": "Apprenticeship (trade, advanced, foundation or modern)"
+                                    },
+                                    {
+                                        "label": "NVQ level one, Foundation GNVQ, Basic Skills",
+                                        "value": "NVQ level one, Foundation GNVQ, Basic Skills"
+                                    },
+                                    {
+                                        "label": "NVQ level two, Intermediate GNVQ, City and Guilds Craft, BTEC First, RSA Diploma",
+                                        "value": "NVQ level two, Intermediate GNVQ, City and Guilds Craft, BTEC First, RSA Diploma"
+                                    },
+                                    {
+                                        "label": "NVQ Level three, Advanced GNVQ, City and Guilds Advanced Craft, ONC, OND, BTEC National, RSA Advanced Diploma",
+                                        "value": "NVQ Level three, Advanced GNVQ, City and Guilds Advanced Craft, ONC, OND, BTEC National, RSA Advanced Diploma"
+                                    },
+                                    {
+                                        "label": "NVQ Level four to five, HNC, HND, RSA Higher Diploma, BTEC Higher, Foundation degree",
+                                        "value": "NVQ Level four to five, HNC, HND, RSA Higher Diploma, BTEC Higher, Foundation degree"
+                                    },
+                                    {
+                                        "label": "Other vocational or work-related qualifications",
+                                        "value": "Other vocational or work-related qualifications"
+                                    },
+                                    {
+                                        "label": "Undergraduate Degree",
+                                        "value": "Undergraduate Degree"
+                                    },
+                                    {
+                                        "label": "Postgraduate Certificate / Diploma",
+                                        "value": "Postgraduate Certificate / Diploma"
+                                    },
+                                    {
+                                        "label": "Masters Degree",
+                                        "value": "Masters Degree"
+                                    },
+                                    {
+                                        "label": "Doctorate Degree (for example PhD)",
+                                        "value": "Doctorate Degree (for example PhD)"
+                                    },
+                                    {
+                                        "label": "Professional qualification (for example teaching, nursing, accountancy)",
+                                        "value": "Professional qualification (for example teaching, nursing, accountancy)"
+                                    },
+                                    {
+                                        "label": "Foreign qualifications (UK equivalent not known)",
+                                        "value": "Foreign qualifications (UK equivalent not known)"
+                                    },
+                                    {
+                                        "label": "No qualifications",
+                                        "value": "No qualifications"
+                                    }
+                                ],
+                                "type": "Checkbox"
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "meta": "region_code",
+                                    "condition": "equals",
+                                    "value": "GB-WLS"
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "qualifications-welsh-question",
+                            "title": "Thinking of any studies, exams or qualifications, which of the following does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> have?",
+                            "description": "Select every option that applies (whether UK or foreign equivalent) if you have any of the qualifications listed",
+                            "type": "General",
+                            "answers": [{
+                                "id": "qualifications-welsh-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "5 or more GCSEs (grades A-Star to C) or O Levels (passes) or CSEs (grade 1), School Certificate, One A-Level, 2 to 3 AS-Levels or VCEs,  Intermediate or National Welsh Baccalaureate (Level two)",
+                                        "value": "5 or more GCSEs (grades A-Star to C) or O Levels (passes) or CSEs (grade 1), School Certificate, One A-Level, 2 to 3 AS-Levels or VCEs,  Intermediate or National Welsh Baccalaureate (Level two)"
+                                    },
+                                    {
+                                        "label": "1 to 4  GCSEs or O Levels or CSEs (any grades), Entry level, Foundation Welsh Baccalaureate (level one)",
+                                        "value": "1 to 4  GCSEs or O Levels or CSEs (any grades), Entry level, Foundation Welsh Baccalaureate (level one)"
+                                    },
+                                    {
+                                        "label": "More than 2 A-Levels, more than 4 AS-levels or VCEs, Higher School Certificate, Advanced Welsh Baccalaureate (level three)",
+                                        "value": "More than 2 A-Levels, more than 4 AS-levels or VCEs, Higher School Certificate, Advanced Welsh Baccalaureate (level three)"
+                                    },
+                                    {
+                                        "label": "Apprenticeship (foundation, modern or higher)",
+                                        "value": "Apprenticeship (foundation, modern or higher)"
+                                    },
+                                    {
+                                        "label": "NVQ level one, Foundation GNVQ, Essential or Key  Skills",
+                                        "value": "NVQ level one, Foundation GNVQ, Essential or Key  Skills"
+                                    },
+                                    {
+                                        "label": "NVQ level two, Intermediate GNVQ, City and Guilds Craft, BTEC First, RSA Diploma",
+                                        "value": "NVQ level two, Intermediate GNVQ, City and Guilds Craft, BTEC First, RSA Diploma"
+                                    },
+                                    {
+                                        "label": "NVQ Level three, Advanced GNVQ, City and Guilds Advanced Craft, ONC, OND, BTEC National, RSA Advanced Diploma",
+                                        "value": "NVQ Level three, Advanced GNVQ, City and Guilds Advanced Craft, ONC, OND, BTEC National, RSA Advanced Diploma"
+                                    },
+                                    {
+                                        "label": "NVQ Level four to five, HNC, HND, RSA Higher Diploma, BTEC Higher",
+                                        "value": "NVQ Level four to five, HNC, HND, RSA Higher Diploma, BTEC Higher"
+                                    },
+                                    {
+                                        "label": "Other vocational or work-related qualifications",
+                                        "value": "Other vocational or work-related qualifications"
+                                    },
+                                    {
+                                        "label": "Undergraduate Degree",
+                                        "value": "Undergraduate Degree"
+                                    },
+                                    {
+                                        "label": "Postgraduate Certificate / Diploma",
+                                        "value": "Postgraduate Certificate / Diploma"
+                                    },
+                                    {
+                                        "label": "Masters Degree",
+                                        "value": "Masters Degree"
+                                    },
+                                    {
+                                        "label": "Doctorate Degree (for example PhD)",
+                                        "value": "Doctorate Degree (for example PhD)"
+                                    },
+                                    {
+                                        "label": "Professional qualification (for example teaching, nursing, accountancy)",
+                                        "value": "Professional qualification (for example teaching, nursing, accountancy)"
+                                    },
+                                    {
+                                        "label": "Foreign qualifications (UK equivalent not known)",
+                                        "value": "Foreign qualifications (UK equivalent not known)"
+                                    },
+                                    {
+                                        "label": "No qualifications",
+                                        "value": "No qualifications"
+                                    }
+                                ],
+                                "type": "Checkbox"
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "meta": "region_code",
+                                    "condition": "not equals",
+                                    "value": "GB-WLS"
+                                }]
+                            }]
+                        }
+                    ]
+                },
+                {
+                    "type": "Question",
+                    "id": "employment-type",
+                    "questions": [{
+                        "id": "employment-type-question",
+                        "title": "Which of the following best describes what <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> was doing last week?",
+                        "guidance": {
+                            "content": [{
+                                "description": "<strong>Include</strong> any paid work, including casual or temporary work, even if only for one hour"
+                            }]
+                        },
+                        "type": "General",
+                        "answers": [{
+                            "id": "employment-type-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "working as an employee",
+                                    "value": "working as an employee"
+                                },
+                                {
+                                    "label": "on a government sponsored training scheme",
+                                    "value": "on a government sponsored training scheme"
+                                },
+                                {
+                                    "label": "self-employed or freelance",
+                                    "value": "self-employed or freelance"
+                                },
+                                {
+                                    "label": "working paid or unpaid for you own or your family’s business",
+                                    "value": "working paid or unpaid for you own or your family’s business"
+                                },
+                                {
+                                    "label": "away from work ill, on maternity leave, on holiday or temporarily laid off",
+                                    "value": "away from work ill, on maternity leave, on holiday or temporarily laid off"
+                                },
+                                {
+                                    "label": "doing any other kind of paid work",
+                                    "value": "doing any other kind of paid work"
+                                },
+                                {
+                                    "label": "none of the above",
+                                    "value": "none of the above"
+                                }
+                            ],
+                            "type": "Checkbox"
+                        }]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "main-job",
+                                "when": [{
+                                    "id": "employment-type-answer",
+                                    "condition": "contains",
+                                    "value": "working as an employee"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "main-job",
+                                "when": [{
+                                    "id": "employment-type-answer",
+                                    "condition": "contains",
+                                    "value": "on a government sponsored training scheme"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "main-job",
+                                "when": [{
+                                    "id": "employment-type-answer",
+                                    "condition": "contains",
+                                    "value": "self-employed or freelance"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "main-job",
+                                "when": [{
+                                    "id": "employment-type-answer",
+                                    "condition": "contains",
+                                    "value": "working paid or unpaid for you own or your family’s business"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "main-job",
+                                "when": [{
+                                    "id": "employment-type-answer",
+                                    "condition": "contains",
+                                    "value": "away from work ill, on maternity leave, on holiday or temporarily laid off"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "main-job",
+                                "when": [{
+                                    "id": "employment-type-answer",
+                                    "condition": "contains",
+                                    "value": "doing any other kind of paid work"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "jobseeker"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Question",
+                    "id": "jobseeker",
+                    "questions": [{
+                        "id": "jobseeker-question",
+                        "title": "Was <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> actively looking for any kind of paid work during the last four weeks?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "jobseeker-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Yes",
+                                    "value": "Yes"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "No"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "job-availability",
+                    "questions": [{
+                        "id": "job-availability-question",
+                        "title": "If a job had been offered to <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> last week, could they have started it within 2 weeks?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "job-availability-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Yes",
+                                    "value": "Yes"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "No"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "job-pending",
+                    "questions": [{
+                        "id": "job-pending-question",
+                        "title": "Last week, was <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> waiting to start a job already accepted?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "job-pending-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Yes",
+                                    "value": "Yes"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "No"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "occupation",
+                    "questions": [{
+                        "id": "occupation-question",
+                        "title": "Which of the following best describes what <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> was doing last week?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "occupation-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "retired (whether receiving a pension or not)",
+                                    "value": "retired (whether receiving a pension or not)"
+                                },
+                                {
+                                    "label": "a student",
+                                    "value": "a student"
+                                },
+                                {
+                                    "label": "looking after home or family",
+                                    "value": "looking after home or family"
+                                },
+                                {
+                                    "label": "long-term sick or disabled",
+                                    "value": "long-term sick or disabled"
+                                },
+                                {
+                                    "label": "other",
+                                    "value": "other"
+                                }
+                            ],
+                            "type": "Checkbox"
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "ever-worked",
+                    "questions": [{
+                        "id": "ever-worked-question",
+                        "title": "Has <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> ever worked?",
+                        "type": "General",
+                        "guidance": {
+                            "content": [{
+                                "title": "Include:",
+                                "list": ["work outside of the United Kingdom.", "even if you are now retired."]
+                            }]
+                        },
+                        "answers": [{
+                            "id": "ever-worked-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Yes",
+                                    "value": "Yes"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "No"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "household-member-completed",
+                                "when": [{
+                                    "id": "ever-worked-answer",
+                                    "condition": "equals",
+                                    "value": "No"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "household-member-completed",
+                                "when": [{
+                                    "id": "ever-worked-answer",
+                                    "condition": "not set"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "main-job"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Question",
+                    "id": "main-job",
+                    "questions": [{
+                        "id": "main-job-question",
+                        "title": "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive }}</em> employment status?",
+                        "guidance": {
+                            "content": [{
+                                "description": "<p>If you are not working answer the remaining questions about your last main job.</p><p>Your main job is the job which you usually work (worked) the most hours</p>"
+                            }]
+                        },
+                        "type": "General",
+                        "answers": [{
+                            "id": "main-job-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "an employee",
+                                    "value": "an employee"
+                                },
+                                {
+                                    "label": "self-employed or freelance without employees",
+                                    "value": "self-employed or freelance without employees"
+                                },
+                                {
+                                    "label": "self-employed with employees",
+                                    "value": "self-employed with employees"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "hours-worked",
+                    "description": "",
+                    "questions": [{
+                        "title": "In <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive }}</em> main job, how many hours a week do they usually work?",
+                        "guidance": {
+                            "content": [{
+                                "description": "Include paid and unpaid overtime"
+                            }]
+                        },
+                        "id": "hours-worked-question",
+                        "type": "General",
+                        "answers": [{
+                            "id": "hours-worked-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "15 or less",
+                                    "value": "15 or less"
+                                },
+                                {
+                                    "label": "16 - 30",
+                                    "value": "16 - 30"
+                                },
+                                {
+                                    "label": "31 - 48",
+                                    "value": "31 - 48"
+                                },
+                                {
+                                    "label": "49 or more",
+                                    "value": "49 or more "
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "work-travel",
+                    "description": "",
+                    "questions": [{
+                        "title": "How does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> usually travel to work?",
+                        "description": "Select the option for the longest part, in distance, of your journey. For example, you travel by bus and by car. Your bus journey is 5 miles, and the car journey is 8 miles. You should select car as your answer.",
+                        "id": "work-travel-question",
+                        "type": "General",
+                        "answers": [{
+                            "id": "work-travel-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Work mainly at or from home",
+                                    "value": "Work mainly at or from home"
+                                },
+                                {
+                                    "label": "Underground, metro, light rail or tram",
+                                    "value": "Underground, metro, light rail or tram"
+                                },
+                                {
+                                    "label": "Train",
+                                    "value": "Train"
+                                },
+                                {
+                                    "label": "Bus, minibus or coach",
+                                    "value": "Bus, minibus or coach "
+                                },
+                                {
+                                    "label": "Taxi",
+                                    "value": "Taxi "
+                                },
+                                {
+                                    "label": "Motorcycle, scooter or moped",
+                                    "value": "Motorcycle, scooter or moped"
+                                },
+                                {
+                                    "label": "Driving a car or van",
+                                    "value": "Driving a car or van"
+                                },
+                                {
+                                    "label": "Passenger in a car or van",
+                                    "value": "Passenger in a car or van"
+                                },
+                                {
+                                    "label": "Bicycle",
+                                    "value": "Bicycle"
+                                },
+                                {
+                                    "label": "On foot",
+                                    "value": "On foot"
+                                },
+                                {
+                                    "label": "Other",
+                                    "value": "Other"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "job-title",
+                    "questions": [{
+                        "id": "job-title-question",
+                        "title": "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive }}</em> full job title?",
+                        "description": "<p>For example, <b>primary school teacher, car mechanic, district nurse, structural engineer</b></p><p>Do not state your grade or pay band</p><p>Please enter your job title in the space provided.</p><p>Do not state your grade or pay band.</p><p>If you are not sure of your job title please give the best information you can.</p>",
+                        "type": "General",
+                        "answers": [{
+                            "id": "job-title-answer",
+                            "label": "Job title",
+                            "mandatory": false,
+                            "type": "TextField"
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "job-description",
+                    "questions": [{
+                        "id": "job-description-question",
+                        "title": "What <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> does in their main job?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "job-description-answer",
+                            "label": "Description",
+                            "mandatory": false,
+                            "type": "TextArea"
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "main-job-type",
+                    "questions": [{
+                        "id": "main-job-type-question",
+                        "title": "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> employment status?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "main-job-type-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Employed by an organisation or business",
+                                    "value": "Employed by an organisation or business"
+                                },
+                                {
+                                    "label": "Self-employed in your own organisation or business",
+                                    "value": "Self-employed in your own organisation or business"
+                                },
+                                {
+                                    "label": "Not working for an organisation or business",
+                                    "value": "Not working for an organisation or business",
+                                    "description": "For example self-employed freelance or work (worked) for a private individual"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "household-member-completed",
+                                "when": [{
+                                    "id": "main-job-type-answer",
+                                    "condition": "equals",
+                                    "value": "Not working for an organisation or business"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "business-name"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Question",
+                    "id": "business-name",
+                    "questions": [{
+                        "id": "business-name-question",
+                        "title": "What is the name of the organisation of business that <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> work for?",
+                        "description": "<p>If you were self-employed in your own organisation or business, enter the name</p><p>This question is asking for the name of the organisation or business that you work (or worked) for in your main job.</p><p>If you can’t remember the name of the organisation, please give the best information you can.</p><p>If you are employed through an agency please enter the name of the business you are working for, not the agency.</p>",
+                        "type": "General",
+                        "answers": [{
+                            "id": "business-name-answer",
+                            "label": "Organisation or business name",
+                            "mandatory": false,
+                            "type": "TextField",
+                            "alias": "company_name"
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "employers-business",
+                    "questions": [{
+                        "id": "employers-business-question",
+                        "title": "What is the main activity of <em>{{answers.company_name}}</em>?",
+                        "description": "<p>Enter the main activity of your employer or business.</p><p>Another way of describing main activity is the industry that your employer or business works in.</p><p>If you are not sure of the main activity of your employer or business please give the best information you can.</p><p>If you are employed through an agency please enter the main activity of the business you are working for, not the agency.</p><p>For example, <b>primary education, repairing cars, contract catering, computer servicing</b></p>",
+                        "type": "General",
+                        "answers": [{
+                            "id": "employers-business-answer",
+                            "label": "Description",
+                            "mandatory": false,
+                            "type": "TextArea"
+                        }]
+                    }]
+                },
+                {
+                    "id": "household-member-completed",
+                    "title": "There are no more questions for {{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+                    "description": "",
+                    "type": "Interstitial"
+                }
+            ]
+        },
+        {
+            "id": "visitors-begin",
+            "title": "VisitorsBegin",
+            "skip_conditions": [{
+                    "when": [{
+                        "id": "overnight-visitors-answer",
+                        "condition": "equals",
+                        "value": "0"
+                    }]
+                },
+                {
+                    "when": [{
+                        "id": "overnight-visitors-answer",
+                        "condition": "not set"
+                    }]
+                }
+            ],
+            "blocks": [{
+                "type": "Interstitial",
+                "id": "visitor-begin-section",
+                "title": "Visitors",
+                "description": "In this section, we’re going to ask you about any visitors that were staying overnight at <em>{{answers.address_line_1}}</em> on 29 November 2017.",
+                "content": [{
+                    "title": "Information you need",
+                    "list": ["Name of visitor", "Gender of visitor", "Date of birth of visitor", "Address of visitor"]
+                }]
+            }]
+        },
+        {
+            "id": "visitors",
+            "title": "Visitors",
+            "routing_rules": [{
+                "repeat": {
+                    "type": "answer_value",
+                    "answer_id": "overnight-visitors-answer"
+                }
+            }],
+            "blocks": [{
+                    "type": "Question",
+                    "id": "visitor-name",
+                    "questions": [{
+                        "id": "visitor-name-question",
+                        "title": "What is the name of visitor {{group_instance + 1}}?",
+                        "type": "General",
+                        "answers": [{
+                                "id": "visitor-first-name",
+                                "label": "First name",
+                                "mandatory": false,
+                                "type": "TextField"
+                            },
+                            {
+                                "id": "visitor-last-name",
+                                "label": "Last name",
+                                "mandatory": false,
+                                "type": "TextField"
+                            }
+                        ]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "visitor-sex",
+                    "questions": [{
+                        "id": "visitor-sex-question",
+                        "title": "What is this person’s sex?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "visitor-sex-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Male",
+                                    "value": "Male"
+                                },
+                                {
+                                    "label": "Female",
+                                    "value": "Female"
+                                }
+                            ],
+                            "type": "Radio"
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "visitor-date-of-birth",
+                    "questions": [{
+                        "id": "visitor-date-of-birth-question",
+                        "title": "What is this person’s date of birth?",
+                        "description": "For example 20 March 1980",
+                        "type": "General",
+                        "answers": [{
+                            "id": "visitor-date-of-birth-answer",
+                            "mandatory": false,
+                            "type": "Date"
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "visitor-uk-resident",
+                    "questions": [{
+                        "id": "visitor-uk-resident-question",
+                        "title": "Does this person usually live in the United Kingdom?",
+                        "type": "General",
+                        "answers": [{
+                                "id": "visitor-uk-resident-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Yes, usually lives in the United Kingdom",
+                                        "value": "Yes, usually lives in the United Kingdom"
+                                    },
+                                    {
+                                        "label": "No, usually lives outside the United Kingdom (please specify)",
+                                        "value": "Other",
+                                        "child_answer_id": "visitor-uk-resident-answer-other"
+                                    }
+                                ],
+                                "type": "Radio"
+                            },
+                            {
+                                "id": "visitor-uk-resident-answer-other",
+                                "parent_answer_id": "visitor-uk-resident-answer",
+                                "type": "TextField",
+                                "mandatory": false,
+                                "label": "Please specify country"
+                            }
+                        ]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "visitor-address",
+                                "when": [{
+                                    "id": "visitor-uk-resident-answer",
+                                    "condition": "equals",
+                                    "value": "Yes, usually lives in the United Kingdom"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "visitor-completed"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Question",
+                    "id": "visitor-address",
+                    "questions": [{
+                        "id": "visitor-address-question",
+                        "title": "Enter details of this person’s usual UK address",
+                        "type": "General",
+                        "answers": [{
+                                "id": "visitor-address-answer-building",
+                                "label": "Building",
+                                "mandatory": false,
+                                "type": "TextField"
+                            },
+                            {
+                                "id": "visitor-address-answer-street",
+                                "label": "Street",
+                                "mandatory": false,
+                                "type": "TextField"
+                            },
+                            {
+                                "id": "visitor-address-answer-city",
+                                "label": "Town or city",
+                                "mandatory": false,
+                                "type": "TextField"
+                            },
+                            {
+                                "id": "visitor-address-answer-county",
+                                "label": "County (optional)",
+                                "mandatory": false,
+                                "type": "TextField"
+                            },
+                            {
+                                "id": "visitor-address-answer-postcode",
+                                "label": "Postcode",
+                                "mandatory": false,
+                                "type": "TextField"
+                            }
+                        ]
+                    }]
+                },
+                {
+                    "id": "visitor-completed",
+                    "title": "You have completed all questions for Visitor {{group_instance + 1}}",
+                    "description": "",
+                    "type": "Interstitial"
+                }
+            ]
+        },
+        {
+            "id": "visitors-interstitial",
+            "title": "Visitors",
+            "skip_conditions": [{
+                    "when": [{
+                        "id": "overnight-visitors-answer",
+                        "condition": "equals",
+                        "value": "0"
+                    }]
+                },
+                {
+                    "when": [{
+                        "id": "overnight-visitors-answer",
+                        "condition": "not set"
+                    }]
+                }
+            ],
+            "blocks": [{
+                "id": "visitors-completed",
+                "type": "Interstitial",
+                "title": "You have successfully completed the ‘Visitors’ section",
+                "description": ""
+            }]
+        },
+        {
+            "id": "questionnaire-completed",
+            "title": "Submit answers",
+            "blocks": [{
+                "type": "Confirmation",
+                "id": "confirmation",
+                "title": "You’re ready to submit your 2017 Census Test",
+                "description": "<p>Thank you for taking part in the 2017 Census Test.</p>",
+                "questions": [{
+                    "answers": [],
+                    "id": "questionnaire-completed-question",
+                    "title": "",
+                    "type": "General",
+                    "guidance": {
+                        "content": [{
+                            "title": "Please note:",
+                            "list": [
+                                "by submitting your responses, you are declaring that you have completed to the best of your knowledge and belief.",
+                                "if you do not submit, your responses will be automatically submitted when the Census 2017 Test closes.",
+                                "after submission you will have an opportunity to provide feedback on your experience."
+                            ]
+                        }]
+                    }
+                }]
+            }]
         }
-      ]
-    }
-  ]
+    ]
 }

--- a/data/en/census_household.json
+++ b/data/en/census_household.json
@@ -1,3935 +1,4572 @@
 {
-    "mime_type": "application/json/ons/eq",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.2",
-    "survey_id": "census",
-    "title": "2017 Census Test",
-    "description": "Census England Household Schema",
-    "theme": "census",
-    "legal_basis": "Voluntary",
-    "navigation": {
-        "visible": true,
-        "sections": [{
-                "title": "Who lives here?",
-                "group_order": [
-                    "who-lives-here",
-                    "who-lives-here-relationship",
-                    "who-lives-here-interstitial"
-                ]
-            },
-            {
-                "title": "Household and Accommodation",
-                "group_order": [
-                    "household-and-accommodation"
-                ]
-            },
-            {
-                "title_from_answers": [
-                    "first-name",
-                    "last-name"
-                ],
-                "group_order": [
-                    "household-member"
-                ]
-            },
-            {
-                "title": "Visitors",
-                "group_order": [
-                    "visitors-begin",
-                    "visitors",
-                    "visitors-interstitial"
-                ]
-            },
-            {
-                "title": "Submit answers",
-                "group_order": [
-                    "questionnaire-completed"
-                ]
-            }
-        ]
-    },
-    "groups": [{
-            "id": "what-is-your-address-group",
-            "title": "What is your address?",
-            "blocks": [{
-                    "type": "Introduction",
-                    "id": "introduction"
-                },
-                {
-                    "type": "Question",
-                    "id": "what-is-your-address",
-                    "questions": [{
-                        "id": "what-is-your-address-question",
-                        "title": "What is your address?",
-                        "type": "General",
-                        "answers": [{
-                                "id": "address-line-1",
-                                "label": "Address Line 1 (Including your house name or number)",
-                                "mandatory": true,
-                                "type": "TextField",
-                                "alias": "address_line_1",
-                                "validation": {
-                                    "messages": {
-                                        "MANDATORY_TEXTFIELD": "Enter an address to continue"
-                                    }
-                                }
-                            },
-                            {
-                                "id": "address-line-2",
-                                "label": "Address Line 2",
-                                "mandatory": false,
-                                "type": "TextField"
-                            },
-                            {
-                                "id": "address-line-3",
-                                "label": "Address Line 3",
-                                "mandatory": false,
-                                "type": "TextField"
-                            },
-                            {
-                                "id": "town-city",
-                                "label": "Town/City",
-                                "mandatory": false,
-                                "type": "TextField"
-                            },
-                            {
-                                "id": "county",
-                                "label": "County",
-                                "mandatory": false,
-                                "type": "TextField"
-                            },
-                            {
-                                "id": "postcode",
-                                "label": "Postcode",
-                                "mandatory": false,
-                                "type": "TextField"
-                            },
-                            {
-                                "id": "country",
-                                "label": "Country",
-                                "mandatory": false,
-                                "type": "TextField"
-                            }
-                        ]
-                    }]
-                }
-            ]
-        },
-        {
-            "id": "who-lives-here",
-            "title": "Who lives here?",
-            "blocks": [{
-                    "type": "Interstitial",
-                    "id": "who-lives-here-section",
-                    "title": "People who live in the household",
-                    "description": "In this section, we’re going to ask you about the people that live at <em>{{answers.address_line_1}}</em>.",
-                    "content": [{
-                        "title": "Information you need",
-                        "list": [
-                            "Names of the people living in household and how they are related",
-                            "The number of visitors staying in the household on 29 November 2017"
-                        ]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "permanent-or-family-home",
-                    "questions": [{
-                        "id": "permanent-or-family-home-question",
-                        "title": "Does anyone live at <em>{{answers.address_line_1}}</em> as their permanent or family home?",
-                        "guidance": {
-                            "content": [{
-                                "title": "Include",
-                                "list": [
-                                    "yourself, if this is your permanent or family home",
-                                    "family members including partners, children and babies born on or before 9 April 2017",
-                                    "students and, or school children who live away from home during term time",
-                                    "housemates tenants or lodgers"
-                                ]
-                            }]
-                        },
-                        "type": "General",
-                        "answers": [{
-                            "id": "permanent-or-family-home-answer",
-                            "mandatory": true,
-                            "guidance": {
-                                "show_guidance": "Show further guidance",
-                                "hide_guidance": "Hide further guidance",
-                                "content": [{
-                                    "description": "For most people, their permanent home will be the address where they spend the most time."
-                                }]
-                            },
-                            "options": [{
-                                    "label": "Yes",
-                                    "value": "Yes"
-                                },
-                                {
-                                    "label": "No",
-                                    "value": "No",
-                                    "description": "For example this is a second address or holiday home"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "household-composition",
-                                "when": [{
-                                    "id": "permanent-or-family-home-answer",
-                                    "condition": "equals",
-                                    "value": "Yes"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "else-permanent-or-family-home",
-                                "when": [{
-                                    "id": "permanent-or-family-home-answer",
-                                    "condition": "equals",
-                                    "value": "No"
-                                }]
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "else-permanent-or-family-home",
-                    "questions": [{
-                        "id": "else-permanent-or-family-home-question",
-                        "title": "Can you confirm no one lives here as their permanent or family home?",
-                        "guidance": {
-                            "content": [{
-                                "title": "This could be:",
-                                "list": [
-                                    "people who usually live outside the UK who are staying in the UK for <b>three months or more</b>",
-                                    "people who work away from home within the UK if this is their permanent or family home",
-                                    "members of the Armed Forces if this is their permanent or family home",
-                                    "people who are temporarily outside the UK for <b>less than 12 months</b>",
-                                    "people staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends",
-                                    "other people who usually live here, including anyone temporarily away from home "
-                                ]
-                            }]
-                        },
-                        "type": "General",
-                        "answers": [{
-                            "id": "else-permanent-or-family-home-answer",
-                            "mandatory": true,
-                            "options": [{
-                                    "label": "Someone lives here as their permanent home",
-                                    "value": "Someone lives here as their permanent home"
-                                },
-                                {
-                                    "label": "No one lives here as their permanent home",
-                                    "value": "No one lives here as their permanent home"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "household-composition",
-                                "when": [{
-                                    "id": "else-permanent-or-family-home-answer",
-                                    "condition": "equals",
-                                    "value": "Someone lives here as their permanent home"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "overnight-visitors",
-                                "when": [{
-                                    "id": "else-permanent-or-family-home-answer",
-                                    "condition": "equals",
-                                    "value": "No one lives here as their permanent home"
-                                }]
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "household-composition",
-                    "questions": [{
-                        "id": "household-composition-question",
-                        "title": "What are the names of everyone who live at <em>{{answers.address_line_1}}</em>?",
-                        "guidance": {
-                            "content": [{
-                                "title": "Include",
-                                "list": [
-                                    "Yourself, if this is your permanent or family home",
-                                    "Family members including partners, children and babies born on or before 9 April 2017",
-                                    "Students and, or school children who live away from home during term time",
-                                    "Housemates tenants or lodgers",
-                                    "Household members who have requested a personal form"
-                                ]
-                            }]
-                        },
-                        "type": "RepeatingAnswer",
-                        "answers": [{
-                                "alias": "first_name",
-                                "id": "first-name",
-                                "label": "First name",
-                                "mandatory": true,
-                                "type": "TextField",
-                                "validation": {
-                                    "messages": {
-                                        "MANDATORY_TEXTFIELD": "Please enter a name or remove the person to continue"
-                                    }
-                                }
-                            },
-                            {
-                                "alias": "middle_names",
-                                "id": "middle-names",
-                                "label": "Middle names",
-                                "mandatory": false,
-                                "type": "TextField"
-                            },
-                            {
-                                "alias": "last_name",
-                                "id": "last-name",
-                                "label": "Last name",
-                                "mandatory": false,
-                                "guidance": {
-                                    "show_guidance": "Show further guidance",
-                                    "hide_guidance": "Hide further guidance",
-                                    "content": [{
-                                            "description": "Enter the current first, middle and last names of all the people who usually live here."
-                                        },
-                                        {
-                                            "description": "If you have not yet named your newborn, please enter ‘Baby’ for their first name and then enter their last name (surname)."
-                                        },
-                                        {
-                                            "description": "Please also include household members who have requested a personal form."
-                                        },
-                                        {
-                                            "description": "Please also include the names of people staying with you temporarily who don’t have a usual address in the UK. This is so that we make sure we count everyone."
-                                        },
-                                        {
-                                            "title": "Include",
-                                            "list": [
-                                                "people who usually live outside the UK who are staying in the UK for <strong>three months or more</strong>",
-                                                "people who work away from home within the UK  if this is their permanent or family home",
-                                                "members of the Armed Forces if this is their permanent or family home",
-                                                "people who are temporarily outside the UK for <strong>less than 12 months</strong>",
-                                                "people staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends"
-                                            ]
-                                        }
-                                    ]
-                                },
-                                "type": "TextField"
-                            }
-                        ]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "everyone-at-address-confirmation",
-                    "description": "<h2 class='neptune'>Your household includes:</h2> {{ [answers.first_name, answers.middle_names, answers.last_name]|format_household_summary }}",
-                    "questions": [{
-                        "id": "everyone-at-address-confirmation-question",
-                        "title": "Is this everyone for whom this is their permanent or family home?",
-                        "description": "Please note that you will need to ensure that everyone is included because you will be unable to make changes later",
-                        "guidance": {
-                            "content": [{
-                                "title": "Include",
-                                "list": [
-                                    "people who usually live outside the UK who are staying in the UK for <b>three months or more</b>",
-                                    "people who work away from home within the UK  if this is their permanent or family home",
-                                    "members of the Armed Forces if this is their permanent or family home",
-                                    "people who are temporarily outside the UK for <b>less than 12 months</b>",
-                                    "people staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends",
-                                    "other people who usually live here, including anyone temporarily away from home"
-                                ]
-                            }]
-                        },
-                        "type": "General",
-                        "answers": [{
-                            "id": "everyone-at-address-confirmation-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "Yes",
-                                    "value": "Yes"
-                                },
-                                {
-                                    "label": "No, I need to add another person",
-                                    "value": "No, I need to add another person"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "household-composition",
-                                "when": [{
-                                    "id": "everyone-at-address-confirmation-answer",
-                                    "condition": "equals",
-                                    "value": "No, I need to add another person"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "overnight-visitors"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "overnight-visitors",
-                    "questions": [{
-                        "id": "overnight-visitors-question",
-                        "title": "How many visitors are staying overnight at <em>{{answers.address_line_1}}</em> on 9th April 2017?",
-                        "guidance": {
-                            "content": [{
-                                "title": "Include",
-                                "list": [
-                                    "people who usually live somewhere else in the UK. For example, friends or relatives",
-                                    "people staying here because it is their second address, for example, for work. Their permanent or family home is elsewhere",
-                                    "people who usually live outside the UK who are visiting the UK for less than three months",
-                                    "people here on holiday"
-                                ]
-                            }]
-                        },
-                        "type": "General",
-                        "answers": [{
-                            "id": "overnight-visitors-answer",
-                            "label": "Number of visitors (enter 0 if no visitors)",
-                            "mandatory": true,
-                            "type": "Number"
-                        }]
-                    }]
-                }
-            ]
-        },
-        {
-            "id": "who-lives-here-relationship",
-            "title": "Relationships",
-            "hide_in_navigation": true,
-            "routing_rules": [{
-                "repeat": {
-                    "type": "answer_count_minus_one",
-                    "answer_id": "first-name"
-                }
-            }],
-            "blocks": [{
-                "type": "Question",
-                "id": "household-relationships",
-                "questions": [{
-                    "id": "household-relationships-question",
-                    "title": "How is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> related to the people below?",
-                    "description": "If members are not related, select the ‘unrelated’ option.</br>If you are the parents of adopted children, select the ‘Mother or father’ option to show your relationship to them.</br>If you have foster children living with you, select the ‘Unrelated’ option.</br>Include half-brothers and half-sisters in the ‘Step-brother or step-sister’ category.</br>Same-sex civil partner is used to describe the relationship between two people who have legally registered a civil partnership.</br>If none of the options fully reflects your relationship, please select the one which you feel best describes your situation.",
-                    "type": "Relationship",
-                    "answers": [{
-                        "id": "household-relationships-answer",
-                        "label": "%(current_person)s is %(other_person)s",
-                        "mandatory": false,
-                        "options": [{
-                                "label": "Husband or wife",
-                                "value": "Husband or wife"
-                            },
-                            {
-                                "label": "Same-sex civil partner",
-                                "value": "Same-sex civil partner"
-                            },
-                            {
-                                "label": "Partner",
-                                "value": "Partner"
-                            },
-                            {
-                                "label": "Grandparent",
-                                "value": "Grandparent"
-                            },
-                            {
-                                "label": "Mother or father",
-                                "value": "Mother or father"
-                            },
-                            {
-                                "label": "Step-mother or step-father",
-                                "value": "Step-mother or step-father"
-                            },
-                            {
-                                "label": "Son or daughter",
-                                "value": "Son or daughter"
-                            },
-                            {
-                                "label": "Step-child",
-                                "value": "Step-child"
-                            },
-                            {
-                                "label": "Brother or sister",
-                                "value": "Brother or sister"
-                            },
-                            {
-                                "label": "Step–brother or step–sister",
-                                "value": "Step–brother or step–sister"
-                            },
-                            {
-                                "label": "Grandchild",
-                                "value": "Grandchild"
-                            },
-                            {
-                                "label": "Relation - other",
-                                "value": "Relation - other"
-                            },
-                            {
-                                "label": "Unrelated (including foster child)",
-                                "value": "Unrelated (including foster child)"
-                            }
-                        ],
-                        "type": "Relationship"
-                    }]
-                }]
-            }]
-        },
-        {
-            "id": "who-lives-here-interstitial",
-            "title": "Who lives here?",
-            "hide_in_navigation": true,
-            "blocks": [{
-                "id": "who-lives-here-completed",
-                "title": "You have successfully completed the ‘Who lives here?’ section",
-                "description": "In the next section we are going to ask you about the household and accommodation you live in.",
-                "type": "Interstitial"
-            }]
-        },
-        {
-            "id": "household-and-accommodation",
-            "title": "Household and Accommodation",
-            "blocks": [{
-                    "type": "Interstitial",
-                    "id": "household-and-accommodation-section",
-                    "title": "Household and accommodation",
-                    "description": "In this section, we’re going to ask you about the household and accommodation you live in.",
-                    "content": [{
-                        "title": "Information you need",
-                        "list": [
-                            "Type of property, and if it’s owned or rented",
-                            "Type of landlord, if the property is rented",
-                            "Number of cars or vans"
-                        ]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "type-of-accommodation",
-                    "questions": [{
-                        "id": "type-of-accommodation-question",
-                        "title": "What type of accommodation is <em>{{answers.address_line_1}}</em>?",
-                        "type": "General",
-                        "answers": [{
-                            "id": "type-of-accommodation-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "Whole house or bungalow",
-                                    "value": "Whole house or bungalow"
-                                },
-                                {
-                                    "label": "Flat, maisonette or apartment (including bedsits)",
-                                    "value": "Flat, maisonette or apartment (including bedsits)"
-                                },
-                                {
-                                    "label": "Caravan or other mobile or temporary structure",
-                                    "value": "Caravan or other mobile or temporary structure"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "type-of-house",
-                                "when": [{
-                                    "id": "type-of-accommodation-answer",
-                                    "condition": "equals",
-                                    "value": "Whole house or bungalow"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "type-of-flat",
-                                "when": [{
-                                    "id": "type-of-accommodation-answer",
-                                    "condition": "equals",
-                                    "value": "Flat, maisonette or apartment (including bedsits)"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "self-contained-accommodation"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "type-of-house",
-                    "questions": [{
-                        "id": "type-of-house-question",
-                        "title": "Is your house or bungalow:",
-                        "type": "General",
-                        "answers": [{
-                            "id": "type-of-house-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "Detached",
-                                    "value": "Detached"
-                                },
-                                {
-                                    "label": "Semi-detached",
-                                    "value": "Semi-detached"
-                                },
-                                {
-                                    "label": "Terraced (including end-terrace)",
-                                    "value": "Terraced"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }],
-                    "routing_rules": [{
-                        "goto": {
-                            "block": "self-contained-accommodation"
-                        }
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "type-of-flat",
-                    "questions": [{
-                        "id": "type-of-flat-question",
-                        "title": "Is your flat, maisonette or apartment:",
-                        "type": "General",
-                        "answers": [{
-                            "id": "type-of-flat-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "In a purpose-built block of flats or tenement",
-                                    "value": "In a purpose-built block of flats or tenement"
-                                },
-                                {
-                                    "label": "Part of a converted or shared house (including bedsits)",
-                                    "value": "Part of a converted or shared house (including bedsits)"
-                                },
-                                {
-                                    "label": "In a commercial building (for example, in an office building, hotel, or over a  shop).",
-                                    "value": "In a commercial building (for example, in an office building, hotel, or over a  shop)."
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "self-contained-accommodation",
-                    "questions": [{
-                        "id": "self-contained-accommodation-question",
-                        "title": "Is the accommodation of <em>{{answers.address_line_1}}</em> self-contained?",
-                        "description": "This means that all the rooms, including the kitchen, bathroom and toilet, are behind a door that only this household can use",
-                        "type": "General",
-                        "answers": [{
-                            "id": "self-contained-accommodation-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "Yes, all the rooms are behind a door that only this household can use",
-                                    "value": "Yes, all the rooms are behind a door that only this household can use"
-                                },
-                                {
-                                    "label": "No",
-                                    "value": "No"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "number-of-bedrooms",
-                    "questions": [{
-                        "id": "number-of-bedrooms-question",
-                        "title": "How many bedrooms are at <em>{{answers.address_line_1}}</em>?",
-                        "guidance": {
-                            "content": [{
-                                "description": "Include all rooms built or converted for use as bedrooms, even if they’re not currently used as bedrooms"
-                            }]
-                        },
-                        "type": "General",
-                        "answers": [{
-                            "id": "number-of-bedrooms-answer",
-                            "label": "Number of bedrooms",
-                            "mandatory": false,
-                            "type": "Number"
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "central-heating",
-                    "questions": [{
-                        "id": "central-heating-question",
-                        "title": "What type of central heating does <em>{{answers.address_line_1}}</em> have?",
-                        "description": "<p>Central heating is a central system that generates heat for multiple rooms.</p><p>Select all that apply, whether or not you use it.</p>",
-                        "type": "General",
-                        "answers": [{
-                            "id": "central-heating-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "Gas",
-                                    "value": "Gas"
-                                },
-                                {
-                                    "label": "Electric (include storage heaters)",
-                                    "value": "Electric (include storage heaters)"
-                                },
-                                {
-                                    "label": "Oil",
-                                    "value": "Oil"
-                                },
-                                {
-                                    "label": "Solid fuel (for example wood, coal)",
-                                    "value": "Solid fuel (for example wood, coal)"
-                                },
-                                {
-                                    "label": "Renewable (for example solar panels)",
-                                    "value": "Renewable (for example solar panels)"
-                                },
-                                {
-                                    "label": "Other central heating",
-                                    "value": "Other central heating"
-                                },
-                                {
-                                    "label": "No central heating",
-                                    "value": "No central heating"
-                                }
-                            ],
-                            "type": "Checkbox"
-                        }]
-                    }],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "own-or-rent",
-                                "when": [{
-                                    "id": "permanent-or-family-home-answer",
-                                    "condition": "equals",
-                                    "value": "Yes"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "own-or-rent",
-                                "when": [{
-                                    "id": "else-permanent-or-family-home-answer",
-                                    "condition": "equals",
-                                    "value": "Someone lives here as their permanent home"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "household-and-accommodation-completed"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "own-or-rent",
-                    "questions": [{
-                        "id": "own-or-rent-question",
-                        "title": "Does your household own or rent <em>{{answers.address_line_1}}</em>?",
-                        "type": "General",
-                        "answers": [{
-                            "id": "own-or-rent-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "Owns outright",
-                                    "value": "Owns outright"
-                                },
-                                {
-                                    "label": "Owns with a mortgage or loan",
-                                    "value": "Owns with a mortgage or loan"
-                                },
-                                {
-                                    "label": "Part owns and part rents (shared ownership)",
-                                    "value": "Part owns and part rents (shared ownership)"
-                                },
-                                {
-                                    "label": "Rents (with or without housing benefit)",
-                                    "value": "Rents (with or without housing benefit)"
-                                },
-                                {
-                                    "label": "Lives here rent free",
-                                    "value": "Lives here rent free"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "number-of-vehicles",
-                                "when": [{
-                                    "id": "own-or-rent-answer",
-                                    "condition": "equals",
-                                    "value": "Owns outright"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "number-of-vehicles",
-                                "when": [{
-                                    "id": "own-or-rent-answer",
-                                    "condition": "equals",
-                                    "value": "Owns with a mortgage or loan"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "landlord"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "landlord",
-                    "questions": [{
-                        "id": "landlord-question",
-                        "title": "Who is your landlord?",
-                        "type": "General",
-                        "answers": [{
-                            "id": "landlord-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "Housing association, housing co-operative, charitable trust, registered social landlord",
-                                    "value": "Housing association, housing co-operative, charitable trust, registered social landlord"
-                                },
-                                {
-                                    "label": "Council (local authority)",
-                                    "value": "Council (local authority)"
-                                },
-                                {
-                                    "label": "Private landlord or letting agency",
-                                    "value": "Private landlord or letting agency"
-                                },
-                                {
-                                    "label": "Employer of a household member",
-                                    "value": "Employer of a household member"
-                                },
-                                {
-                                    "label": "Relative or friend of a household member",
-                                    "value": "Relative or friend of a household member"
-                                },
-                                {
-                                    "label": "Other",
-                                    "value": "Other"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "number-of-vehicles",
-                    "questions": [{
-                        "id": "number-of-vehicles-question",
-                        "title": "How many cars or vans are owned, or available for use, by members of this household?",
-                        "guidance": {
-                            "content": [{
-                                "description": "Include any company cars or vans available for private use"
-                            }]
-                        },
-                        "type": "General",
-                        "answers": [{
-                            "id": "number-of-vehicles-answer",
-                            "label": "Number of cars or vans",
-                            "mandatory": false,
-                            "type": "Number"
-                        }]
-                    }]
-                },
-                {
-                    "id": "household-and-accommodation-completed",
-                    "title": "You have successfully completed the ‘Household and Accommodation’ section",
-                    "description": "",
-                    "type": "Interstitial"
-                }
-            ]
-        },
-        {
-            "id": "household-member",
-            "title": "Household Member Details",
-            "routing_rules": [{
-                "repeat": {
-                    "type": "answer_count",
-                    "answer_id": "first-name"
-                }
-            }],
-            "blocks": [{
-                    "type": "Interstitial",
-                    "id": "household-member-begin-section",
-                    "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}",
-                    "description": "In this section, we’re going to ask you questions about <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em>.",
-                    "content": [{
-                        "title": "Information you need",
-                        "list": [
-                            "Personal details such as date of birth, country of birth, religion etc.",
-                            "Education and qualifications",
-                            "Employment and travel to work",
-                            "Second or holiday homes",
-                            "Unpaid care, health and well-being",
-                            "Languages"
-                        ]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "details-correct",
-                    "questions": [{
-                        "id": "details-correct-question",
-                        "title": "Is the name {{ [answers.first_name[group_instance], answers.middle_names[group_instance], answers.last_name[group_instance]] | format_household_name }} correct, including any middle name(s)?",
-                        "type": "General",
-                        "answers": [{
-                            "id": "details-correct-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "Yes, this is my full name",
-                                    "value": "Yes, this is my full name"
-                                },
-                                {
-                                    "label": "No, I need to change my name",
-                                    "value": "No, I need to change my name"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "correct-name",
-                                "when": [{
-                                    "id": "details-correct-answer",
-                                    "condition": "equals",
-                                    "value": "No, I need to change my name"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "over-16"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "correct-name",
-                    "questions": [{
-                        "id": "correct-name-question",
-                        "title": "What is your correct name?",
-                        "type": "General",
-                        "answers": [{
-                                "id": "correct-first-name",
-                                "label": "First name",
-                                "mandatory": false,
-                                "type": "TextField"
-                            },
-                            {
-                                "id": "correct-middle-names",
-                                "label": "Middle names",
-                                "mandatory": false,
-                                "type": "TextField"
-                            },
-                            {
-                                "id": "correct-last-name",
-                                "label": "Last name",
-                                "mandatory": false,
-                                "type": "TextField"
-                            }
-                        ]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "over-16",
-                    "questions": [{
-                        "id": "over-16-question",
-                        "title": "Are you aged 16 or over?",
-                        "type": "General",
-                        "answers": [{
-                            "id": "over-16-answer",
-                            "mandatory": true,
-                            "options": [{
-                                    "label": "Yes",
-                                    "value": "Yes"
-                                },
-                                {
-                                    "label": "No",
-                                    "value": "No"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "private-response",
-                                "when": [{
-                                    "id": "over-16-answer",
-                                    "condition": "equals",
-                                    "value": "Yes"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "sex"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "private-response",
-                    "questions": [{
-                        "id": "private-response-question",
-                        "title": "Do you want to request a personal form?",
-                        "description": "Anyone aged 16 or over who would like to keep their answers private can request a personal and confidential form.",
-                        "type": "General",
-                        "answers": [{
-                            "id": "private-response-answer",
-                            "mandatory": false,
-                            "guidance": {
-                                "show_guidance": "Show further guidance",
-                                "hide_guidance": "Hide further guidance",
-                                "content": [{
-                                    "description": "If you request a personal or confidential form we will send you a unique access code that will allow you to complete the individual questions for yourself. No-one else will be able to see the answers you provide."
-                                }]
-                            },
-                            "options": [{
-                                    "label": "No, I do not want to request a personal form",
-                                    "value": "No, I do not want to request a personal form"
-                                },
-                                {
-                                    "label": "Yes, I want to request a personal form",
-                                    "value": "Yes, I want to request a personal form"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "request-private-response",
-                                "when": [{
-                                    "id": "private-response-answer",
-                                    "condition": "equals",
-                                    "value": "Yes, I want to request a personal form"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "sex"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "id": "request-private-response",
-                    "title": "Request for personal and confidential form",
-                    "description": "<p>You can <a rel='noopener noreferrer' target='_blank' href='https://census.gov.uk/individualquestionnaire'>request a personal and confidential form online</a>.</p> <p>Alternatively, call <a href='tel:03000683001'>0300 068 3001</a>.</p>",
-                    "type": "Interstitial",
-                    "routing_rules": [{
-                        "goto": {
-                            "block": "household-member-completed"
-                        }
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "sex",
-                    "questions": [{
-                        "id": "sex-question",
-                        "title": "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> sex?",
-                        "type": "General",
-                        "answers": [{
-                            "id": "sex-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "Male",
-                                    "value": "Male"
-                                },
-                                {
-                                    "label": "Female",
-                                    "value": "Female"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "date-of-birth",
-                    "questions": [{
-                        "id": "date-of-birth-question",
-                        "title": "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive }}</em> date of birth?",
-                        "description": "For example 20 March 1980",
-                        "type": "General",
-                        "answers": [{
-                            "id": "date-of-birth-answer",
-                            "mandatory": false,
-                            "type": "Date"
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "marital-status",
-                    "questions": [{
-                        "id": "marital-status-question",
-                        "title": "On 9 April 2017, what is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive }}</em> legal marital or same-sex civil partnership status?",
-                        "description": "If you were married (or formed a registered same-sex partnership) abroad, and this enables you to be recognised as married or civil partnered in the UK, complete the question reflecting that legal partnership.",
-                        "type": "General",
-                        "answers": [{
-                            "id": "marital-status-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "Never married and never registered a same-sex civil partnership",
-                                    "value": "Never married and never registered a same-sex civil partnership"
-                                },
-                                {
-                                    "label": "Married",
-                                    "value": "Married"
-                                },
-                                {
-                                    "label": "In a registered same-sex civil partnership",
-                                    "value": "In a registered same-sex civil partnership"
-                                },
-                                {
-                                    "label": "Separated, but still legally married",
-                                    "value": "Separated, but still legally married"
-                                },
-                                {
-                                    "label": "Separated, but still legally in a same-sex civil partnership",
-                                    "value": "Separated, but still legally in a same-sex civil partnership"
-                                },
-                                {
-                                    "label": "Divorced",
-                                    "value": "Divorced"
-                                },
-                                {
-                                    "label": "Formerly in a same-sex civil partnership which is now legally dissolved",
-                                    "value": "Formerly in a same-sex civil partnership which is now legally dissolved"
-                                },
-                                {
-                                    "label": "Widowed",
-                                    "value": "Widowed"
-                                },
-                                {
-                                    "label": "Surviving partner from a same-sex civil partnership",
-                                    "value": "Surviving partner from a same-sex civil partnership"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "another-address",
-                    "questions": [{
-                        "id": "another-address-question",
-                        "title": "Does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> stay at another address for more than 30 days a year?",
-                        "type": "General",
-                        "guidance": {
-                            "content": [{
-                                "title": "Include:",
-                                "list": [
-                                    "another parent’s address, an armed forces base, a holiday home, or term-time address.",
-                                    "the days you stay at the address do not have to be in a row. They can be at any time during the year."
-                                ],
-                                "description": ""
-                            }]
-                        },
-                        "answers": [{
-                                "id": "another-address-answer",
-                                "mandatory": false,
-                                "options": [{
-                                        "label": "No",
-                                        "value": "No"
-                                    },
-                                    {
-                                        "label": "Yes, an address within the UK",
-                                        "value": "Yes, an address within the UK"
-                                    },
-                                    {
-                                        "label": "Yes, an address outside the UK",
-                                        "value": "Other",
-                                        "child_answer_id": "another-address-answer-other"
-                                    }
-                                ],
-                                "type": "Radio"
-                            },
-                            {
-                                "id": "another-address-answer-other",
-                                "parent_answer_id": "another-address-answer",
-                                "type": "TextField",
-                                "mandatory": false,
-                                "label": "Please specify a country"
-                            }
-                        ]
-                    }],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "in-education",
-                                "when": [{
-                                    "id": "another-address-answer",
-                                    "condition": "equals",
-                                    "value": "No"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "other-address",
-                                "when": [{
-                                    "id": "another-address-answer",
-                                    "condition": "equals",
-                                    "value": "Yes, an address within the UK"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "address-type",
-                                "when": [{
-                                    "id": "another-address-answer",
-                                    "condition": "equals",
-                                    "value": "Other"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "in-education",
-                                "when": [{
-                                    "id": "another-address-answer",
-                                    "condition": "not set"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "address-type",
-                                "when": [{
-                                    "id": "another-address-answer",
-                                    "condition": "not equals",
-                                    "value": "Other"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "in-education"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "other-address",
-                    "questions": [{
-                        "id": "other-address-question",
-                        "title": "Enter details of the other UK address where <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> stay more than 30 days a year",
-                        "type": "General",
-                        "answers": [{
-                                "id": "other-address-answer-building",
-                                "label": "Building",
-                                "mandatory": false,
-                                "type": "TextField"
-                            },
-                            {
-                                "id": "other-address-answer-street",
-                                "label": "Street",
-                                "mandatory": false,
-                                "type": "TextField"
-                            },
-                            {
-                                "id": "other-address-answer-city",
-                                "label": "Town or city",
-                                "mandatory": false,
-                                "type": "TextField"
-                            },
-                            {
-                                "id": "other-address-answer-county",
-                                "label": "County (optional)",
-                                "mandatory": false,
-                                "type": "TextField"
-                            },
-                            {
-                                "id": "other-address-answer-postcode",
-                                "label": "Postcode",
-                                "mandatory": false,
-                                "type": "TextField"
-                            }
-                        ]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "address-type",
-                    "questions": [{
-                        "id": "address-type-question",
-                        "title": "What is that address?",
-                        "type": "General",
-                        "answers": [{
-                                "id": "address-type-answer",
-                                "mandatory": false,
-                                "options": [{
-                                        "label": "Armed forces base address",
-                                        "value": "Armed forces base address"
-                                    },
-                                    {
-                                        "label": "Another address when working away from home",
-                                        "value": "Another address when working away from home"
-                                    },
-                                    {
-                                        "label": "Student’s home address",
-                                        "value": "Student’s home address"
-                                    },
-                                    {
-                                        "label": "Student’s term time address",
-                                        "value": "Student’s term time address"
-                                    },
-                                    {
-                                        "label": "Another parent or guardian’s address",
-                                        "value": "Another parent or guardian’s address"
-                                    },
-                                    {
-                                        "label": "Holiday home",
-                                        "value": "Holiday home"
-                                    },
-                                    {
-                                        "label": "Other (please specify)",
-                                        "value": "Other",
-                                        "child_answer_id": "address-type-answer-other"
-                                    }
-                                ],
-                                "type": "Radio"
-                            },
-                            {
-                                "id": "address-type-answer-other",
-                                "parent_answer_id": "address-type-answer",
-                                "type": "TextField",
-                                "mandatory": false,
-                                "label": "Please specify type of address"
-                            }
-                        ]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "in-education",
-                    "questions": [{
-                        "id": "in-education-question",
-                        "title": "Is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> in full-time education?",
-                        "type": "General",
-                        "answers": [{
-                            "id": "in-education-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "Yes",
-                                    "value": "Yes"
-                                },
-                                {
-                                    "label": "No",
-                                    "value": "No"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "term-time-location",
-                                "when": [{
-                                    "id": "in-education-answer",
-                                    "condition": "equals",
-                                    "value": "Yes"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "country-of-birth"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "term-time-location",
-                    "questions": [{
-                        "id": "term-time-location-question",
-                        "title": "During term time, does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> live at <em>{{answers.address_line_1}}</em> ?",
-                        "type": "General",
-                        "answers": [{
-                            "id": "term-time-location-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "Yes",
-                                    "value": "Yes"
-                                },
-                                {
-                                    "label": "No",
-                                    "value": "No"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "household-member-completed",
-                                "when": [{
-                                    "id": "term-time-location-answer",
-                                    "condition": "equals",
-                                    "value": "No"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "country-of-birth"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "country-of-birth",
-                    "questions": [{
-                            "id": "country-of-birth-england-question",
-                            "title": "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> country of birth?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "country-of-birth-england-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "England",
-                                            "value": "England"
-                                        },
-                                        {
-                                            "label": "Wales",
-                                            "value": "Wales"
-                                        },
-                                        {
-                                            "label": "Scotland",
-                                            "value": "Scotland"
-                                        },
-                                        {
-                                            "label": "Northern Ireland",
-                                            "value": "Northern Ireland"
-                                        },
-                                        {
-                                            "label": "Republic of Ireland",
-                                            "value": "Republic of Ireland"
-                                        },
-                                        {
-                                            "label": "Elsewhere",
-                                            "value": "Other",
-                                            "child_answer_id": "country-of-birth-england-answer-other"
-                                        }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "country-of-birth-england-answer-other",
-                                    "parent_answer_id": "country-of-birth-england-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please specify current name of country"
-                                }
-                            ],
-                            "skip_conditions": [{
-                                "when": [{
-                                    "meta": "region_code",
-                                    "condition": "equals",
-                                    "value": "GB-WLS"
-                                }]
-                            }]
-                        },
-                        {
-                            "id": "country-of-birth-wales-question",
-                            "title": "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> country of birth?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "country-of-birth-wales-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Wales",
-                                            "value": "Wales"
-                                        },
-                                        {
-                                            "label": "England",
-                                            "value": "England"
-                                        },
-                                        {
-                                            "label": "Scotland",
-                                            "value": "Scotland"
-                                        },
-                                        {
-                                            "label": "Northern Ireland",
-                                            "value": "Northern Ireland"
-                                        },
-                                        {
-                                            "label": "Republic of Ireland",
-                                            "value": "Republic of Ireland"
-                                        },
-                                        {
-                                            "label": "Elsewhere",
-                                            "value": "Other",
-                                            "child_answer_id": "country-of-birth-wales-answer-other"
-                                        }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "country-of-birth-wales-answer-other",
-                                    "parent_answer_id": "country-of-birth-wales-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please specify current name of country"
-                                }
-                            ],
-                            "skip_conditions": [{
-                                "when": [{
-                                    "meta": "region_code",
-                                    "condition": "not equals",
-                                    "value": "GB-WLS"
-                                }]
-                            }]
-                        }
-                    ],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "carer",
-                                "when": [{
-                                    "id": "country-of-birth-england-answer",
-                                    "condition": "equals",
-                                    "value": "England"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "carer",
-                                "when": [{
-                                    "id": "country-of-birth-england-answer",
-                                    "condition": "equals",
-                                    "value": "Wales"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "carer",
-                                "when": [{
-                                    "id": "country-of-birth-england-answer",
-                                    "condition": "equals",
-                                    "value": "Scotland"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "carer",
-                                "when": [{
-                                    "id": "country-of-birth-england-answer",
-                                    "condition": "equals",
-                                    "value": "Northern Ireland"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "carer",
-                                "when": [{
-                                    "id": "country-of-birth-wales-answer",
-                                    "condition": "equals",
-                                    "value": "Wales"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "carer",
-                                "when": [{
-                                    "id": "country-of-birth-wales-answer",
-                                    "condition": "equals",
-                                    "value": "England"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "carer",
-                                "when": [{
-                                    "id": "country-of-birth-wales-answer",
-                                    "condition": "equals",
-                                    "value": "Scotland"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "carer",
-                                "when": [{
-                                    "id": "country-of-birth-wales-answer",
-                                    "condition": "equals",
-                                    "value": "Northern Ireland"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "arrive-in-uk"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "arrive-in-uk",
-                    "questions": [{
-                        "id": "arrive-in-uk-question",
-                        "title": "If you were not born in the United Kingdom, when did <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> most recently arrive to live here?",
-                        "guidance": {
-                            "content": [{
-                                "description": "Exclude short visits away from the UK"
-                            }]
-                        },
-                        "type": "General",
-                        "answers": [{
-                            "id": "arrive-in-uk-answer",
-                            "mandatory": false,
-                            "type": "MonthYearDate"
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "length-of-stay",
-                    "questions": [{
-                        "id": "length-of-stay-question",
-                        "title": "Including the time already spent here, how long does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> intend to stay in the United Kingdom?",
-                        "type": "General",
-                        "answers": [{
-                            "id": "length-of-stay-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "Less than 12 months",
-                                    "value": "Less than 12 months"
-                                },
-                                {
-                                    "label": "12 months or more",
-                                    "value": "12 months or more"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "health",
-                    "questions": [{
-                        "id": "health-question",
-                        "title": "How is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> health in general?",
-                        "type": "General",
-                        "answers": [{
-                            "id": "health-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "Very good",
-                                    "value": "Very good"
-                                },
-                                {
-                                    "label": "Good",
-                                    "value": "Good"
-                                },
-                                {
-                                    "label": "Fair",
-                                    "value": "Fair"
-                                },
-                                {
-                                    "label": "Bad",
-                                    "value": "Bad"
-                                },
-                                {
-                                    "label": "Very bad",
-                                    "value": "Very bad"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "carer",
-                    "questions": [{
-                        "id": "carer-question",
-                        "title": "Does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> look after, or give any help or support to family members, friends, neighbours or others?",
-                        "description": "",
-                        "guidance": {
-                            "content": [{
-                                    "title": "Include",
-                                    "list": [
-                                        "long-term physical or mental ill-health/disability",
-                                        "problems related to old age"
-                                    ]
-                                },
-                                {
-                                    "title": "Exclude",
-                                    "list": [
-                                        "anything you do as part of your paid employment"
-                                    ]
-                                }
-                            ]
-                        },
-                        "type": "General",
-                        "answers": [{
-                            "id": "carer-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "No",
-                                    "value": "No"
-                                },
-                                {
-                                    "label": "Yes, 1 -19 hours a week",
-                                    "value": "Yes, 1 -19 hours a week"
-                                },
-                                {
-                                    "label": "Yes, 20 - 49 hours a week",
-                                    "value": "Yes, 20 - 49 hours a week"
-                                },
-                                {
-                                    "label": "Yes, 50 or more hours a week",
-                                    "value": "Yes, 50 or more hours a week"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "national-identity",
-                    "questions": [{
-                            "id": "national-identity-england-question",
-                            "title": "How would you describe <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> national identity?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "national-identity-england-answer",
-                                    "label": "Select all that apply",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "English",
-                                            "value": "English"
-                                        },
-                                        {
-                                            "label": "Welsh",
-                                            "value": "Welsh"
-                                        },
-                                        {
-                                            "label": "Scottish",
-                                            "value": "Scottish"
-                                        },
-                                        {
-                                            "label": "Northern Irish",
-                                            "value": "Northern Irish"
-                                        },
-                                        {
-                                            "label": "British",
-                                            "value": "British"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "child_answer_id": "national-identity-england-answer-other"
-                                        }
-                                    ],
-                                    "type": "Checkbox"
-                                },
-                                {
-                                    "id": "national-identity-england-answer-other",
-                                    "parent_answer_id": "national-identity-england-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please describe your national identity"
-                                }
-                            ],
-                            "skip_conditions": [{
-                                "when": [{
-                                    "meta": "region_code",
-                                    "condition": "equals",
-                                    "value": "GB-WLS"
-                                }]
-                            }]
-                        },
-                        {
-                            "id": "national-identity-wales-question",
-                            "title": "How would you describe <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> national identity?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "national-identity-wales-answer",
-                                    "label": "Select all that apply",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Welsh",
-                                            "value": "Welsh"
-                                        },
-                                        {
-                                            "label": "English",
-                                            "value": "English"
-                                        },
-                                        {
-                                            "label": "Scottish",
-                                            "value": "Scottish"
-                                        },
-                                        {
-                                            "label": "Northern Irish",
-                                            "value": "Northern Irish"
-                                        },
-                                        {
-                                            "label": "British",
-                                            "value": "British"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "child_answer_id": "national-identity-wales-answer-other"
-                                        }
-                                    ],
-                                    "type": "Checkbox"
-                                },
-                                {
-                                    "id": "national-identity-wales-answer-other",
-                                    "parent_answer_id": "national-identity-wales-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please describe your national identity"
-                                }
-                            ],
-                            "skip_conditions": [{
-                                "when": [{
-                                    "meta": "region_code",
-                                    "condition": "not equals",
-                                    "value": "GB-WLS"
-                                }]
-                            }]
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "ethnic-group",
-                    "questions": [{
-                            "id": "ethnic-group-england-question",
-                            "title": "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> ethnic group?",
-                            "description": "It is for you to choose your ethnic group. For example this could be your family or cultural background, or it could be how you would describe yourself.",
-                            "type": "General",
-                            "answers": [{
-                                "id": "ethnic-group-england-answer",
-                                "mandatory": false,
-                                "options": [{
-                                        "label": "White",
-                                        "value": "White",
-                                        "description": "Including English, Welsh, Scottish, Northern Irish, British, Irish, Gypsy, Irish Traveller or any other White background"
-                                    },
-                                    {
-                                        "label": "Mixed or multiple ethnic groups",
-                                        "value": "Mixed or multiple ethnic groups",
-                                        "description": "Including White and Black Caribbean, White and Black African, White and Asian or any other Mixed or multiple ethnic background"
-                                    },
-                                    {
-                                        "label": "Asian or Asian British",
-                                        "value": "Asian or Asian British",
-                                        "description": "Including Indian, Pakistani, Bangladeshi, Chinese or any other Asian background"
-                                    },
-                                    {
-                                        "label": "Black, African, Caribbean or Black British",
-                                        "value": "Black, African, Caribbean or Black British",
-                                        "description": "Including African, Caribbean or any other Black, African or Caribbean background"
-                                    },
-                                    {
-                                        "label": "Other ethnic group",
-                                        "value": "Other ethnic group",
-                                        "description": "Including Arab or any other ethnic group"
-                                    }
-                                ],
-                                "type": "Radio"
-                            }],
-                            "skip_conditions": [{
-                                "when": [{
-                                    "meta": "region_code",
-                                    "condition": "equals",
-                                    "value": "GB-WLS"
-                                }]
-                            }]
-                        },
-                        {
-                            "id": "ethnic-group-wales-question",
-                            "title": "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> ethnic group?",
-                            "description": "It is for you to choose your ethnic group. For example this could be your family or cultural background, or it could be how you would describe yourself.",
-                            "type": "General",
-                            "answers": [{
-                                "id": "ethnic-group-wales-answer",
-                                "mandatory": false,
-                                "options": [{
-                                        "label": "White",
-                                        "value": "White",
-                                        "description": "Including Welsh, English, Scottish, Northern Irish, British, Irish, Gypsy, Irish Traveller or any other White background"
-                                    },
-                                    {
-                                        "label": "Mixed or multiple ethnic groups",
-                                        "value": "Mixed or multiple ethnic groups",
-                                        "description": "Including White and Black Caribbean, White and Black African, White and Asian or any other Mixed or multiple ethnic background"
-                                    },
-                                    {
-                                        "label": "Asian or Asian British",
-                                        "value": "Asian or Asian British",
-                                        "description": "Including Indian, Pakistani, Bangladeshi, Chinese or any other Asian background"
-                                    },
-                                    {
-                                        "label": "Black, African, Caribbean or Black British",
-                                        "value": "Black, African, Caribbean or Black British",
-                                        "description": "Including African, Caribbean or any other Black, African or Caribbean background"
-                                    },
-                                    {
-                                        "label": "Other ethnic group",
-                                        "value": "Other ethnic group",
-                                        "description": "Including Arab or any other ethnic group"
-                                    }
-                                ],
-                                "type": "Radio"
-                            }],
-                            "skip_conditions": [{
-                                "when": [{
-                                    "meta": "region_code",
-                                    "condition": "not equals",
-                                    "value": "GB-WLS"
-                                }]
-                            }]
-                        }
-                    ],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "white-ethnic-group",
-                                "when": [{
-                                    "id": "ethnic-group-england-answer",
-                                    "condition": "equals",
-                                    "value": "White"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "mixed-ethnic-group",
-                                "when": [{
-                                    "id": "ethnic-group-england-answer",
-                                    "condition": "equals",
-                                    "value": "Mixed or multiple ethnic groups"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "asian-ethnic-group",
-                                "when": [{
-                                    "id": "ethnic-group-england-answer",
-                                    "condition": "equals",
-                                    "value": "Asian or Asian British"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "black-ethnic-group",
-                                "when": [{
-                                    "id": "ethnic-group-england-answer",
-                                    "condition": "equals",
-                                    "value": "Black, African, Caribbean or Black British"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "other-ethnic-group",
-                                "when": [{
-                                    "id": "ethnic-group-england-answer",
-                                    "condition": "equals",
-                                    "value": "Other ethnic group"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "white-ethnic-group",
-                                "when": [{
-                                    "id": "ethnic-group-wales-answer",
-                                    "condition": "equals",
-                                    "value": "White"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "mixed-ethnic-group",
-                                "when": [{
-                                    "id": "ethnic-group-wales-answer",
-                                    "condition": "equals",
-                                    "value": "Mixed or multiple ethnic groups"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "asian-ethnic-group",
-                                "when": [{
-                                    "id": "ethnic-group-wales-answer",
-                                    "condition": "equals",
-                                    "value": "Asian or Asian British"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "black-ethnic-group",
-                                "when": [{
-                                    "id": "ethnic-group-wales-answer",
-                                    "condition": "equals",
-                                    "value": "Black, African, Caribbean or Black British"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "other-ethnic-group",
-                                "when": [{
-                                    "id": "ethnic-group-wales-answer",
-                                    "condition": "equals",
-                                    "value": "Other ethnic group"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "sexual-identity",
-                                "when": [{
-                                        "id": "over-16-answer",
-                                        "condition": "equals",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "meta": "variant_flags.sexual_identity",
-                                        "condition": "equals",
-                                        "value": true
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "understand-welsh",
-                                "when": [{
-                                    "meta": "region_code",
-                                    "condition": "equals",
-                                    "value": "GB-WLS"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "language"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "white-ethnic-group",
-                    "questions": [{
-                            "id": "white-ethnic-group-england-question",
-                            "title": "Which one best describes <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> White ethnic group or background?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "white-ethnic-group-england-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "English, Welsh, Scottish, Northern Irish or British",
-                                            "value": "English, Welsh, Scottish, Northern Irish or British"
-                                        },
-                                        {
-                                            "label": "Irish",
-                                            "value": "Irish"
-                                        },
-                                        {
-                                            "label": "Gypsy or Irish Traveller",
-                                            "value": "Gypsy or Irish Traveller"
-                                        },
-                                        {
-                                            "label": "Any other White background",
-                                            "value": "Other",
-                                            "child_answer_id": "white-ethnic-group-england-answer-other"
-                                        }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "white-ethnic-group-england-answer-other",
-                                    "parent_answer_id": "white-ethnic-group-england-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please specify other White background"
-                                }
-                            ],
-                            "skip_conditions": [{
-                                "when": [{
-                                    "meta": "region_code",
-                                    "condition": "equals",
-                                    "value": "GB-WLS"
-                                }]
-                            }]
-                        },
-                        {
-                            "id": "white-ethnic-group-wales-question",
-                            "title": "Which one best describes <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> White ethnic group or background?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "white-ethnic-group-wales-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Welsh, English, Scottish, Northern Irish or British",
-                                            "value": "Welsh, English, Scottish, Northern Irish or British"
-                                        },
-                                        {
-                                            "label": "Irish",
-                                            "value": "Irish"
-                                        },
-                                        {
-                                            "label": "Gypsy or Irish Traveller",
-                                            "value": "Gypsy or Irish Traveller"
-                                        },
-                                        {
-                                            "label": "Any other White background",
-                                            "value": "Other",
-                                            "child_answer_id": "white-ethnic-group-wales-question-other"
-                                        }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "white-ethnic-group-wales-question-other",
-                                    "parent_answer_id": "white-ethnic-group-wales-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please specify other White background"
-                                }
-                            ],
-                            "skip_conditions": [{
-                                "when": [{
-                                    "meta": "region_code",
-                                    "condition": "not equals",
-                                    "value": "GB-WLS"
-                                }]
-                            }]
-                        }
-                    ],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "sexual-identity",
-                                "when": [{
-                                        "id": "over-16-answer",
-                                        "condition": "equals",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "meta": "variant_flags.sexual_identity",
-                                        "condition": "equals",
-                                        "value": true
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "understand-welsh",
-                                "when": [{
-                                    "meta": "region_code",
-                                    "condition": "equals",
-                                    "value": "GB-WLS"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "language"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "mixed-ethnic-group",
-                    "questions": [{
-                        "id": "mixed-ethnic-group-question",
-                        "title": "Which one best describes <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> Mixed, multiple ethnic group or background?",
-                        "type": "General",
-                        "answers": [{
-                                "id": "mixed-ethnic-group-answer",
-                                "mandatory": false,
-                                "options": [{
-                                        "label": "White and Black Caribbean",
-                                        "value": "White and Black Caribbean"
-                                    },
-                                    {
-                                        "label": "White and Black African",
-                                        "value": "White and Black African"
-                                    },
-                                    {
-                                        "label": "White and Asian",
-                                        "value": "White and Asian"
-                                    },
-                                    {
-                                        "label": "Any other Mixed or multiple ethnic background",
-                                        "value": "Other",
-                                        "child_answer_id": "mixed-ethnic-group-answer-other"
-                                    }
-                                ],
-                                "type": "Radio"
-                            },
-                            {
-                                "id": "mixed-ethnic-group-answer-other",
-                                "parent_answer_id": "mixed-ethnic-group-answer",
-                                "type": "TextField",
-                                "mandatory": false,
-                                "label": "Please specify other Mixed or multiple ethnic background"
-                            }
-                        ]
-                    }],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "sexual-identity",
-                                "when": [{
-                                        "id": "over-16-answer",
-                                        "condition": "equals",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "meta": "variant_flags.sexual_identity",
-                                        "condition": "equals",
-                                        "value": true
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "understand-welsh",
-                                "when": [{
-                                    "meta": "region_code",
-                                    "condition": "equals",
-                                    "value": "GB-WLS"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "language"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "asian-ethnic-group",
-                    "questions": [{
-                        "id": "asian-ethnic-group-question",
-                        "title": "Which one best describes <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> Asian, Asian British ethnic group or background?",
-                        "type": "General",
-                        "answers": [{
-                                "id": "asian-ethnic-group-answer",
-                                "mandatory": false,
-                                "options": [{
-                                        "label": "Indian",
-                                        "value": "Indian"
-                                    },
-                                    {
-                                        "label": "Pakistani",
-                                        "value": "Pakistani"
-                                    },
-                                    {
-                                        "label": "Bangladeshi",
-                                        "value": "Bangladeshi"
-                                    },
-                                    {
-                                        "label": "Chinese",
-                                        "value": "Chinese"
-                                    },
-                                    {
-                                        "label": "Any other Asian background",
-                                        "value": "Other",
-                                        "child_answer_id": "asian-ethnic-group-answer-other"
-                                    }
-                                ],
-                                "type": "Radio"
-                            },
-                            {
-                                "id": "asian-ethnic-group-answer-other",
-                                "parent_answer_id": "asian-ethnic-group-answer",
-                                "type": "TextField",
-                                "mandatory": false,
-                                "label": "Please specify other Asian background"
-                            }
-                        ]
-                    }],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "sexual-identity",
-                                "when": [{
-                                        "id": "over-16-answer",
-                                        "condition": "equals",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "meta": "variant_flags.sexual_identity",
-                                        "condition": "equals",
-                                        "value": true
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "understand-welsh",
-                                "when": [{
-                                    "meta": "region_code",
-                                    "condition": "equals",
-                                    "value": "GB-WLS"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "language"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "black-ethnic-group",
-                    "questions": [{
-                        "id": "black-ethnic-group-question",
-                        "title": "Which one best describes <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> Black, African, Caribbean, Black British ethnic group or background?",
-                        "type": "General",
-                        "answers": [{
-                                "id": "black-ethnic-group-answer",
-                                "mandatory": false,
-                                "options": [{
-                                        "label": "African",
-                                        "value": "African"
-                                    },
-                                    {
-                                        "label": "Caribbean",
-                                        "value": "Caribbean"
-                                    },
-                                    {
-                                        "label": "Any other Black, African or Caribbean background",
-                                        "value": "Other",
-                                        "child_answer_id": "black-ethnic-group-answer-other"
-                                    }
-                                ],
-                                "type": "Radio"
-                            },
-                            {
-                                "id": "black-ethnic-group-answer-other",
-                                "parent_answer_id": "black-ethnic-group-answer",
-                                "type": "TextField",
-                                "mandatory": false,
-                                "label": "Please specify other Black, African or Caribbean background"
-                            }
-                        ]
-                    }],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "sexual-identity",
-                                "when": [{
-                                        "id": "over-16-answer",
-                                        "condition": "equals",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "meta": "variant_flags.sexual_identity",
-                                        "condition": "equals",
-                                        "value": true
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "understand-welsh",
-                                "when": [{
-                                    "meta": "region_code",
-                                    "condition": "equals",
-                                    "value": "GB-WLS"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "language"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "other-ethnic-group",
-                    "questions": [{
-                        "id": "other-ethnic-group-question",
-                        "title": "Which one best describes <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> Other ethnic group or background?",
-                        "type": "General",
-                        "answers": [{
-                                "id": "other-ethnic-group-answer",
-                                "mandatory": false,
-                                "options": [{
-                                        "label": "Arab",
-                                        "value": "Arab"
-                                    },
-                                    {
-                                        "label": "Any other ethnic group",
-                                        "value": "Other",
-                                        "child_answer_id": "other-ethnic-group-answer-other"
-                                    }
-                                ],
-                                "type": "Radio"
-                            },
-                            {
-                                "id": "other-ethnic-group-answer-other",
-                                "parent_answer_id": "other-ethnic-group-answer",
-                                "type": "TextField",
-                                "mandatory": false,
-                                "label": "Please specify Other ethnic group"
-                            }
-                        ]
-                    }],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "sexual-identity",
-                                "when": [{
-                                        "id": "over-16-answer",
-                                        "condition": "equals",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "meta": "variant_flags.sexual_identity",
-                                        "condition": "equals",
-                                        "value": true
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "understand-welsh",
-                                "when": [{
-                                    "meta": "region_code",
-                                    "condition": "equals",
-                                    "value": "GB-WLS"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "language"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "sexual-identity",
-                    "questions": [{
-                        "id": "sexual-identity-question",
-                        "title": "Which of the following options best describes how <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> thinks of themselves?",
-                        "type": "General",
-                        "answers": [{
-                                "id": "sexual-identity-answer",
-                                "mandatory": false,
-                                "options": [{
-                                        "label": "Heterosexual or Straight",
-                                        "value": "Heterosexual or Straight"
-                                    },
-                                    {
-                                        "label": "Gay or Lesbian",
-                                        "value": "Gay or Lesbian"
-                                    },
-                                    {
-                                        "label": "Bisexual",
-                                        "value": "Bisexual"
-                                    },
-                                    {
-                                        "label": "Other",
-                                        "value": "Other",
-                                        "child_answer_id": "sexual-identity-answer-other"
-                                    },
-                                    {
-                                        "label": "Prefer not to say",
-                                        "value": "Prefer not to say"
-                                    }
-
-                                ],
-                                "type": "Checkbox"
-                            },
-                            {
-                                "id": "sexual-identity-answer-other",
-                                "parent_answer_id": "sexual-identity-answer",
-                                "type": "TextField",
-                                "mandatory": false,
-                                "label": "Please specify"
-                            }
-                        ]
-                    }],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "understand-welsh",
-                                "when": [{
-                                    "meta": "region_code",
-                                    "condition": "equals",
-                                    "value": "GB-WLS"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "language"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "understand-welsh",
-                    "questions": [{
-                        "id": "understand-welsh-question",
-                        "title": "Can <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> understand, speak, read or write Welsh",
-                        "description": "Select all that apply",
-                        "type": "General",
-                        "answers": [{
-                            "id": "understand-welsh-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "Understand spoken Welsh",
-                                    "value": "Understand spoken Welsh"
-                                },
-                                {
-                                    "label": "Speak Welsh",
-                                    "value": "Speak Welsh"
-                                },
-                                {
-                                    "label": "Read Welsh",
-                                    "value": "Read Welsh"
-                                },
-                                {
-                                    "label": "Write Welsh",
-                                    "value": "Write Welsh"
-                                },
-                                {
-                                    "label": "None of the above",
-                                    "value": "None of the above"
-                                }
-                            ],
-                            "type": "Checkbox"
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "language",
-                    "questions": [{
-                            "id": "language-england-question",
-                            "title": "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> main language?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "language-england-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "English",
-                                            "value": "English"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "description": "Including British Sign Language",
-                                            "child_answer_id": "language-england-answer-other"
-                                        }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "language-england-answer-other",
-                                    "parent_answer_id": "language-england-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please specify main language"
-                                }
-                            ],
-                            "skip_conditions": [{
-                                "when": [{
-                                    "meta": "region_code",
-                                    "condition": "equals",
-                                    "value": "GB-WLS"
-                                }]
-                            }]
-                        },
-                        {
-                            "id": "language-welsh-question",
-                            "title": "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> main language?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "language-welsh-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "English or Welsh",
-                                            "value": "English or Welsh"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "description": "Including British Sign Language",
-                                            "child_answer_id": "language-welsh-answer-other"
-                                        }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "language-welsh-answer-other",
-                                    "parent_answer_id": "language-welsh-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please specify main language"
-                                }
-                            ],
-                            "skip_conditions": [{
-                                "when": [{
-                                    "meta": "region_code",
-                                    "condition": "not equals",
-                                    "value": "GB-WLS"
-                                }]
-                            }]
-                        }
-                    ],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "religion",
-                                "when": [{
-                                    "id": "language-england-answer",
-                                    "condition": "equals",
-                                    "value": "English"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "religion",
-                                "when": [{
-                                    "id": "language-welsh-answer",
-                                    "condition": "equals",
-                                    "value": "English or Welsh"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "english"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "english",
-                    "questions": [{
-                        "id": "english-question",
-                        "title": "How well can <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> speak English?",
-                        "type": "General",
-                        "answers": [{
-                            "id": "english-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "Very well",
-                                    "value": "Very well"
-                                },
-                                {
-                                    "label": "Well",
-                                    "value": "Well"
-                                },
-                                {
-                                    "label": "Not well",
-                                    "value": "Not well"
-                                },
-                                {
-                                    "label": "Not at all",
-                                    "value": "Not at all"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "religion",
-                    "questions": [{
-                        "id": "religion-question",
-                        "title": "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> religion?",
-                        "description": "This question is voluntary",
-                        "type": "General",
-                        "answers": [{
-                                "id": "religion-answer",
-                                "mandatory": false,
-                                "options": [{
-                                        "label": "No religion",
-                                        "value": "No religion"
-                                    },
-                                    {
-                                        "label": "Christianity",
-                                        "value": "Christianity"
-                                    },
-                                    {
-                                        "label": "Buddhism",
-                                        "value": "Buddhism"
-                                    },
-                                    {
-                                        "label": "Hinduism",
-                                        "value": "Hinduism"
-                                    },
-                                    {
-                                        "label": "Judaism",
-                                        "value": "Judaism"
-                                    },
-                                    {
-                                        "label": "Islam",
-                                        "value": "Islam"
-                                    },
-                                    {
-                                        "label": "Sikhism",
-                                        "value": "Sikhism"
-                                    },
-                                    {
-                                        "label": "Any other religion",
-                                        "value": "Other",
-                                        "child_answer_id": "religion-answer-other"
-                                    }
-                                ],
-                                "type": "Checkbox"
-                            },
-                            {
-                                "id": "religion-answer-other",
-                                "parent_answer_id": "religion-answer",
-                                "type": "TextField",
-                                "mandatory": false,
-                                "label": "Please specify other religion"
-                            }
-                        ]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "past-usual-address",
-                    "questions": [{
-                        "id": "past-usual-address-question",
-                        "title": "One year ago, what was your usual address?",
-                        "description": "If you had no usual address one year ago, state the address where you were staying",
-                        "type": "General",
-                        "answers": [{
-                                "id": "past-usual-address-answer",
-                                "mandatory": false,
-                                "guidance": {
-                                    "show_guidance": "Show further guidance",
-                                    "hide_guidance": "Hide further guidance",
-                                    "content": [{
-                                        "description": "In most cases your usual address will be the permanent or family home that you were living in."
-                                    }]
-                                },
-                                "options": [{
-                                        "label": "This address",
-                                        "value": "This address"
-                                    },
-                                    {
-                                        "label": "Student term time or boarding school address in the UK",
-                                        "value": "Student term time or boarding school address in the UK"
-                                    },
-                                    {
-                                        "label": "Another address in the UK",
-                                        "value": "Another address in the UK"
-                                    },
-                                    {
-                                        "label": "An address outside the UK",
-                                        "value": "Other",
-                                        "child_answer_id": "past-usual-address-answer-other"
-                                    }
-                                ],
-                                "type": "Radio"
-                            },
-                            {
-                                "id": "past-usual-address-answer-other",
-                                "parent_answer_id": "past-usual-address-answer",
-                                "type": "TextField",
-                                "mandatory": false,
-                                "label": "Please enter the country"
-                            }
-                        ]
-                    }],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "last-year-address",
-                                "when": [{
-                                    "id": "past-usual-address-answer",
-                                    "condition": "equals",
-                                    "value": "Student term time or boarding school address in the UK"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "last-year-address",
-                                "when": [{
-                                    "id": "past-usual-address-answer",
-                                    "condition": "equals",
-                                    "value": "Another address in the UK"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "passports"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "last-year-address",
-                    "questions": [{
-                        "id": "last-year-address-question",
-                        "title": "Enter details of your address one year ago",
-                        "type": "General",
-                        "answers": [{
-                                "id": "last-year-address-answer-building",
-                                "label": "Building",
-                                "mandatory": false,
-                                "type": "TextField"
-                            },
-                            {
-                                "id": "last-year-address-answer-street",
-                                "label": "Street",
-                                "mandatory": false,
-                                "type": "TextField"
-                            },
-                            {
-                                "id": "last-year-address-answer-city",
-                                "label": "Town or city",
-                                "mandatory": false,
-                                "type": "TextField"
-                            },
-                            {
-                                "id": "last-year-address-answer-county",
-                                "label": "County (optional)",
-                                "mandatory": false,
-                                "type": "TextField"
-                            },
-                            {
-                                "id": "last-year-address-answer-postcode",
-                                "label": "Postcode",
-                                "mandatory": false,
-                                "type": "TextField"
-                            }
-                        ]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "passports",
-                    "questions": [{
-                        "id": "passports-question",
-                        "title": "What passports do you hold?",
-                        "description": "Select all that apply",
-                        "type": "General",
-                        "answers": [{
-                            "id": "passports-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "United Kingdom",
-                                    "value": "United Kingdom"
-                                },
-                                {
-                                    "label": "Irish",
-                                    "value": "Irish"
-                                },
-                                {
-                                    "label": "Other",
-                                    "value": "Other"
-                                },
-                                {
-                                    "label": "None",
-                                    "value": "None"
-                                }
-                            ],
-                            "type": "Checkbox"
-                        }]
-                    }],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "other-passports",
-                                "when": [{
-                                    "id": "passports-answer",
-                                    "condition": "contains",
-                                    "value": "Other"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "disability"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "other-passports",
-                    "questions": [{
-                        "id": "other-passports-question",
-                        "title": "Please specify other passports held",
-                        "type": "General",
-                        "answers": [{
-                            "id": "other-passports-answer",
-                            "label": "Passports held",
-                            "mandatory": false,
-                            "type": "TextField"
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "disability",
-                    "questions": [{
-                        "id": "disability-question",
-                        "title": "Are <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> day-to-day activities limited because of a health problem or disability which has lasted, or is expected to last, at least 12 months?",
-                        "guidance": {
-                            "content": [{
-                                "description": "<strong>Include</strong> problems related to old age"
-                            }]
-                        },
-                        "type": "General",
-                        "answers": [{
-                            "id": "disability-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "Yes, limited a lot",
-                                    "value": "Yes, limited a lot"
-                                },
-                                {
-                                    "label": "Yes, limited a little",
-                                    "value": "Yes, limited a little"
-                                },
-                                {
-                                    "label": "No",
-                                    "value": "No"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "household-member-completed",
-                                "when": [{
-                                    "id": "over-16-answer",
-                                    "condition": "equals",
-                                    "value": "No"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "qualifications"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "qualifications",
-                    "questions": [{
-                            "id": "qualifications-england-question",
-                            "title": "Thinking of any studies, exams or qualifications, which of the following does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> have?",
-                            "description": "Select every option that applies (whether UK or foreign equivalent) if you have any of the qualifications listed",
-                            "type": "General",
-                            "answers": [{
-                                "id": "qualifications-england-answer",
-                                "mandatory": false,
-                                "options": [{
-                                        "label": "5 or more  GCSEs (grades A-Star to C) or O-Levels (passes) or CSEs (grade 1), School Certificate, One A-Level, 2 to 3 AS-Levels or VCEs, Higher Diploma",
-                                        "value": "5 or more  GCSEs (grades A-Star to C) or O-Levels (passes) or CSEs (grade 1), School Certificate, One A-Level, 2 to 3 AS-Levels or VCEs, Higher Diploma"
-                                    },
-                                    {
-                                        "label": "1 to 4 GCSEs or O-Levels or CSEs (any grades), Entry level, Foundation Diploma",
-                                        "value": "1 to 4 GCSEs or O-Levels or CSEs (any grades), Entry level, Foundation Diploma"
-                                    },
-                                    {
-                                        "label": "2 or more  A-Levels, 4 or more  AS-levels or VCEs, Higher School Certificate, Advanced Diploma",
-                                        "value": "2 or more  A-Levels, 4 or more  AS-levels or VCEs, Higher School Certificate, Advanced Diploma"
-                                    },
-                                    {
-                                        "label": "Apprenticeship (trade, advanced, foundation or modern)",
-                                        "value": "Apprenticeship (trade, advanced, foundation or modern)"
-                                    },
-                                    {
-                                        "label": "NVQ level one, Foundation GNVQ, Basic Skills",
-                                        "value": "NVQ level one, Foundation GNVQ, Basic Skills"
-                                    },
-                                    {
-                                        "label": "NVQ level two, Intermediate GNVQ, City and Guilds Craft, BTEC First, RSA Diploma",
-                                        "value": "NVQ level two, Intermediate GNVQ, City and Guilds Craft, BTEC First, RSA Diploma"
-                                    },
-                                    {
-                                        "label": "NVQ Level three, Advanced GNVQ, City and Guilds Advanced Craft, ONC, OND, BTEC National, RSA Advanced Diploma",
-                                        "value": "NVQ Level three, Advanced GNVQ, City and Guilds Advanced Craft, ONC, OND, BTEC National, RSA Advanced Diploma"
-                                    },
-                                    {
-                                        "label": "NVQ Level four to five, HNC, HND, RSA Higher Diploma, BTEC Higher, Foundation degree",
-                                        "value": "NVQ Level four to five, HNC, HND, RSA Higher Diploma, BTEC Higher, Foundation degree"
-                                    },
-                                    {
-                                        "label": "Other vocational or work-related qualifications",
-                                        "value": "Other vocational or work-related qualifications"
-                                    },
-                                    {
-                                        "label": "Undergraduate Degree",
-                                        "value": "Undergraduate Degree"
-                                    },
-                                    {
-                                        "label": "Postgraduate Certificate / Diploma",
-                                        "value": "Postgraduate Certificate / Diploma"
-                                    },
-                                    {
-                                        "label": "Masters Degree",
-                                        "value": "Masters Degree"
-                                    },
-                                    {
-                                        "label": "Doctorate Degree (for example PhD)",
-                                        "value": "Doctorate Degree (for example PhD)"
-                                    },
-                                    {
-                                        "label": "Professional qualification (for example teaching, nursing, accountancy)",
-                                        "value": "Professional qualification (for example teaching, nursing, accountancy)"
-                                    },
-                                    {
-                                        "label": "Foreign qualifications (UK equivalent not known)",
-                                        "value": "Foreign qualifications (UK equivalent not known)"
-                                    },
-                                    {
-                                        "label": "No qualifications",
-                                        "value": "No qualifications"
-                                    }
-                                ],
-                                "type": "Checkbox"
-                            }],
-                            "skip_conditions": [{
-                                "when": [{
-                                    "meta": "region_code",
-                                    "condition": "equals",
-                                    "value": "GB-WLS"
-                                }]
-                            }]
-                        },
-                        {
-                            "id": "qualifications-welsh-question",
-                            "title": "Thinking of any studies, exams or qualifications, which of the following does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> have?",
-                            "description": "Select every option that applies (whether UK or foreign equivalent) if you have any of the qualifications listed",
-                            "type": "General",
-                            "answers": [{
-                                "id": "qualifications-welsh-answer",
-                                "mandatory": false,
-                                "options": [{
-                                        "label": "5 or more GCSEs (grades A-Star to C) or O Levels (passes) or CSEs (grade 1), School Certificate, One A-Level, 2 to 3 AS-Levels or VCEs,  Intermediate or National Welsh Baccalaureate (Level two)",
-                                        "value": "5 or more GCSEs (grades A-Star to C) or O Levels (passes) or CSEs (grade 1), School Certificate, One A-Level, 2 to 3 AS-Levels or VCEs,  Intermediate or National Welsh Baccalaureate (Level two)"
-                                    },
-                                    {
-                                        "label": "1 to 4  GCSEs or O Levels or CSEs (any grades), Entry level, Foundation Welsh Baccalaureate (level one)",
-                                        "value": "1 to 4  GCSEs or O Levels or CSEs (any grades), Entry level, Foundation Welsh Baccalaureate (level one)"
-                                    },
-                                    {
-                                        "label": "More than 2 A-Levels, more than 4 AS-levels or VCEs, Higher School Certificate, Advanced Welsh Baccalaureate (level three)",
-                                        "value": "More than 2 A-Levels, more than 4 AS-levels or VCEs, Higher School Certificate, Advanced Welsh Baccalaureate (level three)"
-                                    },
-                                    {
-                                        "label": "Apprenticeship (foundation, modern or higher)",
-                                        "value": "Apprenticeship (foundation, modern or higher)"
-                                    },
-                                    {
-                                        "label": "NVQ level one, Foundation GNVQ, Essential or Key  Skills",
-                                        "value": "NVQ level one, Foundation GNVQ, Essential or Key  Skills"
-                                    },
-                                    {
-                                        "label": "NVQ level two, Intermediate GNVQ, City and Guilds Craft, BTEC First, RSA Diploma",
-                                        "value": "NVQ level two, Intermediate GNVQ, City and Guilds Craft, BTEC First, RSA Diploma"
-                                    },
-                                    {
-                                        "label": "NVQ Level three, Advanced GNVQ, City and Guilds Advanced Craft, ONC, OND, BTEC National, RSA Advanced Diploma",
-                                        "value": "NVQ Level three, Advanced GNVQ, City and Guilds Advanced Craft, ONC, OND, BTEC National, RSA Advanced Diploma"
-                                    },
-                                    {
-                                        "label": "NVQ Level four to five, HNC, HND, RSA Higher Diploma, BTEC Higher",
-                                        "value": "NVQ Level four to five, HNC, HND, RSA Higher Diploma, BTEC Higher"
-                                    },
-                                    {
-                                        "label": "Other vocational or work-related qualifications",
-                                        "value": "Other vocational or work-related qualifications"
-                                    },
-                                    {
-                                        "label": "Undergraduate Degree",
-                                        "value": "Undergraduate Degree"
-                                    },
-                                    {
-                                        "label": "Postgraduate Certificate / Diploma",
-                                        "value": "Postgraduate Certificate / Diploma"
-                                    },
-                                    {
-                                        "label": "Masters Degree",
-                                        "value": "Masters Degree"
-                                    },
-                                    {
-                                        "label": "Doctorate Degree (for example PhD)",
-                                        "value": "Doctorate Degree (for example PhD)"
-                                    },
-                                    {
-                                        "label": "Professional qualification (for example teaching, nursing, accountancy)",
-                                        "value": "Professional qualification (for example teaching, nursing, accountancy)"
-                                    },
-                                    {
-                                        "label": "Foreign qualifications (UK equivalent not known)",
-                                        "value": "Foreign qualifications (UK equivalent not known)"
-                                    },
-                                    {
-                                        "label": "No qualifications",
-                                        "value": "No qualifications"
-                                    }
-                                ],
-                                "type": "Checkbox"
-                            }],
-                            "skip_conditions": [{
-                                "when": [{
-                                    "meta": "region_code",
-                                    "condition": "not equals",
-                                    "value": "GB-WLS"
-                                }]
-                            }]
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "employment-type",
-                    "questions": [{
-                        "id": "employment-type-question",
-                        "title": "Which of the following best describes what <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> was doing last week?",
-                        "guidance": {
-                            "content": [{
-                                "description": "<strong>Include</strong> any paid work, including casual or temporary work, even if only for one hour"
-                            }]
-                        },
-                        "type": "General",
-                        "answers": [{
-                            "id": "employment-type-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "working as an employee",
-                                    "value": "working as an employee"
-                                },
-                                {
-                                    "label": "on a government sponsored training scheme",
-                                    "value": "on a government sponsored training scheme"
-                                },
-                                {
-                                    "label": "self-employed or freelance",
-                                    "value": "self-employed or freelance"
-                                },
-                                {
-                                    "label": "working paid or unpaid for you own or your family’s business",
-                                    "value": "working paid or unpaid for you own or your family’s business"
-                                },
-                                {
-                                    "label": "away from work ill, on maternity leave, on holiday or temporarily laid off",
-                                    "value": "away from work ill, on maternity leave, on holiday or temporarily laid off"
-                                },
-                                {
-                                    "label": "doing any other kind of paid work",
-                                    "value": "doing any other kind of paid work"
-                                },
-                                {
-                                    "label": "none of the above",
-                                    "value": "none of the above"
-                                }
-                            ],
-                            "type": "Checkbox",
-                            "label": "Select all that apply"
-                        }]
-                    }],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "main-job",
-                                "when": [{
-                                    "id": "employment-type-answer",
-                                    "condition": "contains",
-                                    "value": "working as an employee"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "main-job",
-                                "when": [{
-                                    "id": "employment-type-answer",
-                                    "condition": "contains",
-                                    "value": "on a government sponsored training scheme"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "main-job",
-                                "when": [{
-                                    "id": "employment-type-answer",
-                                    "condition": "contains",
-                                    "value": "self-employed or freelance"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "main-job",
-                                "when": [{
-                                    "id": "employment-type-answer",
-                                    "condition": "contains",
-                                    "value": "working paid or unpaid for you own or your family’s business"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "main-job",
-                                "when": [{
-                                    "id": "employment-type-answer",
-                                    "condition": "contains",
-                                    "value": "away from work ill, on maternity leave, on holiday or temporarily laid off"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "main-job",
-                                "when": [{
-                                    "id": "employment-type-answer",
-                                    "condition": "contains",
-                                    "value": "doing any other kind of paid work"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "jobseeker"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "jobseeker",
-                    "questions": [{
-                        "id": "jobseeker-question",
-                        "title": "Was <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> actively looking for any kind of paid work during the last four weeks?",
-                        "type": "General",
-                        "answers": [{
-                            "id": "jobseeker-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "Yes",
-                                    "value": "Yes"
-                                },
-                                {
-                                    "label": "No",
-                                    "value": "No"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "job-availability",
-                    "questions": [{
-                        "id": "job-availability-question",
-                        "title": "If a job had been offered to <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> last week, could they have started it within 2 weeks?",
-                        "type": "General",
-                        "answers": [{
-                            "id": "job-availability-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "Yes",
-                                    "value": "Yes"
-                                },
-                                {
-                                    "label": "No",
-                                    "value": "No"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "job-pending",
-                    "questions": [{
-                        "id": "job-pending-question",
-                        "title": "Last week, was <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> waiting to start a job already accepted?",
-                        "type": "General",
-                        "answers": [{
-                            "id": "job-pending-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "Yes",
-                                    "value": "Yes"
-                                },
-                                {
-                                    "label": "No",
-                                    "value": "No"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "occupation",
-                    "questions": [{
-                        "id": "occupation-question",
-                        "title": "Which of the following best describes what <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> was doing last week?",
-                        "description": "Select all that apply",
-                        "type": "General",
-                        "answers": [{
-                            "id": "occupation-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "retired (whether receiving a pension or not)",
-                                    "value": "retired (whether receiving a pension or not)"
-                                },
-                                {
-                                    "label": "a student",
-                                    "value": "a student"
-                                },
-                                {
-                                    "label": "looking after home or family",
-                                    "value": "looking after home or family"
-                                },
-                                {
-                                    "label": "long-term sick or disabled",
-                                    "value": "long-term sick or disabled"
-                                },
-                                {
-                                    "label": "other",
-                                    "value": "other"
-                                }
-                            ],
-                            "type": "Checkbox"
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "ever-worked",
-                    "questions": [{
-                        "id": "ever-worked-question",
-                        "title": "Has <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> ever worked?",
-                        "type": "General",
-                        "guidance": {
-                            "content": [{
-                                "title": "Include:",
-                                "list": [
-                                    "work outside of the United Kingdom.",
-                                    "even if you are now retired."
-                                ]
-                            }]
-                        },
-                        "answers": [{
-                            "id": "ever-worked-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "Yes",
-                                    "value": "Yes"
-                                },
-                                {
-                                    "label": "No",
-                                    "value": "No"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "household-member-completed",
-                                "when": [{
-                                    "id": "ever-worked-answer",
-                                    "condition": "equals",
-                                    "value": "No"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "household-member-completed",
-                                "when": [{
-                                    "id": "ever-worked-answer",
-                                    "condition": "not set"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "main-job"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "main-job",
-                    "questions": [{
-                        "id": "main-job-question",
-                        "title": "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive }}</em> employment status?",
-                        "guidance": {
-                            "content": [{
-                                "description": "<p>If you are not working answer the remaining questions about your last main job.</p><p>Your main job is the job which you usually work (worked) the most hours</p>"
-                            }]
-                        },
-                        "type": "General",
-                        "answers": [{
-                            "id": "main-job-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "an employee",
-                                    "value": "an employee"
-                                },
-                                {
-                                    "label": "self-employed or freelance without employees",
-                                    "value": "self-employed or freelance without employees"
-                                },
-                                {
-                                    "label": "self-employed with employees",
-                                    "value": "self-employed with employees"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "hours-worked",
-                    "description": "",
-                    "questions": [{
-                        "title": "In <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive }}</em> main job, how many hours a week do they usually work?",
-                        "guidance": {
-                            "content": [{
-                                "description": "Include paid and unpaid overtime"
-                            }]
-                        },
-                        "id": "hours-worked-question",
-                        "type": "General",
-                        "answers": [{
-                            "id": "hours-worked-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "15 or less",
-                                    "value": "15 or less"
-                                },
-                                {
-                                    "label": "16 - 30",
-                                    "value": "16 - 30"
-                                },
-                                {
-                                    "label": "31 - 48",
-                                    "value": "31 - 48"
-                                },
-                                {
-                                    "label": "49 or more",
-                                    "value": "49 or more "
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "work-travel",
-                    "description": "",
-                    "questions": [{
-                        "title": "How does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> usually travel to work?",
-                        "description": "Select the option for the longest part, in distance, of your journey. For example, you travel by bus and by car. Your bus journey is 5 miles, and the car journey is 8 miles. You should select car as your answer.",
-                        "id": "work-travel-question",
-                        "type": "General",
-                        "answers": [{
-                            "id": "work-travel-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "Work mainly at or from home",
-                                    "value": "Work mainly at or from home"
-                                },
-                                {
-                                    "label": "Underground, metro, light rail or tram",
-                                    "value": "Underground, metro, light rail or tram"
-                                },
-                                {
-                                    "label": "Train",
-                                    "value": "Train"
-                                },
-                                {
-                                    "label": "Bus, minibus or coach",
-                                    "value": "Bus, minibus or coach "
-                                },
-                                {
-                                    "label": "Taxi",
-                                    "value": "Taxi "
-                                },
-                                {
-                                    "label": "Motorcycle, scooter or moped",
-                                    "value": "Motorcycle, scooter or moped"
-                                },
-                                {
-                                    "label": "Driving a car or van",
-                                    "value": "Driving a car or van"
-                                },
-                                {
-                                    "label": "Passenger in a car or van",
-                                    "value": "Passenger in a car or van"
-                                },
-                                {
-                                    "label": "Bicycle",
-                                    "value": "Bicycle"
-                                },
-                                {
-                                    "label": "On foot",
-                                    "value": "On foot"
-                                },
-                                {
-                                    "label": "Other",
-                                    "value": "Other"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "job-title",
-                    "questions": [{
-                        "id": "job-title-question",
-                        "title": "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive }}</em> full job title?",
-                        "description": "<p>For example, <b>primary school teacher, car mechanic, district nurse, structural engineer</b></p><p>Do not state your grade or pay band</p><p>Please enter your job title in the space provided.</p><p>Do not state your grade or pay band.</p><p>If you are not sure of your job title please give the best information you can.</p>",
-                        "type": "General",
-                        "answers": [{
-                            "id": "job-title-answer",
-                            "label": "Job title",
-                            "mandatory": false,
-                            "type": "TextField"
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "job-description",
-                    "questions": [{
-                        "id": "job-description-question",
-                        "title": "What <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> does in their main job?",
-                        "type": "General",
-                        "answers": [{
-                            "id": "job-description-answer",
-                            "label": "Description",
-                            "mandatory": false,
-                            "type": "TextArea"
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "main-job-type",
-                    "questions": [{
-                        "id": "main-job-type-question",
-                        "title": "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> employment status?",
-                        "type": "General",
-                        "answers": [{
-                            "id": "main-job-type-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "Employed by an organisation or business",
-                                    "value": "Employed by an organisation or business"
-                                },
-                                {
-                                    "label": "Self-employed in your own organisation or business",
-                                    "value": "Self-employed in your own organisation or business"
-                                },
-                                {
-                                    "label": "Not working for an organisation or business",
-                                    "value": "Not working for an organisation or business",
-                                    "description": "For example self-employed freelance or work (worked) for a private individual"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "household-member-completed",
-                                "when": [{
-                                    "id": "main-job-type-answer",
-                                    "condition": "equals",
-                                    "value": "Not working for an organisation or business"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "business-name"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "business-name",
-                    "questions": [{
-                        "id": "business-name-question",
-                        "title": "What is the name of the organisation of business that <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> work for?",
-                        "description": "<p>If you were self-employed in your own organisation or business, enter the name</p><p>This question is asking for the name of the organisation or business that you work (or worked) for in your main job.</p><p>If you can’t remember the name of the organisation, please give the best information you can.</p><p>If you are employed through an agency please enter the name of the business you are working for, not the agency.</p>",
-                        "type": "General",
-                        "answers": [{
-                            "id": "business-name-answer",
-                            "label": "Organisation or business name",
-                            "mandatory": false,
-                            "type": "TextField",
-                            "alias": "company_name"
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "employers-business",
-                    "questions": [{
-                        "id": "employers-business-question",
-                        "title": "What is the main activity of <em>{{answers.company_name}}</em>?",
-                        "description": "<p>Enter the main activity of your employer or business.</p><p>Another way of describing main activity is the industry that your employer or business works in.</p><p>If you are not sure of the main activity of your employer or business please give the best information you can.</p><p>If you are employed through an agency please enter the main activity of the business you are working for, not the agency.</p><p>For example, <b>primary education, repairing cars, contract catering, computer servicing</b></p>",
-                        "type": "General",
-                        "answers": [{
-                            "id": "employers-business-answer",
-                            "label": "Description",
-                            "mandatory": false,
-                            "type": "TextArea"
-                        }]
-                    }]
-                },
-                {
-                    "id": "household-member-completed",
-                    "title": "There are no more questions for {{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
-                    "description": "",
-                    "type": "Interstitial"
-                }
-            ]
-        },
-        {
-            "id": "visitors-begin",
-            "title": "VisitorsBegin",
-            "skip_conditions": [{
-                    "when": [{
-                        "id": "overnight-visitors-answer",
-                        "condition": "equals",
-                        "value": "0"
-                    }]
-                },
-                {
-                    "when": [{
-                        "id": "overnight-visitors-answer",
-                        "condition": "not set"
-                    }]
-                }
-            ],
-            "blocks": [{
-                "type": "Interstitial",
-                "id": "visitor-begin-section",
-                "title": "Visitors",
-                "description": "In this section, we’re going to ask you about any visitors that were staying overnight at <em>{{answers.address_line_1}}</em> on 29 November 2017.",
-                "content": [{
-                    "title": "Information you need",
-                    "list": [
-                        "Name of visitor",
-                        "Gender of visitor",
-                        "Date of birth of visitor",
-                        "Address of visitor"
-                    ]
-                }]
-            }]
-        },
-        {
-            "id": "visitors",
-            "title": "Visitors",
-            "routing_rules": [{
-                "repeat": {
-                    "type": "answer_value",
-                    "answer_id": "overnight-visitors-answer"
-                }
-            }],
-            "blocks": [{
-                    "type": "Question",
-                    "id": "visitor-name",
-                    "questions": [{
-                        "id": "visitor-name-question",
-                        "title": "What is the name of visitor {{group_instance + 1}}?",
-                        "type": "General",
-                        "answers": [{
-                                "id": "visitor-first-name",
-                                "label": "First name",
-                                "mandatory": false,
-                                "type": "TextField"
-                            },
-                            {
-                                "id": "visitor-last-name",
-                                "label": "Last name",
-                                "mandatory": false,
-                                "type": "TextField"
-                            }
-                        ]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "visitor-sex",
-                    "questions": [{
-                        "id": "visitor-sex-question",
-                        "title": "What is this person’s sex?",
-                        "type": "General",
-                        "answers": [{
-                            "id": "visitor-sex-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "Male",
-                                    "value": "Male"
-                                },
-                                {
-                                    "label": "Female",
-                                    "value": "Female"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "visitor-date-of-birth",
-                    "questions": [{
-                        "id": "visitor-date-of-birth-question",
-                        "title": "What is this person’s date of birth?",
-                        "description": "For example 20 March 1980",
-                        "type": "General",
-                        "answers": [{
-                            "id": "visitor-date-of-birth-answer",
-                            "mandatory": false,
-                            "type": "Date"
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "visitor-uk-resident",
-                    "questions": [{
-                        "id": "visitor-uk-resident-question",
-                        "title": "Does this person usually live in the United Kingdom?",
-                        "type": "General",
-                        "answers": [{
-                                "id": "visitor-uk-resident-answer",
-                                "mandatory": false,
-                                "options": [{
-                                        "label": "Yes, usually lives in the United Kingdom",
-                                        "value": "Yes, usually lives in the United Kingdom"
-                                    },
-                                    {
-                                        "label": "No, usually lives outside the United Kingdom (please specify)",
-                                        "value": "Other",
-                                        "child_answer_id": "visitor-uk-resident-answer-other"
-                                    }
-                                ],
-                                "type": "Radio"
-                            },
-                            {
-                                "id": "visitor-uk-resident-answer-other",
-                                "parent_answer_id": "visitor-uk-resident-answer",
-                                "type": "TextField",
-                                "mandatory": false,
-                                "label": "Please specify country"
-                            }
-                        ]
-                    }],
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "visitor-address",
-                                "when": [{
-                                    "id": "visitor-uk-resident-answer",
-                                    "condition": "equals",
-                                    "value": "Yes, usually lives in the United Kingdom"
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "visitor-completed"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "visitor-address",
-                    "questions": [{
-                        "id": "visitor-address-question",
-                        "title": "Enter details of this person’s usual UK address",
-                        "type": "General",
-                        "answers": [{
-                                "id": "visitor-address-answer-building",
-                                "label": "Building",
-                                "mandatory": false,
-                                "type": "TextField"
-                            },
-                            {
-                                "id": "visitor-address-answer-street",
-                                "label": "Street",
-                                "mandatory": false,
-                                "type": "TextField"
-                            },
-                            {
-                                "id": "visitor-address-answer-city",
-                                "label": "Town or city",
-                                "mandatory": false,
-                                "type": "TextField"
-                            },
-                            {
-                                "id": "visitor-address-answer-county",
-                                "label": "County (optional)",
-                                "mandatory": false,
-                                "type": "TextField"
-                            },
-                            {
-                                "id": "visitor-address-answer-postcode",
-                                "label": "Postcode",
-                                "mandatory": false,
-                                "type": "TextField"
-                            }
-                        ]
-                    }]
-                },
-                {
-                    "id": "visitor-completed",
-                    "title": "You have completed all questions for Visitor {{group_instance + 1}}",
-                    "description": "",
-                    "type": "Interstitial"
-                }
-            ]
-        },
-        {
-            "id": "visitors-interstitial",
-            "title": "Visitors",
-            "skip_conditions": [{
-                    "when": [{
-                        "id": "overnight-visitors-answer",
-                        "condition": "equals",
-                        "value": "0"
-                    }]
-                },
-                {
-                    "when": [{
-                        "id": "overnight-visitors-answer",
-                        "condition": "not set"
-                    }]
-                }
-            ],
-            "blocks": [{
-                "id": "visitors-completed",
-                "type": "Interstitial",
-                "title": "You have successfully completed the ‘Visitors’ section",
-                "description": ""
-            }]
-        },
-        {
-            "id": "questionnaire-completed",
-            "title": "Submit answers",
-            "blocks": [{
-                "type": "Confirmation",
-                "id": "confirmation",
-                "title": "You’re ready to submit your 2017 Census Test",
-                "description": "<p>Thank you for taking part in the 2017 Census Test.</p>",
-                "questions": [{
-                    "answers": [],
-                    "id": "questionnaire-completed-question",
-                    "title": "",
-                    "type": "General",
-                    "guidance": {
-                        "content": [{
-                            "title": "Please note:",
-                            "list": [
-                                "by submitting your responses, you are declaring that you have completed to the best of your knowledge and belief.",
-                                "if you do not submit, your responses will be automatically submitted when the Census 2017 Test closes.",
-                                "after submission you will have an opportunity to provide feedback on your experience."
-                            ]
-                        }]
-                    }
-                }]
-            }]
-        }
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.2",
+  "survey_id": "census",
+  "title": "2017 Census Test",
+  "description": "Census England Household Schema",
+  "theme": "census",
+  "legal_basis": "Voluntary",
+  "navigation": {
+    "visible": true,
+    "sections": [
+      {
+        "title": "Who lives here?",
+        "group_order": ["who-lives-here", "who-lives-here-relationship", "who-lives-here-interstitial"]
+      },
+      {
+        "title": "Household and Accommodation",
+        "group_order": ["household-and-accommodation"]
+      },
+      {
+        "title_from_answers": ["first-name", "last-name"],
+        "group_order": ["household-member"]
+      },
+      {
+        "title": "Visitors",
+        "group_order": ["visitors-begin", "visitors", "visitors-interstitial"]
+      },
+      {
+        "title": "Submit answers",
+        "group_order": ["questionnaire-completed"]
+      }
     ]
+  },
+  "groups": [
+    {
+      "id": "what-is-your-address-group",
+      "title": "What is your address?",
+      "blocks": [
+        {
+          "type": "Introduction",
+          "id": "introduction"
+        },
+        {
+          "type": "Question",
+          "id": "what-is-your-address",
+          "questions": [
+            {
+              "id": "what-is-your-address-question",
+              "title": "What is your address?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "address-line-1",
+                  "label": "Address Line 1 (Including your house name or number)",
+                  "mandatory": true,
+                  "type": "TextField",
+                  "alias": "address_line_1",
+                  "validation": {
+                    "messages": {
+                      "MANDATORY_TEXTFIELD": "Enter an address to continue"
+                    }
+                  }
+                },
+                {
+                  "id": "address-line-2",
+                  "label": "Address Line 2",
+                  "mandatory": false,
+                  "type": "TextField"
+                },
+                {
+                  "id": "address-line-3",
+                  "label": "Address Line 3",
+                  "mandatory": false,
+                  "type": "TextField"
+                },
+                {
+                  "id": "town-city",
+                  "label": "Town/City",
+                  "mandatory": false,
+                  "type": "TextField"
+                },
+                {
+                  "id": "county",
+                  "label": "County",
+                  "mandatory": false,
+                  "type": "TextField"
+                },
+                {
+                  "id": "postcode",
+                  "label": "Postcode",
+                  "mandatory": false,
+                  "type": "TextField"
+                },
+                {
+                  "id": "country",
+                  "label": "Country",
+                  "mandatory": false,
+                  "type": "TextField"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "who-lives-here",
+      "title": "Who lives here?",
+      "blocks": [
+        {
+          "type": "Interstitial",
+          "id": "who-lives-here-section",
+          "title": "People who live in the household",
+          "description": "In this section, we’re going to ask you about the people that live at <em>{{answers.address_line_1}}</em>.",
+          "content": [
+            {
+              "title": "Information you need",
+              "list": [
+                "Names of the people living in household and how they are related",
+                "The number of visitors staying in the household on 29 November 2017"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "permanent-or-family-home",
+          "questions": [
+            {
+              "id": "permanent-or-family-home-question",
+              "title": "Does anyone live at <em>{{answers.address_line_1}}</em> as their permanent or family home?",
+              "guidance": {
+                "content": [
+                  {
+                    "title": "Include",
+                    "list": [
+                      "yourself, if this is your permanent or family home",
+                      "family members including partners, children and babies born on or before 9 April 2017",
+                      "students and, or school children who live away from home during term time",
+                      "housemates tenants or lodgers"
+                    ]
+                  }
+                ]
+              },
+              "type": "General",
+              "answers": [
+                {
+                  "id": "permanent-or-family-home-answer",
+                  "mandatory": true,
+                  "guidance": {
+                    "show_guidance": "Show further guidance",
+                    "hide_guidance": "Hide further guidance",
+                    "content": [
+                      {
+                        "description": "For most people, their permanent home will be the address where they spend the most time."
+                      }
+                    ]
+                  },
+                  "options": [
+                    {
+                      "label": "Yes",
+                      "value": "Yes"
+                    },
+                    {
+                      "label": "No",
+                      "value": "No",
+                      "description": "For example this is a second address or holiday home"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "household-composition",
+                "when": [
+                  {
+                    "id": "permanent-or-family-home-answer",
+                    "condition": "equals",
+                    "value": "Yes"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "else-permanent-or-family-home",
+                "when": [
+                  {
+                    "id": "permanent-or-family-home-answer",
+                    "condition": "equals",
+                    "value": "No"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "else-permanent-or-family-home",
+          "questions": [
+            {
+              "id": "else-permanent-or-family-home-question",
+              "title": "Can you confirm no one lives here as their permanent or family home?",
+              "guidance": {
+                "content": [
+                  {
+                    "title": "This could be:",
+                    "list": [
+                      "people who usually live outside the UK who are staying in the UK for <b>three months or more</b>",
+                      "people who work away from home within the UK if this is their permanent or family home",
+                      "members of the Armed Forces if this is their permanent or family home",
+                      "people who are temporarily outside the UK for <b>less than 12 months</b>",
+                      "people staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends",
+                      "other people who usually live here, including anyone temporarily away from home "
+                    ]
+                  }
+                ]
+              },
+              "type": "General",
+              "answers": [
+                {
+                  "id": "else-permanent-or-family-home-answer",
+                  "mandatory": true,
+                  "options": [
+                    {
+                      "label": "Someone lives here as their permanent home",
+                      "value": "Someone lives here as their permanent home"
+                    },
+                    {
+                      "label": "No one lives here as their permanent home",
+                      "value": "No one lives here as their permanent home"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "household-composition",
+                "when": [
+                  {
+                    "id": "else-permanent-or-family-home-answer",
+                    "condition": "equals",
+                    "value": "Someone lives here as their permanent home"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "overnight-visitors",
+                "when": [
+                  {
+                    "id": "else-permanent-or-family-home-answer",
+                    "condition": "equals",
+                    "value": "No one lives here as their permanent home"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "household-composition",
+          "questions": [
+            {
+              "id": "household-composition-question",
+              "title": "What are the names of everyone who live at <em>{{answers.address_line_1}}</em>?",
+              "guidance": {
+                "content": [
+                  {
+                    "title": "Include",
+                    "list": [
+                      "Yourself, if this is your permanent or family home",
+                      "Family members including partners, children and babies born on or before 9 April 2017",
+                      "Students and, or school children who live away from home during term time",
+                      "Housemates tenants or lodgers",
+                      "Household members who have requested a personal form"
+                    ]
+                  }
+                ]
+              },
+              "type": "RepeatingAnswer",
+              "answers": [
+                {
+                  "alias": "first_name",
+                  "id": "first-name",
+                  "label": "First name",
+                  "mandatory": true,
+                  "type": "TextField",
+                  "validation": {
+                    "messages": {
+                      "MANDATORY_TEXTFIELD": "Please enter a name or remove the person to continue"
+                    }
+                  }
+                },
+                {
+                  "alias": "middle_names",
+                  "id": "middle-names",
+                  "label": "Middle names",
+                  "mandatory": false,
+                  "type": "TextField"
+                },
+                {
+                  "alias": "last_name",
+                  "id": "last-name",
+                  "label": "Last name",
+                  "mandatory": false,
+                  "guidance": {
+                    "show_guidance": "Show further guidance",
+                    "hide_guidance": "Hide further guidance",
+                    "content": [
+                      {
+                        "description": "Enter the current first, middle and last names of all the people who usually live here."
+                      },
+                      {
+                        "description":
+                          "If you have not yet named your newborn, please enter ‘Baby’ for their first name and then enter their last name (surname)."
+                      },
+                      {
+                        "description": "Please also include household members who have requested a personal form."
+                      },
+                      {
+                        "description":
+                          "Please also include the names of people staying with you temporarily who don’t have a usual address in the UK. This is so that we make sure we count everyone."
+                      },
+                      {
+                        "title": "Include",
+                        "list": [
+                          "people who usually live outside the UK who are staying in the UK for <strong>three months or more</strong>",
+                          "people who work away from home within the UK  if this is their permanent or family home",
+                          "members of the Armed Forces if this is their permanent or family home",
+                          "people who are temporarily outside the UK for <strong>less than 12 months</strong>",
+                          "people staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends"
+                        ]
+                      }
+                    ]
+                  },
+                  "type": "TextField"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "everyone-at-address-confirmation",
+          "description":
+            "<h2 class='neptune'>Your household includes:</h2> {{ [answers.first_name, answers.middle_names, answers.last_name]|format_household_summary }}",
+          "questions": [
+            {
+              "id": "everyone-at-address-confirmation-question",
+              "title": "Is this everyone for whom this is their permanent or family home?",
+              "description": "Please note that you will need to ensure that everyone is included because you will be unable to make changes later",
+              "guidance": {
+                "content": [
+                  {
+                    "title": "Include",
+                    "list": [
+                      "people who usually live outside the UK who are staying in the UK for <b>three months or more</b>",
+                      "people who work away from home within the UK  if this is their permanent or family home",
+                      "members of the Armed Forces if this is their permanent or family home",
+                      "people who are temporarily outside the UK for <b>less than 12 months</b>",
+                      "people staying temporarily who usually live in the UK but do not have another UK address, for example relatives, friends",
+                      "other people who usually live here, including anyone temporarily away from home"
+                    ]
+                  }
+                ]
+              },
+              "type": "General",
+              "answers": [
+                {
+                  "id": "everyone-at-address-confirmation-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Yes",
+                      "value": "Yes"
+                    },
+                    {
+                      "label": "No, I need to add another person",
+                      "value": "No, I need to add another person"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "household-composition",
+                "when": [
+                  {
+                    "id": "everyone-at-address-confirmation-answer",
+                    "condition": "equals",
+                    "value": "No, I need to add another person"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "overnight-visitors"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "overnight-visitors",
+          "questions": [
+            {
+              "id": "overnight-visitors-question",
+              "title": "How many visitors are staying overnight at <em>{{answers.address_line_1}}</em> on 9th April 2017?",
+              "guidance": {
+                "content": [
+                  {
+                    "title": "Include",
+                    "list": [
+                      "people who usually live somewhere else in the UK. For example, friends or relatives",
+                      "people staying here because it is their second address, for example, for work. Their permanent or family home is elsewhere",
+                      "people who usually live outside the UK who are visiting the UK for less than three months",
+                      "people here on holiday"
+                    ]
+                  }
+                ]
+              },
+              "type": "General",
+              "answers": [
+                {
+                  "id": "overnight-visitors-answer",
+                  "label": "Number of visitors (enter 0 if no visitors)",
+                  "mandatory": true,
+                  "type": "Number"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "who-lives-here-relationship",
+      "title": "Relationships",
+      "hide_in_navigation": true,
+      "routing_rules": [
+        {
+          "repeat": {
+            "type": "answer_count_minus_one",
+            "answer_id": "first-name"
+          }
+        }
+      ],
+      "blocks": [
+        {
+          "type": "Question",
+          "id": "household-relationships",
+          "questions": [
+            {
+              "id": "household-relationships-question",
+              "title":
+                "How is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> related to the people below?",
+              "description":
+                "If members are not related, select the ‘unrelated’ option.</br>If you are the parents of adopted children, select the ‘Mother or father’ option to show your relationship to them.</br>If you have foster children living with you, select the ‘Unrelated’ option.</br>Include half-brothers and half-sisters in the ‘Step-brother or step-sister’ category.</br>Same-sex civil partner is used to describe the relationship between two people who have legally registered a civil partnership.</br>If none of the options fully reflects your relationship, please select the one which you feel best describes your situation.",
+              "type": "Relationship",
+              "answers": [
+                {
+                  "id": "household-relationships-answer",
+                  "label": "%(current_person)s is %(other_person)s",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Husband or wife",
+                      "value": "Husband or wife"
+                    },
+                    {
+                      "label": "Same-sex civil partner",
+                      "value": "Same-sex civil partner"
+                    },
+                    {
+                      "label": "Partner",
+                      "value": "Partner"
+                    },
+                    {
+                      "label": "Grandparent",
+                      "value": "Grandparent"
+                    },
+                    {
+                      "label": "Mother or father",
+                      "value": "Mother or father"
+                    },
+                    {
+                      "label": "Step-mother or step-father",
+                      "value": "Step-mother or step-father"
+                    },
+                    {
+                      "label": "Son or daughter",
+                      "value": "Son or daughter"
+                    },
+                    {
+                      "label": "Step-child",
+                      "value": "Step-child"
+                    },
+                    {
+                      "label": "Brother or sister",
+                      "value": "Brother or sister"
+                    },
+                    {
+                      "label": "Step–brother or step–sister",
+                      "value": "Step–brother or step–sister"
+                    },
+                    {
+                      "label": "Grandchild",
+                      "value": "Grandchild"
+                    },
+                    {
+                      "label": "Relation - other",
+                      "value": "Relation - other"
+                    },
+                    {
+                      "label": "Unrelated (including foster child)",
+                      "value": "Unrelated (including foster child)"
+                    }
+                  ],
+                  "type": "Relationship"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "who-lives-here-interstitial",
+      "title": "Who lives here?",
+      "hide_in_navigation": true,
+      "blocks": [
+        {
+          "id": "who-lives-here-completed",
+          "title": "You have successfully completed the ‘Who lives here?’ section",
+          "description": "In the next section we are going to ask you about the household and accommodation you live in.",
+          "type": "Interstitial"
+        }
+      ]
+    },
+    {
+      "id": "household-and-accommodation",
+      "title": "Household and Accommodation",
+      "blocks": [
+        {
+          "type": "Interstitial",
+          "id": "household-and-accommodation-section",
+          "title": "Household and accommodation",
+          "description": "In this section, we’re going to ask you about the household and accommodation you live in.",
+          "content": [
+            {
+              "title": "Information you need",
+              "list": ["Type of property, and if it’s owned or rented", "Type of landlord, if the property is rented", "Number of cars or vans"]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "type-of-accommodation",
+          "questions": [
+            {
+              "id": "type-of-accommodation-question",
+              "title": "What type of accommodation is <em>{{answers.address_line_1}}</em>?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "type-of-accommodation-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Whole house or bungalow",
+                      "value": "Whole house or bungalow"
+                    },
+                    {
+                      "label": "Flat, maisonette or apartment (including bedsits)",
+                      "value": "Flat, maisonette or apartment (including bedsits)"
+                    },
+                    {
+                      "label": "Caravan or other mobile or temporary structure",
+                      "value": "Caravan or other mobile or temporary structure"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "type-of-house",
+                "when": [
+                  {
+                    "id": "type-of-accommodation-answer",
+                    "condition": "equals",
+                    "value": "Whole house or bungalow"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "type-of-flat",
+                "when": [
+                  {
+                    "id": "type-of-accommodation-answer",
+                    "condition": "equals",
+                    "value": "Flat, maisonette or apartment (including bedsits)"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "self-contained-accommodation"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "type-of-house",
+          "questions": [
+            {
+              "id": "type-of-house-question",
+              "title": "Is your house or bungalow:",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "type-of-house-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Detached",
+                      "value": "Detached"
+                    },
+                    {
+                      "label": "Semi-detached",
+                      "value": "Semi-detached"
+                    },
+                    {
+                      "label": "Terraced (including end-terrace)",
+                      "value": "Terraced"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "self-contained-accommodation"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "type-of-flat",
+          "questions": [
+            {
+              "id": "type-of-flat-question",
+              "title": "Is your flat, maisonette or apartment:",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "type-of-flat-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "In a purpose-built block of flats or tenement",
+                      "value": "In a purpose-built block of flats or tenement"
+                    },
+                    {
+                      "label": "Part of a converted or shared house (including bedsits)",
+                      "value": "Part of a converted or shared house (including bedsits)"
+                    },
+                    {
+                      "label": "In a commercial building (for example, in an office building, hotel, or over a  shop).",
+                      "value": "In a commercial building (for example, in an office building, hotel, or over a  shop)."
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "self-contained-accommodation",
+          "questions": [
+            {
+              "id": "self-contained-accommodation-question",
+              "title": "Is the accommodation of <em>{{answers.address_line_1}}</em> self-contained?",
+              "description": "This means that all the rooms, including the kitchen, bathroom and toilet, are behind a door that only this household can use",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "self-contained-accommodation-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Yes, all the rooms are behind a door that only this household can use",
+                      "value": "Yes, all the rooms are behind a door that only this household can use"
+                    },
+                    {
+                      "label": "No",
+                      "value": "No"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "number-of-bedrooms",
+          "questions": [
+            {
+              "id": "number-of-bedrooms-question",
+              "title": "How many bedrooms are at <em>{{answers.address_line_1}}</em>?",
+              "guidance": {
+                "content": [
+                  {
+                    "description": "Include all rooms built or converted for use as bedrooms, even if they’re not currently used as bedrooms"
+                  }
+                ]
+              },
+              "type": "General",
+              "answers": [
+                {
+                  "id": "number-of-bedrooms-answer",
+                  "label": "Number of bedrooms",
+                  "mandatory": false,
+                  "type": "Number"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "central-heating",
+          "questions": [
+            {
+              "id": "central-heating-question",
+              "title": "What type of central heating does <em>{{answers.address_line_1}}</em> have?",
+              "description":
+                "<p>Central heating is a central system that generates heat for multiple rooms.</p><p>Select all that apply, whether or not you use it.</p>",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "central-heating-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Gas",
+                      "value": "Gas"
+                    },
+                    {
+                      "label": "Electric (include storage heaters)",
+                      "value": "Electric (include storage heaters)"
+                    },
+                    {
+                      "label": "Oil",
+                      "value": "Oil"
+                    },
+                    {
+                      "label": "Solid fuel (for example wood, coal)",
+                      "value": "Solid fuel (for example wood, coal)"
+                    },
+                    {
+                      "label": "Renewable (for example solar panels)",
+                      "value": "Renewable (for example solar panels)"
+                    },
+                    {
+                      "label": "Other central heating",
+                      "value": "Other central heating"
+                    },
+                    {
+                      "label": "No central heating",
+                      "value": "No central heating"
+                    }
+                  ],
+                  "type": "Checkbox"
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "own-or-rent",
+                "when": [
+                  {
+                    "id": "permanent-or-family-home-answer",
+                    "condition": "equals",
+                    "value": "Yes"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "own-or-rent",
+                "when": [
+                  {
+                    "id": "else-permanent-or-family-home-answer",
+                    "condition": "equals",
+                    "value": "Someone lives here as their permanent home"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "household-and-accommodation-completed"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "own-or-rent",
+          "questions": [
+            {
+              "id": "own-or-rent-question",
+              "title": "Does your household own or rent <em>{{answers.address_line_1}}</em>?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "own-or-rent-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Owns outright",
+                      "value": "Owns outright"
+                    },
+                    {
+                      "label": "Owns with a mortgage or loan",
+                      "value": "Owns with a mortgage or loan"
+                    },
+                    {
+                      "label": "Part owns and part rents (shared ownership)",
+                      "value": "Part owns and part rents (shared ownership)"
+                    },
+                    {
+                      "label": "Rents (with or without housing benefit)",
+                      "value": "Rents (with or without housing benefit)"
+                    },
+                    {
+                      "label": "Lives here rent free",
+                      "value": "Lives here rent free"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "number-of-vehicles",
+                "when": [
+                  {
+                    "id": "own-or-rent-answer",
+                    "condition": "equals",
+                    "value": "Owns outright"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "number-of-vehicles",
+                "when": [
+                  {
+                    "id": "own-or-rent-answer",
+                    "condition": "equals",
+                    "value": "Owns with a mortgage or loan"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "landlord"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "landlord",
+          "questions": [
+            {
+              "id": "landlord-question",
+              "title": "Who is your landlord?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "landlord-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Housing association, housing co-operative, charitable trust, registered social landlord",
+                      "value": "Housing association, housing co-operative, charitable trust, registered social landlord"
+                    },
+                    {
+                      "label": "Council (local authority)",
+                      "value": "Council (local authority)"
+                    },
+                    {
+                      "label": "Private landlord or letting agency",
+                      "value": "Private landlord or letting agency"
+                    },
+                    {
+                      "label": "Employer of a household member",
+                      "value": "Employer of a household member"
+                    },
+                    {
+                      "label": "Relative or friend of a household member",
+                      "value": "Relative or friend of a household member"
+                    },
+                    {
+                      "label": "Other",
+                      "value": "Other"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "number-of-vehicles",
+          "questions": [
+            {
+              "id": "number-of-vehicles-question",
+              "title": "How many cars or vans are owned, or available for use, by members of this household?",
+              "guidance": {
+                "content": [
+                  {
+                    "description": "Include any company cars or vans available for private use"
+                  }
+                ]
+              },
+              "type": "General",
+              "answers": [
+                {
+                  "id": "number-of-vehicles-answer",
+                  "label": "Number of cars or vans",
+                  "mandatory": false,
+                  "type": "Number"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "household-and-accommodation-completed",
+          "title": "You have successfully completed the ‘Household and Accommodation’ section",
+          "description": "",
+          "type": "Interstitial"
+        }
+      ]
+    },
+    {
+      "id": "household-member",
+      "title": "Household Member Details",
+      "routing_rules": [
+        {
+          "repeat": {
+            "type": "answer_count",
+            "answer_id": "first-name"
+          }
+        }
+      ],
+      "blocks": [
+        {
+          "type": "Interstitial",
+          "id": "household-member-begin-section",
+          "title": "{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}",
+          "description":
+            "In this section, we’re going to ask you questions about <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em>.",
+          "content": [
+            {
+              "title": "Information you need",
+              "list": [
+                "Personal details such as date of birth, country of birth, religion etc.",
+                "Education and qualifications",
+                "Employment and travel to work",
+                "Second or holiday homes",
+                "Unpaid care, health and well-being",
+                "Languages"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "details-correct",
+          "questions": [
+            {
+              "id": "details-correct-question",
+              "title":
+                "Is the name {{ [answers.first_name[group_instance], answers.middle_names[group_instance], answers.last_name[group_instance]] | format_household_name }} correct, including any middle name(s)?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "details-correct-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Yes, this is my full name",
+                      "value": "Yes, this is my full name"
+                    },
+                    {
+                      "label": "No, I need to change my name",
+                      "value": "No, I need to change my name"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "correct-name",
+                "when": [
+                  {
+                    "id": "details-correct-answer",
+                    "condition": "equals",
+                    "value": "No, I need to change my name"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "over-16"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "correct-name",
+          "questions": [
+            {
+              "id": "correct-name-question",
+              "title": "What is your correct name?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "correct-first-name",
+                  "label": "First name",
+                  "mandatory": false,
+                  "type": "TextField"
+                },
+                {
+                  "id": "correct-middle-names",
+                  "label": "Middle names",
+                  "mandatory": false,
+                  "type": "TextField"
+                },
+                {
+                  "id": "correct-last-name",
+                  "label": "Last name",
+                  "mandatory": false,
+                  "type": "TextField"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "over-16",
+          "questions": [
+            {
+              "id": "over-16-question",
+              "title": "Are you aged 16 or over?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "over-16-answer",
+                  "mandatory": true,
+                  "options": [
+                    {
+                      "label": "Yes",
+                      "value": "Yes"
+                    },
+                    {
+                      "label": "No",
+                      "value": "No"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "private-response",
+                "when": [
+                  {
+                    "id": "over-16-answer",
+                    "condition": "equals",
+                    "value": "Yes"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "sex"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "private-response",
+          "questions": [
+            {
+              "id": "private-response-question",
+              "title": "Do you want to request a personal form?",
+              "description": "Anyone aged 16 or over who would like to keep their answers private can request a personal and confidential form.",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "private-response-answer",
+                  "mandatory": false,
+                  "guidance": {
+                    "show_guidance": "Show further guidance",
+                    "hide_guidance": "Hide further guidance",
+                    "content": [
+                      {
+                        "description":
+                          "If you request a personal or confidential form we will send you a unique access code that will allow you to complete the individual questions for yourself. No-one else will be able to see the answers you provide."
+                      }
+                    ]
+                  },
+                  "options": [
+                    {
+                      "label": "No, I do not want to request a personal form",
+                      "value": "No, I do not want to request a personal form"
+                    },
+                    {
+                      "label": "Yes, I want to request a personal form",
+                      "value": "Yes, I want to request a personal form"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "request-private-response",
+                "when": [
+                  {
+                    "id": "private-response-answer",
+                    "condition": "equals",
+                    "value": "Yes, I want to request a personal form"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "sex"
+              }
+            }
+          ]
+        },
+        {
+          "id": "request-private-response",
+          "title": "Request for personal and confidential form",
+          "description":
+            "<p>You can <a rel='noopener noreferrer' target='_blank' href='https://census.gov.uk/individualquestionnaire'>request a personal and confidential form online</a>.</p> <p>Alternatively, call <a href='tel:03000683001'>0300 068 3001</a>.</p>",
+          "type": "Interstitial",
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "household-member-completed"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "sex",
+          "questions": [
+            {
+              "id": "sex-question",
+              "title": "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> sex?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "sex-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Male",
+                      "value": "Male"
+                    },
+                    {
+                      "label": "Female",
+                      "value": "Female"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "date-of-birth",
+          "questions": [
+            {
+              "id": "date-of-birth-question",
+              "title":
+                "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive }}</em> date of birth?",
+              "description": "For example 20 March 1980",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "date-of-birth-answer",
+                  "mandatory": false,
+                  "type": "Date"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "marital-status",
+          "questions": [
+            {
+              "id": "marital-status-question",
+              "title":
+                "On 9 April 2017, what is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive }}</em> legal marital or same-sex civil partnership status?",
+              "description":
+                "If you were married (or formed a registered same-sex partnership) abroad, and this enables you to be recognised as married or civil partnered in the UK, complete the question reflecting that legal partnership.",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "marital-status-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Never married and never registered a same-sex civil partnership",
+                      "value": "Never married and never registered a same-sex civil partnership"
+                    },
+                    {
+                      "label": "Married",
+                      "value": "Married"
+                    },
+                    {
+                      "label": "In a registered same-sex civil partnership",
+                      "value": "In a registered same-sex civil partnership"
+                    },
+                    {
+                      "label": "Separated, but still legally married",
+                      "value": "Separated, but still legally married"
+                    },
+                    {
+                      "label": "Separated, but still legally in a same-sex civil partnership",
+                      "value": "Separated, but still legally in a same-sex civil partnership"
+                    },
+                    {
+                      "label": "Divorced",
+                      "value": "Divorced"
+                    },
+                    {
+                      "label": "Formerly in a same-sex civil partnership which is now legally dissolved",
+                      "value": "Formerly in a same-sex civil partnership which is now legally dissolved"
+                    },
+                    {
+                      "label": "Widowed",
+                      "value": "Widowed"
+                    },
+                    {
+                      "label": "Surviving partner from a same-sex civil partnership",
+                      "value": "Surviving partner from a same-sex civil partnership"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "another-address",
+          "questions": [
+            {
+              "id": "another-address-question",
+              "title":
+                "Does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> stay at another address for more than 30 days a year?",
+              "type": "General",
+              "guidance": {
+                "content": [
+                  {
+                    "title": "Include:",
+                    "list": [
+                      "another parent’s address, an armed forces base, a holiday home, or term-time address.",
+                      "the days you stay at the address do not have to be in a row. They can be at any time during the year."
+                    ],
+                    "description": ""
+                  }
+                ]
+              },
+              "answers": [
+                {
+                  "id": "another-address-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "No",
+                      "value": "No"
+                    },
+                    {
+                      "label": "Yes, an address within the UK",
+                      "value": "Yes, an address within the UK"
+                    },
+                    {
+                      "label": "Yes, an address outside the UK",
+                      "value": "Other",
+                      "child_answer_id": "another-address-answer-other"
+                    }
+                  ],
+                  "type": "Radio"
+                },
+                {
+                  "id": "another-address-answer-other",
+                  "parent_answer_id": "another-address-answer",
+                  "type": "TextField",
+                  "mandatory": false,
+                  "label": "Please specify a country"
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "in-education",
+                "when": [
+                  {
+                    "id": "another-address-answer",
+                    "condition": "equals",
+                    "value": "No"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "other-address",
+                "when": [
+                  {
+                    "id": "another-address-answer",
+                    "condition": "equals",
+                    "value": "Yes, an address within the UK"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "address-type",
+                "when": [
+                  {
+                    "id": "another-address-answer",
+                    "condition": "equals",
+                    "value": "Other"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "in-education",
+                "when": [
+                  {
+                    "id": "another-address-answer",
+                    "condition": "not set"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "address-type",
+                "when": [
+                  {
+                    "id": "another-address-answer",
+                    "condition": "not equals",
+                    "value": "Other"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "in-education"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "other-address",
+          "questions": [
+            {
+              "id": "other-address-question",
+              "title":
+                "Enter details of the other UK address where <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> stay more than 30 days a year",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "other-address-answer-building",
+                  "label": "Building",
+                  "mandatory": false,
+                  "type": "TextField"
+                },
+                {
+                  "id": "other-address-answer-street",
+                  "label": "Street",
+                  "mandatory": false,
+                  "type": "TextField"
+                },
+                {
+                  "id": "other-address-answer-city",
+                  "label": "Town or city",
+                  "mandatory": false,
+                  "type": "TextField"
+                },
+                {
+                  "id": "other-address-answer-county",
+                  "label": "County (optional)",
+                  "mandatory": false,
+                  "type": "TextField"
+                },
+                {
+                  "id": "other-address-answer-postcode",
+                  "label": "Postcode",
+                  "mandatory": false,
+                  "type": "TextField"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "address-type",
+          "questions": [
+            {
+              "id": "address-type-question",
+              "title": "What is that address?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "address-type-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Armed forces base address",
+                      "value": "Armed forces base address"
+                    },
+                    {
+                      "label": "Another address when working away from home",
+                      "value": "Another address when working away from home"
+                    },
+                    {
+                      "label": "Student’s home address",
+                      "value": "Student’s home address"
+                    },
+                    {
+                      "label": "Student’s term time address",
+                      "value": "Student’s term time address"
+                    },
+                    {
+                      "label": "Another parent or guardian’s address",
+                      "value": "Another parent or guardian’s address"
+                    },
+                    {
+                      "label": "Holiday home",
+                      "value": "Holiday home"
+                    },
+                    {
+                      "label": "Other (please specify)",
+                      "value": "Other",
+                      "child_answer_id": "address-type-answer-other"
+                    }
+                  ],
+                  "type": "Radio"
+                },
+                {
+                  "id": "address-type-answer-other",
+                  "parent_answer_id": "address-type-answer",
+                  "type": "TextField",
+                  "mandatory": false,
+                  "label": "Please specify type of address"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "in-education",
+          "questions": [
+            {
+              "id": "in-education-question",
+              "title":
+                "Is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> in full-time education?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "in-education-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Yes",
+                      "value": "Yes"
+                    },
+                    {
+                      "label": "No",
+                      "value": "No"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "term-time-location",
+                "when": [
+                  {
+                    "id": "in-education-answer",
+                    "condition": "equals",
+                    "value": "Yes"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "country-of-birth"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "term-time-location",
+          "questions": [
+            {
+              "id": "term-time-location-question",
+              "title":
+                "During term time, does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> live at <em>{{answers.address_line_1}}</em> ?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "term-time-location-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Yes",
+                      "value": "Yes"
+                    },
+                    {
+                      "label": "No",
+                      "value": "No"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "household-member-completed",
+                "when": [
+                  {
+                    "id": "term-time-location-answer",
+                    "condition": "equals",
+                    "value": "No"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "country-of-birth"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "country-of-birth",
+          "questions": [
+            {
+              "id": "country-of-birth-england-question",
+              "title":
+                "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> country of birth?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "country-of-birth-england-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "England",
+                      "value": "England"
+                    },
+                    {
+                      "label": "Wales",
+                      "value": "Wales"
+                    },
+                    {
+                      "label": "Scotland",
+                      "value": "Scotland"
+                    },
+                    {
+                      "label": "Northern Ireland",
+                      "value": "Northern Ireland"
+                    },
+                    {
+                      "label": "Republic of Ireland",
+                      "value": "Republic of Ireland"
+                    },
+                    {
+                      "label": "Elsewhere",
+                      "value": "Other",
+                      "child_answer_id": "country-of-birth-england-answer-other"
+                    }
+                  ],
+                  "type": "Radio"
+                },
+                {
+                  "id": "country-of-birth-england-answer-other",
+                  "parent_answer_id": "country-of-birth-england-answer",
+                  "type": "TextField",
+                  "mandatory": false,
+                  "label": "Please specify current name of country"
+                }
+              ],
+              "skip_conditions": [
+                {
+                  "when": [
+                    {
+                      "meta": "region_code",
+                      "condition": "equals",
+                      "value": "GB-WLS"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "country-of-birth-wales-question",
+              "title":
+                "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> country of birth?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "country-of-birth-wales-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Wales",
+                      "value": "Wales"
+                    },
+                    {
+                      "label": "England",
+                      "value": "England"
+                    },
+                    {
+                      "label": "Scotland",
+                      "value": "Scotland"
+                    },
+                    {
+                      "label": "Northern Ireland",
+                      "value": "Northern Ireland"
+                    },
+                    {
+                      "label": "Republic of Ireland",
+                      "value": "Republic of Ireland"
+                    },
+                    {
+                      "label": "Elsewhere",
+                      "value": "Other",
+                      "child_answer_id": "country-of-birth-wales-answer-other"
+                    }
+                  ],
+                  "type": "Radio"
+                },
+                {
+                  "id": "country-of-birth-wales-answer-other",
+                  "parent_answer_id": "country-of-birth-wales-answer",
+                  "type": "TextField",
+                  "mandatory": false,
+                  "label": "Please specify current name of country"
+                }
+              ],
+              "skip_conditions": [
+                {
+                  "when": [
+                    {
+                      "meta": "region_code",
+                      "condition": "not equals",
+                      "value": "GB-WLS"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "carer",
+                "when": [
+                  {
+                    "id": "country-of-birth-england-answer",
+                    "condition": "equals",
+                    "value": "England"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "carer",
+                "when": [
+                  {
+                    "id": "country-of-birth-england-answer",
+                    "condition": "equals",
+                    "value": "Wales"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "carer",
+                "when": [
+                  {
+                    "id": "country-of-birth-england-answer",
+                    "condition": "equals",
+                    "value": "Scotland"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "carer",
+                "when": [
+                  {
+                    "id": "country-of-birth-england-answer",
+                    "condition": "equals",
+                    "value": "Northern Ireland"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "carer",
+                "when": [
+                  {
+                    "id": "country-of-birth-wales-answer",
+                    "condition": "equals",
+                    "value": "Wales"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "carer",
+                "when": [
+                  {
+                    "id": "country-of-birth-wales-answer",
+                    "condition": "equals",
+                    "value": "England"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "carer",
+                "when": [
+                  {
+                    "id": "country-of-birth-wales-answer",
+                    "condition": "equals",
+                    "value": "Scotland"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "carer",
+                "when": [
+                  {
+                    "id": "country-of-birth-wales-answer",
+                    "condition": "equals",
+                    "value": "Northern Ireland"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "arrive-in-uk"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "arrive-in-uk",
+          "questions": [
+            {
+              "id": "arrive-in-uk-question",
+              "title":
+                "If you were not born in the United Kingdom, when did <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> most recently arrive to live here?",
+              "guidance": {
+                "content": [
+                  {
+                    "description": "Exclude short visits away from the UK"
+                  }
+                ]
+              },
+              "type": "General",
+              "answers": [
+                {
+                  "id": "arrive-in-uk-answer",
+                  "mandatory": false,
+                  "type": "MonthYearDate"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "length-of-stay",
+          "questions": [
+            {
+              "id": "length-of-stay-question",
+              "title":
+                "Including the time already spent here, how long does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> intend to stay in the United Kingdom?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "length-of-stay-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Less than 12 months",
+                      "value": "Less than 12 months"
+                    },
+                    {
+                      "label": "12 months or more",
+                      "value": "12 months or more"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "health",
+          "questions": [
+            {
+              "id": "health-question",
+              "title":
+                "How is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> health in general?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "health-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Very good",
+                      "value": "Very good"
+                    },
+                    {
+                      "label": "Good",
+                      "value": "Good"
+                    },
+                    {
+                      "label": "Fair",
+                      "value": "Fair"
+                    },
+                    {
+                      "label": "Bad",
+                      "value": "Bad"
+                    },
+                    {
+                      "label": "Very bad",
+                      "value": "Very bad"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "carer",
+          "questions": [
+            {
+              "id": "carer-question",
+              "title":
+                "Does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> look after, or give any help or support to family members, friends, neighbours or others?",
+              "description": "",
+              "guidance": {
+                "content": [
+                  {
+                    "title": "Include",
+                    "list": ["long-term physical or mental ill-health/disability", "problems related to old age"]
+                  },
+                  {
+                    "title": "Exclude",
+                    "list": ["anything you do as part of your paid employment"]
+                  }
+                ]
+              },
+              "type": "General",
+              "answers": [
+                {
+                  "id": "carer-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "No",
+                      "value": "No"
+                    },
+                    {
+                      "label": "Yes, 1 -19 hours a week",
+                      "value": "Yes, 1 -19 hours a week"
+                    },
+                    {
+                      "label": "Yes, 20 - 49 hours a week",
+                      "value": "Yes, 20 - 49 hours a week"
+                    },
+                    {
+                      "label": "Yes, 50 or more hours a week",
+                      "value": "Yes, 50 or more hours a week"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "national-identity",
+          "questions": [
+            {
+              "id": "national-identity-england-question",
+              "title":
+                "How would you describe <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> national identity?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "national-identity-england-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "English",
+                      "value": "English"
+                    },
+                    {
+                      "label": "Welsh",
+                      "value": "Welsh"
+                    },
+                    {
+                      "label": "Scottish",
+                      "value": "Scottish"
+                    },
+                    {
+                      "label": "Northern Irish",
+                      "value": "Northern Irish"
+                    },
+                    {
+                      "label": "British",
+                      "value": "British"
+                    },
+                    {
+                      "label": "Other",
+                      "value": "Other",
+                      "child_answer_id": "national-identity-england-answer-other"
+                    }
+                  ],
+                  "type": "Checkbox"
+                },
+                {
+                  "id": "national-identity-england-answer-other",
+                  "parent_answer_id": "national-identity-england-answer",
+                  "type": "TextField",
+                  "mandatory": false,
+                  "label": "Please describe your national identity"
+                }
+              ],
+              "skip_conditions": [
+                {
+                  "when": [
+                    {
+                      "meta": "region_code",
+                      "condition": "equals",
+                      "value": "GB-WLS"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "national-identity-wales-question",
+              "title":
+                "How would you describe <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> national identity?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "national-identity-wales-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Welsh",
+                      "value": "Welsh"
+                    },
+                    {
+                      "label": "English",
+                      "value": "English"
+                    },
+                    {
+                      "label": "Scottish",
+                      "value": "Scottish"
+                    },
+                    {
+                      "label": "Northern Irish",
+                      "value": "Northern Irish"
+                    },
+                    {
+                      "label": "British",
+                      "value": "British"
+                    },
+                    {
+                      "label": "Other",
+                      "value": "Other",
+                      "child_answer_id": "national-identity-wales-answer-other"
+                    }
+                  ],
+                  "type": "Checkbox"
+                },
+                {
+                  "id": "national-identity-wales-answer-other",
+                  "parent_answer_id": "national-identity-wales-answer",
+                  "type": "TextField",
+                  "mandatory": false,
+                  "label": "Please describe your national identity"
+                }
+              ],
+              "skip_conditions": [
+                {
+                  "when": [
+                    {
+                      "meta": "region_code",
+                      "condition": "not equals",
+                      "value": "GB-WLS"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "ethnic-group",
+          "questions": [
+            {
+              "id": "ethnic-group-england-question",
+              "title":
+                "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> ethnic group?",
+              "description":
+                "It is for you to choose your ethnic group. For example this could be your family or cultural background, or it could be how you would describe yourself.",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "ethnic-group-england-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "White",
+                      "value": "White",
+                      "description": "Including English, Welsh, Scottish, Northern Irish, British, Irish, Gypsy, Irish Traveller or any other White background"
+                    },
+                    {
+                      "label": "Mixed or multiple ethnic groups",
+                      "value": "Mixed or multiple ethnic groups",
+                      "description":
+                        "Including White and Black Caribbean, White and Black African, White and Asian or any other Mixed or multiple ethnic background"
+                    },
+                    {
+                      "label": "Asian or Asian British",
+                      "value": "Asian or Asian British",
+                      "description": "Including Indian, Pakistani, Bangladeshi, Chinese or any other Asian background"
+                    },
+                    {
+                      "label": "Black, African, Caribbean or Black British",
+                      "value": "Black, African, Caribbean or Black British",
+                      "description": "Including African, Caribbean or any other Black, African or Caribbean background"
+                    },
+                    {
+                      "label": "Other ethnic group",
+                      "value": "Other ethnic group",
+                      "description": "Including Arab or any other ethnic group"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ],
+              "skip_conditions": [
+                {
+                  "when": [
+                    {
+                      "meta": "region_code",
+                      "condition": "equals",
+                      "value": "GB-WLS"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "ethnic-group-wales-question",
+              "title":
+                "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> ethnic group?",
+              "description":
+                "It is for you to choose your ethnic group. For example this could be your family or cultural background, or it could be how you would describe yourself.",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "ethnic-group-wales-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "White",
+                      "value": "White",
+                      "description": "Including Welsh, English, Scottish, Northern Irish, British, Irish, Gypsy, Irish Traveller or any other White background"
+                    },
+                    {
+                      "label": "Mixed or multiple ethnic groups",
+                      "value": "Mixed or multiple ethnic groups",
+                      "description":
+                        "Including White and Black Caribbean, White and Black African, White and Asian or any other Mixed or multiple ethnic background"
+                    },
+                    {
+                      "label": "Asian or Asian British",
+                      "value": "Asian or Asian British",
+                      "description": "Including Indian, Pakistani, Bangladeshi, Chinese or any other Asian background"
+                    },
+                    {
+                      "label": "Black, African, Caribbean or Black British",
+                      "value": "Black, African, Caribbean or Black British",
+                      "description": "Including African, Caribbean or any other Black, African or Caribbean background"
+                    },
+                    {
+                      "label": "Other ethnic group",
+                      "value": "Other ethnic group",
+                      "description": "Including Arab or any other ethnic group"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ],
+              "skip_conditions": [
+                {
+                  "when": [
+                    {
+                      "meta": "region_code",
+                      "condition": "not equals",
+                      "value": "GB-WLS"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "white-ethnic-group",
+                "when": [
+                  {
+                    "id": "ethnic-group-england-answer",
+                    "condition": "equals",
+                    "value": "White"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "mixed-ethnic-group",
+                "when": [
+                  {
+                    "id": "ethnic-group-england-answer",
+                    "condition": "equals",
+                    "value": "Mixed or multiple ethnic groups"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "asian-ethnic-group",
+                "when": [
+                  {
+                    "id": "ethnic-group-england-answer",
+                    "condition": "equals",
+                    "value": "Asian or Asian British"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "black-ethnic-group",
+                "when": [
+                  {
+                    "id": "ethnic-group-england-answer",
+                    "condition": "equals",
+                    "value": "Black, African, Caribbean or Black British"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "other-ethnic-group",
+                "when": [
+                  {
+                    "id": "ethnic-group-england-answer",
+                    "condition": "equals",
+                    "value": "Other ethnic group"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "white-ethnic-group",
+                "when": [
+                  {
+                    "id": "ethnic-group-wales-answer",
+                    "condition": "equals",
+                    "value": "White"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "mixed-ethnic-group",
+                "when": [
+                  {
+                    "id": "ethnic-group-wales-answer",
+                    "condition": "equals",
+                    "value": "Mixed or multiple ethnic groups"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "asian-ethnic-group",
+                "when": [
+                  {
+                    "id": "ethnic-group-wales-answer",
+                    "condition": "equals",
+                    "value": "Asian or Asian British"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "black-ethnic-group",
+                "when": [
+                  {
+                    "id": "ethnic-group-wales-answer",
+                    "condition": "equals",
+                    "value": "Black, African, Caribbean or Black British"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "other-ethnic-group",
+                "when": [
+                  {
+                    "id": "ethnic-group-wales-answer",
+                    "condition": "equals",
+                    "value": "Other ethnic group"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "sexual-identity",
+                "when": [
+                  {
+                    "id": "over-16-answer",
+                    "condition": "equals",
+                    "value": "Yes"
+                  },
+                  {
+                    "meta": "variant_flags.sexual_identity",
+                    "condition": "equals",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "understand-welsh",
+                "when": [
+                  {
+                    "meta": "region_code",
+                    "condition": "equals",
+                    "value": "GB-WLS"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "language"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "white-ethnic-group",
+          "questions": [
+            {
+              "id": "white-ethnic-group-england-question",
+              "title":
+                "Which one best describes <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> White ethnic group or background?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "white-ethnic-group-england-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "English, Welsh, Scottish, Northern Irish or British",
+                      "value": "English, Welsh, Scottish, Northern Irish or British"
+                    },
+                    {
+                      "label": "Irish",
+                      "value": "Irish"
+                    },
+                    {
+                      "label": "Gypsy or Irish Traveller",
+                      "value": "Gypsy or Irish Traveller"
+                    },
+                    {
+                      "label": "Any other White background",
+                      "value": "Other",
+                      "child_answer_id": "white-ethnic-group-england-answer-other"
+                    }
+                  ],
+                  "type": "Radio"
+                },
+                {
+                  "id": "white-ethnic-group-england-answer-other",
+                  "parent_answer_id": "white-ethnic-group-england-answer",
+                  "type": "TextField",
+                  "mandatory": false,
+                  "label": "Please specify other White background"
+                }
+              ],
+              "skip_conditions": [
+                {
+                  "when": [
+                    {
+                      "meta": "region_code",
+                      "condition": "equals",
+                      "value": "GB-WLS"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "white-ethnic-group-wales-question",
+              "title":
+                "Which one best describes <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> White ethnic group or background?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "white-ethnic-group-wales-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Welsh, English, Scottish, Northern Irish or British",
+                      "value": "Welsh, English, Scottish, Northern Irish or British"
+                    },
+                    {
+                      "label": "Irish",
+                      "value": "Irish"
+                    },
+                    {
+                      "label": "Gypsy or Irish Traveller",
+                      "value": "Gypsy or Irish Traveller"
+                    },
+                    {
+                      "label": "Any other White background",
+                      "value": "Other",
+                      "child_answer_id": "white-ethnic-group-wales-question-other"
+                    }
+                  ],
+                  "type": "Radio"
+                },
+                {
+                  "id": "white-ethnic-group-wales-question-other",
+                  "parent_answer_id": "white-ethnic-group-wales-answer",
+                  "type": "TextField",
+                  "mandatory": false,
+                  "label": "Please specify other White background"
+                }
+              ],
+              "skip_conditions": [
+                {
+                  "when": [
+                    {
+                      "meta": "region_code",
+                      "condition": "not equals",
+                      "value": "GB-WLS"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "sexual-identity",
+                "when": [
+                  {
+                    "id": "over-16-answer",
+                    "condition": "equals",
+                    "value": "Yes"
+                  },
+                  {
+                    "meta": "variant_flags.sexual_identity",
+                    "condition": "equals",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "understand-welsh",
+                "when": [
+                  {
+                    "meta": "region_code",
+                    "condition": "equals",
+                    "value": "GB-WLS"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "language"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "mixed-ethnic-group",
+          "questions": [
+            {
+              "id": "mixed-ethnic-group-question",
+              "title":
+                "Which one best describes <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> Mixed, multiple ethnic group or background?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "mixed-ethnic-group-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "White and Black Caribbean",
+                      "value": "White and Black Caribbean"
+                    },
+                    {
+                      "label": "White and Black African",
+                      "value": "White and Black African"
+                    },
+                    {
+                      "label": "White and Asian",
+                      "value": "White and Asian"
+                    },
+                    {
+                      "label": "Any other Mixed or multiple ethnic background",
+                      "value": "Other",
+                      "child_answer_id": "mixed-ethnic-group-answer-other"
+                    }
+                  ],
+                  "type": "Radio"
+                },
+                {
+                  "id": "mixed-ethnic-group-answer-other",
+                  "parent_answer_id": "mixed-ethnic-group-answer",
+                  "type": "TextField",
+                  "mandatory": false,
+                  "label": "Please specify other Mixed or multiple ethnic background"
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "sexual-identity",
+                "when": [
+                  {
+                    "id": "over-16-answer",
+                    "condition": "equals",
+                    "value": "Yes"
+                  },
+                  {
+                    "meta": "variant_flags.sexual_identity",
+                    "condition": "equals",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "understand-welsh",
+                "when": [
+                  {
+                    "meta": "region_code",
+                    "condition": "equals",
+                    "value": "GB-WLS"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "language"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "asian-ethnic-group",
+          "questions": [
+            {
+              "id": "asian-ethnic-group-question",
+              "title":
+                "Which one best describes <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> Asian, Asian British ethnic group or background?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "asian-ethnic-group-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Indian",
+                      "value": "Indian"
+                    },
+                    {
+                      "label": "Pakistani",
+                      "value": "Pakistani"
+                    },
+                    {
+                      "label": "Bangladeshi",
+                      "value": "Bangladeshi"
+                    },
+                    {
+                      "label": "Chinese",
+                      "value": "Chinese"
+                    },
+                    {
+                      "label": "Any other Asian background",
+                      "value": "Other",
+                      "child_answer_id": "asian-ethnic-group-answer-other"
+                    }
+                  ],
+                  "type": "Radio"
+                },
+                {
+                  "id": "asian-ethnic-group-answer-other",
+                  "parent_answer_id": "asian-ethnic-group-answer",
+                  "type": "TextField",
+                  "mandatory": false,
+                  "label": "Please specify other Asian background"
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "sexual-identity",
+                "when": [
+                  {
+                    "id": "over-16-answer",
+                    "condition": "equals",
+                    "value": "Yes"
+                  },
+                  {
+                    "meta": "variant_flags.sexual_identity",
+                    "condition": "equals",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "understand-welsh",
+                "when": [
+                  {
+                    "meta": "region_code",
+                    "condition": "equals",
+                    "value": "GB-WLS"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "language"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "black-ethnic-group",
+          "questions": [
+            {
+              "id": "black-ethnic-group-question",
+              "title":
+                "Which one best describes <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> Black, African, Caribbean, Black British ethnic group or background?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "black-ethnic-group-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "African",
+                      "value": "African"
+                    },
+                    {
+                      "label": "Caribbean",
+                      "value": "Caribbean"
+                    },
+                    {
+                      "label": "Any other Black, African or Caribbean background",
+                      "value": "Other",
+                      "child_answer_id": "black-ethnic-group-answer-other"
+                    }
+                  ],
+                  "type": "Radio"
+                },
+                {
+                  "id": "black-ethnic-group-answer-other",
+                  "parent_answer_id": "black-ethnic-group-answer",
+                  "type": "TextField",
+                  "mandatory": false,
+                  "label": "Please specify other Black, African or Caribbean background"
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "sexual-identity",
+                "when": [
+                  {
+                    "id": "over-16-answer",
+                    "condition": "equals",
+                    "value": "Yes"
+                  },
+                  {
+                    "meta": "variant_flags.sexual_identity",
+                    "condition": "equals",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "understand-welsh",
+                "when": [
+                  {
+                    "meta": "region_code",
+                    "condition": "equals",
+                    "value": "GB-WLS"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "language"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "other-ethnic-group",
+          "questions": [
+            {
+              "id": "other-ethnic-group-question",
+              "title":
+                "Which one best describes <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> Other ethnic group or background?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "other-ethnic-group-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Arab",
+                      "value": "Arab"
+                    },
+                    {
+                      "label": "Any other ethnic group",
+                      "value": "Other",
+                      "child_answer_id": "other-ethnic-group-answer-other"
+                    }
+                  ],
+                  "type": "Radio"
+                },
+                {
+                  "id": "other-ethnic-group-answer-other",
+                  "parent_answer_id": "other-ethnic-group-answer",
+                  "type": "TextField",
+                  "mandatory": false,
+                  "label": "Please specify Other ethnic group"
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "sexual-identity",
+                "when": [
+                  {
+                    "id": "over-16-answer",
+                    "condition": "equals",
+                    "value": "Yes"
+                  },
+                  {
+                    "meta": "variant_flags.sexual_identity",
+                    "condition": "equals",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "understand-welsh",
+                "when": [
+                  {
+                    "meta": "region_code",
+                    "condition": "equals",
+                    "value": "GB-WLS"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "language"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "sexual-identity",
+          "questions": [
+            {
+              "id": "sexual-identity-question",
+              "title":
+                "Which of the following options best describes how <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> thinks of themselves?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "sexual-identity-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Heterosexual or Straight",
+                      "value": "Heterosexual or Straight"
+                    },
+                    {
+                      "label": "Gay or Lesbian",
+                      "value": "Gay or Lesbian"
+                    },
+                    {
+                      "label": "Bisexual",
+                      "value": "Bisexual"
+                    },
+                    {
+                      "label": "Other",
+                      "value": "Other",
+                      "child_answer_id": "sexual-identity-answer-other"
+                    },
+                    {
+                      "label": "Prefer not to say",
+                      "value": "Prefer not to say"
+                    }
+                  ],
+                  "type": "Checkbox"
+                },
+                {
+                  "id": "sexual-identity-answer-other",
+                  "parent_answer_id": "sexual-identity-answer",
+                  "type": "TextField",
+                  "mandatory": false,
+                  "label": "Please specify"
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "understand-welsh",
+                "when": [
+                  {
+                    "meta": "region_code",
+                    "condition": "equals",
+                    "value": "GB-WLS"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "language"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "understand-welsh",
+          "questions": [
+            {
+              "id": "understand-welsh-question",
+              "title":
+                "Can <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> understand, speak, read or write Welsh",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "understand-welsh-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Understand spoken Welsh",
+                      "value": "Understand spoken Welsh"
+                    },
+                    {
+                      "label": "Speak Welsh",
+                      "value": "Speak Welsh"
+                    },
+                    {
+                      "label": "Read Welsh",
+                      "value": "Read Welsh"
+                    },
+                    {
+                      "label": "Write Welsh",
+                      "value": "Write Welsh"
+                    },
+                    {
+                      "label": "None of the above",
+                      "value": "None of the above"
+                    }
+                  ],
+                  "type": "Checkbox"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "language",
+          "questions": [
+            {
+              "id": "language-england-question",
+              "title":
+                "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> main language?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "language-england-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "English",
+                      "value": "English"
+                    },
+                    {
+                      "label": "Other",
+                      "value": "Other",
+                      "description": "Including British Sign Language",
+                      "child_answer_id": "language-england-answer-other"
+                    }
+                  ],
+                  "type": "Radio"
+                },
+                {
+                  "id": "language-england-answer-other",
+                  "parent_answer_id": "language-england-answer",
+                  "type": "TextField",
+                  "mandatory": false,
+                  "label": "Please specify main language"
+                }
+              ],
+              "skip_conditions": [
+                {
+                  "when": [
+                    {
+                      "meta": "region_code",
+                      "condition": "equals",
+                      "value": "GB-WLS"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "language-welsh-question",
+              "title":
+                "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> main language?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "language-welsh-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "English or Welsh",
+                      "value": "English or Welsh"
+                    },
+                    {
+                      "label": "Other",
+                      "value": "Other",
+                      "description": "Including British Sign Language",
+                      "child_answer_id": "language-welsh-answer-other"
+                    }
+                  ],
+                  "type": "Radio"
+                },
+                {
+                  "id": "language-welsh-answer-other",
+                  "parent_answer_id": "language-welsh-answer",
+                  "type": "TextField",
+                  "mandatory": false,
+                  "label": "Please specify main language"
+                }
+              ],
+              "skip_conditions": [
+                {
+                  "when": [
+                    {
+                      "meta": "region_code",
+                      "condition": "not equals",
+                      "value": "GB-WLS"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "religion",
+                "when": [
+                  {
+                    "id": "language-england-answer",
+                    "condition": "equals",
+                    "value": "English"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "religion",
+                "when": [
+                  {
+                    "id": "language-welsh-answer",
+                    "condition": "equals",
+                    "value": "English or Welsh"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "english"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "english",
+          "questions": [
+            {
+              "id": "english-question",
+              "title":
+                "How well can <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> speak English?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "english-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Very well",
+                      "value": "Very well"
+                    },
+                    {
+                      "label": "Well",
+                      "value": "Well"
+                    },
+                    {
+                      "label": "Not well",
+                      "value": "Not well"
+                    },
+                    {
+                      "label": "Not at all",
+                      "value": "Not at all"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "religion",
+          "questions": [
+            {
+              "id": "religion-question",
+              "title":
+                "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> religion?",
+              "description": "This question is voluntary",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "religion-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "No religion",
+                      "value": "No religion"
+                    },
+                    {
+                      "label": "Christianity",
+                      "value": "Christianity"
+                    },
+                    {
+                      "label": "Buddhism",
+                      "value": "Buddhism"
+                    },
+                    {
+                      "label": "Hinduism",
+                      "value": "Hinduism"
+                    },
+                    {
+                      "label": "Judaism",
+                      "value": "Judaism"
+                    },
+                    {
+                      "label": "Islam",
+                      "value": "Islam"
+                    },
+                    {
+                      "label": "Sikhism",
+                      "value": "Sikhism"
+                    },
+                    {
+                      "label": "Any other religion",
+                      "value": "Other",
+                      "child_answer_id": "religion-answer-other"
+                    }
+                  ],
+                  "type": "Checkbox"
+                },
+                {
+                  "id": "religion-answer-other",
+                  "parent_answer_id": "religion-answer",
+                  "type": "TextField",
+                  "mandatory": false,
+                  "label": "Please specify other religion"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "past-usual-address",
+          "questions": [
+            {
+              "id": "past-usual-address-question",
+              "title": "One year ago, what was your usual address?",
+              "description": "If you had no usual address one year ago, state the address where you were staying",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "past-usual-address-answer",
+                  "mandatory": false,
+                  "guidance": {
+                    "show_guidance": "Show further guidance",
+                    "hide_guidance": "Hide further guidance",
+                    "content": [
+                      {
+                        "description": "In most cases your usual address will be the permanent or family home that you were living in."
+                      }
+                    ]
+                  },
+                  "options": [
+                    {
+                      "label": "This address",
+                      "value": "This address"
+                    },
+                    {
+                      "label": "Student term time or boarding school address in the UK",
+                      "value": "Student term time or boarding school address in the UK"
+                    },
+                    {
+                      "label": "Another address in the UK",
+                      "value": "Another address in the UK"
+                    },
+                    {
+                      "label": "An address outside the UK",
+                      "value": "Other",
+                      "child_answer_id": "past-usual-address-answer-other"
+                    }
+                  ],
+                  "type": "Radio"
+                },
+                {
+                  "id": "past-usual-address-answer-other",
+                  "parent_answer_id": "past-usual-address-answer",
+                  "type": "TextField",
+                  "mandatory": false,
+                  "label": "Please enter the country"
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "last-year-address",
+                "when": [
+                  {
+                    "id": "past-usual-address-answer",
+                    "condition": "equals",
+                    "value": "Student term time or boarding school address in the UK"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "last-year-address",
+                "when": [
+                  {
+                    "id": "past-usual-address-answer",
+                    "condition": "equals",
+                    "value": "Another address in the UK"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "passports"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "last-year-address",
+          "questions": [
+            {
+              "id": "last-year-address-question",
+              "title": "Enter details of your address one year ago",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "last-year-address-answer-building",
+                  "label": "Building",
+                  "mandatory": false,
+                  "type": "TextField"
+                },
+                {
+                  "id": "last-year-address-answer-street",
+                  "label": "Street",
+                  "mandatory": false,
+                  "type": "TextField"
+                },
+                {
+                  "id": "last-year-address-answer-city",
+                  "label": "Town or city",
+                  "mandatory": false,
+                  "type": "TextField"
+                },
+                {
+                  "id": "last-year-address-answer-county",
+                  "label": "County (optional)",
+                  "mandatory": false,
+                  "type": "TextField"
+                },
+                {
+                  "id": "last-year-address-answer-postcode",
+                  "label": "Postcode",
+                  "mandatory": false,
+                  "type": "TextField"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "passports",
+          "questions": [
+            {
+              "id": "passports-question",
+              "title": "What passports do you hold?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "passports-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "United Kingdom",
+                      "value": "United Kingdom"
+                    },
+                    {
+                      "label": "Irish",
+                      "value": "Irish"
+                    },
+                    {
+                      "label": "Other",
+                      "value": "Other"
+                    },
+                    {
+                      "label": "None",
+                      "value": "None"
+                    }
+                  ],
+                  "type": "Checkbox"
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "other-passports",
+                "when": [
+                  {
+                    "id": "passports-answer",
+                    "condition": "contains",
+                    "value": "Other"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "disability"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "other-passports",
+          "questions": [
+            {
+              "id": "other-passports-question",
+              "title": "Please specify other passports held",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "other-passports-answer",
+                  "label": "Passports held",
+                  "mandatory": false,
+                  "type": "TextField"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "disability",
+          "questions": [
+            {
+              "id": "disability-question",
+              "title":
+                "Are <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive}}</em> day-to-day activities limited because of a health problem or disability which has lasted, or is expected to last, at least 12 months?",
+              "guidance": {
+                "content": [
+                  {
+                    "description": "<strong>Include</strong> problems related to old age"
+                  }
+                ]
+              },
+              "type": "General",
+              "answers": [
+                {
+                  "id": "disability-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Yes, limited a lot",
+                      "value": "Yes, limited a lot"
+                    },
+                    {
+                      "label": "Yes, limited a little",
+                      "value": "Yes, limited a little"
+                    },
+                    {
+                      "label": "No",
+                      "value": "No"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "household-member-completed",
+                "when": [
+                  {
+                    "id": "over-16-answer",
+                    "condition": "equals",
+                    "value": "No"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "qualifications"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "qualifications",
+          "questions": [
+            {
+              "id": "qualifications-england-question",
+              "title":
+                "Thinking of any studies, exams or qualifications, which of the following does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> have?",
+              "description": "Select every option that applies (whether UK or foreign equivalent) if you have any of the qualifications listed",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "qualifications-england-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label":
+                        "5 or more  GCSEs (grades A-Star to C) or O-Levels (passes) or CSEs (grade 1), School Certificate, One A-Level, 2 to 3 AS-Levels or VCEs, Higher Diploma",
+                      "value":
+                        "5 or more  GCSEs (grades A-Star to C) or O-Levels (passes) or CSEs (grade 1), School Certificate, One A-Level, 2 to 3 AS-Levels or VCEs, Higher Diploma"
+                    },
+                    {
+                      "label": "1 to 4 GCSEs or O-Levels or CSEs (any grades), Entry level, Foundation Diploma",
+                      "value": "1 to 4 GCSEs or O-Levels or CSEs (any grades), Entry level, Foundation Diploma"
+                    },
+                    {
+                      "label": "2 or more  A-Levels, 4 or more  AS-levels or VCEs, Higher School Certificate, Advanced Diploma",
+                      "value": "2 or more  A-Levels, 4 or more  AS-levels or VCEs, Higher School Certificate, Advanced Diploma"
+                    },
+                    {
+                      "label": "Apprenticeship (trade, advanced, foundation or modern)",
+                      "value": "Apprenticeship (trade, advanced, foundation or modern)"
+                    },
+                    {
+                      "label": "NVQ level one, Foundation GNVQ, Basic Skills",
+                      "value": "NVQ level one, Foundation GNVQ, Basic Skills"
+                    },
+                    {
+                      "label": "NVQ level two, Intermediate GNVQ, City and Guilds Craft, BTEC First, RSA Diploma",
+                      "value": "NVQ level two, Intermediate GNVQ, City and Guilds Craft, BTEC First, RSA Diploma"
+                    },
+                    {
+                      "label": "NVQ Level three, Advanced GNVQ, City and Guilds Advanced Craft, ONC, OND, BTEC National, RSA Advanced Diploma",
+                      "value": "NVQ Level three, Advanced GNVQ, City and Guilds Advanced Craft, ONC, OND, BTEC National, RSA Advanced Diploma"
+                    },
+                    {
+                      "label": "NVQ Level four to five, HNC, HND, RSA Higher Diploma, BTEC Higher, Foundation degree",
+                      "value": "NVQ Level four to five, HNC, HND, RSA Higher Diploma, BTEC Higher, Foundation degree"
+                    },
+                    {
+                      "label": "Other vocational or work-related qualifications",
+                      "value": "Other vocational or work-related qualifications"
+                    },
+                    {
+                      "label": "Undergraduate Degree",
+                      "value": "Undergraduate Degree"
+                    },
+                    {
+                      "label": "Postgraduate Certificate / Diploma",
+                      "value": "Postgraduate Certificate / Diploma"
+                    },
+                    {
+                      "label": "Masters Degree",
+                      "value": "Masters Degree"
+                    },
+                    {
+                      "label": "Doctorate Degree (for example PhD)",
+                      "value": "Doctorate Degree (for example PhD)"
+                    },
+                    {
+                      "label": "Professional qualification (for example teaching, nursing, accountancy)",
+                      "value": "Professional qualification (for example teaching, nursing, accountancy)"
+                    },
+                    {
+                      "label": "Foreign qualifications (UK equivalent not known)",
+                      "value": "Foreign qualifications (UK equivalent not known)"
+                    },
+                    {
+                      "label": "No qualifications",
+                      "value": "No qualifications"
+                    }
+                  ],
+                  "type": "Checkbox"
+                }
+              ],
+              "skip_conditions": [
+                {
+                  "when": [
+                    {
+                      "meta": "region_code",
+                      "condition": "equals",
+                      "value": "GB-WLS"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "qualifications-welsh-question",
+              "title":
+                "Thinking of any studies, exams or qualifications, which of the following does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> have?",
+              "description": "Select every option that applies (whether UK or foreign equivalent) if you have any of the qualifications listed",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "qualifications-welsh-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label":
+                        "5 or more GCSEs (grades A-Star to C) or O Levels (passes) or CSEs (grade 1), School Certificate, One A-Level, 2 to 3 AS-Levels or VCEs,  Intermediate or National Welsh Baccalaureate (Level two)",
+                      "value":
+                        "5 or more GCSEs (grades A-Star to C) or O Levels (passes) or CSEs (grade 1), School Certificate, One A-Level, 2 to 3 AS-Levels or VCEs,  Intermediate or National Welsh Baccalaureate (Level two)"
+                    },
+                    {
+                      "label": "1 to 4  GCSEs or O Levels or CSEs (any grades), Entry level, Foundation Welsh Baccalaureate (level one)",
+                      "value": "1 to 4  GCSEs or O Levels or CSEs (any grades), Entry level, Foundation Welsh Baccalaureate (level one)"
+                    },
+                    {
+                      "label": "More than 2 A-Levels, more than 4 AS-levels or VCEs, Higher School Certificate, Advanced Welsh Baccalaureate (level three)",
+                      "value": "More than 2 A-Levels, more than 4 AS-levels or VCEs, Higher School Certificate, Advanced Welsh Baccalaureate (level three)"
+                    },
+                    {
+                      "label": "Apprenticeship (foundation, modern or higher)",
+                      "value": "Apprenticeship (foundation, modern or higher)"
+                    },
+                    {
+                      "label": "NVQ level one, Foundation GNVQ, Essential or Key  Skills",
+                      "value": "NVQ level one, Foundation GNVQ, Essential or Key  Skills"
+                    },
+                    {
+                      "label": "NVQ level two, Intermediate GNVQ, City and Guilds Craft, BTEC First, RSA Diploma",
+                      "value": "NVQ level two, Intermediate GNVQ, City and Guilds Craft, BTEC First, RSA Diploma"
+                    },
+                    {
+                      "label": "NVQ Level three, Advanced GNVQ, City and Guilds Advanced Craft, ONC, OND, BTEC National, RSA Advanced Diploma",
+                      "value": "NVQ Level three, Advanced GNVQ, City and Guilds Advanced Craft, ONC, OND, BTEC National, RSA Advanced Diploma"
+                    },
+                    {
+                      "label": "NVQ Level four to five, HNC, HND, RSA Higher Diploma, BTEC Higher",
+                      "value": "NVQ Level four to five, HNC, HND, RSA Higher Diploma, BTEC Higher"
+                    },
+                    {
+                      "label": "Other vocational or work-related qualifications",
+                      "value": "Other vocational or work-related qualifications"
+                    },
+                    {
+                      "label": "Undergraduate Degree",
+                      "value": "Undergraduate Degree"
+                    },
+                    {
+                      "label": "Postgraduate Certificate / Diploma",
+                      "value": "Postgraduate Certificate / Diploma"
+                    },
+                    {
+                      "label": "Masters Degree",
+                      "value": "Masters Degree"
+                    },
+                    {
+                      "label": "Doctorate Degree (for example PhD)",
+                      "value": "Doctorate Degree (for example PhD)"
+                    },
+                    {
+                      "label": "Professional qualification (for example teaching, nursing, accountancy)",
+                      "value": "Professional qualification (for example teaching, nursing, accountancy)"
+                    },
+                    {
+                      "label": "Foreign qualifications (UK equivalent not known)",
+                      "value": "Foreign qualifications (UK equivalent not known)"
+                    },
+                    {
+                      "label": "No qualifications",
+                      "value": "No qualifications"
+                    }
+                  ],
+                  "type": "Checkbox"
+                }
+              ],
+              "skip_conditions": [
+                {
+                  "when": [
+                    {
+                      "meta": "region_code",
+                      "condition": "not equals",
+                      "value": "GB-WLS"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "employment-type",
+          "questions": [
+            {
+              "id": "employment-type-question",
+              "title":
+                "Which of the following best describes what <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> was doing last week?",
+              "guidance": {
+                "content": [
+                  {
+                    "description": "<strong>Include</strong> any paid work, including casual or temporary work, even if only for one hour"
+                  }
+                ]
+              },
+              "type": "General",
+              "answers": [
+                {
+                  "id": "employment-type-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "working as an employee",
+                      "value": "working as an employee"
+                    },
+                    {
+                      "label": "on a government sponsored training scheme",
+                      "value": "on a government sponsored training scheme"
+                    },
+                    {
+                      "label": "self-employed or freelance",
+                      "value": "self-employed or freelance"
+                    },
+                    {
+                      "label": "working paid or unpaid for you own or your family’s business",
+                      "value": "working paid or unpaid for you own or your family’s business"
+                    },
+                    {
+                      "label": "away from work ill, on maternity leave, on holiday or temporarily laid off",
+                      "value": "away from work ill, on maternity leave, on holiday or temporarily laid off"
+                    },
+                    {
+                      "label": "doing any other kind of paid work",
+                      "value": "doing any other kind of paid work"
+                    },
+                    {
+                      "label": "none of the above",
+                      "value": "none of the above"
+                    }
+                  ],
+                  "type": "Checkbox"
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "main-job",
+                "when": [
+                  {
+                    "id": "employment-type-answer",
+                    "condition": "contains",
+                    "value": "working as an employee"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "main-job",
+                "when": [
+                  {
+                    "id": "employment-type-answer",
+                    "condition": "contains",
+                    "value": "on a government sponsored training scheme"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "main-job",
+                "when": [
+                  {
+                    "id": "employment-type-answer",
+                    "condition": "contains",
+                    "value": "self-employed or freelance"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "main-job",
+                "when": [
+                  {
+                    "id": "employment-type-answer",
+                    "condition": "contains",
+                    "value": "working paid or unpaid for you own or your family’s business"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "main-job",
+                "when": [
+                  {
+                    "id": "employment-type-answer",
+                    "condition": "contains",
+                    "value": "away from work ill, on maternity leave, on holiday or temporarily laid off"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "main-job",
+                "when": [
+                  {
+                    "id": "employment-type-answer",
+                    "condition": "contains",
+                    "value": "doing any other kind of paid work"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "jobseeker"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "jobseeker",
+          "questions": [
+            {
+              "id": "jobseeker-question",
+              "title":
+                "Was <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> actively looking for any kind of paid work during the last four weeks?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "jobseeker-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Yes",
+                      "value": "Yes"
+                    },
+                    {
+                      "label": "No",
+                      "value": "No"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "job-availability",
+          "questions": [
+            {
+              "id": "job-availability-question",
+              "title":
+                "If a job had been offered to <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> last week, could they have started it within 2 weeks?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "job-availability-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Yes",
+                      "value": "Yes"
+                    },
+                    {
+                      "label": "No",
+                      "value": "No"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "job-pending",
+          "questions": [
+            {
+              "id": "job-pending-question",
+              "title":
+                "Last week, was <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> waiting to start a job already accepted?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "job-pending-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Yes",
+                      "value": "Yes"
+                    },
+                    {
+                      "label": "No",
+                      "value": "No"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "occupation",
+          "questions": [
+            {
+              "id": "occupation-question",
+              "title":
+                "Which of the following best describes what <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> was doing last week?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "occupation-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "retired (whether receiving a pension or not)",
+                      "value": "retired (whether receiving a pension or not)"
+                    },
+                    {
+                      "label": "a student",
+                      "value": "a student"
+                    },
+                    {
+                      "label": "looking after home or family",
+                      "value": "looking after home or family"
+                    },
+                    {
+                      "label": "long-term sick or disabled",
+                      "value": "long-term sick or disabled"
+                    },
+                    {
+                      "label": "other",
+                      "value": "other"
+                    }
+                  ],
+                  "type": "Checkbox"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "ever-worked",
+          "questions": [
+            {
+              "id": "ever-worked-question",
+              "title": "Has <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> ever worked?",
+              "type": "General",
+              "guidance": {
+                "content": [
+                  {
+                    "title": "Include:",
+                    "list": ["work outside of the United Kingdom.", "even if you are now retired."]
+                  }
+                ]
+              },
+              "answers": [
+                {
+                  "id": "ever-worked-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Yes",
+                      "value": "Yes"
+                    },
+                    {
+                      "label": "No",
+                      "value": "No"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "household-member-completed",
+                "when": [
+                  {
+                    "id": "ever-worked-answer",
+                    "condition": "equals",
+                    "value": "No"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "household-member-completed",
+                "when": [
+                  {
+                    "id": "ever-worked-answer",
+                    "condition": "not set"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "main-job"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "main-job",
+          "questions": [
+            {
+              "id": "main-job-question",
+              "title":
+                "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive }}</em> employment status?",
+              "guidance": {
+                "content": [
+                  {
+                    "description":
+                      "<p>If you are not working answer the remaining questions about your last main job.</p><p>Your main job is the job which you usually work (worked) the most hours</p>"
+                  }
+                ]
+              },
+              "type": "General",
+              "answers": [
+                {
+                  "id": "main-job-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "an employee",
+                      "value": "an employee"
+                    },
+                    {
+                      "label": "self-employed or freelance without employees",
+                      "value": "self-employed or freelance without employees"
+                    },
+                    {
+                      "label": "self-employed with employees",
+                      "value": "self-employed with employees"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "hours-worked",
+          "description": "",
+          "questions": [
+            {
+              "title":
+                "In <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive }}</em> main job, how many hours a week do they usually work?",
+              "guidance": {
+                "content": [
+                  {
+                    "description": "Include paid and unpaid overtime"
+                  }
+                ]
+              },
+              "id": "hours-worked-question",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "hours-worked-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "15 or less",
+                      "value": "15 or less"
+                    },
+                    {
+                      "label": "16 - 30",
+                      "value": "16 - 30"
+                    },
+                    {
+                      "label": "31 - 48",
+                      "value": "31 - 48"
+                    },
+                    {
+                      "label": "49 or more",
+                      "value": "49 or more "
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "work-travel",
+          "description": "",
+          "questions": [
+            {
+              "title":
+                "How does <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> usually travel to work?",
+              "description":
+                "Select the option for the longest part, in distance, of your journey. For example, you travel by bus and by car. Your bus journey is 5 miles, and the car journey is 8 miles. You should select car as your answer.",
+              "id": "work-travel-question",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "work-travel-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Work mainly at or from home",
+                      "value": "Work mainly at or from home"
+                    },
+                    {
+                      "label": "Underground, metro, light rail or tram",
+                      "value": "Underground, metro, light rail or tram"
+                    },
+                    {
+                      "label": "Train",
+                      "value": "Train"
+                    },
+                    {
+                      "label": "Bus, minibus or coach",
+                      "value": "Bus, minibus or coach "
+                    },
+                    {
+                      "label": "Taxi",
+                      "value": "Taxi "
+                    },
+                    {
+                      "label": "Motorcycle, scooter or moped",
+                      "value": "Motorcycle, scooter or moped"
+                    },
+                    {
+                      "label": "Driving a car or van",
+                      "value": "Driving a car or van"
+                    },
+                    {
+                      "label": "Passenger in a car or van",
+                      "value": "Passenger in a car or van"
+                    },
+                    {
+                      "label": "Bicycle",
+                      "value": "Bicycle"
+                    },
+                    {
+                      "label": "On foot",
+                      "value": "On foot"
+                    },
+                    {
+                      "label": "Other",
+                      "value": "Other"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "job-title",
+          "questions": [
+            {
+              "id": "job-title-question",
+              "title":
+                "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name_possessive }}</em> full job title?",
+              "description":
+                "<p>For example, <b>primary school teacher, car mechanic, district nurse, structural engineer</b></p><p>Do not state your grade or pay band</p><p>Please enter your job title in the space provided.</p><p>Do not state your grade or pay band.</p><p>If you are not sure of your job title please give the best information you can.</p>",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "job-title-answer",
+                  "label": "Job title",
+                  "mandatory": false,
+                  "type": "TextField"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "job-description",
+          "questions": [
+            {
+              "id": "job-description-question",
+              "title":
+                "What <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> does in their main job?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "job-description-answer",
+                  "label": "Description",
+                  "mandatory": false,
+                  "type": "TextArea"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "main-job-type",
+          "questions": [
+            {
+              "id": "main-job-type-question",
+              "title":
+                "What is <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> employment status?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "main-job-type-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Employed by an organisation or business",
+                      "value": "Employed by an organisation or business"
+                    },
+                    {
+                      "label": "Self-employed in your own organisation or business",
+                      "value": "Self-employed in your own organisation or business"
+                    },
+                    {
+                      "label": "Not working for an organisation or business",
+                      "value": "Not working for an organisation or business",
+                      "description": "For example self-employed freelance or work (worked) for a private individual"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "household-member-completed",
+                "when": [
+                  {
+                    "id": "main-job-type-answer",
+                    "condition": "equals",
+                    "value": "Not working for an organisation or business"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "business-name"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "business-name",
+          "questions": [
+            {
+              "id": "business-name-question",
+              "title":
+                "What is the name of the organisation of business that <em>{{[answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name}}</em> work for?",
+              "description":
+                "<p>If you were self-employed in your own organisation or business, enter the name</p><p>This question is asking for the name of the organisation or business that you work (or worked) for in your main job.</p><p>If you can’t remember the name of the organisation, please give the best information you can.</p><p>If you are employed through an agency please enter the name of the business you are working for, not the agency.</p>",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "business-name-answer",
+                  "label": "Organisation or business name",
+                  "mandatory": false,
+                  "type": "TextField",
+                  "alias": "company_name"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "employers-business",
+          "questions": [
+            {
+              "id": "employers-business-question",
+              "title": "What is the main activity of <em>{{answers.company_name}}</em>?",
+              "description":
+                "<p>Enter the main activity of your employer or business.</p><p>Another way of describing main activity is the industry that your employer or business works in.</p><p>If you are not sure of the main activity of your employer or business please give the best information you can.</p><p>If you are employed through an agency please enter the main activity of the business you are working for, not the agency.</p><p>For example, <b>primary education, repairing cars, contract catering, computer servicing</b></p>",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "employers-business-answer",
+                  "label": "Description",
+                  "mandatory": false,
+                  "type": "TextArea"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "household-member-completed",
+          "title": "There are no more questions for {{ [answers.first_name[group_instance], answers.last_name[group_instance]] | format_household_name }}",
+          "description": "",
+          "type": "Interstitial"
+        }
+      ]
+    },
+    {
+      "id": "visitors-begin",
+      "title": "VisitorsBegin",
+      "skip_conditions": [
+        {
+          "when": [
+            {
+              "id": "overnight-visitors-answer",
+              "condition": "equals",
+              "value": "0"
+            }
+          ]
+        },
+        {
+          "when": [
+            {
+              "id": "overnight-visitors-answer",
+              "condition": "not set"
+            }
+          ]
+        }
+      ],
+      "blocks": [
+        {
+          "type": "Interstitial",
+          "id": "visitor-begin-section",
+          "title": "Visitors",
+          "description":
+            "In this section, we’re going to ask you about any visitors that were staying overnight at <em>{{answers.address_line_1}}</em> on 29 November 2017.",
+          "content": [
+            {
+              "title": "Information you need",
+              "list": ["Name of visitor", "Gender of visitor", "Date of birth of visitor", "Address of visitor"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "visitors",
+      "title": "Visitors",
+      "routing_rules": [
+        {
+          "repeat": {
+            "type": "answer_value",
+            "answer_id": "overnight-visitors-answer"
+          }
+        }
+      ],
+      "blocks": [
+        {
+          "type": "Question",
+          "id": "visitor-name",
+          "questions": [
+            {
+              "id": "visitor-name-question",
+              "title": "What is the name of visitor {{group_instance + 1}}?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "visitor-first-name",
+                  "label": "First name",
+                  "mandatory": false,
+                  "type": "TextField"
+                },
+                {
+                  "id": "visitor-last-name",
+                  "label": "Last name",
+                  "mandatory": false,
+                  "type": "TextField"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "visitor-sex",
+          "questions": [
+            {
+              "id": "visitor-sex-question",
+              "title": "What is this person’s sex?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "visitor-sex-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Male",
+                      "value": "Male"
+                    },
+                    {
+                      "label": "Female",
+                      "value": "Female"
+                    }
+                  ],
+                  "type": "Radio"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "visitor-date-of-birth",
+          "questions": [
+            {
+              "id": "visitor-date-of-birth-question",
+              "title": "What is this person’s date of birth?",
+              "description": "For example 20 March 1980",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "visitor-date-of-birth-answer",
+                  "mandatory": false,
+                  "type": "Date"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "visitor-uk-resident",
+          "questions": [
+            {
+              "id": "visitor-uk-resident-question",
+              "title": "Does this person usually live in the United Kingdom?",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "visitor-uk-resident-answer",
+                  "mandatory": false,
+                  "options": [
+                    {
+                      "label": "Yes, usually lives in the United Kingdom",
+                      "value": "Yes, usually lives in the United Kingdom"
+                    },
+                    {
+                      "label": "No, usually lives outside the United Kingdom (please specify)",
+                      "value": "Other",
+                      "child_answer_id": "visitor-uk-resident-answer-other"
+                    }
+                  ],
+                  "type": "Radio"
+                },
+                {
+                  "id": "visitor-uk-resident-answer-other",
+                  "parent_answer_id": "visitor-uk-resident-answer",
+                  "type": "TextField",
+                  "mandatory": false,
+                  "label": "Please specify country"
+                }
+              ]
+            }
+          ],
+          "routing_rules": [
+            {
+              "goto": {
+                "block": "visitor-address",
+                "when": [
+                  {
+                    "id": "visitor-uk-resident-answer",
+                    "condition": "equals",
+                    "value": "Yes, usually lives in the United Kingdom"
+                  }
+                ]
+              }
+            },
+            {
+              "goto": {
+                "block": "visitor-completed"
+              }
+            }
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "visitor-address",
+          "questions": [
+            {
+              "id": "visitor-address-question",
+              "title": "Enter details of this person’s usual UK address",
+              "type": "General",
+              "answers": [
+                {
+                  "id": "visitor-address-answer-building",
+                  "label": "Building",
+                  "mandatory": false,
+                  "type": "TextField"
+                },
+                {
+                  "id": "visitor-address-answer-street",
+                  "label": "Street",
+                  "mandatory": false,
+                  "type": "TextField"
+                },
+                {
+                  "id": "visitor-address-answer-city",
+                  "label": "Town or city",
+                  "mandatory": false,
+                  "type": "TextField"
+                },
+                {
+                  "id": "visitor-address-answer-county",
+                  "label": "County (optional)",
+                  "mandatory": false,
+                  "type": "TextField"
+                },
+                {
+                  "id": "visitor-address-answer-postcode",
+                  "label": "Postcode",
+                  "mandatory": false,
+                  "type": "TextField"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "visitor-completed",
+          "title": "You have completed all questions for Visitor {{group_instance + 1}}",
+          "description": "",
+          "type": "Interstitial"
+        }
+      ]
+    },
+    {
+      "id": "visitors-interstitial",
+      "title": "Visitors",
+      "skip_conditions": [
+        {
+          "when": [
+            {
+              "id": "overnight-visitors-answer",
+              "condition": "equals",
+              "value": "0"
+            }
+          ]
+        },
+        {
+          "when": [
+            {
+              "id": "overnight-visitors-answer",
+              "condition": "not set"
+            }
+          ]
+        }
+      ],
+      "blocks": [
+        {
+          "id": "visitors-completed",
+          "type": "Interstitial",
+          "title": "You have successfully completed the ‘Visitors’ section",
+          "description": ""
+        }
+      ]
+    },
+    {
+      "id": "questionnaire-completed",
+      "title": "Submit answers",
+      "blocks": [
+        {
+          "type": "Confirmation",
+          "id": "confirmation",
+          "title": "You’re ready to submit your 2017 Census Test",
+          "description": "<p>Thank you for taking part in the 2017 Census Test.</p>",
+          "questions": [
+            {
+              "answers": [],
+              "id": "questionnaire-completed-question",
+              "title": "",
+              "type": "General",
+              "guidance": {
+                "content": [
+                  {
+                    "title": "Please note:",
+                    "list": [
+                      "by submitting your responses, you are declaring that you have completed to the best of your knowledge and belief.",
+                      "if you do not submit, your responses will be automatically submitted when the Census 2017 Test closes.",
+                      "after submission you will have an opportunity to provide feedback on your experience."
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/data/en/census_individual.json
+++ b/data/en/census_individual.json
@@ -751,7 +751,6 @@
                         "type": "General",
                         "answers": [{
                                 "id": "national-identity-england-answer",
-                                "label": "Select all that apply",
                                 "mandatory": false,
                                 "guidance": {
                                     "show_guidance": "Show further guidance",
@@ -820,7 +819,6 @@
                         "type": "General",
                         "answers": [{
                                 "id": "national-identity-wales-answer",
-                                "label": "Select all that apply",
                                 "mandatory": false,
                                 "guidance": {
                                     "show_guidance": "Show further guidance",
@@ -1667,7 +1665,6 @@
                 "questions": [{
                     "id": "understand-welsh-question",
                     "title": "Can you understand, speak, read or write Welsh?",
-                    "description": "Select all that apply",
                     "type": "General",
                     "answers": [{
                         "id": "understand-welsh-answer",
@@ -2082,7 +2079,6 @@
                 "questions": [{
                     "id": "passports-question",
                     "title": "What passports do you hold?",
-                    "description": "Select all that apply",
                     "type": "General",
                     "answers": [{
                         "id": "passports-answer",
@@ -2394,7 +2390,6 @@
                 "questions": [{
                     "id": "employment-type-question",
                     "title": "Last week were you:",
-                    "description": "Select all that apply",
                     "guidance": {
                         "content": [{
                             "description": "<strong>Include</strong> any paid work, including casual or temporary work, even if only for one hour"
@@ -2582,7 +2577,6 @@
                 "questions": [{
                     "id": "occupation-question",
                     "title": "Last week, were you:",
-                    "description": "Select all that apply",
                     "type": "General",
                     "answers": [{
                         "id": "occupation-answer",

--- a/data/en/mbs_0111.json
+++ b/data/en/mbs_0111.json
@@ -220,7 +220,6 @@
                     "answers": [{
                         "type": "Checkbox",
                         "id": "changes-in-total-turnover-answer-6-0",
-                        "label": "Select all that apply",
                         "mandatory": true,
                         "options": [{
                                 "label": "Special events (e.g.  sporting events)",

--- a/data/en/test_radio_checkbox_descriptions.json
+++ b/data/en/test_radio_checkbox_descriptions.json
@@ -1,104 +1,119 @@
 {
-    "mime_type": "application/json/ons/eq",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.1",
-    "survey_id": "0",
-    "title": "Test Survey - Checkbox and Radio option descriptions",
-    "description": "",
-    "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
-    "groups": [{
-        "id": "radio-checkbox-descriptio",
-        "title": "Did this business make major changes in the following areas?",
-        "blocks": [{
-                "type": "Question",
-                "id": "checkbox-block",
-                "title": "Did this business make major changes in the following areas?",
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.1",
+  "survey_id": "0",
+  "title": "Test Survey - Checkbox and Radio option descriptions",
+  "description": "",
+  "theme": "default",
+  "legal_basis": "StatisticsOfTradeAct",
+  "groups": [
+    {
+      "id": "radio-checkbox-descriptio",
+      "title": "Did this business make major changes in the following areas?",
+      "blocks": [
+        {
+          "type": "Question",
+          "id": "checkbox-block",
+          "title": "Did this business make major changes in the following areas?",
 
-                "description": "<p>Include all <strong>new</strong> and <strong>significantly improved</strong> forms of organisation, business structures or practices aimed at raising internal efficiency or the effectiveness of approaching markets and customers.</p>",
-                "questions": [{
-                    "answers": [{
-                        "id": "checkbox-answer",
-                        "label": "Did this business make major changes in the following areas?",
-                        "mandatory": true,
-                        "options": [{
-                                "label": "New business practices for organising procedures",
-                                "value": "New business practices for organising procedures",
-                                "description": "For example supply chain management, business re-engineering, knowledge management, lean production, quality management"
-                            },
-                            {
-                                "label": "New methods of organising work responsibilities and decision making",
-                                "value": "New methods of organising work responsibilities and decision making",
-                                "description": "For example first use of a new system of employee responsibilities, team work, decentralisation, integration or de-integration of departments, education / training systems"
-                            },
-                            {
-                                "label": "New methods of organising external relationships with other firms or public institutions",
-                                "value": "New methods of organising external relationships with other firms or public institutions",
-                                "description": "For example first use of alliances, partnerships, outsourcing or sub-contracting"
-                            },
-                            {
-                                "label": "Implementation of changes to marketing concepts or strategies",
-                                "value": "Implementation of changes to marketing concepts or strategies"
-                            }
-                        ],
-                        "q_code": "10",
-                        "type": "Checkbox",
-                        "validation": {
-                            "messages": {}
-                        }
-                    }],
-                    "description": "Select all that apply",
-                    "id": "checkbox-question",
-                    "title": "Did this business make major changes in the following areas?",
-                    "type": "General"
-                }]
-            },
+          "description":
+            "<p>Include all <strong>new</strong> and <strong>significantly improved</strong> forms of organisation, business structures or practices aimed at raising internal efficiency or the effectiveness of approaching markets and customers.</p>",
+          "questions": [
             {
-                "type": "Question",
-                "id": "radio-block",
-                "description": "",
-                "questions": [{
-                    "answers": [{
-                        "id": "radio-answer",
-                        "label": "Did this business make major changes in the following areas?",
-                        "mandatory": true,
-                        "options": [{
-                                "label": "New business practices for organising procedures",
-                                "value": "New business practices for organising procedures",
-                                "description": "For example supply chain management, business re-engineering, knowledge management, lean production, quality management"
-                            },
-                            {
-                                "label": "New methods of organising work responsibilities and decision making",
-                                "value": "New methods of organising work responsibilities and decision making",
-                                "description": "For example first use of a new system of employee responsibilities, team work, decentralisation, integration or de-integration of departments, education / training systems"
-                            },
-                            {
-                                "label": "New methods of organising external relationships with other firms or public institutions",
-                                "value": "New methods of organising external relationships with other firms or public institutions",
-                                "description": "For example first use of alliances, partnerships, outsourcing or sub-contracting"
-                            },
-                            {
-                                "label": "Implementation of changes to marketing concepts or strategies",
-                                "value": "Implementation of changes to marketing concepts or strategies"
-                            }
-                        ],
-                        "q_code": "20",
-                        "type": "Radio",
-                        "validation": {
-                            "messages": {}
-                        }
-                    }],
-                    "description": "",
-                    "id": "radio-question",
-                    "title": "Did this business make major changes in the following areas?",
-                    "type": "General"
-                }],
-                "title": "Business Strategy and Practices Part Two"
-            },
-            {
-                "type": "Summary",
-                "id": "summary"
+              "answers": [
+                {
+                  "id": "checkbox-answer",
+                  "label": "Did this business make major changes in the following areas?",
+                  "mandatory": true,
+                  "options": [
+                    {
+                      "label": "New business practices for organising procedures",
+                      "value": "New business practices for organising procedures",
+                      "description": "For example supply chain management, business re-engineering, knowledge management, lean production, quality management"
+                    },
+                    {
+                      "label": "New methods of organising work responsibilities and decision making",
+                      "value": "New methods of organising work responsibilities and decision making",
+                      "description":
+                        "For example first use of a new system of employee responsibilities, team work, decentralisation, integration or de-integration of departments, education / training systems"
+                    },
+                    {
+                      "label": "New methods of organising external relationships with other firms or public institutions",
+                      "value": "New methods of organising external relationships with other firms or public institutions",
+                      "description": "For example first use of alliances, partnerships, outsourcing or sub-contracting"
+                    },
+                    {
+                      "label": "Implementation of changes to marketing concepts or strategies",
+                      "value": "Implementation of changes to marketing concepts or strategies"
+                    }
+                  ],
+                  "q_code": "10",
+                  "type": "Checkbox",
+                  "validation": {
+                    "messages": {}
+                  }
+                }
+              ],
+              "id": "checkbox-question",
+              "title": "Did this business make major changes in the following areas?",
+              "type": "General"
             }
-        ]
-    }]
+          ]
+        },
+        {
+          "type": "Question",
+          "id": "radio-block",
+          "description": "",
+          "questions": [
+            {
+              "answers": [
+                {
+                  "id": "radio-answer",
+                  "label": "Did this business make major changes in the following areas?",
+                  "mandatory": true,
+                  "options": [
+                    {
+                      "label": "New business practices for organising procedures",
+                      "value": "New business practices for organising procedures",
+                      "description": "For example supply chain management, business re-engineering, knowledge management, lean production, quality management"
+                    },
+                    {
+                      "label": "New methods of organising work responsibilities and decision making",
+                      "value": "New methods of organising work responsibilities and decision making",
+                      "description":
+                        "For example first use of a new system of employee responsibilities, team work, decentralisation, integration or de-integration of departments, education / training systems"
+                    },
+                    {
+                      "label": "New methods of organising external relationships with other firms or public institutions",
+                      "value": "New methods of organising external relationships with other firms or public institutions",
+                      "description": "For example first use of alliances, partnerships, outsourcing or sub-contracting"
+                    },
+                    {
+                      "label": "Implementation of changes to marketing concepts or strategies",
+                      "value": "Implementation of changes to marketing concepts or strategies"
+                    }
+                  ],
+                  "q_code": "20",
+                  "type": "Radio",
+                  "validation": {
+                    "messages": {}
+                  }
+                }
+              ],
+              "description": "",
+              "id": "radio-question",
+              "title": "Did this business make major changes in the following areas?",
+              "type": "General"
+            }
+          ],
+          "title": "Business Strategy and Practices Part Two"
+        },
+        {
+          "type": "Summary",
+          "id": "summary"
+        }
+      ]
+    }
+  ]
 }

--- a/data/en/test_radio_checkbox_descriptions.json
+++ b/data/en/test_radio_checkbox_descriptions.json
@@ -1,119 +1,103 @@
 {
-  "mime_type": "application/json/ons/eq",
-  "schema_version": "0.0.1",
-  "data_version": "0.0.1",
-  "survey_id": "0",
-  "title": "Test Survey - Checkbox and Radio option descriptions",
-  "description": "",
-  "theme": "default",
-  "legal_basis": "StatisticsOfTradeAct",
-  "groups": [
-    {
-      "id": "radio-checkbox-descriptio",
-      "title": "Did this business make major changes in the following areas?",
-      "blocks": [
-        {
-          "type": "Question",
-          "id": "checkbox-block",
-          "title": "Did this business make major changes in the following areas?",
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "survey_id": "0",
+    "title": "Test Survey - Checkbox and Radio option descriptions",
+    "description": "",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "groups": [{
+        "id": "radio-checkbox-descriptio",
+        "title": "Did this business make major changes in the following areas?",
+        "blocks": [{
+                "type": "Question",
+                "id": "checkbox-block",
+                "title": "Did this business make major changes in the following areas?",
 
-          "description":
-            "<p>Include all <strong>new</strong> and <strong>significantly improved</strong> forms of organisation, business structures or practices aimed at raising internal efficiency or the effectiveness of approaching markets and customers.</p>",
-          "questions": [
+                "description": "<p>Include all <strong>new</strong> and <strong>significantly improved</strong> forms of organisation, business structures or practices aimed at raising internal efficiency or the effectiveness of approaching markets and customers.</p>",
+                "questions": [{
+                    "answers": [{
+                        "id": "checkbox-answer",
+                        "label": "Did this business make major changes in the following areas?",
+                        "mandatory": true,
+                        "options": [{
+                                "label": "New business practices for organising procedures",
+                                "value": "New business practices for organising procedures",
+                                "description": "For example supply chain management, business re-engineering, knowledge management, lean production, quality management"
+                            },
+                            {
+                                "label": "New methods of organising work responsibilities and decision making",
+                                "value": "New methods of organising work responsibilities and decision making",
+                                "description": "For example first use of a new system of employee responsibilities, team work, decentralisation, integration or de-integration of departments, education / training systems"
+                            },
+                            {
+                                "label": "New methods of organising external relationships with other firms or public institutions",
+                                "value": "New methods of organising external relationships with other firms or public institutions",
+                                "description": "For example first use of alliances, partnerships, outsourcing or sub-contracting"
+                            },
+                            {
+                                "label": "Implementation of changes to marketing concepts or strategies",
+                                "value": "Implementation of changes to marketing concepts or strategies"
+                            }
+                        ],
+                        "q_code": "10",
+                        "type": "Checkbox",
+                        "validation": {
+                            "messages": {}
+                        }
+                    }],
+                    "id": "checkbox-question",
+                    "title": "Did this business make major changes in the following areas?",
+                    "type": "General"
+                }]
+            },
             {
-              "answers": [
-                {
-                  "id": "checkbox-answer",
-                  "label": "Did this business make major changes in the following areas?",
-                  "mandatory": true,
-                  "options": [
-                    {
-                      "label": "New business practices for organising procedures",
-                      "value": "New business practices for organising procedures",
-                      "description": "For example supply chain management, business re-engineering, knowledge management, lean production, quality management"
-                    },
-                    {
-                      "label": "New methods of organising work responsibilities and decision making",
-                      "value": "New methods of organising work responsibilities and decision making",
-                      "description":
-                        "For example first use of a new system of employee responsibilities, team work, decentralisation, integration or de-integration of departments, education / training systems"
-                    },
-                    {
-                      "label": "New methods of organising external relationships with other firms or public institutions",
-                      "value": "New methods of organising external relationships with other firms or public institutions",
-                      "description": "For example first use of alliances, partnerships, outsourcing or sub-contracting"
-                    },
-                    {
-                      "label": "Implementation of changes to marketing concepts or strategies",
-                      "value": "Implementation of changes to marketing concepts or strategies"
-                    }
-                  ],
-                  "q_code": "10",
-                  "type": "Checkbox",
-                  "validation": {
-                    "messages": {}
-                  }
-                }
-              ],
-              "id": "checkbox-question",
-              "title": "Did this business make major changes in the following areas?",
-              "type": "General"
-            }
-          ]
-        },
-        {
-          "type": "Question",
-          "id": "radio-block",
-          "description": "",
-          "questions": [
+                "type": "Question",
+                "id": "radio-block",
+                "description": "",
+                "questions": [{
+                    "answers": [{
+                        "id": "radio-answer",
+                        "label": "Did this business make major changes in the following areas?",
+                        "mandatory": true,
+                        "options": [{
+                                "label": "New business practices for organising procedures",
+                                "value": "New business practices for organising procedures",
+                                "description": "For example supply chain management, business re-engineering, knowledge management, lean production, quality management"
+                            },
+                            {
+                                "label": "New methods of organising work responsibilities and decision making",
+                                "value": "New methods of organising work responsibilities and decision making",
+                                "description": "For example first use of a new system of employee responsibilities, team work, decentralisation, integration or de-integration of departments, education / training systems"
+                            },
+                            {
+                                "label": "New methods of organising external relationships with other firms or public institutions",
+                                "value": "New methods of organising external relationships with other firms or public institutions",
+                                "description": "For example first use of alliances, partnerships, outsourcing or sub-contracting"
+                            },
+                            {
+                                "label": "Implementation of changes to marketing concepts or strategies",
+                                "value": "Implementation of changes to marketing concepts or strategies"
+                            }
+                        ],
+                        "q_code": "20",
+                        "type": "Radio",
+                        "validation": {
+                            "messages": {}
+                        }
+                    }],
+                    "description": "",
+                    "id": "radio-question",
+                    "title": "Did this business make major changes in the following areas?",
+                    "type": "General"
+                }],
+                "title": "Business Strategy and Practices Part Two"
+            },
             {
-              "answers": [
-                {
-                  "id": "radio-answer",
-                  "label": "Did this business make major changes in the following areas?",
-                  "mandatory": true,
-                  "options": [
-                    {
-                      "label": "New business practices for organising procedures",
-                      "value": "New business practices for organising procedures",
-                      "description": "For example supply chain management, business re-engineering, knowledge management, lean production, quality management"
-                    },
-                    {
-                      "label": "New methods of organising work responsibilities and decision making",
-                      "value": "New methods of organising work responsibilities and decision making",
-                      "description":
-                        "For example first use of a new system of employee responsibilities, team work, decentralisation, integration or de-integration of departments, education / training systems"
-                    },
-                    {
-                      "label": "New methods of organising external relationships with other firms or public institutions",
-                      "value": "New methods of organising external relationships with other firms or public institutions",
-                      "description": "For example first use of alliances, partnerships, outsourcing or sub-contracting"
-                    },
-                    {
-                      "label": "Implementation of changes to marketing concepts or strategies",
-                      "value": "Implementation of changes to marketing concepts or strategies"
-                    }
-                  ],
-                  "q_code": "20",
-                  "type": "Radio",
-                  "validation": {
-                    "messages": {}
-                  }
-                }
-              ],
-              "description": "",
-              "id": "radio-question",
-              "title": "Did this business make major changes in the following areas?",
-              "type": "General"
+                "type": "Summary",
+                "id": "summary"
             }
-          ],
-          "title": "Business Strategy and Practices Part Two"
-        },
-        {
-          "type": "Summary",
-          "id": "summary"
-        }
-      ]
-    }
-  ]
+        ]
+    }]
 }


### PR DESCRIPTION

<img width="638" alt="screen shot 2018-01-23 at 11 03 11" src="https://user-images.githubusercontent.com/930398/35273771-a89efe8a-0031-11e8-813f-04a4f04e7453.png">


### What is the context of this PR?

Adds a label to fieldsets of checkboxes that states "Select all that apply:".

- Introduces `.field__label` element of the `field` block.
- Added this to template for multiple-choice answers if the type is "checkbox".
- Removes existing instances of this text from schemas to prevent deuplication

### How to review 

- Navigate to "test_checkbox" schema.
- Confirm text/styling
- Confirm no existing schemas contain this text anymore in labels/descriptions.

