### PR TITLE
Fix test_numbers.json schema to pass validation.

### DIFF
--- a/data/en/test_numbers.json
+++ b/data/en/test_numbers.json
@@ -20,7 +20,13 @@
                                 "label": "Minimum Value",
                                 "mandatory": true,
                                 "type": "Number",
-                                "decimal_places": 2
+                                "decimal_places": 2,
+                                "min_value": {
+                                    "value": 0
+                                },
+                                "max_value": {
+                                    "value": 1000
+                                }
                             },
                             {
                                 "id": "set-maximum",
@@ -29,7 +35,13 @@
                                 "label": "Maximum Value",
                                 "mandatory": true,
                                 "type": "Number",
-                                "decimal_places": 2
+                                "decimal_places": 2,
+                                "min_value": {
+                                    "value": 1001
+                                },
+                                "max_value": {
+                                    "value": 10000
+                                }
                             }
                         ],
                         "description": "",

--- a/tests/functional/spec/numbers.spec.js
+++ b/tests/functional/spec/numbers.spec.js
@@ -12,7 +12,7 @@ describe('NumericRange', function() {
       .then(() => {
         return browser
           .setValue(SetMinMax.setMinimum(), '10')
-          .setValue(SetMinMax.setMaximum(), '20')
+          .setValue(SetMinMax.setMaximum(), '1020')
           .click(SetMinMax.submit())
           .setValue(TestMinMax.testRange(), '10')
           .setValue(TestMinMax.testMin(), '123')
@@ -28,14 +28,14 @@ describe('NumericRange', function() {
       .then(() => {
         return browser
           .setValue(SetMinMax.setMinimum(), '10')
-          .setValue(SetMinMax.setMaximum(), '20')
+          .setValue(SetMinMax.setMaximum(), '1020')
           .click(SetMinMax.submit())
           .setValue(TestMinMax.testRange(), '9')
           .setValue(TestMinMax.testRangeExclusive(), '10')
           .setValue(TestMinMax.testMin(), '0')
           .setValue(TestMinMax.testMax(), '12345')
           .setValue(TestMinMax.testMinExclusive(), '123')
-          .setValue(TestMinMax.testMaxExclusive(), '1234')
+          .setValue(TestMinMax.testMaxExclusive(), '12345')
           .setValue(TestMinMax.testPercent(), '101')
           .setValue(TestMinMax.testDecimal(), '5.4')
           .click(TestMinMax.submit())
@@ -55,7 +55,7 @@ describe('NumericRange', function() {
       .then(() => {
         return browser
           .setValue(SetMinMax.setMinimum(), '10')
-          .setValue(SetMinMax.setMaximum(), '20')
+          .setValue(SetMinMax.setMaximum(), '1020')
           .click(SetMinMax.submit())
           .setValue(TestMinMax.testRange(), '12.344')
           .setValue(TestMinMax.testDecimal(), '11.234')

--- a/tests/functional/spec/save_sign_out.spec.js
+++ b/tests/functional/spec/save_sign_out.spec.js
@@ -12,7 +12,7 @@ describe('SaveSignOut', function() {
       .then(() => {
         return browser
           .setValue(SetMinMax.setMinimum(), '10')
-          .setValue(SetMinMax.setMaximum(), '20')
+          .setValue(SetMinMax.setMaximum(), '1020')
           .click(SetMinMax.submit())
           .click(TestMinMax.saveSignOut())
           .getUrl().should.eventually.contain('signed-out')
@@ -28,7 +28,7 @@ describe('SaveSignOut', function() {
           .getUrl().should.eventually.contain(TestMinMax.pageName)
           .setValue(TestMinMax.testRange(), '10')
           .setValue(TestMinMax.testMin(), '123')
-          .setValue(TestMinMax.testMax(), '456')
+          .setValue(TestMinMax.testMax(), '1000')
           .setValue(TestMinMax.testPercent(), '100')
           .click(TestMinMax.submit())
           .getUrl().should.eventually.contain(SummaryPage.pageName)


### PR DESCRIPTION
Adds a min/max to the question that sets the min/max values for the subsequent range questions.

This essentially prevents the situation where a user may input a max value that is smaller than the min value.

Ideally we would validate that max is greater than min on the set-min-max-block question but this isnt necessary to satisfy any requirements at the moment.

### What is the context of this PR?
Fixes #1460 

### How to review 
- Run unit tests and assert that schema validation does not fail
- Test that in the set-min-max-block question it is not possible to enter a max value than is less than the entered min value