### PR TITLE
Ru ref and survey id on contact page

### DIFF
--- a/app/templates/static/contact-us.html
+++ b/app/templates/static/contact-us.html
@@ -1,7 +1,7 @@
 {% extends 'layouts/_twocol.html' %}
 {% import 'macros/helpers.html' as helpers %}
 
-{% set survey_title  = 'About ONS' %}
+{% set survey_title  = 'ONS Business Surveys' %}
 
 <header class="page__header">
     {% block header %}
@@ -15,72 +15,72 @@
 
 <div class="page">
     <div class="page__content">
-            <div class="grid grid--reverse">
-                <div class="grid__col col-4@m">
-                </div>
-                <div class="grid__col col-7@m pull-1@m">
-                    <main role="main" id="main" class="page__main">
-                        {% block content %}
-                    </br>
-                        <div class="'group" id="rsi">
+        <div class="grid grid--reverse">
+            <div class="grid__col col-4@m">
+            </div>
+            <div class="grid__col col-7@m pull-1@m">
+                <main role="main" id="main" class="page__main">
+                    {% block content %}
+                    <br>
+                    <div class="'group" id="rsi">
                         <div class="block" id>
-                        <section class="section id">
-                        <h1 class="section__title saturn">
-                            Contact us
-                        </h1>
-                        <div class="question">
-                            <h2 class="question__title neptune">
-                                Email
-                            </h2>
-                            <div class="question__description mars">
-                                <p>{{helpers.email_address()}}</p>
-                            </div>
-                            <h2 class="question__title neptune">
-                                Telephone
-                            </h2>
-                            <div class="question__description mars">
-                                <p>{{helpers.telephone_number()}}</p>
-                            </div>
-                            <div class="question__description mars">
-                                <p>Opening hours:</p>
-                                <p>Monday to Thursday 8:30am – 5:00pm</p>
-                                <p>Friday 8:30am - 4:30pm</p>
-                            </div>
-                            <h2 class="question__title neptune">
-                                Post
-                            </h2>
-                            <div class="question__description mars">
-                                <p>
-                                Office for National Statistics
-                                <br>
-                                Government Buildings
-                                <br>
-                                Cardiff Road
-                                <br>
-                                    Newport
-                                    <br>
-                                    South Wales
-                                <br>
-                                    NP10 8XG
-                                </p>
-                            </div>
+                            <section class="section id">
+                                <h1 class="section__title saturn">
+                                    Contact us
+                                </h1>
+                                <div class="question">
+                                    <h2 class="question__title neptune">
+                                        Telephone
+                                    </h2>
+                                    <div class="question__description mars">
+                                        <p>{{helpers.telephone_number()}}</p>
+                                    </div>
+                                    {% if session %}
+                                    <p>
+                                        Please quote the reference <b>{{session.ru_ref}}</b> when contacting ONS about this survey.
+                                    </p>
+                                    <p>
+                                        Your Survey ID is <b>{{survey_id}}</b>.
+                                    </p>
+                                    {% endif %}
+                                    <div class="question__description mars">
+                                        <h3 class="question__title venus">Opening hours:</h3>
+                                        <p>
+                                            Monday to Thursday 8:30am – 5:00pm<br>
+                                            Friday 8:30am - 4:30pm
+                                        </p>
+                                    </div>
+                                    <p>This office is closed during public holidays</p>
+                                    <h2 class="question__title neptune">
+                                        Email
+                                    </h2>
+                                    <div class="question__description mars">
+                                        <p>{{helpers.email_address(subject="{{ru_ref}}")}}</p>
+                                    </div>
+                                    <h2 class="question__title neptune">
+                                        Post
+                                    </h2>
+                                    <div class="question__description mars">
+                                        <p>
+                                            Office for National Statistics<br>
+                                            Government Buildings<br>
+                                            Cardiff Road<br>
+                                            Newport<br>
+                                            South Wales<br>
+                                            NP10 8XG
+                                        </p>
+                                    </div>
+                                </div>
+                            </section>
                         </div>
