### PR TITLE
Add dropdown input type

### DIFF
--- a/app/forms/fields.py
+++ b/app/forms/fields.py
@@ -29,6 +29,7 @@ def get_field(answer, label, error_messages, answer_store):
             'MonthYearDate': get_month_year_field,
             'TextArea': get_text_area_field,
             'TextField': get_string_field,
+            'Dropdown': get_dropdown_field,
         }[answer['type']](answer, label, guidance, error_messages)
 
     if field is None:
@@ -138,6 +139,18 @@ def _coerce_str_unless_none(value):
     :return: str(value) or None if value is None
     """
     return str(value) if value is not None else None
+
+
+def get_dropdown_field(answer, label, guidance, error_messages):
+    validate_with = get_mandatory_validator(answer, error_messages, 'MANDATORY_DROPDOWN')
+
+    return SelectField(
+        label=label,
+        description=guidance,
+        choices=[('', 'Select an answer')] + build_choices(answer['options']),
+        default='',
+        validators=validate_with,
+    )
 
 
 def get_select_field(answer, label, guidance, error_messages):

--- a/app/templates/partials/answers/dropdown.html
+++ b/app/templates/partials/answers/dropdown.html
@@ -1,0 +1,12 @@
+{% set select = form[answer['id']] %}
+
+<div class="field field--select">
+    {% set label = {
+        "for": answer.id,
+        "text": answer.label,
+        "description": answer.description if answer.description
+    } %}
+
+    {% include 'partials/forms/label.html' %}
+    {% include 'partials/forms/select.html' %}
+</div>

--- a/app/templates/partials/forms/label.html
+++ b/app/templates/partials/forms/label.html
@@ -6,12 +6,10 @@
 
 {% if label.text %}
 <label {{attr|xmlattr}}>
-  <div class="label__inner">
     {{label.text}}
     {% if label.description %}
       <br />
       <span class="label__description pluto">{{label.description}}</span>
     {% endif %}
-  </div>
 </label>
 {% endif %}

--- a/app/templates/partials/forms/select.html
+++ b/app/templates/partials/forms/select.html
@@ -1,11 +1,14 @@
 <select class='input input--select' id='{{select.name}}' name='{{select.name}}'>
 
   {%- for option_value, option in select.choices -%}
-    <option {{{
-      "value": option_value,
-      "selected": "selected" if select.data == option_value,
-      "disabled": "disabled" if option_value == '' and select.flags.required
-    }|xmlattr}}>{{option}}</option>
+
+    {% set attributes = {
+        "value": option_value,
+        "selected": "" if select.data == option_value,
+        "disabled": "" if option_value == '' and select.flags.required
+        } %}
+
+    <option {{attributes|xmlattr}}>{{option}}</option>
 
   {%- endfor -%}
 

--- a/app/templating/summary/question.py
+++ b/app/templating/summary/question.py
@@ -62,6 +62,8 @@ class Question:
             return checkbox_answers or None
         elif answer_schema['type'] == 'Radio':
             return self._build_radio_answer(answer_value, answer_schema)
+        elif answer_schema['type'] == 'Dropdown':
+            return self._build_dropdown_answer(answer_value, answer_schema)
         return answer_value
 
     @staticmethod
@@ -93,4 +95,10 @@ class Question:
             if option['value'].lower() == 'other' and answer != option['value']:
                 return answer if answer else option['label']
             elif answer == option['value']:
+                return option['label']
+
+    @staticmethod
+    def _build_dropdown_answer(answer, answer_schema):
+        for option in answer_schema['options']:
+            if answer == option['value']:
                 return option['label']

--- a/app/validation/error_messages.py
+++ b/app/validation/error_messages.py
@@ -4,6 +4,7 @@ error_messages = {
     'MANDATORY_NUMBER': 'Enter an answer to continue.',
     'MANDATORY_TEXTAREA': 'Enter an answer to continue.',
     'MANDATORY_RADIO': 'Select an answer to continue.',
+    'MANDATORY_DROPDOWN': 'Select an answer to continue.',
     'MANDATORY_CHECKBOX': 'Select all that apply to continue.',
     'MANDATORY_DATE': 'Enter a date to continue.',
     'NUMBER_TOO_SMALL': 'Enter an answer more than or equal to %(min)s.',

--- a/data/en/test_dropdown_mandatory.json
+++ b/data/en/test_dropdown_mandatory.json
@@ -1,0 +1,47 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "0",
+    "title": "Dropdown Mandatory",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "groups": [{
+        "id": "dropdown",
+        "title": "Dropdown Mandatory",
+        "blocks": [{
+                "type": "Question",
+                "id": "dropdown-mandatory",
+                "questions": [{
+                    "type": "General",
+                    "id": "dropdown-mandatory-question",
+                    "title": "Which football team do your support?",
+                    "answers": [{
+                        "type": "Dropdown",
+                        "id": "dropdown-mandatory-answer",
+                        "mandatory": true,
+                        "label": "Football team",
+                        "description": "Your favourite team from the Premier League.",
+                        "options": [{
+                                "label": "Liverpool",
+                                "value": "Liverpool"
+                            },
+                            {
+                                "label": "Chelsea",
+                                "value": "Chelsea"
+                            },
+                            {
+                                "label": "Rugby is better!",
+                                "value": "Rugby is better!"
+                            }
+                        ]
+                    }]
+                }]
+            },
+            {
+                "type": "Summary",
+                "id": "summary"
+            }
+        ]
+    }]
+}

--- a/data/en/test_dropdown_mandatory_with_overridden_error.json
+++ b/data/en/test_dropdown_mandatory_with_overridden_error.json
@@ -1,0 +1,51 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "0",
+    "title": "Dropdown Mandatory With Overridden Error",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "groups": [{
+        "id": "dropdown",
+        "title": "Dropdown Mandatory With Overridden Error",
+        "blocks": [{
+                "type": "Question",
+                "id": "dropdown-mandatory-with-overridden-error",
+                "questions": [{
+                    "type": "General",
+                    "id": "dropdown-mandatory-with-overridden-error-question",
+                    "title": "Which football team do your support?",
+                    "answers": [{
+                        "type": "Dropdown",
+                        "id": "dropdown-mandatory-with-overridden-answer",
+                        "mandatory": true,
+                        "label": "Football team",
+                        "options": [{
+                                "label": "Liverpool",
+                                "value": "Liverpool"
+                            },
+                            {
+                                "label": "Chelsea",
+                                "value": "Chelsea"
+                            },
+                            {
+                                "label": "Rugby is better!",
+                                "value": "Rugby is better!"
+                            }
+                        ],
+                        "validation": {
+                            "messages": {
+                                "MANDATORY_DROPDOWN": "Overridden test error message."
+                            }
+                        }
+                    }]
+                }]
+            },
+            {
+                "type": "Summary",
+                "id": "summary"
+            }
+        ]
+    }]
+}

--- a/data/en/test_dropdown_optional.json
+++ b/data/en/test_dropdown_optional.json
@@ -1,0 +1,47 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "0",
+    "title": "Dropdown Mandatory",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "groups": [{
+        "id": "dropdown",
+        "title": "Dropdown Optional",
+        "blocks": [{
+                "type": "Question",
+                "id": "dropdown-optional",
+                "questions": [{
+                    "type": "General",
+                    "id": "dropdown-optional-question",
+                    "title": "Which football team do your support?",
+                    "answers": [{
+                        "type": "Dropdown",
+                        "id": "dropdown-optional-answer",
+                        "mandatory": false,
+                        "label": "Football team",
+                        "description": "Your favourite team from the Premier League.",
+                        "options": [{
+                                "label": "Liverpool",
+                                "value": "Liverpool"
+                            },
+                            {
+                                "label": "Chelsea",
+                                "value": "Chelsea"
+                            },
+                            {
+                                "label": "Rugby is better!",
+                                "value": "Rugby is better!"
+                            }
+                        ]
+                    }]
+                }]
+            },
+            {
+                "type": "Summary",
+                "id": "summary"
+            }
+        ]
+    }]
+}

--- a/tests/app/forms/test_fields.py
+++ b/tests/app/forms/test_fields.py
@@ -200,6 +200,40 @@ class TestFields(unittest.TestCase):
         self.assertEqual(unbound_field.kwargs['description'], radio_json['guidance'])
         self.assertEqual(unbound_field.kwargs['choices'], expected_choices)
 
+    def test_dropdown_field(self):
+        dropdown_json = {
+            'type': 'Dropdown',
+            'id': 'dropdown-mandatory-with-label-answer',
+            'mandatory': True,
+            'label': 'Please choose an option',
+            'description': 'This is a mandatory dropdown, therefore you must select a value!.',
+            'options': [
+                {
+                    'label': 'Liverpool',
+                    'value': 'Liverpool'
+                },
+                {
+                    'label': 'Chelsea',
+                    'value': 'Chelsea'
+                },
+                {
+                    'label': 'Rugby is better!',
+                    'value': 'Rugby is better!'
+                }
+            ]
+        }
+
+        unbound_field = get_field(dropdown_json, dropdown_json['label'], error_messages, self.answer_store)
+
+        expected_choices = [('', 'Select an answer')] + \
+                           [(option['label'], option['value']) for option in dropdown_json['options']]
+
+        self.assertTrue(unbound_field.field_class == SelectField)
+        self.assertEqual(unbound_field.kwargs['label'], dropdown_json['label'])
+        self.assertEqual(unbound_field.kwargs['description'], '')
+        self.assertEqual(unbound_field.kwargs['default'], '')
+        self.assertEqual(unbound_field.kwargs['choices'], expected_choices)
+
     def test__coerce_str_unless_none(self):
         # pylint: disable=protected-access
         self.assertEqual(_coerce_str_unless_none(1), '1')

--- a/tests/functional/generate_pages.py
+++ b/tests/functional/generate_pages.py
@@ -160,7 +160,7 @@ def process_answer(question_type, answer, page_spec, long_names, page_name):
     elif answer['type'] in 'MonthYearDate':
         page_spec.write(_write_month_year_date_answer(answer['id'], prefix))
 
-    elif answer['type'] in ('TextField', 'Number', 'TextArea', 'Currency', 'Percentage', 'Relationship', 'Unit'):
+    elif answer['type'] in ('TextField', 'Number', 'TextArea', 'Currency', 'Percentage', 'Relationship', 'Unit', 'Dropdown'):
 
         answer_context = {
             'answerName': camel_case(answer_name),

--- a/tests/functional/pages/components/dropdown/mandatory/dropdown-mandatory.page.js
+++ b/tests/functional/pages/components/dropdown/mandatory/dropdown-mandatory.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class DropdownMandatoryPage extends QuestionPage {
+
+  constructor() {
+    super('dropdown-mandatory');
+  }
+
+  answer() {
+    return '#dropdown-mandatory-answer';
+  }
+
+  answerLabel() { return '#label-dropdown-mandatory-answer'; }
+
+}
+module.exports = new DropdownMandatoryPage();

--- a/tests/functional/pages/components/dropdown/mandatory/summary.page.js
+++ b/tests/functional/pages/components/dropdown/mandatory/summary.page.js
@@ -1,0 +1,15 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  dropdownMandatoryAnswer() { return '#dropdown-mandatory-answer-answer'; }
+
+  dropdownMandatoryAnswerEdit() { return '[data-qa="dropdown-mandatory-answer-edit"]'; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/pages/components/dropdown/mandatory_with_label/dropdown-mandatory-with-label.page.js
+++ b/tests/functional/pages/components/dropdown/mandatory_with_label/dropdown-mandatory-with-label.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class DropdownMandatoryWithLabelPage extends QuestionPage {
+
+  constructor() {
+    super('dropdown-mandatory-with-label');
+  }
+
+  answer() {
+    return '#dropdown-mandatory-with-label-answer';
+  }
+
+  answerLabel() { return '#label-dropdown-mandatory-with-label-answer'; }
+
+}
+module.exports = new DropdownMandatoryWithLabelPage();

--- a/tests/functional/pages/components/dropdown/mandatory_with_label/summary.page.js
+++ b/tests/functional/pages/components/dropdown/mandatory_with_label/summary.page.js
@@ -1,0 +1,15 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  dropdownMandatoryWithLabelAnswer() { return '#dropdown-mandatory-with-label-answer-answer'; }
+
+  dropdownMandatoryWithLabelAnswerEdit() { return '[data-qa="dropdown-mandatory-with-label-answer-edit"]'; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/pages/components/dropdown/mandatory_with_overridden_error/dropdown-mandatory-with-overridden-error.page.js
+++ b/tests/functional/pages/components/dropdown/mandatory_with_overridden_error/dropdown-mandatory-with-overridden-error.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class DropdownMandatoryWithOverriddenErrorPage extends QuestionPage {
+
+  constructor() {
+    super('dropdown-mandatory-with-overridden-error');
+  }
+
+  answer() {
+    return '#dropdown-mandatory-with-overridden-answer';
+  }
+
+  answerLabel() { return '#label-dropdown-mandatory-with-overridden-answer'; }
+
+}
+module.exports = new DropdownMandatoryWithOverriddenErrorPage();

--- a/tests/functional/pages/components/dropdown/mandatory_with_overridden_error/summary.page.js
+++ b/tests/functional/pages/components/dropdown/mandatory_with_overridden_error/summary.page.js
@@ -1,0 +1,15 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  dropdownMandatoryWithOverriddenAnswer() { return '#dropdown-mandatory-with-overridden-answer-answer'; }
+
+  dropdownMandatoryWithOverriddenAnswerEdit() { return '[data-qa="dropdown-mandatory-with-overridden-answer-edit"]'; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/pages/components/dropdown/optional/dropdown-optional.page.js
+++ b/tests/functional/pages/components/dropdown/optional/dropdown-optional.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class DropdownOptionalPage extends QuestionPage {
+
+  constructor() {
+    super('dropdown-optional');
+  }
+
+  answer() {
+    return '#dropdown-optional-answer';
+  }
+
+  answerLabel() { return '#label-dropdown-optional-answer'; }
+
+}
+module.exports = new DropdownOptionalPage();

--- a/tests/functional/pages/components/dropdown/optional/summary.page.js
+++ b/tests/functional/pages/components/dropdown/optional/summary.page.js
@@ -1,0 +1,15 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  dropdownOptionalAnswer() { return '#dropdown-optional-answer-answer'; }
+
+  dropdownOptionalAnswerEdit() { return '[data-qa="dropdown-optional-answer-edit"]'; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/spec/components/dropdown.spec.js
+++ b/tests/functional/spec/components/dropdown.spec.js
@@ -1,0 +1,137 @@
+const helpers = require('../../helpers');
+
+describe('Component: Dropdown', function() {
+  //Mandatory
+  describe('Given I start a Mandatory Dropdown survey', function() {
+
+    const DropdownMandatoryPage = require('../../pages/components/dropdown/mandatory/dropdown-mandatory.page');
+    const DropdownSummaryPage = require('../../pages/components/dropdown/mandatory/summary.page');
+    const schema = 'test_dropdown_mandatory.json';
+
+    it('When I have selected a dropdown option, Then the selected option should be displayed in the summary', function() {
+      return helpers.openQuestionnaire(schema)
+        .then(() => {
+          return browser
+            .selectByValue(DropdownMandatoryPage.answer(), "Rugby is better!")
+            .click(DropdownMandatoryPage.submit())
+            .getText(DropdownSummaryPage.dropdownMandatoryAnswer()).should.eventually.contain("Rugby is better!");
+        });
+    });
+
+    it('When I have not selected a dropdown option and click Continue, Then the default error message should be displayed', function() {
+      return helpers.openQuestionnaire(schema)
+        .then(() => {
+          return browser
+            .click(DropdownMandatoryPage.submit())
+            .getText(DropdownMandatoryPage.errorNumber(1)).should.eventually.contain("Select an answer to continue.");
+        });
+    });
+
+    it('When I have selected a dropdown option and I try to select a default (disabled) dropdown option, Then the already selected option should be displayed in summary', function() {
+      return helpers.openQuestionnaire(schema)
+        .then(() => {
+          return browser
+            .selectByValue(DropdownMandatoryPage.answer(), "Liverpool")
+            .selectByValue(DropdownMandatoryPage.answer(), "")
+            .click(DropdownMandatoryPage.submit())
+            .getText(DropdownSummaryPage.dropdownMandatoryAnswer()).should.eventually.contain("Liverpool");
+        });
+    });
+
+    it('When I click the dropdown label, Then the dropdown should be focused', function() {
+      return helpers.openQuestionnaire(schema)
+        .then(() => {
+          return browser
+            .click(DropdownMandatoryPage.answerLabel())
+            .hasFocus(DropdownMandatoryPage.answer()).should.eventually.be.true;
+        });
+    });
+
+    it('When I\'m on the summary page and I click Edit then Continue, Then the answer on the summary page should be unchanged', function() {
+      return helpers.openQuestionnaire(schema)
+        .then(() => {
+          return browser
+            .selectByValue(DropdownMandatoryPage.answer(), "Rugby is better!")
+            .click(DropdownMandatoryPage.submit())
+            .getText(DropdownSummaryPage.dropdownMandatoryAnswer()).should.eventually.contain("Rugby is better!")
+            .click(DropdownSummaryPage.dropdownMandatoryAnswerEdit())
+            .click(DropdownMandatoryPage.submit())
+            .getText(DropdownSummaryPage.dropdownMandatoryAnswer()).should.eventually.contain("Rugby is better!");
+        });
+    });
+
+    it('When I\'m on the summary page and I click Edit and change the answer, Then the newly selected answer should be displayed in the summary', function() {
+      return helpers.openQuestionnaire(schema)
+        .then(() => {
+          return browser
+            .selectByValue(DropdownMandatoryPage.answer(), "Rugby is better!")
+            .click(DropdownMandatoryPage.submit())
+            .getText(DropdownSummaryPage.dropdownMandatoryAnswer()).should.eventually.contain("Rugby is better!")
+            .click(DropdownSummaryPage.dropdownMandatoryAnswerEdit())
+            .click(DropdownMandatoryPage.submit())
+            .getText(DropdownSummaryPage.dropdownMandatoryAnswer()).should.eventually.contain("Rugby is better!")
+            .click(DropdownSummaryPage.dropdownMandatoryAnswerEdit())
+            .selectByValue(DropdownMandatoryPage.answer(), "Liverpool")
+            .click(DropdownMandatoryPage.submit())
+            .getText(DropdownSummaryPage.dropdownMandatoryAnswer()).should.eventually.contain("Liverpool");
+        });
+    });
+  });
+
+  describe('Given I start a Mandatory With Overridden Error Dropdown survey', function() {
+
+    const DropdownMandatoryPage = require('../../pages/components/dropdown/mandatory_with_overridden_error/dropdown-mandatory-with-overridden-error.page');
+
+    before(function() {
+      return helpers.openQuestionnaire('test_dropdown_mandatory_with_overridden_error.json');
+    });
+
+    it('When I have not selected a dropdown option and click Continue, Then the overridden error message should be displayed', function() {
+      return browser
+        .click(DropdownMandatoryPage.submit())
+        .getText(DropdownMandatoryPage.errorNumber(1)).should.eventually.contain("Overridden test error message.");
+    });
+  });
+
+  //Optional
+  describe('Given I start a Optional Dropdown survey', function() {
+
+    const DropdownOptionalPage = require('../../pages/components/dropdown/optional/dropdown-optional.page');
+    const DropdownSummaryPage = require('../../pages/components/dropdown/optional/summary.page');
+    const schema = 'test_dropdown_optional.json';
+
+    it('When I have not selected a dropdown option, Then the summary should display "No answer provided"', function() {
+      return helpers.openQuestionnaire(schema)
+        .then(() => {
+          return browser
+            .click(DropdownOptionalPage.submit())
+            .getText(DropdownSummaryPage.dropdownOptionalAnswer()).should.eventually.contain("No answer provided");
+        });
+    });
+
+    it('When I have selected a dropdown option, Then the selected option should be displayed in the summary', function() {
+      return helpers.openQuestionnaire(schema)
+        .then(() => {
+          return browser
+            .selectByValue(DropdownOptionalPage.answer(), "Rugby is better!")
+            .click(DropdownOptionalPage.submit())
+            .getText(DropdownSummaryPage.dropdownOptionalAnswer()).should.eventually.contain("Rugby is better!");
+        });
+    });
+
+    it('When I have selected a dropdown option and I reselect the default option (Select an answer), Then the summary should display "No answer provided"', function() {
+      return helpers.openQuestionnaire(schema)
+        .then(() => {
+          return browser
+            .selectByValue(DropdownOptionalPage.answer(), "Chelsea")
+            .click(DropdownOptionalPage.submit())
+            .getText(DropdownSummaryPage.dropdownOptionalAnswer()).should.eventually.contain("Chelsea")
+            .click(DropdownSummaryPage.dropdownOptionalAnswerEdit())
+            .selectByValue(DropdownOptionalPage.answer(), "")
+            .click(DropdownOptionalPage.submit())
+            .getText(DropdownSummaryPage.dropdownOptionalAnswer()).should.eventually.contain("No answer provided");
+        });
+    });
+  });
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3765,15 +3765,15 @@ glob2base@^0.0.12:
   dependencies:
     find-index "^0.1.1"
 
-glob@7.1.1:
+glob@7.1.1, glob@lucetius/node-glob#chimp:
   version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
+  resolved "https://codeload.github.com/lucetius/node-glob/tar.gz/51c7ca6e69bfbd17db5f1ea710e3f2a7a457d9ce"
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
     inherits "2"
     minimatch "^3.0.2"
-    once "^1.3.0"
+    once "1.3.0"
     path-is-absolute "^1.0.0"
 
 glob@^4.0.6, glob@^4.3.1:
@@ -3814,17 +3814,6 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.0, glob@^7.1.1, gl
     inherits "2"
     minimatch "^3.0.4"
     once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@lucetius/node-glob#chimp:
-  version "7.1.1"
-  resolved "https://codeload.github.com/lucetius/node-glob/tar.gz/51c7ca6e69bfbd17db5f1ea710e3f2a7a457d9ce"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.2"
-    once "1.3.0"
     path-is-absolute "^1.0.0"
 
 glob@~3.1.21:
@@ -9353,6 +9342,12 @@ which@1.1.1:
   dependencies:
     is-absolute "^0.1.7"
 
+which@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
+  dependencies:
+    isexe "^2.0.0"
+
 wide-align@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.2.tgz#571e0f1b0604636ebc0dfc21b0339bbe31341710"
@@ -9579,7 +9574,7 @@ yargs@^7.0.0:
     y18n "^3.2.1"
     yargs-parser "^5.0.0"
 
-yargs@^8.0.1, yargs@^8.0.2:
+yargs@^8.0.1:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
   dependencies:


### PR DESCRIPTION
### What is the context of this PR?
A new drop-down feature for survey runner. Trello card indicates specifics.

Card: https://trello.com/c/lZqYhhjw/1328-add-dropdown-input-type-m

### How to review

1. Run unit tests: `pipenv run ./scripts/run_tests_unit.sh`
2. Run functional tests: `yarn test_functional`
3. Run survey launcher and runner.

Schemas:
```
test_dropdown_mandatory.json
test_dropdown_mandatory_with_overridden_error.json
test_dropdown_optional.json
```

For the new schemas, test that:

1. You **must** choose an option if **mandatory.**
2. You are **able** to unselect an option if **not** mandatory.
3. Summary page shows `"No answer provided"` if no option chosen on optional survey,
3. The default mandatory error message is `"Select an answer to continue"`
4. The default mandatory error message can be overridden in the schema.

Ensure that all the drop-down tests pass and validate all the schemas are correct and the structure is valid.
