### PR TITLE
Fix to correct checkbox answers being passed to summary

### DIFF
--- a/app/templating/summary/question.py
+++ b/app/templating/summary/question.py
@@ -69,13 +69,14 @@ class Question:
         multiple_answers = []
         CheckboxSummaryAnswer = collections.namedtuple('CheckboxSummaryAnswer', 'label should_display_other')
         for option in answer_schema['options']:
-            if option['label'] in answer:
+            if option['value'] in answer:
                 if option['value'].lower() == 'other':
                     summary_option_display_value = option['label']
                     multiple_answers.append(CheckboxSummaryAnswer(label=summary_option_display_value,
                                                                   should_display_other=True))
                 else:
-                    multiple_answers.append(CheckboxSummaryAnswer(label=option['label'], should_display_other=False))
+                    multiple_answers.append(CheckboxSummaryAnswer(label=option['label'],
+                                                                  should_display_other=False))
         return multiple_answers
 
     def _build_date_range_answer(self, answer):

--- a/tests/app/templating/summary/test_question.py
+++ b/tests/app/templating/summary/test_question.py
@@ -166,7 +166,7 @@ class TestQuestion(TestCase):
         answer_store = AnswerStore([{
             'answer_id': 'answer_1',
             'block_id': '',
-            'value': ['Other option label', ''],
+            'value': ['other', ''],
             'answer_instance': 0,
         }])
         metadata = mock.MagicMock()


### PR DESCRIPTION
### What is the context of this PR?
Issue when Label and Value were different answers were not displaying on the Summary page

Card: https://trello.com/c/SIXvWzP1/1806-eq-survey-runner-1443-if-label-and-value-are-not-identical-answer-is-not-displayed-on-summary-issue

Fixes: https://github.com/ONSdigital/eq-survey-runner/issues/1443

### How to review 
Edit an answer with the type Checkbox so the Value and Label do not match and check if it is still displayed on the Summary page.
`1_0005_updated.json` is a good choice for editing and testing this