-                        </section>
-                        </div>
-                        </div>
-                    </main>
-                    {% endblock %}
-                </div>
+                    </div>
+                </main>
+                {% endblock %}
             </div>
         </div>
     </div>
-
+</div>
 
 {% block footer %}
 {% include 'partials/footer2.html' %}
 {% endblock %}
-
-
-
-
-

--- a/app/views/static.py
+++ b/app/views/static.py
@@ -1,25 +1,38 @@
-from flask import Blueprint
+from flask import Blueprint, current_app
 from flask_themes2 import render_theme_template
 
-from app.helpers import template_helper
-
+from app.globals import get_session_store
+from app.utilities.schema import load_schema_from_params
 
 from structlog import get_logger
 
 logger = get_logger()
 
-contact_blueprint = Blueprint('contact', __name__,)
+contact_blueprint = Blueprint(name='contact', import_name=__name__)
 
 
 @contact_blueprint.route('/contact-us', methods=['GET'])
 def contact():
-    return render_theme_template('default', 'static/contact-us.html')
+    session = None
+    survey_id = None
+    session_store = get_session_store()
+
+    if session_store:
+        session = session_store.session_data
+        schema = load_schema_from_params(session.eq_id, session.form_type)
+        survey_id = schema.json['survey_id']
+
+    contact_template = render_theme_template(theme='default',
+                                             template_name='static/contact-us.html',
+                                             session=session,
+                                             survey_id=survey_id,
+                                             analytics_ua_id=current_app.config['EQ_UA_ID'])
+    return contact_template
 
 
 @contact_blueprint.route('/cookies-privacy', methods=['GET'])
 def legal():
-    return render_theme_template('default', 'static/cookies-privacy.html')
-
-
-def _render_template(template, **kwargs):
-    return template_helper.render_template(template, **kwargs)
+    cookie_template = render_theme_template(theme='default',
+                                            template_name='static/cookies-privacy.html',
+                                            analytics_ua_id=current_app.config['EQ_UA_ID'])
+    return cookie_template

--- a/tests/integration/views/test_static.py
+++ b/tests/integration/views/test_static.py
@@ -1,0 +1,25 @@
+import mock
+from flask import json
+
+from tests.integration.integration_test_case import IntegrationTestCase
+
+with open('data/en/1_0205.json') as json_data:
+    data = json.load(json_data)
+
+
+class TestStatic(IntegrationTestCase):
+    @mock.patch('app.utilities.schema.load_schema_from_params')
+    def test_contact(self, mock_contact):
+        mock_contact.return_value = data
+        self.launchSurvey('test', '0205')
+        self.get('/contact-us')
+        self.assertInPage('123456789012A')
+
+    def test_contact_with_no_session(self):
+        self.get('/contact-us')
+        self.assertNotInPage('Please quote the reference')
+        self.assertInPage('Opening hours')
+
+    def test_cookies_and_privacy(self):
+        self.get('/cookies-privacy')
+        self.assertInPage('We can only use your information for research and statistical purposes. ')

--- a/tests/integration/views/test_view_submission.py
+++ b/tests/integration/views/test_view_submission.py
@@ -2,6 +2,7 @@ from tests.integration.integration_test_case import IntegrationTestCase
 from mock import Mock
 from flask import current_app
 
+
 class TestViewSubmission(IntegrationTestCase):
 
     def setUp(self):


### PR DESCRIPTION
### What is the context of this PR?
Now passes though the Survey_ID and Ru_Ref to the Contact page and when respondent wants to email passes the Ru_Ref to the subject line of the email.

Card: https://trello.com/c/qj51cXTL/1422-ru-ref-and-survey-id-on-contact-page-s

### How to review 
Open a survey and go to Contact Us page to check if they appear.
Also, when you click on the email link the Ru_Ref is passed into the email subject.