### PR TITLE
Ensure schema validator is running during tests

### DIFF
--- a/scripts/test_schemas.sh
+++ b/scripts/test_schemas.sh
@@ -1,25 +1,61 @@
 #!/usr/bin/env bash
 
 docker pull onsdigital/eq-schema-validator
-validator=$(docker run -d -p 5001:5000 onsdigital/eq-schema-validator)
+validator="$(docker run -d -p 5001:5000 onsdigital/eq-schema-validator)"
 
 sleep 3
 
-echo "Testing Schemas"
+green="$(tput setaf 2)"
+red="$(tput setaf 1)"
+default="$(tput sgr0)"
+checks=4
+
+until [ "$checks" == 0 ]; do
+    response="$(curl -so /dev/null -w '%{http_code}' http://localhost:5001/status)"
+
+    if [ "$response" != "200" ]; then
+        echo "${red}---Error: Schema Validator Not Reachable---"
+        echo "HTTP Status: $response"
+        if [ "$checks"  != 1 ]; then
+            echo -e "Retrying...${default}\\n"
+            sleep 5
+        else
+            echo -e "Exiting...${default}\\n"
+            exit
+        fi
+        (( checks-- ))
+    else
+        (( checks=0 ))
+    fi
+
+done  
 
 exit=0
 
-for schema in $(find $1 -name '*.json');
-do
-echo $schema
-result=$(curl -X POST -H "Content-Type: text/plain" --data "$(cat $schema)" http://localhost:5001/validate 2>/dev/null)
-if [ "$result" != "{}" ] && [ "$result" != "" ]; then
-echo "---Schema Failed Validation---"
-echo "Error: [$result]"
-exit=1
-fi
+echo "---Testing Schemas---"
+failed=0
+passed=0
+
+for schema in $(find "$1" -name '*.json'); do
+
+    result="$(curl -s -w 'HTTPSTATUS:%{http_code}' -X POST -H "Content-Type: application/json" -d @"$schema" http://localhost:5001/validate | tr -d '\n')"
+    result_response="${result//*HTTPSTATUS:/}"
+    result_body="${result//HTTPSTATUS:*/}"
+
+    if [ "$result_response" == "200" ] && [ "$result_body" == "{}" ]; then
+        echo -e "${green}$schema - PASSED${default}"
+        (( passed++ ))
+    else
+        echo -e "\\n${red}$schema - FAILED"
+        echo "HTTP Status @ /validate: [$result_response]"
+        echo -e "Error: [$result_body]${default}\\n"
+        (( failed++ ))
+        exit=1
+    fi
+
 done
 
-docker rm -f $validator
+echo -e "\\n${green}$passed Passed${default} - ${red}$failed Failed${default}"
 
-exit $exit
+docker rm -f "$validator"
+exit "$exit"


### PR DESCRIPTION
### Context
- Checks if schema validator is running
- Feedback provided on success/fail of tests

Fixes Issue:  #1445 
Fixes Issue:  #1434 

### How to review 
1. Test the schemas against validator using Docker.
2. Test the schemas locally.
    - Run `test_schemas.sh` when validator is not running.
    - Run `test_schemas.sh` when validator is running and contains broken schemas.


