### PR TITLE
Don't hold the connection on the Submitter object

### DIFF
--- a/app/submitter/submitter.py
+++ b/app/submitter/submitter.py
@@ -30,26 +30,25 @@ class RabbitMQSubmitter():
             self.rabbitmq_url = 'amqp://{host}:{port}/%2F'.format(host=host, port=port)
             self.rabbitmq_secondary_url = 'amqp://{host}:{port}/%2F'.format(host=secondary_host, port=port)
 
-        self.connection = None
-
     def _connect(self):
         try:
             logger.info('attempt to open connection', server='primary', category='rabbitmq')
-            self.connection = BlockingConnection(URLParameters(self.rabbitmq_url))
+            return BlockingConnection(URLParameters(self.rabbitmq_url))
         except AMQPError as e:
             logger.error('unable to open connection', exc_info=e, server='primary', category='rabbitmq')
             try:
                 logger.info('attempt to open connection', server='secondary', category='rabbitmq')
-                self.connection = BlockingConnection(URLParameters(self.rabbitmq_secondary_url))
+                return BlockingConnection(URLParameters(self.rabbitmq_secondary_url))
             except AMQPError as err:
                 logger.error('unable to open connection', exc_info=e, server='secondary', category='rabbitmq')
                 raise err
 
-    def _disconnect(self):
+    @staticmethod
+    def _disconnect(connection):
         try:
-            if self.connection:
+            if connection:
                 logger.info('attempt to close connection', category='rabbitmq')
-                self.connection.close()
+                connection.close()
         except AMQPError as e:
             logger.error('unable to close connection', exc_info=e, category='rabbitmq')
 
@@ -63,9 +62,10 @@ class RabbitMQSubmitter():
         message_as_string = str(message)
         logger.info('sending message', category='rabbitmq')
         logger.info('message payload', message=message_as_string, category='rabbitmq')
+        connection = None
         try:
-            self._connect()
-            channel = self.connection.channel()
+            connection = self._connect()
+            channel = connection.channel()
             channel.queue_declare(queue=queue, durable=True)
             properties = BasicProperties(headers={},
                                          delivery_mode=2)
@@ -87,4 +87,5 @@ class RabbitMQSubmitter():
             logger.error('unable to send message', exc_info=e, category='rabbitmq')
             return False
         finally:
-            self._disconnect()
+            if connection:
+                self._disconnect(connection)


### PR DESCRIPTION
### What is the context of this PR?
Fixes #1451 
The connection was perviously held on the Submitter this caused overlap under load as the connection would be closed when another thread was using it

### How to review 
Under load the submitter should not fail to submit messages to the queue

