### PR TITLE
Enable Runner to reconnect to the database

### DIFF
--- a/app/setup.py
+++ b/app/setup.py
@@ -163,6 +163,8 @@ def create_app(setting_overrides=None):  # noqa: C901  pylint: disable=too-compl
 def setup_database(application):
     application.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
+    application.config['SQLALCHEMY_POOL_RECYCLE'] = 60
+
     driver = application.config['EQ_SERVER_SIDE_STORAGE_DATABASE_DRIVER']
 
     if not application.config['SQLALCHEMY_DATABASE_URI']:


### PR DESCRIPTION
Defined a SQLALCHEMY_POOL_RECYCLE to enable Runner to reconnect to the database after an outage.

### How To Review

Run in AWS. 
Restart / resize or upgrade the database to cause it to disconnect.
Once the DB is back up the application should reconnect