### PR TITLE
Add the ability to have Section Summaries

### DIFF
--- a/app/templates/confirmation.html
+++ b/app/templates/confirmation.html
@@ -3,5 +3,10 @@
 {% block page_title %}{{_("Submit answers")}} - {{survey_title}}{% endblock %}
 
 {% block submit_button %}
-  <button class="btn btn--primary btn--lg btn--loader js-btn-submit" data-qa="btn-submit" data-loading-msg="Submitting&hellip;" type="submit">Submit answers</button>
+
+{% if content.summary and content.summary.summary_type == 'SectionSummary' %}
+    <button class="btn btn--primary btn--lg btn--loader js-btn-submit" data-qa="btn-submit">Continue</button>
+{% else  %}
+    <button class="btn btn--primary btn--lg btn--loader js-btn-submit" data-qa="btn-submit" data-loading-msg="Submitting&hellip;" type="submit">Submit answers</button>
+{% endif %}
 {% endblock %}

--- a/app/templates/partials/summary/summary.html
+++ b/app/templates/partials/summary/summary.html
@@ -4,11 +4,9 @@
   <div class="summary">
 
     {% for group in content.summary.groups %}
-
       {% if group.title %}
-      <h2 class="summary__title saturn" id="{{group.id}}">{{group.title}}</h2>
+        <h2 class="summary__title saturn" id="{{group.id}}">{{group.title}}</h2>
       {% endif %}
-
       <div class="summary__block">
 
         {% for block in group.blocks %}

--- a/app/templates/sectionsummary.html
+++ b/app/templates/sectionsummary.html
@@ -1,0 +1,1 @@
+{% extends theme('summary.html') %}

--- a/app/templates/summary.html
+++ b/app/templates/summary.html
@@ -1,5 +1,4 @@
 {% import 'macros/helpers.html' as helpers %}
-
 {% extends theme('confirmation.html') -%}
 
 {% block page_title -%}{{_("Summary")}} - {{survey_title}}{% endblock -%}
@@ -15,8 +14,9 @@
 
 {% block main -%}
 
+{% if content.summary.summary_type == 'Summary' %}
 <div>
-  <h1 class="saturn">Your answers</h1>
+  <h1 class="saturn">{{content.summary.title}}</h1>
   <div class="print__message panel panel--simple panel--error">
     <h2 class="saturn">Please remember to submit these answers.</h2>
   </div>
@@ -24,6 +24,16 @@
     <h2 class="neptune">Please check your answers carefully before submitting.</h2>
   </div>
 </div>
+{% else %}
+<div>
+    {% set group = content.summary.groups %}
+    <h1 class="saturn">{{content.summary.title}}</h1>
+    <div class="print__hidden panel panel--simple panel--success">
+        <strong>This section is now complete</strong>
+        <p>You can review your answers below</p>
+    </div>
+</div>
+{% endif %}
 
 {% include theme('partials/summary/summary.html') %}
 

