### PR TITLE
Improved test coverage of converter.py

### DIFF
--- a/app/submitter/convert_payload_0_0_1.py
+++ b/app/submitter/convert_payload_0_0_1.py
@@ -1,0 +1,91 @@
+from collections import OrderedDict
+from datetime import datetime
+
+
+def convert_answers_to_payload_0_0_1(answer_store, schema, routing_path):
+    """
+    Convert answers into the data format below
+    'data': {
+          '001': '01-01-2016',
+          '002': '30-03-2016'
+        }
+    :param answer_store: questionnaire answers
+    :param schema: QuestionnaireSchema class with popuated schema json
+    :param routing_path: the path followed in the questionnaire
+    :return: data in a formatted form
+    """
+    data = OrderedDict()
+    for location in routing_path:
+        answer_ids = schema.get_answer_ids_for_block(location.block_id)
+        answers_in_block = answer_store.filter(answer_ids, location.group_instance)
+        answer_schema_list = schema.get_answers_by_id_for_block(location.block_id)
+
+        for answer in answers_in_block:
+            answer_schema = answer_schema_list[answer['answer_id']]
+
+            value = answer['value']
+
+            if answer_schema is not None and value is not None and 'parent_answer_id' not in answer_schema:
+                if 'q_code' in answer_schema and (answer_schema['type'] != 'Checkbox' or any('q_code' not in option for option in
+                                                                                             answer_schema['options'])):
+
+                    answer_data = _get_answer_data(data, answer_schema['q_code'], value)
+                    if answer_data is not None:
+                        data[answer_schema['q_code']] = _format_downstream_answer(answer_schema['type'], answer['value'], answer_data)
+                else:
+                    data.update(_get_checkbox_answer_data(answer_store, answer_schema, value))
+    return data
+
+
+def _format_downstream_answer(answer_type, answer_value, answer_data):
+    if answer_type == 'Date':
+        return datetime.strptime(answer_value, '%Y-%m-%d').strftime('%d/%m/%Y')
+
+    if answer_type == 'MonthYearDate':
+        return datetime.strptime(answer_value, '%Y-%m').strftime('%m/%Y')
+
+    return answer_data
+
+
+def _get_answer_data(original_data, item_code, value):
+
+    if item_code in original_data:
+        data_to_return = original_data[item_code]
+        if not isinstance(data_to_return, list):
+            data_to_return = [data_to_return]
+        data_to_return.append(_encode_value(value))
+
+        return data_to_return
+    return _encode_value(value)
+
+
+def _get_checkbox_answer_data(answer_store, checkboxes_with_qcode, value):
+
+    checkbox_answer_data = OrderedDict()
+
+    for user_answer in value:
+        # find the option in the schema which matches the users answer
+        option = next((option for option in checkboxes_with_qcode['options'] if option['value'] == user_answer), None)
+
+        if option:
+            if 'child_answer_id' in option:
+                filtered = answer_store.filter(answer_ids=[option['child_answer_id']])
+
+                if filtered.count() > 1:
+                    raise Exception('Multiple answers found for {}'.format(option['child_answer_id']))
+
+                # if the user has selected 'other' we need to find the value it refers to.
+                # when non-mandatory, the other box value can be empty, in this case we just use its value
+                checkbox_answer_data[option['q_code']] = option['value']
+            else:
+                checkbox_answer_data[option['q_code']] = user_answer
+
+    return checkbox_answer_data
+
+
+def _encode_value(value):
+    if isinstance(value, str):
+        if value == '':
+            return None
+        return value
+    return str(value)

--- a/app/submitter/convert_payload_0_0_2.py
+++ b/app/submitter/convert_payload_0_0_2.py
@@ -1,0 +1,39 @@
+def convert_answers_to_payload_0_0_2(answer_store, schema, routing_path):
+    """
+    Convert answers into the data format below
+    'data': [
+        {
+            'value': 'Joe Bloggs',
+            'block_id': 'household-composition',
+            'answer_id': 'household-full-name',
+            'group_id': 'multiple-questions-group',
+            'group_instance': 0,
+            'answer_instance': 0
+        },
+        {
+            'value': 'Fred Flintstone',
+            'block_id': 'household-composition',
+            'answer_id': 'household-full-name',
+            'group_id': 'multiple-questions-group',
+            'group_instance': 0,
+            'answer_instance': 1
+        },
+        {
+            'value': 'Husband or wife',
+            'block_id': 'relationships',
+            'answer_id': 'who-is-related',
+            'group_id': 'household-relationships',
+            'group_instance': 0,
+            'answer_instance': 0
+        }
+    ]
+    :param answer_store: questionnaire answers
+    :param routing_path: the path followed in the questionnaire
+    :return: data in a formatted form
+    """
+    data = []
+    for location in routing_path:
+        answer_ids = schema.get_answer_ids_for_block(location.block_id)
+        answers_in_block = answer_store.filter(answer_ids, location.group_instance)
+        data.extend(answers_in_block)
+    return data

--- a/app/submitter/converter.py
+++ b/app/submitter/converter.py
@@ -1,6 +1,7 @@
-from collections import OrderedDict
 from datetime import datetime, timezone
 from structlog import get_logger
+from app.submitter.convert_payload_0_0_1 import convert_answers_to_payload_0_0_1
+from app.submitter.convert_payload_0_0_2 import convert_answers_to_payload_0_0_2
 
 logger = get_logger()
 
@@ -62,138 +63,14 @@ def convert_answers(metadata, schema, answer_store, routing_path, flushed=False)
         payload['case_ref'] = metadata['case_ref']
 
     if schema.json['data_version'] == '0.0.2':
-        payload['data'] = convert_answers_to_census_data(answer_store, schema, routing_path)
+        payload['data'] = convert_answers_to_payload_0_0_2(answer_store, schema, routing_path)
     elif schema.json['data_version'] == '0.0.1':
-        payload['data'] = convert_answers_to_data(answer_store, schema, routing_path)
+        payload['data'] = convert_answers_to_payload_0_0_1(answer_store, schema, routing_path)
     else:
         raise DataVersionError(schema.json['data_version'])
 
     logger.debug('converted answer ready for submission')
     return payload
-
-
-def convert_answers_to_data(answer_store, schema, routing_path):
-    """
-    Convert answers into the data format below
-    'data': {
-          '001': '01-01-2016',
-          '002': '30-03-2016'
-        }
-    :param answer_store: questionnaire answers
-    :param schema: QuestionnaireSchema class with popuated schema json
-    :param routing_path: the path followed in the questionnaire
-    :return: data in a formatted form
-    """
-    data = OrderedDict()
-    for location in routing_path:
-        answer_ids = schema.get_answer_ids_for_block(location.block_id)
-        answers_in_block = answer_store.filter(answer_ids, location.group_instance)
-        answer_schema_list = schema.get_answers_by_id_for_block(location.block_id)
-
-        for answer in answers_in_block:
-            answer_schema = answer_schema_list[answer['answer_id']]
-
-            value = answer['value']
-
-            if answer_schema is not None and value is not None and 'parent_answer_id' not in answer_schema:
-                if answer_schema['type'] != 'Checkbox' or any('q_code' not in option for option in
-                                                              answer_schema['options']):
-                    if 'q_code' not in answer_schema:
-                        continue
-
-                    answer_data = _get_answer_data(data, answer_schema['q_code'], value)
-                    if answer_data is not None:
-                        data[answer_schema['q_code']] = _format_downstream_answer(answer_schema['type'], answer['value'], answer_data)
-                else:
-                    data.update(_get_checkbox_answer_data(answer_store, answer_schema, value))
-    return data
-
-
-def _format_downstream_answer(answer_type, answer_value, answer_data):
-    if answer_type == 'Date':
-        return datetime.strptime(answer_value, '%Y-%m-%d').strftime('%d/%m/%Y')
-
-    if answer_type == 'MonthYearDate':
-        return datetime.strptime(answer_value, '%Y-%m').strftime('%m/%Y')
-
-    return answer_data
-
-
-def _get_answer_data(original_data, item_code, value):
-
-    if item_code in original_data:
-        data_to_return = original_data[item_code]
-        if not isinstance(data_to_return, list):
-            data_to_return = [data_to_return]
-        data_to_return.append(_encode_value(value))
-
-        return data_to_return
-    return _encode_value(value)
-
-
-def _get_checkbox_answer_data(answer_store, checkboxes_with_qcode, value):
-
-    checkbox_answer_data = OrderedDict()
-
-    for user_answer in value:
-        # find the option in the schema which matches the users answer
-        option = next((option for option in checkboxes_with_qcode['options'] if option['value'] == user_answer), None)
-
-        if option:
-            if 'child_answer_id' in option:
-                filtered = answer_store.filter(answer_ids=[option['child_answer_id']])
-
-                if filtered.count() > 1:
-                    raise Exception('Multiple answers found for {}'.format(option['child_answer_id']))
-
-                # if the user has selected 'other' we need to find the value it refers to.
-                # when non-mandatory, the other box value can be empty, in this case we just use its value
-                checkbox_answer_data[option['q_code']] = option['value']
-            else:
-                checkbox_answer_data[option['q_code']] = user_answer
-
-    return checkbox_answer_data
-
-
-def convert_answers_to_census_data(answer_store, schema, routing_path):
-    """
-    Convert answers into the data format below
-    'data': [
-        {
-            'value': 'Joe Bloggs',
-            'block_id': 'household-composition',
-            'answer_id': 'household-full-name',
-            'group_id': 'multiple-questions-group',
-            'group_instance': 0,
-            'answer_instance': 0
-        },
-        {
-            'value': 'Fred Flintstone',
-            'block_id': 'household-composition',
-            'answer_id': 'household-full-name',
-            'group_id': 'multiple-questions-group',
-            'group_instance': 0,
-            'answer_instance': 1
-        },
-        {
-            'value': 'Husband or wife',
-            'block_id': 'relationships',
-            'answer_id': 'who-is-related',
-            'group_id': 'household-relationships',
-            'group_instance': 0,
-            'answer_instance': 0
-        }
-    ]
-    :param answer_store: questionnaire answers
-    :param routing_path: the path followed in the questionnaire
-    :return: data in a formatted form
-    """
-    data = []
-    for location in routing_path:
-        answer_ids = schema.get_answer_ids_for_block(location.block_id)
-        answers_in_block = answer_store.filter(answer_ids, location.group_instance)
-        data.extend(answers_in_block)
-    return data
 
 
 def _build_collection(metadata):
