### PR TITLE
SessionData to ignore new attributes

### DIFF
--- a/app/data_model/session_data.py
+++ b/app/data_model/session_data.py
@@ -1,6 +1,6 @@
 class SessionData(object):
 
-    def __init__(self, tx_id, eq_id, form_type, period_str, language_code=None, survey_url=None, ru_name=None, ru_ref=None, submitted_time=None):
+    def __init__(self, tx_id, eq_id, form_type, period_str, language_code, survey_url, ru_name, ru_ref, submitted_time=None, **_):
         self.tx_id = tx_id
         self.eq_id = eq_id
         self.form_type = form_type

--- a/tests/app/data_model/TestSessionData.py
+++ b/tests/app/data_model/TestSessionData.py
@@ -1,0 +1,12 @@
+from app.data_model.session_data import SessionData
+
+
+class TestSessionData(SessionData):
+
+    def __init__(self, tx_id, eq_id, form_type, period_str, language_code, survey_url, ru_name,
+                 ru_ref, submitted_time=None, additional_value=None, second_additional_value=None):
+        super().__init__(tx_id, eq_id, form_type, period_str, language_code, survey_url, ru_name, ru_ref,
+                         submitted_time)
+
+        self.additional_value = additional_value
+        self.second_additional_value = second_additional_value

--- a/tests/app/data_model/test_session_store.py
+++ b/tests/app/data_model/test_session_store.py
@@ -4,6 +4,7 @@ from mock import patch
 from app.data_model.session_store import SessionStore
 from app.data_model.session_data import SessionData
 from tests.app.app_context_test_case import AppContextTestCase
+from tests.app.data_model.TestSessionData import TestSessionData
 
 
 class SessionStoreTest(AppContextTestCase):
@@ -66,3 +67,45 @@ class SessionStoreTest(AppContextTestCase):
 
                 # No database calls should have been made
                 self.assertFalse(delete.called)
+
+    def test_session_store_ignores_new_values_in_session_data(self):
+        new_session_data = TestSessionData(
+            tx_id='tx_id',
+            eq_id='eq_id',
+            form_type='form_type',
+            period_str='period_str',
+            language_code=None,
+            survey_url=None,
+            ru_name='ru_name',
+            ru_ref='ru_ref',
+            additional_value='some cool new value you do not know about yet'
+        )
+
+        with self._app.test_request_context():
+            self.session_store.create('eq_session_id', 'test', new_session_data).save()
+
+            session_store = SessionStore('user_ik', 'pepper', 'eq_session_id')
+
+            self.assertFalse(hasattr(session_store.session_data, 'additional_value'))
+
+    def test_session_store_ignores_multiple_new_values_in_session_data(self):
+        new_session_data = TestSessionData(
+            tx_id='tx_id',
+            eq_id='eq_id',
+            form_type='form_type',
+            period_str='period_str',
+            language_code=None,
+            survey_url=None,
+            ru_name='ru_name',
+            ru_ref='ru_ref',
+            additional_value='some cool new value you do not know about yet',
+            second_additional_value='some other not so cool value'
+        )
+
+        with self._app.test_request_context():
+            self.session_store.create('eq_session_id', 'test', new_session_data).save()
+
+            session_store = SessionStore('user_ik', 'pepper', 'eq_session_id')
+
+            self.assertFalse(hasattr(session_store.session_data, 'additional_value'))
+            self.assertFalse(hasattr(session_store.session_data, 'second_additional_value'))


### PR DESCRIPTION
 - SessionData should now be forward compatible

### What is the context of this PR?
When new variables are added to session data during deployment if a session is created with the new code but then later accessed by the old code then an error is thrown.

### How to review 
Create a session on a version of the code with new session data (https://github.com/ONSdigital/eq-survey-runner/pull/1467) then return to this branch and you should be able to resume.
