### PR TITLE
Add group_id and block_id back onto Answer

### DIFF
--- a/app/data_model/answer_store.py
+++ b/app/data_model/answer_store.py
@@ -6,9 +6,12 @@ import simplejson as json
 
 
 class Answer(object):
-    def __init__(self, answer_id, value, group_instance=0, answer_instance=0):
+    def __init__(self, answer_id, value, group_instance=0, answer_instance=0, group_id=None, block_id=None):
         if answer_id is None or value is None:
             raise ValueError("Both 'answer_id' and 'value' must be set for Answer")
+
+        self.group_id = group_id
+        self.block_id = block_id
 
         self.answer_id = answer_id
         self.group_instance = group_instance

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -535,9 +535,17 @@ def update_questionnaire_store_with_form_data(questionnaire_store, location, ans
                 else:
                     formatted_answer_value = _format_answer_value(answer_value)
                     if formatted_answer_value:
-                        answer = Answer(answer_id=answer_id, value=formatted_answer_value, group_instance=location.group_instance)
+                        answer = Answer(answer_id=answer_id,
+                                        value=formatted_answer_value,
+                                        group_instance=location.group_instance,
+                                        group_id=location.group_id,
+                                        block_id=location.block_id)
             elif answer_value is not None:
-                answer = Answer(answer_id=answer_id, value=answer_value, group_instance=location.group_instance)
+                answer = Answer(answer_id=answer_id,
+                                value=answer_value,
+                                group_instance=location.group_instance,
+                                group_id=location.group_id,
+                                block_id=location.block_id)
             else:
                 _remove_answer_from_questionnaire_store(answer_id, questionnaire_store)
 

--- a/tests/app/forms/test_household_composition.py
+++ b/tests/app/forms/test_household_composition.py
@@ -208,32 +208,44 @@ class TestHouseholdCompositionForm(AppContextTestCase):
                     'group_instance': 0,
                     'answer_id': 'first-name',
                     'answer_instance': 0,
-                    'value': 'Joe'
+                    'value': 'Joe',
+                    'block_id': None,
+                    'group_id': None,
                 }, {
                     'group_instance': 0,
                     'answer_id': 'middle-names',
                     'answer_instance': 0,
-                    'value': ''
+                    'value': '',
+                    'block_id': None,
+                    'group_id': None,
                 }, {
                     'group_instance': 0,
                     'answer_id': 'last-name',
                     'answer_instance': 0,
-                    'value': 'Bloggs'
+                    'value': 'Bloggs',
+                    'block_id': None,
+                    'group_id': None,
                 }, {
                     'group_instance': 0,
                     'answer_id': 'first-name',
                     'answer_instance': 1,
-                    'value': 'Bob'
+                    'value': 'Bob',
+                    'block_id': None,
+                    'group_id': None,
                 }, {
                     'group_instance': 0,
                     'answer_id': 'middle-names',
                     'answer_instance': 1,
-                    'value': ''
+                    'value': '',
+                    'block_id': None,
+                    'group_id': None,
                 }, {
                     'group_instance': 0,
                     'answer_id': 'last-name',
                     'answer_instance': 1,
-                    'value': 'Seymour'
+                    'value': 'Seymour',
+                    'block_id': None,
+                    'group_id': None,
                 }
             ]
 

--- a/tests/app/forms/test_household_relationship_form.py
+++ b/tests/app/forms/test_household_relationship_form.py
@@ -127,17 +127,23 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
                 'group_instance': 0,
                 'answer_id': 'who-is-related',
                 'answer_instance': 0,
-                'value': 'Husband or Wife'
+                'value': 'Husband or Wife',
+                'block_id': None,
+                'group_id': None,
             }, {
                 'group_instance': 0,
                 'answer_id': 'who-is-related',
                 'answer_instance': 1,
-                'value': 'Son or daughter'
+                'value': 'Son or daughter',
+                'block_id': None,
+                'group_id': None,
             }, {
                 'group_instance': 0,
                 'answer_id': 'who-is-related',
                 'answer_instance': 2,
-                'value': 'Unrelated'
+                'value': 'Unrelated',
+                'block_id': None,
+                'group_id': None,
             }
         ]
 

