### PR TITLE
README updates for local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Upgrade pip and install dependencies:
 
 ```
 brew install pyenv
+pyenv install
 pip install --upgrade pip setuptools pipenv
 pipenv install --dev
 ```
@@ -94,6 +95,12 @@ Install yarn with:
 
 ```
 npm install yarn --global
+```
+
+Fetch npm dependencies (Note that this overrides the python version defined in `.python-version`):
+
+```
+PYENV_VERSION=system yarn
 ```
 
 Compile the project with


### PR DESCRIPTION
### What is the context of this PR?
Update README instructions for local setup to include a step to install python3.4. Whilst setting up on a fresh machine I found that `pipenv install` was failing because it couldn't find python3.4.

Also when running `yarn` to install npm dependencies the fibers package was failing due to node-gyp not working on python3.

### How to review 
Remove python3.4 from your machine and follow the local setup steps. Verify that the app's pipenv gets set up correct.