@@ -214,14 +91,6 @@ def _build_metadata(metadata):
         downstream_metadata['ref_period_end_date'] = metadata['ref_p_end_date']
 
     return downstream_metadata
-
-
-def _encode_value(value):
-    if isinstance(value, str):
-        if value == '':
-            return None
-        return value
-    return str(value)
 
 
 def convert_feedback(message, name, email, url, metadata, survey_id):

--- a/tests/app/submitter/test_convert_payload_0_0_1.py
+++ b/tests/app/submitter/test_convert_payload_0_0_1.py
@@ -1,0 +1,955 @@
+from app.data_model.answer_store import AnswerStore
+from app.questionnaire.questionnaire_schema import QuestionnaireSchema
+from app.questionnaire.location import Location
+from app.submitter.converter import convert_answers
+from app.submitter.convert_payload_0_0_1 import convert_answers_to_payload_0_0_1
+from tests.app.submitter.test_converter import TestConverter, create_answer
+
+
+class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-methods
+
+    def test_convert_answers_to_payload_0_0_1_with_key_error(self):
+        with self._app.test_request_context():
+            user_answer = [create_answer('ABC', '2016-01-01', group_id='group-1', block_id='block-1'),
+                           create_answer('DEF', '2016-03-30', group_id='group-1', block_id='block-1'),
+                           create_answer('GHI', '2016-05-30', group_id='group-1', block_id='block-1')]
+
+            questionnaire = {
+                'survey_id': '021',
+                'data_version': '0.0.1',
+                'sections': [
+                    {
+                        'id': 'section-1',
+                        'groups': [
+                            {
+                                'id': 'group-1',
+                                'blocks': [
+                                    {
+                                        'id': 'block-1',
+                                        'questions': [
+                                            {
+                                                'id': 'question-1',
+                                                'answers': [
+                                                    {
+                                                        'id': 'LMN',
+                                                        'type': 'TextField',
+                                                        'q_code': '001'
+                                                    },
+                                                    {
+                                                        'id': 'DEF',
+                                                        'type': 'TextField',
+                                                        'q_code': '002'
+                                                    },
+                                                    {
+                                                        'id': 'JKL',
+                                                        'type': 'TextField',
+                                                        'q_code': '003'
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            routing_path = [Location(group_id='group-1', group_instance=0, block_id='block-1')]
+            answer_object = (convert_answers_to_payload_0_0_1(AnswerStore(user_answer), QuestionnaireSchema(questionnaire), routing_path))
+            self.assertEqual(answer_object['002'], '2016-03-30')
+            self.assertEqual(len(answer_object), 1)
+
+    def test_answer_with_zero(self):
+        with self._app.test_request_context():
+            user_answer = [create_answer('GHI', 0, group_id='group-1', block_id='block-1')]
+
+            questionnaire = {
+                'survey_id': '021',
+                'data_version': '0.0.1',
+                'sections': [
+                    {
+                        'id': 'section-1',
+                        'groups': [
+                            {
+                                'id': 'group-1',
+                                'blocks': [
+                                    {
+                                        'id': 'block-1',
+                                        'questions': [
+                                            {
+                                                'id': 'question-2',
+                                                'answers': [
+                                                    {
+                                                        'id': 'GHI',
+                                                        'type': 'TextField',
+                                                        'q_code': '003'
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            routing_path = [Location(group_id='group-1', group_instance=0, block_id='block-1')]
+
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+
+            # Check the converter correctly
+            self.assertEqual('0', answer_object['data']['003'])
+
+    def test_answer_with_float(self):
+        with self._app.test_request_context():
+            user_answer = [create_answer('GHI', 10.02, group_id='group-1', block_id='block-1')]
+
+            questionnaire = {
+                'survey_id': '021',
+                'data_version': '0.0.1',
+                'sections': [
+                    {
+                        'id': 'section-1',
+                        'groups': [
+                            {
+                                'id': 'group-1',
+                                'blocks': [
+                                    {
+                                        'id': 'block-1',
+                                        'questions': [
+                                            {
+                                                'id': 'question-2',
+                                                'answers': [
+                                                    {
+                                                        'id': 'GHI',
+                                                        'type': 'TextField',
+                                                        'q_code': '003'
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            routing_path = [Location(group_id='group-1', group_instance=0, block_id='block-1')]
+
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+
+            # Check the converter correctly
+            self.assertEqual('10.02', answer_object['data']['003'])
+
+    def test_answer_with_string(self):
+        with self._app.test_request_context():
+            user_answer = [create_answer('GHI', 'String test + !', group_id='group-1', block_id='block-1')]
+
+            questionnaire = {
+                'survey_id': '021',
+                'data_version': '0.0.1',
+                'sections': [
+                    {
+                        'id': 'section-1',
+                        'groups': [
+                            {
+                                'id': 'group-1',
+                                'blocks': [
+                                    {
+                                        'id': 'block-1',
+                                        'questions': [
+                                            {
+                                                'id': 'question-2',
+                                                'answers': [
+                                                    {
+                                                        'id': 'GHI',
+                                                        'type': 'TextField',
+                                                        'q_code': '003'
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            routing_path = [Location(group_id='group-1', group_instance=0, block_id='block-1')]
+
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+
+            # Check the converter correctly
+            self.assertEqual('String test + !', answer_object['data']['003'])
+
+    def test_answer_with_multiple_instances(self):
+        with self._app.test_request_context():
+            user_answer = [create_answer('GHI', 0, group_id='group-1', block_id='block-1'),
+                           create_answer('GHI', value=1, answer_instance=1, group_id='group-1', block_id='block-1'),
+                           create_answer('GHI', value=2, answer_instance=2, group_id='group-1', block_id='block-1')]
+
+            questionnaire = {
+                'survey_id': '021',
+                'data_version': '0.0.1',
+                'sections': [
+                    {
+                        'id': 'section-1',
+                        'groups': [
+                            {
+                                'id': 'group-1',
+                                'blocks': [
+                                    {
+                                        'id': 'block-1',
+                                        'questions': [
+                                            {
+                                                'id': 'question-2',
+                                                'answers': [
+                                                    {
+                                                        'id': 'GHI',
+                                                        'type': 'TextField',
+                                                        'q_code': '003'
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            routing_path = [Location(group_id='group-1', group_instance=0, block_id='block-1')]
+
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+
+            # Check the converter correctly
+            self.assertEqual(answer_object['data']['003'], ['0', '1', '2'])
+
+    def test_get_checkbox_answer_with_duplicate_child_answer_ids(self):
+        with self._app.test_request_context():
+            routing_path = [Location(group_id='favourite-food', group_instance=0, block_id='crisps')]
+            answers = [create_answer('crisps-answer', [
+                'Ready salted',
+                'Other'
+            ], group_id='favourite-food', block_id='crisps')]
+
+            answers += [create_answer('other-answer-mandatory', 'Other', group_id='favourite-food', block_id='crisps',
+                                      group_instance=1)]
+            answers += [create_answer('other-answer-mandatory', 'Other', group_id='favourite-food', block_id='crisps',
+                                      group_instance=1)]
+
+            questionnaire = {
+                'survey_id': '999',
+                'data_version': '0.0.1',
+                'sections': [
+                    {
+                        'id': 'favourite-food-section',
+                        'groups': [
+                            {
+                                'id': 'favourite-food',
+                                'blocks': [
+                                    {
+                                        'id': 'crisps',
+                                        'questions': [
+                                            {
+                                                'id': 'crisps-question',
+                                                'answers': [
+                                                    {
+                                                        'id': 'crisps-answer',
+                                                        'type': 'Checkbox',
+                                                        'options': [
+                                                            {
+                                                                'label': 'Other',
+                                                                'q_code': '4',
+                                                                'description': 'Choose any other flavour',
+                                                                'value': 'Other',
+                                                                'child_answer_id': 'other-answer-mandatory'
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+        with self.assertRaises(Exception) as err:
+            convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
+        self.assertEqual('Multiple answers found for {}'.format('other-answer-mandatory'), str(err.exception))
+
+    def test_converter_checkboxes_with_q_codes(self):
+        with self._app.test_request_context():
+            routing_path = [Location(group_id='favourite-food', group_instance=0, block_id='crisps')]
+            answers = [create_answer('crisps-answer', [
+                'Ready salted',
+                'Sweet chilli'
+            ], group_id='favourite-food', block_id='crisps')]
+
+            questionnaire = {
+                'survey_id': '999',
+                'data_version': '0.0.1',
+                'sections': [
+                    {
+                        'id': 'favourite-food-section',
+                        'groups': [
+                            {
+                                'id': 'favourite-food',
+                                'blocks': [
+                                    {
+                                        'id': 'crisps',
+                                        'questions': [
+                                            {
+                                                'id': 'crisps-question',
+                                                'answers': [
+                                                    {
+                                                        'id': 'crisps-answer',
+                                                        'type': 'Checkbox',
+                                                        'options': [
+                                                            {
+                                                                'label': 'Ready salted',
+                                                                'value': 'Ready salted',
+                                                                'q_code': '1'
+                                                            },
+                                                            {
+                                                                'label': 'Sweet chilli',
+                                                                'value': 'Sweet chilli',
+                                                                'q_code': '2'
+                                                            },
+                                                            {
+                                                                'label': 'Cheese and onion',
+                                                                'value': 'Cheese and onion',
+                                                                'q_code': '3'
+                                                            },
+                                                            {
+                                                                'label': 'Other',
+                                                                'q_code': '4',
+                                                                'description': 'Choose any other flavour',
+                                                                'value': 'Other',
+                                                                'child_answer_id': 'other-answer-mandatory'
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        'parent_answer_id': 'crisps-answer',
+                                                        'mandatory': True,
+                                                        'id': 'other-answer-mandatory',
+                                                        'label': 'Please specify other',
+                                                        'type': 'TextField'
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            # When
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 2)
+            self.assertEqual(answer_object['data']['1'], 'Ready salted')
+            self.assertEqual(answer_object['data']['2'], 'Sweet chilli')
+
+    def test_converter_checkboxes_with_q_codes_and_other_value(self):
+        with self._app.test_request_context():
+            routing_path = [Location(group_id='favourite-food', group_instance=0, block_id='crisps')]
+            answers = [create_answer('crisps-answer', [
+                'Ready salted',
+                'Other'
+            ], group_id='favourite-food', block_id='crisps')]
+
+            answers += [create_answer('other-answer-mandatory', 'Bacon', group_id='favourite-food', block_id='crisps')]
+
+            questionnaire = {
+                'survey_id': '999',
+                'data_version': '0.0.1',
+                'sections': [
+                    {
+                        'id': 'favourite-food-section',
+                        'groups': [
+                            {
+                                'id': 'favourite-food',
+                                'blocks': [
+                                    {
+                                        'id': 'crisps',
+                                        'questions': [
+                                            {
+                                                'id': 'crisps-question',
+                                                'answers': [
+                                                    {
+                                                        'id': 'crisps-answer',
+                                                        'type': 'Checkbox',
+                                                        'options': [
+                                                            {
+                                                                'label': 'Ready salted',
+                                                                'value': 'Ready salted',
+                                                                'q_code': '1'
+                                                            },
+                                                            {
+                                                                'label': 'Sweet chilli',
+                                                                'value': 'Sweet chilli',
+                                                                'q_code': '2'
+                                                            },
+                                                            {
+                                                                'label': 'Cheese and onion',
+                                                                'value': 'Cheese and onion',
+                                                                'q_code': '3'
+                                                            },
+                                                            {
+                                                                'label': 'Other',
+                                                                'q_code': '4',
+                                                                'description': 'Choose any other flavour',
+                                                                'value': 'Other',
+                                                                'child_answer_id': 'other-answer-mandatory'
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        'parent_answer_id': 'crisps-answer',
+                                                        'mandatory': True,
+                                                        'id': 'other-answer-mandatory',
+                                                        'label': 'Please specify other',
+                                                        'type': 'TextField'
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            # When
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 2)
+            self.assertEqual(answer_object['data']['1'], 'Ready salted')
+            self.assertEqual(answer_object['data']['4'], 'Other')
+
+    def test_converter_q_codes_for_empty_strings(self):
+        with self._app.test_request_context():
+            routing_path = [Location(group_id='favourite-food', group_instance=0, block_id='crisps')]
+            answers = [create_answer('crisps-answer', '', group_id='favourite-food', block_id='crisps')]
+            answers += [
+                create_answer('other-crisps-answer', 'Ready salted', group_id='favourite-food', block_id='crisps')]
+
+            questionnaire = {
+                'survey_id': '999',
+                'data_version': '0.0.1',
+                'sections': [
+                    {
+                        'id': 'favourite-food-section',
+                        'groups': [
+                            {
+                                'id': 'favourite-food',
+                                'blocks': [
+                                    {
+                                        'id': 'crisps',
+                                        'questions': [
+                                            {
+                                                'id': 'crisps-question',
+                                                'answers': [
+                                                    {
+                                                        'id': 'crisps-answer',
+                                                        'type': 'TextArea',
+                                                        'options': [],
+                                                        'q_code': '1'
+                                                    },
+                                                    {
+                                                        'id': 'other-crisps-answer',
+                                                        'type': 'TextArea',
+                                                        'options': [],
+                                                        'q_code': '2'
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            # When
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 1)
+            self.assertEqual(answer_object['data']['2'], 'Ready salted')
+
+    def test_radio_answer(self):
+        with self._app.test_request_context():
+            routing_path = [Location(group_id='radio-group', group_instance=0, block_id='radio-block')]
+            user_answer = [create_answer('radio-answer', 'Coffee', group_id='radio-group', block_id='radio-block')]
+
+            questionnaire = {
+                'data_version': '0.0.1',
+                'survey_id': '0',
+                'sections': [
+                    {
+                        'id': 'radio-section',
+                        'groups': [
+                            {
+                                'id': 'radio-group',
+                                'blocks': [
+                                    {
+                                        'id': 'radio-block',
+                                        'questions': [
+                                            {
+                                                'id': 'radio-question',
+                                                'answers': [
+                                                    {
+                                                        'type': 'Radio',
+                                                        'id': 'radio-answer',
+                                                        'q_code': '1',
+                                                        'options': [
+                                                            {
+                                                                'label': 'Coffee',
+                                                                'value': 'Coffee'
+                                                            },
+                                                            {
+                                                                'label': 'Tea',
+                                                                'value': 'Tea'
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            # When
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 1)
+            self.assertEqual(answer_object['data']['1'], 'Coffee')
+
+    def test_number_answer(self):
+        with self._app.test_request_context():
+            routing_path = [Location(group_id='number-group', group_instance=0, block_id='number-block')]
+            user_answer = [create_answer('number-answer', 0.9999, group_id='number-block', block_id='number-block')]
+
+            questionnaire = {
+                'data_version': '0.0.1',
+                'survey_id': '0',
+                'sections': [
+                    {
+                        'id': 'number-section',
+                        'groups': [
+                            {
+                                'id': 'number-group',
+                                'blocks': [
+                                    {
+                                        'id': 'number-block',
+                                        'questions': [
+                                            {
+                                                'id': 'number-question',
+                                                'answers': [
+                                                    {
+                                                        'id': 'number-answer',
+                                                        'type': 'Number',
+                                                        'q_code': '1'
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            # When
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 1)
+            self.assertEqual(answer_object['data']['1'], '0.9999')
+
+    def test_percentage_answer(self):
+        with self._app.test_request_context():
+            routing_path = [Location(group_id='percentage-group', group_instance=0, block_id='percentage-block')]
+            user_answer = [create_answer('percentage-answer', 100, group_id='percentage-group', block_id='percentage-block')]
+
+            questionnaire = {
+                'data_version': '0.0.1',
+                'survey_id': '0',
+                'sections': [
+                    {
+                        'id': 'percentage-section',
+                        'groups': [
+                            {
+                                'id': 'percentage-group',
+                                'blocks': [
+                                    {
+                                        'id': 'percentage-block',
+                                        'questions': [
+                                            {
+                                                'id': 'percentage-question',
+                                                'answers': [
+                                                    {
+                                                        'id': 'percentage-answer',
+                                                        'type': 'Percentage',
+                                                        'q_code': '1'
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            # When
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 1)
+            self.assertEqual(answer_object['data']['1'], '100')
+
+    def test_textarea_answer(self):
+        with self._app.test_request_context():
+            routing_path = [Location(group_id='textarea-group', group_instance=0, block_id='textarea-block')]
+            user_answer = [create_answer('textarea-answer', 'example text.', group_id='textarea-group', block_id='textarea-block')]
+
+            questionnaire = {
+                'data_version': '0.0.1',
+                'survey_id': '0',
+                'sections': [
+                    {
+                        'id': 'textarea-section',
+                        'groups': [
+                            {
+                                'id': 'textarea-group',
+                                'blocks': [
+                                    {
+                                        'id': 'textarea-block',
+                                        'questions': [
+                                            {
+                                                'id': 'textarea-question',
+                                                'answers': [
+                                                    {
+                                                        'id': 'textarea-answer',
+                                                        'q_code': '1',
+                                                        'type': 'TextArea'
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            # When
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 1)
+            self.assertEqual(answer_object['data']['1'], 'example text.')
+
+    def test_currency_answer(self):
+        with self._app.test_request_context():
+            routing_path = [Location(group_id='currency-group', group_instance=0, block_id='currency-block')]
+            user_answer = [create_answer('currency-answer', 99.99, group_id='currency-group', block_id='currency-block')]
+
+            questionnaire = {
+                'data_version': '0.0.1',
+                'survey_id': '0',
+                'sections': [
+                    {
+                        'id': 'currency-section',
+                        'groups': [
+                            {
+                                'id': 'currency-group',
+                                'blocks': [
+                                    {
+                                        'id': 'currency-block',
+                                        'questions': [
+                                            {
+                                                'id': 'currency-question',
+                                                'answers': [
+                                                    {
+                                                        'id': 'currency-answer',
+                                                        'type': 'Currency',
+                                                        'q_code': '1'
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            # When
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 1)
+            self.assertEqual(answer_object['data']['1'], '99.99')
+
+    def test_dropdown_answer(self):
+        with self._app.test_request_context():
+            routing_path = [Location(group_id='dropdown-group', group_instance=0, block_id='dropdown-block')]
+            user_answer = [create_answer('dropdown-answer', 'Liverpool', group_id='dropdown-group', block_id='dropdown-block')]
+
+            questionnaire = {
+                'data_version': '0.0.1',
+                'survey_id': '0',
+                'sections': [
+                    {
+                        'id': 'dropdown-section',
+                        'groups': [
+                            {
+                                'id': 'dropdown-group',
+                                'blocks': [
+                                    {
+                                        'id': 'dropdown-block',
+                                        'questions': [
+                                            {
+                                                'id': 'dropdown-question',
+                                                'answers': [
+                                                    {
+                                                        'id': 'dropdown-answer',
+                                                        'type': 'Dropdown',
+                                                        'q_code': '1',
+                                                        'options': [
+                                                            {
+                                                                'label': 'Liverpool',
+                                                                'value': 'Liverpool'
+                                                            },
+                                                            {
+                                                                'label': 'Chelsea',
+                                                                'value': 'Chelsea'
+                                                            },
+                                                            {
+                                                                'label': 'Rugby is better!',
+                                                                'value': 'Rugby is better!'
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            # When
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 1)
+            self.assertEqual(answer_object['data']['1'], 'Liverpool')
+
+    def test_date_answer(self):
+        with self._app.test_request_context():
+            routing_path = [Location(group_id='date-group', group_instance=0, block_id='date-block')]
+            user_answer = [create_answer('single-date-answer', '1990-02-01', group_id='date-group', block_id='date-block'),
+                           create_answer('month-year-answer', '1990-01', group_id='date-group', block_id='date-block')]
+
+            questionnaire = {
+                'data_version': '0.0.1',
+                'survey_id': '0',
+                'sections': [
+                    {
+                        'id': 'date-section',
+                        'groups': [
+                            {
+                                'id': 'date-group',
+                                'blocks': [
+                                    {
+                                        'id': 'date-block',
+                                        'questions': [
+                                            {
+                                                'id': 'single-date-question',
+                                                'answers': [
+                                                    {
+                                                        'id': 'single-date-answer',
+                                                        'type': 'Date',
+                                                        'q_code': '1'
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                'id': 'month-year-question',
+                                                'answers': [
+                                                    {
+                                                        'id': 'month-year-answer',
+                                                        'type': 'MonthYearDate',
+                                                        'q_code': '2'
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+            # When
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 2)
+            self.assertEqual(answer_object['data']['1'], '01/02/1990')
+            self.assertEqual(answer_object['data']['2'], '01/1990')
+
+    def test_unit_answer(self):
+        with self._app.test_request_context():
+            routing_path = [Location(group_id='unit-group', group_instance=0, block_id='unit-block')]
+            user_answer = [create_answer('unit-answer', 10, group_id='unit-group', block_id='unit-block')]
+
+            questionnaire = {
+                'data_version': '0.0.1',
+                'survey_id': '0',
+                'sections': [
+                    {
+                        'id': 'unit-section',
+                        'groups': [
+                            {
+                                'id': 'unit-group',
+                                'blocks': [
+                                    {
+                                        'id': 'unit-block',
+                                        'questions': [
+                                            {
+                                                'id': 'unit-question',
+                                                'answers': [
+                                                    {
+                                                        'id': 'unit-answer',
+                                                        'type': 'Unit',
+                                                        'q_code': '1'
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            # When
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 1)
+            self.assertEqual(answer_object['data']['1'], '10')
+
+    def test_relationship_answer(self):
+        with self._app.test_request_context():
+            routing_path = [Location(group_id='relationship-group', group_instance=0, block_id='relationship-block')]
+            user_answer = [create_answer('relationship-answer', 'Unrelated', group_id='relationship-group', block_id='relationship-block'),
+                           create_answer('relationship-answer', 'Partner', group_id='relationship-group', block_id='relationship-block',
+                                         answer_instance=1),
+                           create_answer('relationship-answer', 'Husband or wife', group_id='relationship-group', block_id='relationship-block',
+                                         answer_instance=2)]
+
+            questionnaire = {
+                'data_version': '0.0.1',
+                'survey_id': '0',
+                'sections': [
+                    {
+                        'id': 'relationship-section',
+                        'groups': [
+                            {
+                                'id': 'relationship-group',
+                                'blocks': [
+                                    {
+                                        'type': 'Question',
+                                        'id': 'relationship-block',
+                                        'questions': [
+                                            {
+                                                'id': 'relationship-question',
+                                                'type': 'Relationship',
+                                                'answers': [
+                                                    {
+                                                        'id': 'relationship-answer',
+                                                        'q_code': '1',
+                                                        'type': 'Relationship',
+                                                        'options': [
+                                                            {
+                                                                'label': 'Husband or wife',
+                                                                'value': 'Husband or wife'
+                                                            },
+                                                            {
+                                                                'label': 'Partner',
+                                                                'value': 'Partner'
+                                                            },
+                                                            {
+                                                                'label': 'Unrelated',
+                                                                'value': 'Unrelated'
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            # When
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 1)
+            self.assertEqual(answer_object['data']['1'], ['Unrelated', 'Partner', 'Husband or wife'])

--- a/tests/app/submitter/test_convert_payload_0_0_2.py
+++ b/tests/app/submitter/test_convert_payload_0_0_2.py
@@ -1,0 +1,657 @@
+from app.data_model.answer_store import AnswerStore
+from app.questionnaire.questionnaire_schema import QuestionnaireSchema
+from app.questionnaire.location import Location
+from app.submitter.converter import convert_answers
+from tests.app.submitter.test_converter import TestConverter, create_answer
+
+
+class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-methods
+
+    def test_convert_answers_to_payload_0_0_2(self):
+        with self._app.test_request_context():
+            routing_path = [Location(group_id='personal details', group_instance=0, block_id='about you'),
+                            Location(group_id='household', group_instance=0, block_id='where you live'),
+                            Location(group_id='household', group_instance=1, block_id='where you live')]
+            answers = [create_answer('name', 'Joe Bloggs', group_id='personal details', block_id='about you'),
+                       create_answer('name', 'Fred Bloggs', group_id='personal details', block_id='about you',
+                                     answer_instance=1),
+                       create_answer('address', '62 Somewhere', group_id='household', block_id='where you live'),
+                       create_answer('address', '63 Somewhere', group_id='household', block_id='where you live',
+                                     group_instance=1)]
+
+            questionnaire = {
+                'survey_id': '021',
+                'data_version': '0.0.2',
+                'sections': [
+                    {
+                        'id': 'household-section',
+                        'groups': [
+                            {
+                                'id': 'personal details',
+                                'blocks': [
+                                    {
+                                        'id': 'about you',
+                                        'questions': [
+                                            {
+                                                'id': 'crisps-question',
+                                                'answers': [
+                                                    {
+                                                        'id': 'name',
+                                                        'type': 'TextField'
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                'id': 'household',
+                                'blocks': [
+                                    {
+                                        'id': 'where you live',
+                                        'questions': [
+                                            {
+                                                'id': 'crisps-question',
+                                                'answers': [
+                                                    {
+                                                        'id': 'address',
+                                                        'type': 'TextField'
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            # When
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 4)
+            self.assertEqual(answer_object['data'][0]['group_id'], 'personal details')
+            self.assertEqual(answer_object['data'][0]['group_instance'], 0)
+            self.assertEqual(answer_object['data'][0]['block_id'], 'about you')
+            self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
+            self.assertEqual(answer_object['data'][0]['value'], 'Joe Bloggs')
+
+            self.assertEqual(answer_object['data'][1]['group_id'], 'personal details')
+            self.assertEqual(answer_object['data'][1]['group_instance'], 0)
+            self.assertEqual(answer_object['data'][1]['block_id'], 'about you')
+            self.assertEqual(answer_object['data'][1]['answer_instance'], 1)
+            self.assertEqual(answer_object['data'][1]['value'], 'Fred Bloggs')
+
+            self.assertEqual(answer_object['data'][2]['group_id'], 'household')
+            self.assertEqual(answer_object['data'][2]['group_instance'], 0)
+            self.assertEqual(answer_object['data'][2]['block_id'], 'where you live')
+            self.assertEqual(answer_object['data'][2]['answer_instance'], 0)
+            self.assertEqual(answer_object['data'][2]['value'], '62 Somewhere')
+
+            self.assertEqual(answer_object['data'][3]['group_id'], 'household')
+            self.assertEqual(answer_object['data'][3]['group_instance'], 1)
+            self.assertEqual(answer_object['data'][3]['block_id'], 'where you live')
+            self.assertEqual(answer_object['data'][3]['answer_instance'], 0)
+            self.assertEqual(answer_object['data'][3]['value'], '63 Somewhere')
+
+    def test_convert_payload_0_0_2_multiple_answers(self):
+        with self._app.test_request_context():
+            routing_path = [Location(group_id='favourite-food', group_instance=0, block_id='crisps')]
+            answers = [
+                create_answer('crisps-answer', ['Ready salted', 'Sweet chilli'], group_id='favourite-food', block_id='crisps')]
+
+            questionnaire = {
+                'survey_id': '021',
+                'data_version': '0.0.2',
+                'sections': [
+                    {
+                        'id': 'favourite-food-section',
+                        'groups': [
+                            {
+                                'id': 'favourite-food',
+                                'blocks': [
+                                    {
+                                        'id': 'crisps',
+                                        'questions': [
+                                            {
+                                                'id': 'crisps-question',
+                                                'answers': [
+                                                    {
+                                                        'id': 'crisps-answer',
+                                                        'type': 'Checkbox',
+                                                        'options': [
+                                                            {
+                                                                'label': 'Ready salted',
+                                                                'value': 'Ready salted'
+                                                            },
+                                                            {
+                                                                'label': 'Sweet chilli',
+                                                                'value': 'Sweet chilli'
+                                                            },
+                                                            {
+                                                                'label': 'Cheese and onion',
+                                                                'value': 'Cheese and onion'
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            # When
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 1)
+            self.assertEqual(answer_object['data'][0]['group_id'], 'favourite-food')
+            self.assertEqual(answer_object['data'][0]['group_instance'], 0)
+            self.assertEqual(answer_object['data'][0]['block_id'], 'crisps')
+            self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
+            self.assertEqual(answer_object['data'][0]['value'], ['Ready salted', 'Sweet chilli'])
+
+    def test_radio_answer(self):
+        with self._app.test_request_context():
+            routing_path = [Location(group_id='radio-group', group_instance=0, block_id='radio-block')]
+            user_answer = [create_answer('radio-answer', 'Coffee', group_id='radio-group', block_id='radio-block')]
+
+            questionnaire = {
+                'data_version': '0.0.2',
+                'survey_id': '0',
+                'sections': [
+                    {
+                        'id': 'radio-section',
+                        'groups': [
+                            {
+                                'id': 'radio-group',
+                                'blocks': [
+                                    {
+                                        'id': 'radio-block',
+                                        'questions': [
+                                            {
+                                                'id': 'radio-question',
+                                                'answers': [
+                                                    {
+                                                        'type': 'Radio',
+                                                        'id': 'radio-answer',
+                                                        'options': [
+                                                            {
+                                                                'label': 'Coffee',
+                                                                'value': 'Coffee'
+                                                            },
+                                                            {
+                                                                'label': 'Tea',
+                                                                'value': 'Tea'
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            # When
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 1)
+            self.assertEqual(answer_object['data'][0]['value'], 'Coffee')
+            self.assertEqual(answer_object['data'][0]['group_id'], 'radio-group')
+            self.assertEqual(answer_object['data'][0]['block_id'], 'radio-block')
+            self.assertEqual(answer_object['data'][0]['group_instance'], 0)
+            self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
+
+    def test_number_answer(self):
+        with self._app.test_request_context():
+            routing_path = [Location(group_id='number-group', group_instance=0, block_id='number-block')]
+            user_answer = [create_answer('number-answer', 1.755, group_id='number-group', block_id='number-block')]
+
+            questionnaire = {
+                'data_version': '0.0.2',
+                'survey_id': '0',
+                'sections': [
+                    {
+                        'id': 'number-section',
+                        'groups': [
+                            {
+                                'id': 'number-group',
+                                'blocks': [
+                                    {
+                                        'id': 'number-block',
+                                        'questions': [
+                                            {
+                                                'id': 'number-question',
+                                                'answers': [
+                                                    {
+                                                        'id': 'number-answer',
+                                                        'type': 'Number'
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            # When
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 1)
+            self.assertEqual(answer_object['data'][0]['value'], 1.755)
+            self.assertEqual(answer_object['data'][0]['group_id'], 'number-group')
+            self.assertEqual(answer_object['data'][0]['block_id'], 'number-block')
+            self.assertEqual(answer_object['data'][0]['group_instance'], 0)
+            self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
+
+    def test_percentage_answer(self):
+        with self._app.test_request_context():
+            routing_path = [Location(group_id='percentage-group', group_instance=0, block_id='percentage-block')]
+            user_answer = [create_answer('percentage-answer', 99, group_id='percentage-group', block_id='percentage-block')]
+
+            questionnaire = {
+                'data_version': '0.0.2',
+                'survey_id': '0',
+                'sections': [
+                    {
+                        'id': 'percentage-section',
+                        'groups': [
+                            {
+                                'id': 'percentage-group',
+                                'blocks': [
+                                    {
+                                        'id': 'percentage-block',
+                                        'questions': [
+                                            {
+                                                'id': 'percentage-question',
+                                                'answers': [
+                                                    {
+                                                        'id': 'percentage-answer',
+                                                        'type': 'Percentage'
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            # When
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 1)
+            self.assertEqual(answer_object['data'][0]['value'], 99)
+            self.assertEqual(answer_object['data'][0]['group_id'], 'percentage-group')
+            self.assertEqual(answer_object['data'][0]['block_id'], 'percentage-block')
+            self.assertEqual(answer_object['data'][0]['group_instance'], 0)
+            self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
+
+    def test_textarea_answer(self):
+        with self._app.test_request_context():
+            routing_path = [Location(group_id='textarea-group', group_instance=0, block_id='textarea-block')]
+            user_answer = [create_answer('textarea-answer', 'This is an example text!', group_id='textarea-group', block_id='textarea-block')]
+
+            questionnaire = {
+                'data_version': '0.0.2',
+                'survey_id': '0',
+                'sections': [
+                    {
+                        'id': 'textarea-section',
+                        'groups': [
+                            {
+                                'id': 'textarea-group',
+                                'blocks': [
+                                    {
+                                        'id': 'textarea-block',
+                                        'questions': [
+                                            {
+                                                'id': 'textarea-question',
+                                                'answers': [
+                                                    {
+                                                        'id': 'textarea-answer',
+                                                        'type': 'TextArea'
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            # When
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 1)
+            self.assertEqual(answer_object['data'][0]['value'], 'This is an example text!')
+            self.assertEqual(answer_object['data'][0]['group_id'], 'textarea-group')
+            self.assertEqual(answer_object['data'][0]['block_id'], 'textarea-block')
+            self.assertEqual(answer_object['data'][0]['group_instance'], 0)
+            self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
+
+    def test_currency_answer(self):
+        with self._app.test_request_context():
+            routing_path = [Location(group_id='currency-group', group_instance=0, block_id='currency-block')]
+            user_answer = [create_answer('currency-answer', 100, group_id='currency-group', block_id='currency-block')]
+
+            questionnaire = {
+                'data_version': '0.0.2',
+                'survey_id': '0',
+                'sections': [
+                    {
+                        'id': 'currency-section',
+                        'groups': [
+                            {
+                                'id': 'currency-group',
+                                'blocks': [
+                                    {
+                                        'id': 'currency-block',
+                                        'questions': [
+                                            {
+                                                'id': 'currency-question',
+                                                'answers': [
+                                                    {
+                                                        'id': 'currency-answer',
+                                                        'type': 'Currency'
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            # When
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 1)
+            self.assertEqual(answer_object['data'][0]['value'], 100)
+            self.assertEqual(answer_object['data'][0]['group_id'], 'currency-group')
+            self.assertEqual(answer_object['data'][0]['block_id'], 'currency-block')
+            self.assertEqual(answer_object['data'][0]['group_instance'], 0)
+            self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
+
+    def test_dropdown_answer(self):
+        with self._app.test_request_context():
+            routing_path = [Location(group_id='dropdown-group', group_instance=0, block_id='dropdown-block')]
+            user_answer = [create_answer('dropdown-answer', 'Rugby is better!', group_id='dropdown-group', block_id='dropdown-block')]
+
+            questionnaire = {
+                'data_version': '0.0.2',
+                'survey_id': '0',
+                'sections': [
+                    {
+                        'id': 'dropdown-section',
+                        'groups': [
+                            {
+                                'id': 'dropdown-group',
+                                'blocks': [
+                                    {
+                                        'id': 'dropdown-block',
+                                        'questions': [
+                                            {
+                                                'id': 'dropdown-question',
+                                                'answers': [
+                                                    {
+                                                        'id': 'dropdown-answer',
+                                                        'type': 'Dropdown',
+                                                        'options': [
+                                                            {
+                                                                'label': 'Liverpool',
+                                                                'value': 'Liverpool'
+                                                            },
+                                                            {
+                                                                'label': 'Chelsea',
+                                                                'value': 'Chelsea'
+                                                            },
+                                                            {
+                                                                'label': 'Rugby is better!',
+                                                                'value': 'Rugby is better!'
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            # When
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 1)
+            self.assertEqual(answer_object['data'][0]['value'], 'Rugby is better!')
+            self.assertEqual(answer_object['data'][0]['group_id'], 'dropdown-group')
+            self.assertEqual(answer_object['data'][0]['block_id'], 'dropdown-block')
+            self.assertEqual(answer_object['data'][0]['group_instance'], 0)
+            self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
+
+    def test_date_answer(self):
+        with self._app.test_request_context():
+            routing_path = [Location(group_id='date-group', group_instance=0, block_id='date-block')]
+            user_answer = [create_answer('single-date-answer', '01-01-1990', group_id='date-group', block_id='date-block'),
+                           create_answer('month-year-answer', '01-1990', group_id='date-group', block_id='date-block')]
+
+            questionnaire = {
+                'data_version': '0.0.2',
+                'survey_id': '0',
+                'sections': [
+                    {
+                        'id': 'date-section',
+                        'groups': [
+                            {
+                                'id': 'date-group',
+                                'blocks': [
+                                    {
+                                        'id': 'date-block',
+                                        'questions': [
+                                            {
+                                                'id': 'single-date-question',
+                                                'answers': [
+                                                    {
+                                                        'id': 'single-date-answer',
+                                                        'type': 'Date'
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                'id': 'month-year-question',
+                                                'answers': [
+                                                    {
+                                                        'id': 'month-year-answer',
+                                                        'type': 'MonthYearDate'
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            # When
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 2)
+            self.assertEqual(answer_object['data'][0]['value'], '01-01-1990')
+            self.assertEqual(answer_object['data'][0]['group_id'], 'date-group')
+            self.assertEqual(answer_object['data'][0]['block_id'], 'date-block')
+            self.assertEqual(answer_object['data'][0]['group_instance'], 0)
+            self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
+
+            self.assertEqual(answer_object['data'][1]['value'], '01-1990')
+            self.assertEqual(answer_object['data'][1]['group_id'], 'date-group')
+            self.assertEqual(answer_object['data'][1]['block_id'], 'date-block')
+            self.assertEqual(answer_object['data'][1]['group_instance'], 0)
+            self.assertEqual(answer_object['data'][1]['answer_instance'], 0)
+
+    def test_unit_answer(self):
+        with self._app.test_request_context():
+            routing_path = [Location(group_id='unit-group', group_instance=0, block_id='unit-block')]
+            user_answer = [create_answer('unit-answer', 10, group_id='unit-group', block_id='unit-block')]
+
+            questionnaire = {
+                'data_version': '0.0.2',
+                'survey_id': '0',
+                'sections': [
+                    {
+                        'id': 'unit-section',
+                        'groups': [
+                            {
+                                'id': 'unit-group',
+                                'blocks': [
+                                    {
+                                        'id': 'unit-block',
+                                        'questions': [
+                                            {
+                                                'id': 'unit-question',
+                                                'answers': [
+                                                    {
+                                                        'id': 'unit-answer',
+                                                        'type': 'Unit'
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            # When
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 1)
+            self.assertEqual(answer_object['data'][0]['value'], 10)
+            self.assertEqual(answer_object['data'][0]['group_id'], 'unit-group')
+            self.assertEqual(answer_object['data'][0]['block_id'], 'unit-block')
+            self.assertEqual(answer_object['data'][0]['group_instance'], 0)
+            self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
+
+    def test_relationship_answer(self):
+        with self._app.test_request_context():
+            routing_path = [Location(group_id='relationship-group', group_instance=0, block_id='relationship-block')]
+            user_answer = [create_answer('relationship-answer', 'Unrelated', group_id='relationship-group', block_id='relationship-block'),
+                           create_answer('relationship-answer', 'Partner', group_id='relationship-group', block_id='relationship-block',
+                                         answer_instance=1),
+                           create_answer('relationship-answer', 'Husband or wife', group_id='relationship-group', block_id='relationship-block',
+                                         answer_instance=2)]
+
+            questionnaire = {
+                'data_version': '0.0.2',
+                'survey_id': '0',
+                'sections': [
+                    {
+                        'id': 'relationship-section',
+                        'groups': [
+                            {
+                                'id': 'relationship-group',
+                                'blocks': [
+                                    {
+                                        'type': 'Question',
+                                        'id': 'relationship-block',
+                                        'questions': [
+                                            {
+                                                'id': 'relationship-question',
+                                                'type': 'Relationship',
+                                                'answers': [
+                                                    {
+                                                        'id': 'relationship-answer',
+                                                        'q_code': '1',
+                                                        'type': 'Relationship',
+                                                        'options': [
+                                                            {
+                                                                'label': 'Husband or wife',
+                                                                'value': 'Husband or wife'
+                                                            },
+                                                            {
+                                                                'label': 'Partner',
+                                                                'value': 'Partner'
+                                                            },
+                                                            {
+                                                                'label': 'Unrelated',
+                                                                'value': 'Unrelated'
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            # When
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 3)
+            self.assertEqual(answer_object['data'][0]['value'], 'Unrelated')
+            self.assertEqual(answer_object['data'][0]['group_id'], 'relationship-group')
+            self.assertEqual(answer_object['data'][0]['block_id'], 'relationship-block')
+            self.assertEqual(answer_object['data'][0]['group_instance'], 0)
+            self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
+
+            self.assertEqual(answer_object['data'][1]['value'], 'Partner')
+            self.assertEqual(answer_object['data'][1]['group_id'], 'relationship-group')
+            self.assertEqual(answer_object['data'][1]['block_id'], 'relationship-block')
+            self.assertEqual(answer_object['data'][1]['group_instance'], 0)
+            self.assertEqual(answer_object['data'][1]['answer_instance'], 1)
+
+            self.assertEqual(answer_object['data'][2]['value'], 'Husband or wife')
+            self.assertEqual(answer_object['data'][2]['group_id'], 'relationship-group')
+            self.assertEqual(answer_object['data'][2]['block_id'], 'relationship-block')
+            self.assertEqual(answer_object['data'][2]['group_instance'], 0)
+            self.assertEqual(answer_object['data'][2]['answer_instance'], 2)

--- a/tests/app/submitter/test_converter.py
+++ b/tests/app/submitter/test_converter.py
@@ -6,7 +6,7 @@ from app.data_model.answer_store import AnswerStore
 from app.questionnaire.questionnaire_schema import QuestionnaireSchema
 from app.questionnaire.location import Location
 from app.storage.metadata_parser import parse_metadata
-from app.submitter.converter import convert_answers, DataVersionError, convert_answers_to_data
+from app.submitter.converter import convert_answers, DataVersionError
 from tests.app.app_context_test_case import AppContextTestCase
 
 
@@ -84,108 +84,6 @@ class TestConverter(AppContextTestCase):  # pylint: disable=too-many-public-meth
 
             self.assertTrue(answer_object['flushed'])
 
-    def test_convert_answers(self):
-        with self._app.test_request_context():
-            user_answer = [create_answer('ABC', '2016-01-01', group_id='group-1', block_id='block-1'),
-                           create_answer('DEF', '2016-03-30', group_id='group-1', block_id='block-1')]
-
-            questionnaire = {
-                'survey_id': '021',
-                'data_version': '0.0.1',
-                'sections': [{
-                    'id': 'section1',
-                    'groups': [
-                        {
-                            'id': 'group-1',
-                            'blocks': [
-                                {
-                                    'id': 'block-1',
-                                    'questions': [{
-                                        'id': 'question-1',
-                                        'answers': [
-                                            {
-                                                'id': 'ABC',
-                                                'type': 'TextField',
-                                                'q_code': '001'
-                                            },
-                                            {
-                                                'id': 'DEF',
-                                                'type': 'TextField',
-                                                'q_code': '002'
-                                            }
-                                        ]
-                                    }]
-                                }
-                            ]
-                        }
-                    ]
-                }]
-            }
-
-            routing_path = [Location(group_id='group-1', group_instance=0, block_id='block-1')]
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
-
-            self.assertEqual(answer_object['type'], 'uk.gov.ons.edc.eq:surveyresponse')
-            self.assertEqual(answer_object['version'], '0.0.1')
-            self.assertEqual(answer_object['origin'], 'uk.gov.ons.edc.eq')
-            self.assertEqual(answer_object['survey_id'], '021')
-            self.assertEqual(answer_object['collection']['exercise_sid'], self.metadata['collection_exercise_sid'])
-            self.assertEqual(answer_object['collection']['instrument_id'], self.metadata['form_type'])
-            self.assertEqual(answer_object['collection']['period'], self.metadata['period_id'])
-            self.assertEqual(answer_object['metadata']['user_id'], self.metadata['user_id'])
-            self.assertEqual(answer_object['metadata']['ru_ref'], self.metadata['ru_ref'])
-            self.assertEqual(answer_object['data']['001'], '2016-01-01')
-            self.assertEqual(answer_object['data']['002'], '2016-03-30')
-
-    def test_convert_answers_to_data_with_key_error(self):
-        with self._app.test_request_context():
-            user_answer = [create_answer('ABC', '2016-01-01', group_id='group-1', block_id='block-1'),
-                           create_answer('DEF', '2016-03-30', group_id='group-1', block_id='block-1'),
-                           create_answer('GHI', '2016-05-30', group_id='group-1', block_id='block-1')]
-
-            questionnaire = {
-                'survey_id': '021',
-                'data_version': '0.0.1',
-                'sections': [{
-                    'id': 'section1',
-                    'groups': [
-                        {
-                            'id': 'group-1',
-                            'blocks': [
-                                {
-                                    'id': 'block-1',
-                                    'questions': [{
-                                        'id': 'question-1',
-                                        'answers': [
-                                            {
-                                                'id': 'LMN',
-                                                'type': 'TextField',
-                                                'q_code': '001'
-                                            },
-                                            {
-                                                'id': 'DEF',
-                                                'type': 'TextField',
-                                                'q_code': '002'
-                                            },
-                                            {
-                                                'id': 'JKL',
-                                                'type': 'TextField',
-                                                'q_code': '003'
-                                            },
-                                        ]
-                                    }]
-                                }
-                            ]
-                        }
-                    ]
-                }]
-            }
-
-            routing_path = [Location(group_id='group-1', group_instance=0, block_id='block-1')]
-            answer_object = (convert_answers_to_data(AnswerStore(user_answer), QuestionnaireSchema(questionnaire), routing_path))
-            self.assertEqual(answer_object['002'], '2016-03-30')
-            self.assertEqual(len(answer_object), 1)
-
     def test_submitted_at_should_be_set_in_payload(self):
         with self._app.test_request_context():
             user_answer = [create_answer('GHI', 0)]
@@ -224,351 +122,6 @@ class TestConverter(AppContextTestCase):  # pylint: disable=too-many-public-meth
 
             self.assertEqual(answer_object['case_ref'], self.metadata['case_ref'])
 
-    def test_answer_with_zero(self):
-        with self._app.test_request_context():
-            user_answer = [create_answer('GHI', 0, group_id='group-1', block_id='block-1')]
-
-            questionnaire = {
-                'survey_id': '021',
-                'data_version': '0.0.1',
-                'sections': [{
-                    'id': 'section1',
-                    'groups': [
-                        {
-                            'id': 'group-1',
-                            'blocks': [
-                                {
-                                    'id': 'block-1',
-                                    'questions': [{
-                                        'id': 'question-2',
-                                        'answers': [
-                                            {
-                                                'id': 'GHI',
-                                                'type': 'TextField',
-                                                'q_code': '003'
-                                            }
-                                        ]
-                                    }]
-                                }
-                            ]
-                        }
-                    ]
-                }]
-            }
-
-            routing_path = [Location(group_id='group-1', group_instance=0, block_id='block-1')]
-
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
-
-            # Check the converter correctly
-            self.assertEqual('0', answer_object['data']['003'])
-
-    def test_answer_with_float(self):
-        with self._app.test_request_context():
-            user_answer = [create_answer('GHI', 10.02, group_id='group-1', block_id='block-1')]
-
-            questionnaire = {
-                'survey_id': '021',
-                'data_version': '0.0.1',
-                'sections': [{
-                    'id': 'section1',
-                    'groups': [
-                        {
-                            'id': 'group-1',
-                            'blocks': [
-                                {
-                                    'id': 'block-1',
-                                    'questions': [{
-                                        'id': 'question-2',
-                                        'answers': [
-                                            {
-                                                'id': 'GHI',
-                                                'type': 'TextField',
-                                                'q_code': '003'
-                                            }
-                                        ]
-                                    }]
-                                }
-                            ]
-                        }
-                    ]
-                }]
-            }
-
-            routing_path = [Location(group_id='group-1', group_instance=0, block_id='block-1')]
-
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
-
-            # Check the converter correctly
-            self.assertEqual('10.02', answer_object['data']['003'])
-
-    def test_answer_with_string(self):
-        with self._app.test_request_context():
-            user_answer = [create_answer('GHI', 'String test + !', group_id='group-1', block_id='block-1')]
-
-            questionnaire = {
-                'survey_id': '021',
-                'data_version': '0.0.1',
-                'sections': [{
-                    'id': 'section1',
-                    'groups': [
-                        {
-                            'id': 'group-1',
-                            'blocks': [
-                                {
-                                    'id': 'block-1',
-                                    'questions': [{
-                                        'id': 'question-2',
-                                        'answers': [
-                                            {
-                                                'id': 'GHI',
-                                                'type': 'TextField',
-                                                'q_code': '003'
-                                            }
-                                        ]
-                                    }]
-                                }
-                            ]
-                        }
-                    ]
-                }]
-            }
-
-            routing_path = [Location(group_id='group-1', group_instance=0, block_id='block-1')]
-
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
-
-            # Check the converter correctly
-            self.assertEqual('String test + !', answer_object['data']['003'])
-
-    def test_answer_with_multiple_instances(self):
-        with self._app.test_request_context():
-            user_answer = [create_answer('GHI', 0, group_id='group-1', block_id='block-1'),
-                           create_answer('GHI', value=1, answer_instance=1, group_id='group-1', block_id='block-1'),
-                           create_answer('GHI', value=2, answer_instance=2, group_id='group-1', block_id='block-1')]
-
-            questionnaire = {
-                'survey_id': '021',
-                'data_version': '0.0.1',
-                'sections': [{
-                    'id': 'section1',
-                    'groups': [
-                        {
-                            'id': 'group-1',
-                            'blocks': [
-                                {
-                                    'id': 'block-1',
-                                    'questions': [{
-                                        'id': 'question-2',
-                                        'answers': [
-                                            {
-                                                'id': 'GHI',
-                                                'type': 'TextField',
-                                                'q_code': '003'
-                                            }
-                                        ]
-                                    }]
-                                }
-                            ]
-                        }
-                    ]
-                }]
-            }
-
-            routing_path = [Location(group_id='group-1', group_instance=0, block_id='block-1')]
-
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
-
-            # Check the converter correctly
-            self.assertEqual(answer_object['data']['003'], ['0', '1', '2'])
-
-    def test_get_checkbox_answer_with_duplicate_child_answer_ids(self):
-        with self._app.test_request_context():
-            routing_path = [Location(group_id='favourite-food', group_instance=0, block_id='crisps')]
-            answers = [create_answer('crisps-answer', [
-                'Ready salted',
-                'Other'
-            ], group_id='favourite-food', block_id='crisps')]
-
-            answers += [create_answer('other-answer-mandatory', 'Other', group_id='favourite-food', block_id='crisps',
-                                      group_instance=1)]
-            answers += [create_answer('other-answer-mandatory', 'Other', group_id='favourite-food', block_id='crisps',
-                                      group_instance=1)]
-
-            questionnaire = {
-                'survey_id': '999',
-                'data_version': '0.0.1',
-                'sections': [{
-                    'id': 'favourite-food-section',
-                    'groups': [{
-                        'id': 'favourite-food',
-                        'blocks': [
-                            {
-                                'id': 'crisps',
-                                'questions': [{
-                                    'id': 'crisps-question',
-                                    'answers': [
-                                        {
-                                            'id': 'crisps-answer',
-                                            'type': 'Checkbox',
-                                            'options': [
-                                                {
-                                                    'label': 'Other',
-                                                    'q_code': '4',
-                                                    'description': 'Choose any other flavour',
-                                                    'value': 'Other',
-                                                    'child_answer_id': 'other-answer-mandatory'
-                                                }
-                                            ]
-                                        },
-                                    ]
-                                }]
-                            }
-                        ]
-                    }]
-                }]
-            }
-
-        with self.assertRaises(Exception) as err:
-            convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
-        self.assertEqual('Multiple answers found for {}'.format('other-answer-mandatory'), str(err.exception))
-
-    def test_convert_census_answers(self):
-        with self._app.test_request_context():
-            routing_path = [Location(group_id='personal details', group_instance=0, block_id='about you'),
-                            Location(group_id='household', group_instance=0, block_id='where you live'),
-                            Location(group_id='household', group_instance=1, block_id='where you live')]
-            answers = [create_answer('name', 'Joe Bloggs', group_id='personal details', block_id='about you'),
-                       create_answer('name', 'Fred Bloggs', group_id='personal details', block_id='about you',
-                                     answer_instance=1),
-                       create_answer('address', '62 Somewhere', group_id='household', block_id='where you live'),
-                       create_answer('address', '63 Somewhere', group_id='household', block_id='where you live',
-                                     group_instance=1)]
-
-            questionnaire = {
-                'survey_id': '021',
-                'data_version': '0.0.2',
-                'sections': [{
-                    'id': 'section1',
-                    'groups': [
-                        {
-                            'id': 'personal details',
-                            'blocks': [
-                                {
-                                    'id': 'about you',
-                                    'questions': [{
-                                        'id': 'crisps-question',
-                                        'answers': [
-                                            {
-                                                'id': 'name',
-                                                'type': 'TextField'
-                                            }
-                                        ]
-                                    }]
-                                }]
-                        },
-                        {
-                            'id': 'household',
-                            'blocks': [
-                                {
-                                    'id': 'where you live',
-                                    'questions': [{
-                                        'id': 'crisps-question',
-                                        'answers': [
-                                            {
-                                                'id': 'address',
-                                                'type': 'TextField'
-                                            }
-                                        ]
-                                    }]
-                                }]
-                        }]
-                }]
-            }
-
-            # When
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
-
-            # Then
-            self.assertEqual(len(answer_object['data']), 4)
-            self.assertEqual(answer_object['data'][0]['group_id'], 'personal details')
-            self.assertEqual(answer_object['data'][0]['group_instance'], 0)
-            self.assertEqual(answer_object['data'][0]['block_id'], 'about you')
-            self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
-            self.assertEqual(answer_object['data'][0]['value'], 'Joe Bloggs')
-
-            self.assertEqual(answer_object['data'][1]['group_id'], 'personal details')
-            self.assertEqual(answer_object['data'][1]['group_instance'], 0)
-            self.assertEqual(answer_object['data'][1]['block_id'], 'about you')
-            self.assertEqual(answer_object['data'][1]['answer_instance'], 1)
-            self.assertEqual(answer_object['data'][1]['value'], 'Fred Bloggs')
-
-            self.assertEqual(answer_object['data'][2]['group_id'], 'household')
-            self.assertEqual(answer_object['data'][2]['group_instance'], 0)
-            self.assertEqual(answer_object['data'][2]['block_id'], 'where you live')
-            self.assertEqual(answer_object['data'][2]['answer_instance'], 0)
-            self.assertEqual(answer_object['data'][2]['value'], '62 Somewhere')
-
-            self.assertEqual(answer_object['data'][3]['group_id'], 'household')
-            self.assertEqual(answer_object['data'][3]['group_instance'], 1)
-            self.assertEqual(answer_object['data'][3]['block_id'], 'where you live')
-            self.assertEqual(answer_object['data'][3]['answer_instance'], 0)
-            self.assertEqual(answer_object['data'][3]['value'], '63 Somewhere')
-
-    def test_convert_census_answers_multiple_answers(self):
-        with self._app.test_request_context():
-            routing_path = [Location(group_id='favourite-food', group_instance=0, block_id='crisps')]
-            answers = [
-                create_answer('crisps-answer', ['Ready salted', 'Sweet chilli'], group_id='favourite-food', block_id='crisps')]
-
-            questionnaire = {
-                'survey_id': '021',
-                'data_version': '0.0.2',
-                'sections': [{
-                    'id': 'section1',
-                    'groups': [{
-                        'id': 'favourite-food',
-                        'blocks': [{
-                            'id': 'crisps',
-                            'questions': [{
-                                'id': 'crisps-question',
-                                'answers': [
-                                    {
-                                        'id': 'crisps-answer',
-                                        'type': 'Checkbox',
-                                        'options': [
-                                            {
-                                                'label': 'Ready salted',
-                                                'value': 'Ready salted'
-                                            },
-                                            {
-                                                'label': 'Sweet chilli',
-                                                'value': 'Sweet chilli'
-                                            },
-                                            {
-                                                'label': 'Cheese and onion',
-                                                'value': 'Cheese and onion'
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }]
-                        }]
-                    }]
-                }]
-            }
-
-            # When
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
-
-            # Then
-            self.assertEqual(len(answer_object['data']), 1)
-            self.assertEqual(answer_object['data'][0]['group_id'], 'favourite-food')
-            self.assertEqual(answer_object['data'][0]['group_instance'], 0)
-            self.assertEqual(answer_object['data'][0]['block_id'], 'crisps')
-            self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
-            self.assertEqual(answer_object['data'][0]['value'], ['Ready salted', 'Sweet chilli'])
-
     def test_converter_raises_runtime_error_for_unsupported_version(self):
         with self._app.test_request_context():
             questionnaire = {
@@ -581,204 +134,62 @@ class TestConverter(AppContextTestCase):  # pylint: disable=too-many-public-meth
 
             self.assertEqual(str(err.exception), 'Data version -0.0.1 not supported')
 
-    def test_converter_checkboxes_with_q_codes(self):
+    def test_convert_answers(self):
         with self._app.test_request_context():
-            routing_path = [Location(group_id='favourite-food', group_instance=0, block_id='crisps')]
-            answers = [create_answer('crisps-answer', [
-                'Ready salted',
-                'Sweet chilli'
-            ], group_id='favourite-food', block_id='crisps')]
+            user_answer = [create_answer('ABC', '2016-01-01', group_id='group-1', block_id='block-1'),
+                           create_answer('DEF', '2016-03-30', group_id='group-1', block_id='block-1')]
 
             questionnaire = {
-                'survey_id': '999',
+                'survey_id': '021',
                 'data_version': '0.0.1',
-                'sections': [{
-                    'id': 'section1',
-                    'groups': [
-                        {
-                            'id': 'favourite-food',
-                            'blocks': [
-                                {
-                                    'id': 'crisps',
-                                    'questions': [{
-                                        'id': 'crisps-question',
-                                        'answers': [
+                'sections': [
+                    {
+                        'id': 'section-1',
+                        'groups': [
+                            {
+                                'id': 'group-1',
+                                'blocks': [
+                                    {
+                                        'id': 'block-1',
+                                        'questions': [
                                             {
-                                                'id': 'crisps-answer',
-                                                'type': 'Checkbox',
-                                                'options': [
+                                                'id': 'question-1',
+                                                'answers': [
                                                     {
-                                                        'label': 'Ready salted',
-                                                        'value': 'Ready salted',
-                                                        'q_code': '1'
+                                                        'id': 'ABC',
+                                                        'type': 'TextField',
+                                                        'q_code': '001'
                                                     },
                                                     {
-                                                        'label': 'Sweet chilli',
-                                                        'value': 'Sweet chilli',
-                                                        'q_code': '2'
-                                                    },
-                                                    {
-                                                        'label': 'Cheese and onion',
-                                                        'value': 'Cheese and onion',
-                                                        'q_code': '3'
-                                                    },
-                                                    {
-                                                        'label': 'Other',
-                                                        'q_code': '4',
-                                                        'description': 'Choose any other flavour',
-                                                        'value': 'Other',
-                                                        'child_answer_id': 'other-answer-mandatory'
+                                                        'id': 'DEF',
+                                                        'type': 'TextField',
+                                                        'q_code': '002'
                                                     }
                                                 ]
-                                            },
-                                            {
-                                                'parent_answer_id': 'crisps-answer',
-                                                'mandatory': True,
-                                                'id': 'other-answer-mandatory',
-                                                'label': 'Please specify other',
-                                                'type': 'TextField'
                                             }
                                         ]
-                                    }]
-                                }
-                            ]
-                        }
-                    ]
-                }]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
             }
 
-            # When
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
+            routing_path = [Location(group_id='group-1', group_instance=0, block_id='block-1')]
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
 
-            # Then
-            self.assertEqual(len(answer_object['data']), 2)
-            self.assertEqual(answer_object['data']['1'], 'Ready salted')
-            self.assertEqual(answer_object['data']['2'], 'Sweet chilli')
-
-    def test_converter_checkboxes_with_q_codes_and_other_value(self):
-        with self._app.test_request_context():
-            routing_path = [Location(group_id='favourite-food', group_instance=0, block_id='crisps')]
-            answers = [create_answer('crisps-answer', [
-                'Ready salted',
-                'Other'
-            ], group_id='favourite-food', block_id='crisps')]
-
-            answers += [create_answer('other-answer-mandatory', 'Bacon', group_id='favourite-food', block_id='crisps')]
-
-            questionnaire = {
-                'survey_id': '999',
-                'data_version': '0.0.1',
-                'sections': [{
-                    'id': 'section1',
-                    'groups': [
-                        {
-                            'id': 'favourite-food',
-                            'blocks': [
-                                {
-                                    'id': 'crisps',
-                                    'questions': [{
-                                        'id': 'crisps-question',
-                                        'answers': [
-                                            {
-                                                'id': 'crisps-answer',
-                                                'type': 'Checkbox',
-                                                'options': [
-                                                    {
-                                                        'label': 'Ready salted',
-                                                        'value': 'Ready salted',
-                                                        'q_code': '1'
-                                                    },
-                                                    {
-                                                        'label': 'Sweet chilli',
-                                                        'value': 'Sweet chilli',
-                                                        'q_code': '2'
-                                                    },
-                                                    {
-                                                        'label': 'Cheese and onion',
-                                                        'value': 'Cheese and onion',
-                                                        'q_code': '3'
-                                                    },
-                                                    {
-                                                        'label': 'Other',
-                                                        'q_code': '4',
-                                                        'description': 'Choose any other flavour',
-                                                        'value': 'Other',
-                                                        'child_answer_id': 'other-answer-mandatory'
-                                                    }
-                                                ]
-                                            },
-                                            {
-                                                'parent_answer_id': 'crisps-answer',
-                                                'mandatory': True,
-                                                'id': 'other-answer-mandatory',
-                                                'label': 'Please specify other',
-                                                'type': 'TextField'
-                                            }
-                                        ]
-                                    }]
-                                }
-                            ]
-                        }
-                    ]
-                }]
-            }
-
-            # When
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
-
-            # Then
-            self.assertEqual(len(answer_object['data']), 2)
-            self.assertEqual(answer_object['data']['1'], 'Ready salted')
-            self.assertEqual(answer_object['data']['4'], 'Other')
-
-    def test_converter_q_codes_for_empty_strings(self):
-        with self._app.test_request_context():
-            routing_path = [Location(group_id='favourite-food', group_instance=0, block_id='crisps')]
-            answers = [create_answer('crisps-answer', '', group_id='favourite-food', block_id='crisps')]
-            answers += [
-                create_answer('other-crisps-answer', 'Ready salted', group_id='favourite-food', block_id='crisps')]
-
-            questionnaire = {
-                'survey_id': '999',
-                'data_version': '0.0.1',
-                'sections': [{
-                    'id': 'section1',
-                    'groups': [
-                        {
-                            'id': 'favourite-food',
-                            'blocks': [
-                                {
-                                    'id': 'crisps',
-                                    'questions': [{
-                                        'id': 'crisps-question',
-                                        'answers': [
-                                            {
-                                                'id': 'crisps-answer',
-                                                'type': 'TextArea',
-                                                'options': [],
-                                                'q_code': '1'
-                                            },
-                                            {
-                                                'id': 'other-crisps-answer',
-                                                'type': 'TextArea',
-                                                'options': [],
-                                                'q_code': '2'
-                                            }
-                                        ]
-                                    }]
-                                }
-                            ]
-                        }
-                    ]
-                }]
-            }
-
-            # When
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
-
-            # Then
-            self.assertEqual(len(answer_object['data']), 1)
-            self.assertEqual(answer_object['data']['2'], 'Ready salted')
+            self.assertEqual(answer_object['type'], 'uk.gov.ons.edc.eq:surveyresponse')
+            self.assertEqual(answer_object['version'], '0.0.1')
+            self.assertEqual(answer_object['origin'], 'uk.gov.ons.edc.eq')
+            self.assertEqual(answer_object['survey_id'], '021')
+            self.assertEqual(answer_object['collection']['exercise_sid'], self.metadata['collection_exercise_sid'])
+            self.assertEqual(answer_object['collection']['instrument_id'], self.metadata['form_type'])
+            self.assertEqual(answer_object['collection']['period'], self.metadata['period_id'])
+            self.assertEqual(answer_object['metadata']['user_id'], self.metadata['user_id'])
+            self.assertEqual(answer_object['metadata']['ru_ref'], self.metadata['ru_ref'])
+            self.assertEqual(answer_object['data']['001'], '2016-01-01')
+            self.assertEqual(answer_object['data']['002'], '2016-03-30')
 
 
 def create_answer(answer_id, value, group_id=None, block_id=None, answer_instance=0, group_instance=0):


### PR DESCRIPTION
### What is the context of this PR?
#1466 removed a schema-specific test. In an effort to make sure we don't lose any test coverage, more convert tests have been added.

- Added test conversion for the following answer types:
   - radio
   - number
   - percentage
   - textarea
   - currency
   - dropdown
   - date
   - unit
   - relationship

### How to review 
1. Run `pipenv run scripts/run_tests_unit.sh`
2. Ensure that all units tests pass.
3. Ensure all the new tests are correct and the structure is valid.