--- a/tests/integration/census/test_census_communal_submission_data.py
+++ b/tests/integration/census/test_census_communal_submission_data.py
@@ -18,31 +18,41 @@ class TestCensusCommunalSubmissionData(IntegrationTestCase):
         expected_downstream_data = [
             {
                 'value': 'Hotel',
+                'group_id': 'communal-establishment',
                 'answer_id': 'establishment-type-answer',
+                'block_id': 'establishment-type',
                 'answer_instance': 0,
                 'group_instance': 0
             },
             {
                 'value': '',
+                'group_id': 'communal-establishment',
                 'answer_id': 'establishment-type-answer-other',
+                'block_id': 'establishment-type',
                 'answer_instance': 0,
                 'group_instance': 0
             },
             {
                 'value': 20,
+                'group_id': 'communal-establishment',
                 'answer_id': 'bed-spaces-answer',
+                'block_id': 'bed-spaces',
                 'answer_instance': 0,
                 'group_instance': 0
             },
             {
                 'value': 'Yes',
+                'group_id': 'communal-establishment',
                 'answer_id': 'usual-residents-answer',
+                'block_id': 'usual-residents',
                 'answer_instance': 0,
                 'group_instance': 0
             },
             {
                 'value': 99,
+                'group_id': 'communal-establishment',
                 'answer_id': 'usual-residents-number-answer',
+                'block_id': 'usual-residents-number',
                 'answer_instance': 0,
                 'group_instance': 0
             },
@@ -53,49 +63,65 @@ class TestCensusCommunalSubmissionData(IntegrationTestCase):
                     'Staff',
                     'Other'
                 ],
+                'group_id': 'communal-establishment',
                 'answer_id': 'describe-residents-answer',
+                'block_id': 'describe-residents',
                 'answer_instance': 0,
                 'group_instance': 0
             },
             {
                 'value': 'Sports visitors',
+                'group_id': 'communal-establishment',
                 'answer_id': 'describe-residents-answer-other',
+                'block_id': 'describe-residents',
                 'answer_instance': 0,
                 'group_instance': 0
             },
             {
                 'value': 'Online',
+                'group_id': 'communal-establishment',
                 'answer_id': 'completion-preference-individual-answer',
+                'block_id': 'completion-preference-individual',
                 'answer_instance': 0,
                 'group_instance': 0
             },
             {
                 'value': 'Online',
+                'group_id': 'communal-establishment',
                 'answer_id': 'completion-preference-establishment-answer',
+                'block_id': 'completion-preference-establishment',
                 'answer_instance': 0,
                 'group_instance': 0
             },
             {
                 'value': 'Yes',
+                'group_id': 'communal-establishment',
                 'answer_id': 'further-contact-answer',
+                'block_id': 'further-contact',
                 'answer_instance': 0,
                 'group_instance': 0
             },
             {
                 'value': '0123456789',
+                'group_id': 'communal-establishment',
                 'answer_id': 'contact-details-answer-phone',
+                'block_id': 'contact-details',
                 'answer_instance': 0,
                 'group_instance': 0
             },
             {
                 'value': 'danny.boje@gmail.com',
+                'group_id': 'communal-establishment',
                 'answer_id': 'contact-details-answer-email',
+                'block_id': 'contact-details',
                 'answer_instance': 0,
                 'group_instance': 0
             },
             {
                 'value': 'Danny',
+                'group_id': 'communal-establishment',
                 'answer_id': 'contact-details-answer-name',
+                'block_id': 'contact-details',
                 'answer_instance': 0,
                 'group_instance': 0
             }