--- a/app/templating/summary_context.py
+++ b/app/templating/summary_context.py
@@ -8,6 +8,7 @@ def build_summary_rendering_context(schema, sections, answer_store, metadata):
     """
     Build questionnaire summary context containing metadata and content from the answers of the questionnaire
     :param schema: schema of the current questionnaire
+    :param sections: the sections of the current schema
     :param answer_store: all of the answers to the questionnaire
     :param metadata: all of the metadata
     :return: questionnaire summary context

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -678,7 +678,7 @@ def _get_front_end_navigation(answer_store, current_location, metadata, routing_
     completed_blocks = get_completed_blocks(current_user)
     navigation = Navigation(g.schema, answer_store, metadata, completed_blocks, routing_path)
     block_json = g.schema.get_block(current_location.block_id)
-    if block_json is not None and block_json['type'] in ('Question', 'Interstitial', 'Confirmation', 'Summary'):
+    if block_json['type'] != 'Introduction':
         return navigation.build_navigation(current_location.group_id, current_location.group_instance)
 
     return None

--- a/data/en/test_section_summary.json
+++ b/data/en/test_section_summary.json
@@ -1,0 +1,227 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "999",
+    "title": "Section Summary",
+    "description": "A questionnaire to test section summaries",
+    "theme": "default",
+    "legal_basis": "Voluntary",
+    "view_submitted_response": {
+        "enabled": true,
+        "duration": 9000
+    },
+    "navigation": {
+        "visible": true
+    },
+    "sections": [{
+            "id": "property-details-section",
+            "title": "Property Details Section",
+            "groups": [{
+                    "id": "property-details",
+                    "title": "Property Details",
+                    "blocks": [{
+                            "id": "insurance-type",
+                            "title": "Property Details",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "insurance-type-question",
+                                "title": "What kind of insurance would you like?",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "insurance-type-answer",
+                                    "type": "Radio",
+                                    "label": "",
+                                    "mandatory": false,
+                                    "options": [{
+                                            "label": "Buildings",
+                                            "value": "Buildings"
+                                        },
+                                        {
+                                            "label": "Contents",
+                                            "value": "Contents"
+                                        },
+                                        {
+                                            "label": "Both",
+                                            "value": "Both"
+                                        }
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "insurance-address",
+                            "title": "Property Details",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "insurance-address-question",
+                                "title": "What is the address you would like to insure?",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "insurance-address-answer",
+                                    "type": "TextArea",
+                                    "label": "",
+                                    "mandatory": false
+                                }]
+                            }]
+                        }
+                    ]
+                },
+                {
+                    "id": "address-length",
+                    "title": "Address Duration",
+                    "blocks": [{
+                            "id": "address-duration",
+                            "title": "Address Duration",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "address-duration-question",
+                                "title": "Have you been living at this address for over 5 years?",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "address-duration-answer",
+                                    "type": "Radio",
+                                    "mandatory": false,
+                                    "options": [{
+                                            "label": "Yes",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "No"
+                                        }
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "property-details-summary",
+                            "type": "SectionSummary"
+                        }
+                    ]
+
+                }
+
+            ]
+        },
+        {
+            "id": "house-details-section",
+            "title": "House Details Section",
+            "groups": [{
+                "id": "house-details",
+                "title": "House Details",
+                "skip_conditions": [{
+                        "when": [{
+                            "id": "insurance-type-answer",
+                            "condition": "equals",
+                            "value": "Contents"
+                        }]
+                    },
+                    {
+                        "when": [{
+                            "id": "insurance-type-answer",
+                            "condition": "not set"
+                        }]
+                    }
+                ],
+                "blocks": [{
+                        "id": "house-type",
+                        "title": "House Details",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "house-type-question",
+                            "title": "What kind of house is it?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "house-type-answer",
+                                "type": "Radio",
+                                "label": "",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Detached",
+                                        "value": "Detached"
+                                    },
+                                    {
+                                        "label": "Semi-detached",
+                                        "value": "Semi-detached"
+                                    },
+                                    {
+                                        "label": "Terrace",
+                                        "value": "Terrace"
+                                    }
+                                ]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "household-details-summary",
+                        "type": "SectionSummary"
+                    }
+
+                ]
+            }]
+        },
+        {
+            "id": "household-composition-section",
+            "title": "Household Composition Section",
+            "groups": [{
+                "id": "multiple-questions-group",
+                "title": "Household Details",
+                "blocks": [{
+                    "id": "household-composition",
+                    "title": "Household Details",
+                    "type": "Question",
+                    "questions": [{
+                        "id": "household-composition-question",
+                        "title": "List the names of everyone  who lives here.",
+                        "number": "2",
+                        "guidance": {
+                            "content": [{
+                                "title": "Include",
+                                "list": [
+                                    "Yourself, if this is your permanent or family home",
+                                    "Family members including partners, children and babies born on or before 9 April 2017",
+                                    "Students and, or school children who live away from home during term time",
+                                    "Housemates tenants or lodgers"
+                                ]
+                            }]
+                        },
+                        "type": "RepeatingAnswer",
+                        "answers": [{
+                                "alias": "first_name",
+                                "id": "first-name",
+                                "label": "First name",
+                                "mandatory": true,
+                                "type": "TextField",
+                                "validation": {
+                                    "messages": {
+                                        "MANDATORY_TEXTFIELD": "Please enter a name or remove the person to continue"
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "last_name",
+                                "id": "last-name",
+                                "label": "Last name",
+                                "mandatory": false,
+                                "type": "TextField"
+                            }
+                        ]
+                    }]
+                }]
+            }]
+        },
+        {
+            "id": "summary-section",
+            "title": "Summary",
+            "groups": [{
+                "blocks": [{
+                    "id": "summary",
+                    "type": "Summary"
+                }],
+                "id": "summary-group",
+                "title": "Summary"
+            }]
+        }
+    ]
+}

--- a/tests/app/templating/test_summary_context.py
+++ b/tests/app/templating/test_summary_context.py
@@ -1,8 +1,10 @@
+from flask import g
 from mock import MagicMock, Mock, patch
 
 from app.data_model.answer_store import AnswerStore
 from app.questionnaire.location import Location
 from app.templating.summary_context import build_summary_rendering_context
+from app.templating.view_context import build_view_context_for_summary
 from app.utilities.schema import load_schema_from_params
 
 from tests.app.app_context_test_case import AppContextTestCase
@@ -65,3 +67,64 @@ class TestSummaryContext(AppContextTestCase):
 
         answer = context[0]['blocks'][0]['questions'][0]['answers'][0]
         self.assertEqual(answer['value'], '&lt;&gt;&#34;&#39;&amp;')
+
+
+class TestSectionSummaryContext(AppContextTestCase):
+    metadata = {
+        'return_by': '2016-10-10',
+        'ref_p_start_date': '2016-10-10',
+        'ref_p_end_date': '2016-10-10',
+        'ru_ref': 'def123',
+        'ru_name': 'Mr Cloggs',
+        'trad_as': 'Samsung',
+        'tx_id': '12345678-1234-5678-1234-567812345678',
+        'period_str': '201610',
+        'employment_date': '2016-10-10',
+        'collection_exercise_sid': '789',
+        'form_type': '0102',
+        'eq_id': '1',
+    }
+
+    def setUp(self):
+        super().setUp()
+        self.schema = load_schema_from_params('test', 'section_summary')
+        self.answer_store = AnswerStore()
+
+    def test_build_summary_rendering_context(self):
+        answer_store = MagicMock()
+        current_location = Location(
+            block_id='property-details-summary',
+            group_id='property-details',
+            group_instance=0,
+        )
+        routing_path = [Location(
+            block_id='property-details-summary',
+            group_id='property-details',
+            group_instance=0,
+        )]
+        navigator = Mock()
+        navigator.get_full_routing_path = Mock(return_value=routing_path)
+
+        with patch('app.templating.summary_context.PathFinder', return_value=navigator):
+            context = build_summary_rendering_context(self.schema, answer_store, self.metadata, current_location)
+
+        self.assertEqual(len(context), 0)
+
+    def test_build_view_context_for_summary(self):
+        block_type = 'SectionSummary'
+        csrf_token = None
+        variables = None
+
+        g.schema = load_schema_from_params('test', 'section_summary')
+
+        section = g.schema.json
+        current_location = Location(
+            block_id='property-details-summary',
+            group_id='property-details',
+            group_instance=0,
+        )
+
+        context = build_view_context_for_summary(self.metadata, self.answer_store, section, block_type, variables,
+                                                 csrf_token, current_location)
+
+        self.assertEqual(len(context), 3)

--- a/tests/functional/generate_pages.py
+++ b/tests/functional/generate_pages.py
@@ -77,6 +77,13 @@ REPEATING_ANSWER_ADD_REMOVE = r"""  addPerson() {
   }
 
 """
+SECTION_SUMMARY_ANSWER_GETTER = Template(r"""  ${answerName}() { return '#${answerId}-answer'; }
+
+""")
+
+SECTION_SUMMARY_ANSWER_EDIT_GETTER = Template(r"""  ${answerName}Edit() { return '[data-qa="${answerId}-edit"]'; }
+
+""")
 
 SUMMARY_ANSWER_GETTER = Template(r"""  ${answerName}() { return '#${answerId}-answer'; }
 
