### PR TITLE
Add CDN to CSP header

### DIFF
--- a/app/setup.py
+++ b/app/setup.py
@@ -45,7 +45,7 @@ CACHE_HEADERS = {
 CSP_POLICY = {
     'default-src': ["'self'", ],
     'script-src': ["'self'", 'https://www.google-analytics.com', ],
-    'img-src': ["'self'", 'data:', 'https://www.google-analytics.com', ]
+    'img-src': ["'self'", 'data:', 'https://www.google-analytics.com', 'https://cdn.ons.gov.uk']
 }
 
 cache = Cache()

--- a/tests/integration/test_app_create.py
+++ b/tests/integration/test_app_create.py
@@ -84,7 +84,7 @@ class TestCreateApp(unittest.TestCase):
                 csp_policy_parts
             )
             self.assertIn(
-                "img-src 'self' data: https://www.google-analytics.com", csp_policy_parts)
+                "img-src 'self' data: https://www.google-analytics.com https://cdn.ons.gov.uk", csp_policy_parts)
 
     # Indirectly covered by higher level integration
     # tests, keeping to highlight that create_app is where


### PR DESCRIPTION
### What is the context of this PR?
Adds the ONS CDN domain to the CSP header.

### How to review 
- Check that the header contains the correct value
- Navigate to a page which shows an icon from the pattern library, check that the icons show and check that there are no errors in the console