--- a/tests/integration/census/test_census_household_submission_data.py
+++ b/tests/integration/census/test_census_household_submission_data.py
@@ -18,132 +18,176 @@ class TestCensusHouseholdSubmissionData(IntegrationTestCase):
             {
                 'answer_id': 'address-line-1',
                 'answer_instance': 0,
+                'block_id': 'what-is-your-address',
+                'group_id': 'what-is-your-address-group',
                 'group_instance': 0,
                 'value': '44 hill side'
             },
             {
                 'answer_id': 'address-line-2',
                 'answer_instance': 0,
+                'block_id': 'what-is-your-address',
+                'group_id': 'what-is-your-address-group',
                 'group_instance': 0,
                 'value': 'cimla'
             },
             {
                 'answer_id': 'county',
                 'answer_instance': 0,
+                'block_id': 'what-is-your-address',
+                'group_id': 'what-is-your-address-group',
                 'group_instance': 0,
                 'value': 'west glamorgan'
             },
             {
                 'answer_id': 'country',
                 'answer_instance': 0,
+                'block_id': 'what-is-your-address',
+                'group_id': 'what-is-your-address-group',
                 'group_instance': 0,
                 'value': 'wales'
             },
             {
                 'answer_id': 'postcode',
                 'answer_instance': 0,
+                'block_id': 'what-is-your-address',
+                'group_id': 'what-is-your-address-group',
                 'group_instance': 0,
                 'value': 'cf336gn'
             },
             {
                 'answer_id': 'address-line-3',
                 'answer_instance': 0,
+                'block_id': 'what-is-your-address',
+                'group_id': 'what-is-your-address-group',
                 'group_instance': 0,
                 'value': ''
             },
             {
                 'answer_id': 'town-city',
                 'answer_instance': 0,
+                'block_id': 'what-is-your-address',
+                'group_id': 'what-is-your-address-group',
                 'group_instance': 0,
                 'value': 'neath'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'permanent-or-family-home-answer',
+                'block_id': 'permanent-or-family-home',
+                'group_id': 'who-lives-here',
                 'answer_instance': 0,
                 'value': 'Yes'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'middle-names',
+                'block_id': None,
+                'group_id': None,
                 'answer_instance': 0,
                 'value': 'K'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'first-name',
+                'block_id': None,
+                'group_id': None,
                 'answer_instance': 0,
                 'value': 'Danny'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'last-name',
+                'block_id': None,
+                'group_id': None,
                 'answer_instance': 0,
                 'value': 'Boje'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'middle-names',
+                'block_id': None,
+                'group_id': None,
                 'answer_instance': 1,
                 'value': 'K'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'first-name',
+                'block_id': None,
+                'group_id': None,
                 'answer_instance': 1,
                 'value': 'Anjali'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'last-name',
+                'block_id': None,
+                'group_id': None,
                 'answer_instance': 1,
                 'value': 'Yo'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'everyone-at-address-confirmation-answer',
+                'block_id': 'everyone-at-address-confirmation',
+                'group_id': 'who-lives-here',
                 'answer_instance': 0,
                 'value': 'Yes'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'overnight-visitors-answer',
+                'block_id': 'overnight-visitors',
+                'group_id': 'who-lives-here',
                 'answer_instance': 0,
                 'value': 2
             },
             {
                 'group_instance': 0,
                 'answer_id': 'household-relationships-answer',
+                'block_id': None,
+                'group_id': None,
                 'answer_instance': 0,
                 'value': 'Husband or wife'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'type-of-accommodation-answer',
+                'block_id': 'type-of-accommodation',
+                'group_id': 'household-and-accommodation',
                 'answer_instance': 0,
                 'value': 'Whole house or bungalow'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'type-of-house-answer',
+                'block_id': 'type-of-house',
+                'group_id': 'household-and-accommodation',
                 'answer_instance': 0,
                 'value': 'Detached'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'self-contained-accommodation-answer',
+                'block_id': 'self-contained-accommodation',
+                'group_id': 'household-and-accommodation',
                 'answer_instance': 0,
                 'value': 'No'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'number-of-bedrooms-answer',
+                'block_id': 'number-of-bedrooms',
+                'group_id': 'household-and-accommodation',
                 'answer_instance': 0,
                 'value': 2
             },
             {
                 'group_instance': 0,
                 'answer_id': 'central-heating-answer',
+                'block_id': 'central-heating',
+                'group_id': 'household-and-accommodation',
                 'answer_instance': 0,
                 'value': [
                     'Gas',
@@ -158,138 +202,184 @@ class TestCensusHouseholdSubmissionData(IntegrationTestCase):
             {
                 'group_instance': 0,
                 'answer_id': 'own-or-rent-answer',
+                'block_id': 'own-or-rent',
+                'group_id': 'household-and-accommodation',
                 'answer_instance': 0,
                 'value': 'Owns outright'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'number-of-vehicles-answer',
+                'block_id': 'number-of-vehicles',
+                'group_id': 'household-and-accommodation',
                 'answer_instance': 0,
                 'value': 2
             },
             {
                 'group_instance': 0,
                 'answer_id': 'over-16-answer',
+                'block_id': 'over-16',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'Yes'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'private-response-answer',
+                'block_id': 'private-response',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'No, I do not want to request a personal form'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'sex-answer',
+                'block_id': 'sex',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'Male'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'date-of-birth-answer',
+                'block_id': 'date-of-birth',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': '1988-05-12'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'marital-status-answer',
+                'block_id': 'marital-status',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'In a registered same-sex civil partnership'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'another-address-answer',
+                'block_id': 'another-address',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'Yes, an address within the UK'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'another-address-answer-other',
+                'block_id': 'another-address',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': ''
             },
             {
                 'group_instance': 0,
                 'answer_id': 'other-address-answer-building',
+                'block_id': 'other-address',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': '12'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'other-address-answer-street',
+                'block_id': 'other-address',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': ''
             },
             {
                 'group_instance': 0,
                 'answer_id': 'other-address-answer-city',
+                'block_id': 'other-address',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'Newport'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'other-address-answer-county',
+                'block_id': 'other-address',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': ''
             },
             {
                 'group_instance': 0,
                 'answer_id': 'other-address-answer-postcode',
+                'block_id': 'other-address',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'NP10 8XG'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'address-type-answer',
+                'block_id': 'address-type',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'Other'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'address-type-answer-other',
+                'block_id': 'address-type',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'Friends Home'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'in-education-answer',
+                'block_id': 'in-education',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'Yes'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'term-time-location-answer',
+                'block_id': 'term-time-location',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'Yes'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'country-of-birth-england-answer-other',
+                'block_id': 'country-of-birth',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': ''
             },
             {
                 'group_instance': 0,
                 'answer_id': 'country-of-birth-england-answer',
+                'block_id': 'country-of-birth',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'England'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'country-of-birth-wales-answer-other',
+                'block_id': 'country-of-birth',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': ''
             },
             {
                 'group_instance': 0,
                 'answer_id': 'carer-answer',
+                'block_id': 'carer',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'Yes, 1 -19 hours a week'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'national-identity-england-answer',
+                'block_id': 'national-identity',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': [
                     'English',
@@ -303,60 +393,80 @@ class TestCensusHouseholdSubmissionData(IntegrationTestCase):
             {
                 'group_instance': 0,
                 'answer_id': 'national-identity-wales-answer',
+                'block_id': 'national-identity',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': []
             },
             {
                 'group_instance': 0,
                 'answer_id': 'national-identity-wales-answer-other',
+                'block_id': 'national-identity',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': ''
             },
             {
                 'group_instance': 0,
                 'answer_id': 'national-identity-england-answer-other',
+                'block_id': 'national-identity',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'Ind'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'ethnic-group-england-answer',
+                'block_id': 'ethnic-group',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'Other ethnic group'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'other-ethnic-group-answer',
+                'block_id': 'other-ethnic-group',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'Other'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'other-ethnic-group-answer-other',
+                'block_id': 'other-ethnic-group',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'Telugu'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'language-england-answer-other',
+                'block_id': 'language',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': ''
             },
             {
                 'group_instance': 0,
                 'answer_id': 'language-england-answer',
+                'block_id': 'language',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'English'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'language-welsh-answer-other',
+                'block_id': 'language',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': ''
             },
             {
                 'group_instance': 0,
                 'answer_id': 'religion-answer',
+                'block_id': 'religion',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': [
                     'No religion',
@@ -371,24 +481,32 @@ class TestCensusHouseholdSubmissionData(IntegrationTestCase):
             {
                 'group_instance': 0,
                 'answer_id': 'religion-answer-other',
+                'block_id': 'religion',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'Ind'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'past-usual-address-answer',
+                'block_id': 'past-usual-address',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'This address'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'past-usual-address-answer-other',
+                'block_id': 'past-usual-address',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': ''
             },
             {
                 'group_instance': 0,
                 'answer_id': 'passports-answer',
+                'block_id': 'passports',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': [
                     'United Kingdom'
@@ -397,18 +515,24 @@ class TestCensusHouseholdSubmissionData(IntegrationTestCase):
             {
                 'group_instance': 0,
                 'answer_id': 'disability-answer',
+                'block_id': 'disability',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'Yes, limited a lot'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'qualifications-welsh-answer',
+                'block_id': 'qualifications',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': []
             },
             {
                 'group_instance': 0,
                 'answer_id': 'qualifications-england-answer',
+                'block_id': 'qualifications',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': [
                     'Masters Degree',
@@ -418,6 +542,8 @@ class TestCensusHouseholdSubmissionData(IntegrationTestCase):
             {
                 'group_instance': 0,
                 'answer_id': 'employment-type-answer',
+                'block_id': 'employment-type',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': [
                     'none of the above'
@@ -426,24 +552,32 @@ class TestCensusHouseholdSubmissionData(IntegrationTestCase):
             {
                 'group_instance': 0,
                 'answer_id': 'jobseeker-answer',
+                'block_id': 'jobseeker',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'Yes'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'job-availability-answer',
+                'block_id': 'job-availability',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'Yes'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'job-pending-answer',
+                'block_id': 'job-pending',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'Yes'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'occupation-answer',
+                'block_id': 'occupation',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': [
                     'a student',
@@ -453,198 +587,264 @@ class TestCensusHouseholdSubmissionData(IntegrationTestCase):
             {
                 'group_instance': 0,
                 'answer_id': 'ever-worked-answer',
+                'block_id': 'ever-worked',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'Yes'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'main-job-answer',
+                'block_id': 'main-job',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'an employee'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'hours-worked-answer',
+                'block_id': 'hours-worked',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': '31 - 48'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'work-travel-answer',
+                'block_id': 'work-travel',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'Train'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'job-title-answer',
+                'block_id': 'job-title',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'Software Engineer'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'job-description-answer',
+                'block_id': 'job-description',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'Development'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'employers-business-answer',
+                'block_id': 'employers-business',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'Civil Servant'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'main-job-type-answer',
+                'block_id': 'main-job-type',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'Employed by an organisation or business'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'business-name-answer',
+                'block_id': 'business-name',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'ONS'
             },
             {
                 'group_instance': 1,
                 'answer_id': 'over-16-answer',
+                'block_id': 'over-16',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'Yes'
             },
             {
                 'group_instance': 1,
                 'answer_id': 'private-response-answer',
+                'block_id': 'private-response',
+                'group_id': 'household-member',
                 'answer_instance': 0,
                 'value': 'Yes, I want to request a personal form'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'visitor-first-name',
+                'block_id': 'visitor-name',
+                'group_id': 'visitors',
                 'answer_instance': 0,
                 'value': 'Diya'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'visitor-last-name',
+                'block_id': 'visitor-name',
+                'group_id': 'visitors',
                 'answer_instance': 0,
                 'value': 'K'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'visitor-sex-answer',
+                'block_id': 'visitor-sex',
+                'group_id': 'visitors',
                 'answer_instance': 0,
                 'value': 'Female'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'visitor-date-of-birth-answer',
+                'block_id': 'visitor-date-of-birth',
+                'group_id': 'visitors',
                 'answer_instance': 0,
                 'value': '2016-11-04'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'visitor-uk-resident-answer-other',
+                'block_id': 'visitor-uk-resident',
+                'group_id': 'visitors',
                 'answer_instance': 0,
                 'value': ''
             },
             {
                 'group_instance': 0,
                 'answer_id': 'visitor-uk-resident-answer',
+                'block_id': 'visitor-uk-resident',
+                'group_id': 'visitors',
                 'answer_instance': 0,
                 'value': 'Yes, usually lives in the United Kingdom'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'visitor-address-answer-postcode',
+                'block_id': 'visitor-address',
+                'group_id': 'visitors',
                 'answer_instance': 0,
                 'value': '530003'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'visitor-address-answer-street',
+                'block_id': 'visitor-address',
+                'group_id': 'visitors',
                 'answer_instance': 0,
                 'value': ''
             },
             {
                 'group_instance': 0,
                 'answer_id': 'visitor-address-answer-building',
+                'block_id': 'visitor-address',
+                'group_id': 'visitors',
                 'answer_instance': 0,
                 'value': '309'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'visitor-address-answer-city',
+                'block_id': 'visitor-address',
+                'group_id': 'visitors',
                 'answer_instance': 0,
                 'value': 'Vizag'
             },
             {
                 'group_instance': 0,
                 'answer_id': 'visitor-address-answer-county',
+                'block_id': 'visitor-address',
+                'group_id': 'visitors',
                 'answer_instance': 0,
                 'value': ''
             },
             {
                 'group_instance': 1,
                 'answer_id': 'visitor-first-name',
+                'block_id': 'visitor-name',
+                'group_id': 'visitors',
                 'answer_instance': 0,
                 'value': 'Niki'
             },
             {
                 'group_instance': 1,
                 'answer_id': 'visitor-last-name',
+                'block_id': 'visitor-name',
+                'group_id': 'visitors',
                 'answer_instance': 0,
                 'value': 'K'
             },
             {
                 'group_instance': 1,
                 'answer_id': 'visitor-sex-answer',
+                'block_id': 'visitor-sex',
+                'group_id': 'visitors',
                 'answer_instance': 0,
                 'value': 'Male'
             },
             {
                 'group_instance': 1,
                 'answer_id': 'visitor-date-of-birth-answer',
+                'block_id': 'visitor-date-of-birth',
+                'group_id': 'visitors',
                 'answer_instance': 0,
                 'value': '1985-10-17'
             },
             {
                 'group_instance': 1,
                 'answer_id': 'visitor-uk-resident-answer-other',
+                'block_id': 'visitor-uk-resident',
+                'group_id': 'visitors',
                 'answer_instance': 0,
                 'value': ''
             },
             {
                 'group_instance': 1,
                 'answer_id': 'visitor-uk-resident-answer',
+                'block_id': 'visitor-uk-resident',
+                'group_id': 'visitors',
                 'answer_instance': 0,
                 'value': 'Yes, usually lives in the United Kingdom'
             },
             {
                 'group_instance': 1,
                 'answer_id': 'visitor-address-answer-postcode',
+                'block_id': 'visitor-address',
+                'group_id': 'visitors',
                 'answer_instance': 0,
                 'value': '12345'
             },
             {
                 'group_instance': 1,
                 'answer_id': 'visitor-address-answer-street',
+                'block_id': 'visitor-address',
+                'group_id': 'visitors',
                 'answer_instance': 0,
                 'value': ''
             },
             {
                 'group_instance': 1,
                 'answer_id': 'visitor-address-answer-building',
+                'block_id': 'visitor-address',
+                'group_id': 'visitors',
                 'answer_instance': 0,
                 'value': '1009'
             },
             {
                 'group_instance': 1,
                 'answer_id': 'visitor-address-answer-city',
+                'block_id': 'visitor-address',
+                'group_id': 'visitors',
                 'answer_instance': 0,
                 'value': 'Detroit'
             },
             {
                 'group_instance': 1,
                 'answer_id': 'visitor-address-answer-county',
+                'block_id': 'visitor-address',
+                'group_id': 'visitors',
                 'answer_instance': 0,
                 'value': ''
             }

--- a/tests/integration/census/test_census_individual_submission_data.py
+++ b/tests/integration/census/test_census_individual_submission_data.py
@@ -17,144 +17,191 @@ class TestCensusIndividualSubmissionData(IntegrationTestCase):
         expected_downstream_data = [
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'Danny',
+                'block_id': 'correct-name',
                 'answer_instance': 0,
                 'answer_id': 'first-name'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'K',
+                'block_id': 'correct-name',
                 'answer_instance': 0,
                 'answer_id': 'middle-names'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'Boje',
+                'block_id': 'correct-name',
                 'answer_instance': 0,
                 'answer_id': 'last-name'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'Male',
+                'block_id': 'sex',
                 'answer_instance': 0,
                 'answer_id': 'sex-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': '1988-05-12',
+                'block_id': 'date-of-birth',
                 'answer_instance': 0,
                 'answer_id': 'date-of-birth-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'In a registered same-sex civil partnership',
+                'block_id': 'marital-status',
                 'answer_instance': 0,
                 'answer_id': 'marital-status-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'Yes, an address within the UK',
+                'block_id': 'another-address',
                 'answer_instance': 0,
                 'answer_id': 'another-address-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': '',
+                'block_id': 'another-address',
                 'answer_instance': 0,
                 'answer_id': 'another-address-answer-other'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'Newport',
+                'block_id': 'other-address',
                 'answer_instance': 0,
                 'answer_id': 'other-address-answer-city'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': '',
+                'block_id': 'other-address',
                 'answer_instance': 0,
                 'answer_id': 'other-address-answer-street'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': '',
+                'block_id': 'other-address',
                 'answer_instance': 0,
                 'answer_id': 'other-address-answer-county'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': '12',
+                'block_id': 'other-address',
                 'answer_instance': 0,
                 'answer_id': 'other-address-answer-building'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'NP10 8XG',
+                'block_id': 'other-address',
                 'answer_instance': 0,
                 'answer_id': 'other-address-answer-postcode'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'Friends Home',
+                'block_id': 'address-type',
                 'answer_instance': 0,
                 'answer_id': 'address-type-answer-other'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'Other',
+                'block_id': 'address-type',
                 'answer_instance': 0,
                 'answer_id': 'address-type-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'Yes',
+                'block_id': 'in-education',
                 'answer_instance': 0,
                 'answer_id': 'in-education-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'here, at this address',
+                'block_id': 'term-time-location',
                 'answer_instance': 0,
                 'answer_id': 'term-time-location-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': '',
+                'block_id': 'country-of-birth',
                 'answer_instance': 0,
                 'answer_id': 'country-of-birth-wales-answer-other'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'England',
+                'block_id': 'country-of-birth',
                 'answer_instance': 0,
                 'answer_id': 'country-of-birth-england-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': '',
+                'block_id': 'country-of-birth',
                 'answer_instance': 0,
                 'answer_id': 'country-of-birth-england-answer-other'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'Yes, 1 -19 hours a week',
+                'block_id': 'carer',
                 'answer_instance': 0,
                 'answer_id': 'carer-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'Ind',
+                'block_id': 'national-identity',
                 'answer_instance': 0,
                 'answer_id': 'national-identity-england-answer-other'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': '',
+                'block_id': 'national-identity',
                 'answer_instance': 0,
                 'answer_id': 'national-identity-wales-answer-other'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': [
                     'English',
                     'Welsh',
@@ -163,59 +210,77 @@ class TestCensusIndividualSubmissionData(IntegrationTestCase):
                     'British',
                     'Other'
                 ],
+                'block_id': 'national-identity',
                 'answer_instance': 0,
                 'answer_id': 'national-identity-england-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': [],
+                'block_id': 'national-identity',
                 'answer_instance': 0,
                 'answer_id': 'national-identity-wales-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'Other ethnic group',
+                'block_id': 'ethnic-group',
                 'answer_instance': 0,
                 'answer_id': 'ethnic-group-england-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'Other',
+                'block_id': 'other-ethnic-group',
                 'answer_instance': 0,
                 'answer_id': 'other-ethnic-group-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'Telugu',
+                'block_id': 'other-ethnic-group',
                 'answer_instance': 0,
                 'answer_id': 'other-ethnic-group-answer-other'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': '',
+                'block_id': 'language',
                 'answer_instance': 0,
                 'answer_id': 'language-welsh-answer-other'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'English',
+                'block_id': 'language',
                 'answer_instance': 0,
                 'answer_id': 'language-england-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': '',
+                'block_id': 'language',
                 'answer_instance': 0,
                 'answer_id': 'language-england-answer-other'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': [],
+                'block_id': 'religion',
                 'answer_instance': 0,
                 'answer_id': 'religion-welsh-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': [
                     'No religion',
                     'Christian (Including Church of England, Catholic, Protestant and all other Christian denominations)',
@@ -226,154 +291,201 @@ class TestCensusIndividualSubmissionData(IntegrationTestCase):
                     'Sikh',
                     'Other'
                 ],
+                'block_id': 'religion',
                 'answer_instance': 0,
                 'answer_id': 'religion-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': '',
+                'block_id': 'religion',
                 'answer_instance': 0,
                 'answer_id': 'religion-welsh-answer-other'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'Ind',
+                'block_id': 'religion',
                 'answer_instance': 0,
                 'answer_id': 'religion-answer-other'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'This address',
+                'block_id': 'past-usual-address',
                 'answer_instance': 0,
                 'answer_id': 'past-usual-address-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': '',
+                'block_id': 'past-usual-address',
                 'answer_instance': 0,
                 'answer_id': 'past-usual-address-answer-other'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': [
                     'United Kingdom'
                 ],
+                'block_id': 'passports',
                 'answer_instance': 0,
                 'answer_id': 'passports-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'Yes, limited a lot',
+                'block_id': 'disability',
                 'answer_instance': 0,
                 'answer_id': 'disability-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': [
                     'Masters Degree',
                     'Postgraduate Certificate / Diploma'
                 ],
+                'block_id': 'qualifications',
                 'answer_instance': 0,
                 'answer_id': 'qualifications-england-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': [],
+                'block_id': 'qualifications',
                 'answer_instance': 0,
                 'answer_id': 'qualifications-welsh-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'No',
+                'block_id': 'volunteering',
                 'answer_instance': 0,
                 'answer_id': 'volunteering-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': [
                     'none of the above?'
                 ],
+                'block_id': 'employment-type',
                 'answer_instance': 0,
                 'answer_id': 'employment-type-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'Yes',
+                'block_id': 'jobseeker',
                 'answer_instance': 0,
                 'answer_id': 'jobseeker-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'Yes',
+                'block_id': 'job-availability',
                 'answer_instance': 0,
                 'answer_id': 'job-availability-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'Yes',
+                'block_id': 'job-pending',
                 'answer_instance': 0,
                 'answer_id': 'job-pending-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': [
                     'a student?',
                     'long-term sick or disabled?'
                 ],
+                'block_id': 'occupation',
                 'answer_instance': 0,
                 'answer_id': 'occupation-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'Yes',
+                'block_id': 'ever-worked',
                 'answer_instance': 0,
                 'answer_id': 'ever-worked-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'an employee?',
+                'block_id': 'main-job',
                 'answer_instance': 0,
                 'answer_id': 'main-job-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'Software Engineer',
+                'block_id': 'job-title',
                 'answer_instance': 0,
                 'answer_id': 'job-title-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'Development',
+                'block_id': 'job-description',
                 'answer_instance': 0,
                 'answer_id': 'job-description-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': '31 - 48',
+                'block_id': 'hours-worked',
                 'answer_instance': 0,
                 'answer_id': 'hours-worked-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'Train',
+                'block_id': 'work-travel',
                 'answer_instance': 0,
                 'answer_id': 'work-travel-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'Civil Servant',
+                'block_id': 'employers-business',
                 'answer_instance': 0,
                 'answer_id': 'employers-business-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'Employed by an organisation or business',
+                'block_id': 'main-job-type',
                 'answer_instance': 0,
                 'answer_id': 'main-job-type-answer'
             },
             {
                 'group_instance': 0,
+                'group_id': 'household-member',
                 'value': 'ONS',
+                'block_id': 'business-name',
                 'answer_instance': 0,
                 'answer_id': 'business-name-answer'
             }

--- a/tests/integration/views/test_dump.py
+++ b/tests/integration/views/test_dump.py
@@ -67,13 +67,17 @@ class TestDumpAnswers(IntegrationTestCase):
                     'value': '',
                     'answer_instance': 0,
                     'group_instance': 0,
-                    'answer_id': 'other-answer-mandatory'
+                    'answer_id': 'other-answer-mandatory',
+                    'block_id': 'radio-mandatory',
+                    'group_id': 'radio',
                 },
                 {
                     'value': 'Toast',
                     'answer_instance': 0,
                     'group_instance': 0,
-                    'answer_id': 'radio-mandatory-answer'
+                    'answer_id': 'radio-mandatory-answer',
+                    'block_id': 'radio-mandatory',
+                    'group_id': 'radio',
                 }
             ]
         }
@@ -190,7 +194,9 @@ class TestDumpSubmission(IntegrationTestCase):
                         'answer_id': 'radio-mandatory-answer',
                         'answer_instance': 0,
                         'group_instance': 0,
-                        'value': 'Coffee'
+                        'value': 'Coffee',
+                        'block_id': 'radio-mandatory',
+                        'group_id': 'radio'
                     },
                 ],
                 'metadata': {

--- a/tests/integration/views/test_questionnaire.py
+++ b/tests/integration/views/test_questionnaire.py
@@ -52,6 +52,8 @@ class TestQuestionnaire(IntegrationTestCase):
             'answer_id': 'total-retail-turnover-answer',
             'answer_instance': 0,
             'value': '1000',
+            'group_id': 'rsi',
+            'block_id': 'total-retail-turnover'
         }, self.question_store.answer_store.answers)
 
     def test_update_questionnaire_store_with_date_form_data(self):
@@ -75,6 +77,8 @@ class TestQuestionnaire(IntegrationTestCase):
             'answer_id': 'single-date-answer',
             'answer_instance': 0,
             'value': '2016-03-12',
+            'group_id': 'dates',
+            'block_id': 'date-block'
         }, self.question_store.answer_store.answers)
 
         self.assertIn({
@@ -82,6 +86,8 @@ class TestQuestionnaire(IntegrationTestCase):
             'answer_id': 'month-year-answer',
             'answer_instance': 0,
             'value': '2014-11',
+            'group_id': 'dates',
+            'block_id': 'date-block'
         }, self.question_store.answer_store.answers)
 
     def test_update_questionnaire_store_with_empty_day_month_year_date(self):


### PR DESCRIPTION
### What is the context of this PR?
Make the Answer object forward compatible

### How to review 
When I start a survey on the old version of eQ, continue on the new version, and return to the old version, it should continue to work
