### PR TITLE
Fix to pass ru_ref into subject using session data

### DIFF
--- a/app/templates/static/contact-us.html
+++ b/app/templates/static/contact-us.html
@@ -55,7 +55,7 @@
                                         Email
                                     </h2>
                                     <div class="question__description mars">
-                                        <p>{{helpers.email_address(subject="{{ru_ref}}")}}</p>
+                                        <p>{{helpers.email_address(subject=session.ru_ref)}}</p>
                                     </div>
                                     <h2 class="question__title neptune">
                                         Post


### PR DESCRIPTION
### What is the context of this PR?
Ru_Ref was not being passed into email subject 

Card: https://trello.com/c/HW87sRMn/1824-eq-survey-runner-1455-ruref-not-displayed-in-subject-when-respondent-click-on-email-form-contact-us-page-issue

Fixes: https://github.com/ONSdigital/eq-survey-runner/issues/1455

### How to review 
Navigate to Contact-Us page and click the email to check if the Ru_Ref is passed as the subject in your email.