@@ -205,8 +212,12 @@ def process_summary(schema_data, page_spec):
                             'answerName': camel_case(answer_name),
                             'answerId': answer['id']
                         }
-                        page_spec.write(SUMMARY_ANSWER_GETTER.substitute(answer_context))
-                        page_spec.write(SUMMARY_ANSWER_EDIT_GETTER.substitute(answer_context))
+                        if block['type'] == 'SectionSummary':
+                            page_spec.write(SECTION_SUMMARY_ANSWER_GETTER.substitute(answer_context))
+                            page_spec.write(SECTION_SUMMARY_ANSWER_EDIT_GETTER.substitute(answer_context))
+
+                    page_spec.write(SUMMARY_ANSWER_GETTER.substitute(answer_context))
+                    page_spec.write(SUMMARY_ANSWER_EDIT_GETTER.substitute(answer_context))
 
             group_context = {
                 'group_id_camel': camel_case(generate_pascal_case_from_id(group['id'])),
@@ -280,8 +291,7 @@ def process_block(block, dir_out, schema_data, spec_file, relative_require='..')
         page_spec.write(HEADER.substitute(block_context))
         page_spec.write(CLASS_NAME.substitute(block_context))
         page_spec.write(CONSTRUCTOR.substitute(block_context))
-
-        if block['type'] == 'Summary':
+        if block['type'] in ('Summary', 'SectionSummary'):
             process_summary(schema_data, page_spec)
         else:
             num_questions = len(block.get('questions', []))

--- a/tests/functional/pages/surveys/section_summary/address-duration.page.js
+++ b/tests/functional/pages/surveys/section_summary/address-duration.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class AddressDurationPage extends QuestionPage {
+
+  constructor() {
+    super('address-duration');
+  }
+
+  yes() {
+    return '#address-duration-answer-0';
+  }
+
+  yesLabel() { return '#label-address-duration-answer-0'; }
+
+  no() {
+    return '#address-duration-answer-1';
+  }
+
+  noLabel() { return '#label-address-duration-answer-1'; }
+
+}
+module.exports = new AddressDurationPage();

--- a/tests/functional/pages/surveys/section_summary/house-type.page.js
+++ b/tests/functional/pages/surveys/section_summary/house-type.page.js
@@ -1,0 +1,29 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class HouseTypePage extends QuestionPage {
+
+  constructor() {
+    super('house-type');
+  }
+
+  detached() {
+    return '#house-type-answer-0';
+  }
+
+  detachedLabel() { return '#label-house-type-answer-0'; }
+
+  semiDetached() {
+    return '#house-type-answer-1';
+  }
+
+  semiDetachedLabel() { return '#label-house-type-answer-1'; }
+
+  terrace() {
+    return '#house-type-answer-2';
+  }
+
+  terraceLabel() { return '#label-house-type-answer-2'; }
+
+}
+module.exports = new HouseTypePage();

--- a/tests/functional/pages/surveys/section_summary/insurance-address.page.js
+++ b/tests/functional/pages/surveys/section_summary/insurance-address.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class InsuranceAddressPage extends QuestionPage {
+
+  constructor() {
+    super('insurance-address');
+  }
+
+  answer() {
+    return '#insurance-address-answer';
+  }
+
+  answerLabel() { return '#label-insurance-address-answer'; }
+
+}
+module.exports = new InsuranceAddressPage();

--- a/tests/functional/pages/surveys/section_summary/insurance-type.page.js
+++ b/tests/functional/pages/surveys/section_summary/insurance-type.page.js
@@ -1,0 +1,29 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class InsuranceTypePage extends QuestionPage {
+
+  constructor() {
+    super('insurance-type');
+  }
+
+  buildings() {
+    return '#insurance-type-answer-0';
+  }
+
+  buildingsLabel() { return '#label-insurance-type-answer-0'; }
+
+  contents() {
+    return '#insurance-type-answer-1';
+  }
+
+  contentsLabel() { return '#label-insurance-type-answer-1'; }
+
+  both() {
+    return '#insurance-type-answer-2';
+  }
+
+  bothLabel() { return '#label-insurance-type-answer-2'; }
+
+}
+module.exports = new InsuranceTypePage();

--- a/tests/functional/pages/surveys/section_summary/property-details-summary.page.js
+++ b/tests/functional/pages/surveys/section_summary/property-details-summary.page.js
@@ -1,0 +1,45 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class PropertyDetailsSummaryPage extends QuestionPage {
+
+  constructor() {
+    super('property-details-summary');
+  }
+
+  insuranceTypeAnswer() { return '#insurance-type-answer-answer'; }
+
+  insuranceTypeAnswerEdit() { return '[data-qa="insurance-type-answer-edit"]'; }
+
+  insuranceAddressAnswer() { return '#insurance-address-answer-answer'; }
+
+  insuranceAddressAnswerEdit() { return '[data-qa="insurance-address-answer-edit"]'; }
+
+  propertyDetailsTitle() { return '#property-details'; }
+
+  addressDurationAnswer() { return '#address-duration-answer-answer'; }
+
+  addressDurationAnswerEdit() { return '[data-qa="address-duration-answer-edit"]'; }
+
+  addressLengthTitle() { return '#address-length'; }
+
+  propertyDetailsSectionSummaryTitle() { return '#property-details-section-summary'; }
+
+  houseTypeAnswer() { return '#house-type-answer-answer'; }
+
+  houseTypeAnswerEdit() { return '[data-qa="house-type-answer-edit"]'; }
+
+  houseDetailsTitle() { return '#house-details'; }
+
+  householdDetailsSectionSummaryTitle() { return '#household-details-section-summary'; }
+
+  lastName() { return '#last-name-answer'; }
+
+  lastNameEdit() { return '[data-qa="last-name-edit"]'; }
+
+  multipleQuestionsGroupTitle() { return '#multiple-questions-group'; }
+
+  summaryGroupTitle() { return '#summary-group'; }
+
+}
+module.exports = new PropertyDetailsSummaryPage();

--- a/tests/functional/spec/section_summary.spec.js
+++ b/tests/functional/spec/section_summary.spec.js
@@ -1,0 +1,58 @@
+const helpers = require('../helpers');
+const HouseTypePage = require('../pages/surveys/section_summary/house-type.page.js');
+const InsuranceAddressPage = require('../pages/surveys/section_summary/insurance-address.page.js');
+const InsuranceTypePage = require('../pages/surveys/section_summary/insurance-type.page.js');
+const AddressDurationPage = require('../pages/surveys/section_summary/address-duration.page.js');
+const PropertyDetailsSummaryPage = require('../pages/surveys/section_summary/property-details-summary.page.js');
+
+describe('Section Summary', function() {
+  describe('Given I start a Test Section Summary survey', function() {
+
+    const schema = 'test_section_summary.json';
+
+    it('When I have selected a set of answers , Then the selected option should be displayed on the section summary', function() {
+      return helpers.openQuestionnaire(schema)
+        .then(() => {
+          return browser
+           .click(InsuranceTypePage.buildings())
+           .click(InsuranceTypePage.submit())
+           .click(InsuranceAddressPage.submit())
+           .click(AddressDurationPage.yes())
+           .click(AddressDurationPage.submit())
+           .getText(PropertyDetailsSummaryPage.insuranceTypeAnswer()).should.eventually.contain('Buildings');
+      });
+    });
+
+  it('When I have selected an answer , And want to change that answer on the section summary, Then the selected option should be displayed on the section summary', function() {
+      return helpers.openQuestionnaire(schema)
+        .then(() => {
+         return browser
+           .click(InsuranceTypePage.buildings())
+           .click(InsuranceTypePage.submit())
+           .click(InsuranceAddressPage.submit())
+           .click(AddressDurationPage.submit())
+           .getText(PropertyDetailsSummaryPage.insuranceTypeAnswer()).should.eventually.contain('Buildings')
+           .click(PropertyDetailsSummaryPage.insuranceTypeAnswerEdit())
+           .click(InsuranceTypePage.contents())
+           .click(InsuranceTypePage.submit())
+           .click(InsuranceAddressPage.submit())
+           .click(AddressDurationPage.submit())
+           .getText(PropertyDetailsSummaryPage.insuranceTypeAnswer()).should.eventually.contain('Contents');
+      });
+    });
+
+   it('When I have selected an answer , And decide to continue on the section summary page, Then I should be taken to the next section', function() {
+      return helpers.openQuestionnaire(schema)
+        .then(() => {
+         return browser
+           .click(InsuranceTypePage.buildings())
+           .click(InsuranceTypePage.submit())
+           .click(InsuranceAddressPage.submit())
+           .click(AddressDurationPage.submit())
+           .click(PropertyDetailsSummaryPage.submit())
+           .getUrl().should.eventually.contain(HouseTypePage.pageName);
+        });
+    });
+  });
+
+});


### PR DESCRIPTION
### What is the context of this PR?
Introducing Section Summaries into Runner.
Card: https://trello.com/c/AC1836ru/1800-section-summary-m

### How to review 
Review this first: https://github.com/ONSdigital/eq-schema-validator/pull/31
Open `test_section_summary.json`, check that section summaries are working and matches design on card.
Ensure that all tests pass as usual.