### PR TITLE
Enhance logic for section links

### DIFF
--- a/app/globals.py
+++ b/app/globals.py
@@ -8,6 +8,7 @@ from app.settings import EQ_SESSION_ID, USER_IK
 from app.data_model.questionnaire_store import QuestionnaireStore
 from app.data_model.session_store import SessionStore
 from app.storage.encrypted_questionnaire_storage import EncryptedQuestionnaireStorage
+from app.questionnaire.completeness import Completeness
 
 logger = get_logger()
 
@@ -65,6 +66,23 @@ def get_answer_store(user):
 def get_completed_blocks(user):
     questionnaire_store = get_questionnaire_store(user.user_id, user.user_ik)
     return questionnaire_store.completed_blocks
+
+
+def get_completeness(user):
+    from app.helpers.path_finder_helper import path_finder
+
+    completeness_object = g.get('_completeness')
+
+    if completeness_object is None:
+        metadata = get_metadata(user)
+        answer_store = get_answer_store(user)
+        completed_blocks = get_completed_blocks(user)
+        routing_path = path_finder.get_full_routing_path()
+
+        completeness_object = g._completeness = Completeness(
+            g.schema, answer_store, completed_blocks, routing_path, metadata)
+
+    return completeness_object
 
 
 def get_dynamodb():

--- a/app/questionnaire/completeness.py
+++ b/app/questionnaire/completeness.py
@@ -1,0 +1,193 @@
+from app.questionnaire.location import Location
+from app.questionnaire.questionnaire_schema import QuestionnaireSchema
+from app.questionnaire.rules import evaluate_skip_conditions, get_number_of_repeats
+
+
+class Completeness:
+    NOT_STARTED = 'NOT_STARTED'
+    STARTED = 'STARTED'
+    SKIPPED = 'SKIPPED'
+    COMPLETED = 'COMPLETED'
+    INVALID = 'INVALID'
+
+    # for the purposes of deriving completeness all of the following states
+    # allow a block to be marked as complete so long as at least
+    # one item is complete
+    COMPLETED_STATES = (COMPLETED, INVALID, SKIPPED,)
+
+    def __init__(self, schema, answer_store, completed_blocks, routing_path, metadata):
+        self.answer_store = answer_store
+        self.completed_blocks = completed_blocks
+        self.routing_path = routing_path
+        self.metadata = metadata
+        self.schema = schema
+
+    def is_section_complete(self, section):
+        return self.get_state_for_section(section) == self.COMPLETED
+
+    def is_group_complete(self, group, group_instance=None):
+        return self.get_state_for_group(group, group_instance=group_instance) == self.COMPLETED
+
+    def is_block_complete(self, location):
+        return location in self.completed_blocks
+
+    def all_sections_complete(self):
+        return all(state in [self.COMPLETED, self.SKIPPED] for state in self._get_all_section_states())
+
+    def any_section_complete(self):
+        return any(state == self.COMPLETED for state in self._get_all_section_states())
+
+    def get_state_for_section(self, section):
+        if isinstance(section, str):
+            # lookup section by section ID
+            section = self.schema.get_section(section)
+
+        group_states = [
+            self.get_state_for_group(group) for group in section['groups']
+        ]
+
+        def eval_state(state_to_compare):
+            return (state == state_to_compare for state in group_states)
+
+        section_state = self.NOT_STARTED
+
+        if group_states:
+            if all(eval_state(self.SKIPPED)):
+                section_state = self.SKIPPED
+
+            elif all(eval_state(self.INVALID)):
+                section_state = self.INVALID
+
+            elif any(eval_state(self.STARTED)):
+                section_state = self.STARTED
+
+            elif all(state in self.COMPLETED_STATES for state in group_states):
+                section_state = self.COMPLETED
+
+        return section_state
+
+    def get_state_for_group(self, group, group_instance=None):
+        if isinstance(group, str):
+            # lookup group by group ID
+            group = self.schema.get_group(group)
+
+        if (QuestionnaireSchema.is_confirmation_group(group) or
+                QuestionnaireSchema.is_summary_group(group)):
+            # summary/confirmations are special cases as we don't want to
+            # render until the whole survey is complete. They're also never
+            # show as complete
+            return self.NOT_STARTED if self.all_sections_complete() else self.SKIPPED
+
+        if self._should_skip(group):
+            return self.SKIPPED
+
+        block_states = [
+            state for location, state in
+            self._get_block_states_for_group(group, group_instance)
+        ]
+
+        def eval_state(state_to_compare):
+            return (state == state_to_compare for state in block_states)
+
+        group_state = self.NOT_STARTED
+
+        if all(eval_state(self.SKIPPED)):
+            group_state = self.SKIPPED
+
+        elif not self.routing_path:
+            group_state = self.NOT_STARTED
+
+        elif all(eval_state(self.INVALID)):
+            group_state = self.INVALID
+
+        elif all(state in self.COMPLETED_STATES for state in block_states):
+            group_state = self.COMPLETED
+
+        elif any(eval_state(self.COMPLETED)):
+            group_state = self.STARTED
+
+        return group_state
+
+    def get_first_incomplete_location_in_survey(self):
+        incomplete_locations = (
+            self.get_first_incomplete_location_in_section(section)
+            for section in self.schema.sections
+        )
+        return next(filter(None, incomplete_locations), None)
+
+    def get_first_incomplete_location_in_section(self, section):
+        incomplete_locations = (
+            self.get_first_incomplete_location_in_group(group)
+            for group in section['groups']
+        )
+        return next(filter(None, incomplete_locations), None)
+
+    def get_first_incomplete_location_in_group(self, group, group_instance=None):
+        if self._should_skip(group):
+            return
+
+        incomplete_locations = (
+            location for location, state in
+            self._get_block_states_for_group(
+                group, group_instance=group_instance)
+            if state not in self.COMPLETED_STATES
+        )
+        return next(incomplete_locations, None)
+
+    def get_latest_location(self):
+        latest_location = self.routing_path[0]
+
+        if self.completed_blocks:
+            latest_location = self.get_first_incomplete_location_in_survey()
+
+            if not latest_location:
+                # survey is complete
+                latest_location = self.routing_path[-1]
+
+        return latest_location
+
+    def _get_block_states_for_group(self, group, group_instance=None):
+        if group_instance is not None:
+            start_instance = max_instance = group_instance
+        else:
+            max_instance = get_number_of_repeats(group, self.schema, self.routing_path, self.answer_store) - 1
+            start_instance = 0
+
+        for current_instance in range(start_instance, max_instance + 1):
+            for block in group['blocks']:
+                location = Location(group['id'], current_instance, block['id'])
+
+                if self._should_skip(block):
+                    state = self.SKIPPED
+                elif self._is_valid_for_completeness(block, location):
+                    state = self.COMPLETED if self.is_block_complete(location) else self.NOT_STARTED
+                else:
+                    # block is not a question block or is not on the routing path
+                    state = self.INVALID
+
+                yield location, state
+
+    def _get_all_section_states(self):
+        return (
+            self.get_state_for_section(section)
+            for section in self._get_all_question_sections()
+        )
+
+    def _get_all_question_sections(self):
+        return (
+            section for section in self.schema.sections
+            if not (
+                QuestionnaireSchema.is_summary_section(section) or
+                QuestionnaireSchema.is_confirmation_section(section))
+        )
+
+    def _should_skip(self, group_or_block):
+        return (
+            'skip_conditions' in group_or_block and
+            evaluate_skip_conditions(group_or_block['skip_conditions'], self.metadata, self.answer_store)
+        )
+
+    def _is_valid_for_completeness(self, block, location):
+        """Returns True if the given block should be checked for completeness
+        """
+        return block['type'] in ('Question', 'ConfirmationQuestion') and location in self.routing_path

--- a/app/questionnaire/navigation.py
+++ b/app/questionnaire/navigation.py
@@ -1,11 +1,10 @@
-import copy
 from collections import defaultdict
 
 from structlog import get_logger
 
+from app.questionnaire.completeness import Completeness
 from app.questionnaire.location import Location
-from app.questionnaire.path_finder import PathFinder
-from app.questionnaire.rules import evaluate_repeat, evaluate_skip_conditions
+from app.questionnaire.rules import evaluate_repeat, get_answer_ids_on_routing_path
 
 logger = get_logger()
 
@@ -15,12 +14,20 @@ class Navigation(object):
     Reads navigation config from the schema and returns collections of dicts that describe
     completion status of each group
     """
-    def __init__(self, schema, answer_store, metadata, completed_blocks, routing_path):
+    def __init__(
+            self,
+            schema,
+            answer_store,
+            metadata,
+            completed_blocks,
+            routing_path,
+            completeness):
         self.schema = schema
         self.metadata = metadata
         self.answer_store = answer_store
         self.completed_blocks = completed_blocks
         self.routing_path = routing_path
+        self.completeness = completeness
 
     def build_navigation(self, current_group_id, current_group_instance):
         """
@@ -34,8 +41,6 @@ class Navigation(object):
         if navigation_block is None or navigation_block.get('visible', True) is False:
             return None
 
-        summary_or_confirmation_blocks = self.schema.get_summary_and_confirmation_blocks()
-
         navigation = []
 
         for section in self.schema.sections:
@@ -43,138 +48,95 @@ class Navigation(object):
             if not non_skipped_groups:
                 continue
 
-            first_group_id = non_skipped_groups[0]
-            first_block_id = self.schema.get_first_block_id_for_group(first_group_id)
+            target_location = self._get_location_for_section(section, non_skipped_groups)
 
-            if first_block_id in summary_or_confirmation_blocks \
-                    and self._can_reach_summary_confirmation(first_group_id, first_block_id) is False:
-                continue
+            # if the first group in a section is a repeating group then repeat the section
+            # navigation link for each repeat instead of rendering the section title
+            repeating_rule = None
+            if len(non_skipped_groups) == 1:
+                repeating_rule = self.schema.get_repeat_rule(non_skipped_groups[0])
 
-            repeating_rule = self.schema.get_repeat_rule(
-                self.schema.get_group(first_group_id))
             if repeating_rule:
                 navigation.extend(self._build_repeating_navigation(repeating_rule, section, current_group_id,
                                                                    current_group_instance))
             else:
-                navigation.append(self._build_single_navigation(section, current_group_id,
-                                                                Location(first_group_id, 0, first_block_id)))
+                navigation.append(
+                    self._build_single_navigation(
+                        section, current_group_id, target_location))
 
         return navigation
 
     def _get_non_skipped_groups(self, section):
         return [
-            group['id'] for group in self._get_visible_groups_for_section(section)
-            if not self._should_skip_group(group)
+            group for group in section['groups']
+            if self.completeness.get_state_for_group(group) != Completeness.SKIPPED
         ]
 
-    def _should_skip_group(self, group):
-        skip_conditions = group.get('skip_conditions')
-
-        if skip_conditions:
-            return evaluate_skip_conditions(skip_conditions, self.metadata, self.answer_store)
-
-        for block in reversed(group['blocks']):
-            skip_conditions = block.get('skip_conditions')
-            return evaluate_skip_conditions(skip_conditions, self.metadata, self.answer_store)
-
-        return False
-
-    def _can_reach_summary_confirmation(self, group_id, block_id):
-        if self.routing_path and Location(group_id, 0, block_id) in self.routing_path and \
-                self.completed_blocks and set(self.routing_path[:-1]).issubset(self.completed_blocks):
-            return True
-
-        return False
-
     def _build_single_navigation(self, section, current_group_id, first_location):
-        group_ids = (group['id'] for group in self._get_visible_groups_for_section(section))
+        group_ids = (group['id'] for group in section['groups'])
         is_highlighted = current_group_id in group_ids
-        is_completed = self._is_completed(section)
+        is_completed = self.completeness.is_section_complete(section)
 
         return self._generate_item(section['title'], is_completed, first_location, is_highlighted)
 
     def _build_repeating_navigation(self, repeating_rule, section, current_group_id, current_group_instance):
-        first_group = next(self._get_visible_groups_for_section(section))
-        first_location = Location(first_group['id'], 0, first_group['blocks'][0]['id'])
-        answer_ids_on_path = PathFinder.get_answer_ids_on_routing_path(self.schema, self.routing_path)
+        groups = section['groups']
+        answer_ids_on_path = get_answer_ids_on_routing_path(self.schema, self.routing_path)
         no_of_repeats = evaluate_repeat(repeating_rule, self.answer_store, answer_ids_on_path)
 
         repeating_nav = []
-
         if repeating_rule['type'] == 'answer_count':
-            is_current_group = first_group['id'] == current_group_id
             link_names = self._generate_link_names(section['title_from_answers'])
 
-            repeating_nav = self._generate_repeated_items(link_names, first_location, section, no_of_repeats,
-                                                          is_current_group, current_group_instance)
+            for group in groups:
+                is_current_group = group['id'] == current_group_id
+                repeating_nav += self._generate_repeated_items(
+                    link_names, group, no_of_repeats, is_current_group, current_group_instance)
 
         elif no_of_repeats > 0:
-            item = self._build_single_repeating_navigation(section, current_group_id, first_location, no_of_repeats)
+            target_location = self._get_location_for_section(section, groups)
+            item = self._build_single_repeating_navigation(section, current_group_id, target_location)
             repeating_nav.append(item)
 
         return repeating_nav
 
-    def _build_single_repeating_navigation(self, section, current_group_id, first_location, no_of_repeats):
-        group_ids = (group['id'] for group in self._get_visible_groups_for_section(section))
+    def _build_single_repeating_navigation(self, section, current_group_id, target_location):
+        group_ids = (group['id'] for group in section['groups'])
         is_highlighted = current_group_id in group_ids
-        is_completed = self._is_completed_single_repeating(no_of_repeats, section)
-        return self._generate_item(section['title'], is_completed, first_location, is_highlighted)
+        is_completed = self.completeness.is_section_complete(section)
+        return self._generate_item(section['title'], is_completed, target_location, is_highlighted)
 
-    def _is_completed_single_repeating(self, no_of_repeats, section):
-        for i in range(no_of_repeats):
-            if self._is_completed(section, i) is False:
-                return False
-
-        return True
-
-    def _is_completed(self, section, group_instance=0):
-        """
-        Determines whether an item can be marked as complete in navigation
-
-        :param completed_id: The block_id which indicates whether this group has been completed
-        :param group_instance: Used for repeating groups
-        :return:
-        """
-        contains_group_in_routing_path = False
-        for group in section['groups']:
-            group_id = group['id']
-            for location in self.routing_path:
-                if location.group_id == group_id and location.group_instance == group_instance:
-                    contains_group_in_routing_path = True
-                    if location not in self.completed_blocks:
-                        return False
-
-        return contains_group_in_routing_path
-
-    def _generate_repeated_items(self, link_names, first_location, section, no_of_repeats, is_current_group,
+    def _generate_repeated_items(self, link_names, group, no_of_repeats, is_current_group,
                                  current_group_instance):
         """
         Generates a lists of navigation items
 
         :param link_names: The list of titles to use for each link
-        :param first_location: The first group location
+        :param target_location: The target for the section link
         :param completed_id: The block_id which indicates whether this group has been completed
         :param no_of_repeats: The number of times to repeat
         :param is_current_group: Whether the repeated items are being generated for the current selected group
         :param current_group_instance: The current selected group_instance
         :return: A list of navigation items represented as dicts
         """
+        if not link_names:
+            return []
+
         nav_items = []
 
         for i in range(no_of_repeats):
-            location = copy.copy(first_location)
-            location.group_instance = i
+            location = self._get_location_for_group(group, group_instance=i)
             is_current_group_instance = is_current_group and i == current_group_instance
+            is_completed = self.completeness.is_group_complete(group, group_instance=i)
 
-            if link_names:
-                nav_item = self._generate_item(
-                    name=link_names.get(i),
-                    completed=self._is_completed(section, i),
-                    location=location,
-                    highlight=is_current_group_instance,
-                    repeating=True,
-                )
-                nav_items.append(nav_item)
+            nav_item = self._generate_item(
+                name=link_names.get(i),
+                completed=is_completed,
+                location=location,
+                highlight=is_current_group_instance,
+                repeating=True,
+            )
+            nav_items.append(nav_item)
 
         return nav_items
 
@@ -200,9 +162,58 @@ class Navigation(object):
 
         return link_names
 
-    @staticmethod
-    def _get_visible_groups_for_section(section):
-        return (
-            group for group in section['groups']
-            if not group.get('hide_in_navigation')
+    def _get_location_for_section(self, section, groups):
+        section_completeness = self.completeness.get_state_for_section(section)
+        first_incomplete = self.completeness.get_first_incomplete_location_in_section(section)
+        first_group, last_group = groups[0], groups[-1]
+
+        return self._get_location_for_completeness(
+            section_completeness,
+            first_group,
+            last_group,
+            first_group['blocks'][0],
+            last_group['blocks'][-1],
+            first_incomplete
         )
+
+    def _get_location_for_group(self, group, group_instance=None):
+        """Gets the location for a link used for a repeating group
+        """
+        group_completeness = self.completeness.get_state_for_group(group, group_instance=group_instance)
+        first_incomplete = self.completeness.get_first_incomplete_location_in_group(group, group_instance=group_instance)
+
+        return self._get_location_for_completeness(
+            group_completeness,
+            group,
+            group,
+            group['blocks'][0],
+            group['blocks'][-1],
+            first_incomplete,
+            group_instance=group_instance or 0
+        )
+
+    @staticmethod
+    def _get_location_for_completeness(
+            completeness_state,
+            first_group,
+            last_group,
+            first_block,
+            last_block,
+            first_incomplete,
+            group_instance=0):
+        if completeness_state == Completeness.STARTED:
+            # if it's been started then get the first incomplete block within that section
+            location = first_incomplete
+        else:
+            if completeness_state == Completeness.NOT_STARTED or last_block['type'] != 'SectionSummary':
+                # if the section hasn't been started or it is complete but has no section summary
+                # go to the first block
+                target_group, target_block = first_group, first_block
+
+            else:
+                target_group, target_block = last_group, last_block
+
+            location = Location(
+                target_group['id'], group_instance, target_block['id'])
+
+        return location

--- a/app/questionnaire/questionnaire_schema.py
+++ b/app/questionnaire/questionnaire_schema.py
@@ -139,6 +139,38 @@ class QuestionnaireSchema(object):  # pylint: disable=too-many-public-methods
         for question_json in block_json.get('questions', []):
             yield question_json
 
+    @staticmethod
+    def is_summary_section(section):
+        for group in section['groups']:
+            if QuestionnaireSchema.is_summary_group(group):
+                return True
+
+        return False
+
+    @staticmethod
+    def is_summary_group(group):
+        for block in group['blocks']:
+            if block['type'] == 'Summary':
+                return True
+
+        return False
+
+    @staticmethod
+    def is_confirmation_section(section):
+        for group in section['groups']:
+            if QuestionnaireSchema.is_confirmation_group(group):
+                return True
+
+        return False
+
+    @staticmethod
+    def is_confirmation_group(group):
+        for block in group['blocks']:
+            if block['type'] == 'Confirmation':
+                return True
+
+        return False
+
     def _parse_schema(self):
         self._sections_by_id = self._get_sections_by_id()
         self._groups_by_id = get_nested_schema_objects(self._sections_by_id, 'groups')

--- a/app/questionnaire/rules.py
+++ b/app/questionnaire/rules.py
@@ -197,6 +197,26 @@ def get_answer_store_value(answer_index, answer_store, group_instance):
     return filtered[0]['value'] if filtered.count() == 1 else None
 
 
+def get_number_of_repeats(group, schema, routing_path, answer_store):
+    repeating_rule = schema.get_repeat_rule(group)
+
+    if repeating_rule:
+        answer_ids_on_path = get_answer_ids_on_routing_path(
+            schema, routing_path)
+        return evaluate_repeat(repeating_rule, answer_store, answer_ids_on_path)
+
+    return 1
+
+
+def get_answer_ids_on_routing_path(schema, path):
+    answer_ids_on_path = []
+    for location in path:
+        answer_ids_on_path.extend(
+            schema.get_answers_by_id_for_block(location.block_id))
+
+    return answer_ids_on_path
+
+
 def get_metadata_value(metadata, keys):
     if not _contains_in_dict(metadata, keys):
         return None

--- a/app/views/session.py
+++ b/app/views/session.py
@@ -8,8 +8,7 @@ from structlog import get_logger
 
 from app.authentication.authenticator import store_session, decrypt_token
 from app.authentication.jti_claim_storage import JtiTokenUsed, use_jti_claim
-from app.globals import get_answer_store, get_completed_blocks
-from app.questionnaire.path_finder import PathFinder
+from app.globals import get_completeness
 from app.settings import ACCOUNT_URL
 from app.storage.metadata_parser import parse_metadata
 from app.utilities.schema import load_schema_from_metadata
@@ -75,9 +74,7 @@ def login():
     if 'account_service_url' in metadata and metadata.get('account_service_url'):
         cookie_session[ACCOUNT_URL] = metadata.get('account_service_url')
 
-    completed_blocks = get_completed_blocks(current_user)
-    navigator = PathFinder(g.schema, get_answer_store(current_user), metadata, completed_blocks)
-    current_location = navigator.get_latest_location(completed_blocks)
+    current_location = get_completeness(current_user).get_latest_location()
 
     return redirect(current_location.url(metadata))
 

--- a/data/en/0_rogue_one.json
+++ b/data/en/0_rogue_one.json
@@ -270,8 +270,7 @@
                     "id": "summary"
                 }],
                 "id": "summary-group",
-                "title": "",
-                "hide_in_navigation": true
+                "title": ""
             }
         ]
     }]

--- a/data/en/census_household.json
+++ b/data/en/census_household.json
@@ -380,7 +380,6 @@
                 {
                     "id": "who-lives-here-relationship",
                     "title": "Relationships",
-                    "hide_in_navigation": true,
                     "routing_rules": [{
                         "repeat": {
                             "type": "answer_count_minus_one",
@@ -460,7 +459,6 @@
                 {
                     "id": "who-lives-here-interstitial",
                     "title": "Who lives here?",
-                    "hide_in_navigation": true,
                     "blocks": [{
                         "id": "who-lives-here-completed",
                         "title": "You have successfully completed the ‘Who lives here?’ section",
@@ -3668,7 +3666,7 @@
                             "when": [{
                                 "id": "overnight-visitors-answer",
                                 "condition": "equals",
-                                "value": "0"
+                                "value": 0
                             }]
                         },
                         {
@@ -3866,7 +3864,7 @@
                             "when": [{
                                 "id": "overnight-visitors-answer",
                                 "condition": "equals",
-                                "value": "0"
+                                "value": 0
                             }]
                         },
                         {

--- a/data/en/test_navigation_completeness.json
+++ b/data/en/test_navigation_completeness.json
@@ -152,6 +152,7 @@
         },
         {
             "id": "summary-section",
+            "title": "Summary",
             "groups": [{
                 "blocks": [{
                     "type": "Summary",

--- a/data/en/test_navigation_routing.json
+++ b/data/en/test_navigation_routing.json
@@ -131,6 +131,7 @@
         },
         {
             "id": "summary-section",
+            "title": "Summary",
             "groups": [{
                 "blocks": [{
                     "type": "Summary",

--- a/data/en/test_relationship_household.json
+++ b/data/en/test_relationship_household.json
@@ -121,8 +121,7 @@
                     "id": "summary"
                 }],
                 "id": "summary-group",
-                "title": "",
-                "hide_in_navigation": true
+                "title": ""
             }
         ]
     }]

--- a/data/en/test_repeating_and_conditional_routing.json
+++ b/data/en/test_repeating_and_conditional_routing.json
@@ -144,8 +144,7 @@
                     "id": "summary"
                 }],
                 "id": "summary-group",
-                "title": "",
-                "hide_in_navigation": true
+                "title": ""
             }
         ]
     }]

--- a/data/en/test_skip_condition_block.json
+++ b/data/en/test_skip_condition_block.json
@@ -76,8 +76,7 @@
                     "id": "summary"
                 }],
                 "id": "summary-group",
-                "title": "",
-                "hide_in_navigation": true
+                "title": ""
             }
         ]
     }]

--- a/tests/app/questionnaire/test_completeness.py
+++ b/tests/app/questionnaire/test_completeness.py
@@ -1,0 +1,518 @@
+from tests.app.app_context_test_case import AppContextTestCase
+
+from app.data_model.answer_store import AnswerStore, Answer
+from app.questionnaire.location import Location
+from app.questionnaire.completeness import Completeness
+from app.questionnaire.questionnaire_schema import QuestionnaireSchema
+from app.utilities.schema import load_schema_from_params
+
+
+class TestCompleteness(AppContextTestCase): # pylint: disable=too-many-public-methods
+    def test_no_groups(self):
+        schema = load_schema_from_params('test', 'navigation_completeness')
+
+        schema.json['sections'][0]['groups'] = []
+
+        progress = Completeness(schema, AnswerStore(), [], [], metadata={})
+
+        progress_value = progress.get_state_for_section('coffee-section')
+        self.assertEqual(Completeness.NOT_STARTED, progress_value)
+
+    def test_not_started_section(self):
+        schema = load_schema_from_params('test', 'navigation_completeness')
+
+        routing_path = [
+            Location('coffee-group', 0, 'coffee'),
+        ]
+
+        progress = Completeness(schema, AnswerStore(), [], routing_path, metadata={})
+
+        progress_value = progress.get_state_for_section('coffee-section')
+        self.assertEqual(Completeness.NOT_STARTED, progress_value)
+
+    def test_started_section(self):
+        schema = load_schema_from_params('test', 'navigation_completeness')
+
+        completed_blocks = [
+            Location('coffee-group', 0, 'coffee'),
+        ]
+
+        routing_path = [
+            Location('coffee-group', 0, 'coffee'),
+            Location('coffee-group', 0, 'response-yes'),
+        ]
+
+        progress = Completeness(
+            schema, AnswerStore(), completed_blocks, routing_path, metadata={})
+
+        progress_value = progress.get_state_for_section('coffee-section')
+        self.assertEqual(Completeness.STARTED, progress_value)
+
+    def test_completed_section(self):
+        schema = load_schema_from_params('test', 'navigation_completeness')
+
+        completed_blocks = [
+            Location('coffee-group', 0, 'coffee'),
+            Location('coffee-group', 0, 'response-yes'),
+        ]
+
+        routing_path = [
+            Location('coffee-group', 0, 'coffee'),
+            Location('coffee-group', 0, 'response-yes'),
+        ]
+        progress = Completeness(
+            schema, AnswerStore(), completed_blocks, routing_path, metadata={})
+
+        progress_value = progress.get_state_for_section('coffee-section')
+        self.assertEqual(Completeness.COMPLETED, progress_value)
+
+    def test_all_sections_complete_no_blocks_completed(self):
+        schema = load_schema_from_params('test', 'navigation_completeness')
+
+        routing_path = [
+            Location('coffee-group', 0, 'coffee'),
+            Location('coffee-group', 0, 'response-yes'),
+        ]
+
+        progress = Completeness(schema, AnswerStore(), [], routing_path, metadata={})
+        self.assertFalse(progress.all_sections_complete())
+
+    def test_all_sections_complete_one_block_completes(self):
+        schema = load_schema_from_params('test', 'navigation_completeness')
+
+        completed_blocks = [
+            Location('coffee-group', 0, 'coffee'),
+            Location('coffee-group', 0, 'response-yes'),
+        ]
+        routing_path = [
+            Location('coffee-group', 0, 'coffee'),
+            Location('coffee-group', 0, 'response-yes'),
+            Location('toast-group', 0, 'toast'),
+        ]
+
+        progress = Completeness(
+            schema, AnswerStore(), completed_blocks, routing_path, metadata={})
+        self.assertFalse(progress.all_sections_complete())
+
+    def test_all_sections_complete_all_blocks_completed(self):
+        schema = load_schema_from_params('test', 'navigation_completeness')
+
+        completed_blocks = [
+            Location('coffee-group', 0, 'coffee'),
+            Location('coffee-group', 0, 'response-yes'),
+            Location('toast-group', 0, 'toast'),
+        ]
+        routing_path = [
+            Location('coffee-group', 0, 'coffee'),
+            Location('coffee-group', 0, 'response-yes'),
+            Location('toast-group', 0, 'toast'),
+        ]
+
+        progress = Completeness(
+            schema, AnswerStore(), completed_blocks, routing_path, metadata={})
+        self.assertTrue(progress.all_sections_complete())
+
+    def test_any_section_complete_none(self):
+        schema = load_schema_from_params('test', 'navigation_completeness')
+        progress = Completeness(schema, AnswerStore(), [], [], metadata={})
+        self.assertFalse(progress.any_section_complete())
+
+    def test_any_section_complete_one(self):
+        schema = load_schema_from_params('test', 'navigation_completeness')
+        completed_blocks = [
+            Location('coffee-group', 0, 'coffee'),
+            Location('coffee-group', 0, 'response-yes'),
+        ]
+        routing_path = [
+            Location('coffee-group', 0, 'coffee'),
+            Location('coffee-group', 0, 'response-yes'),
+        ]
+
+        progress = Completeness(
+            schema, AnswerStore(), completed_blocks, routing_path, metadata={})
+        self.assertTrue(progress.any_section_complete())
+
+    def test_any_section_complete_all(self):
+        schema = load_schema_from_params('test', 'navigation_completeness')
+        completed_blocks = [
+            Location('coffee-group', 0, 'coffee'),
+            Location('coffee-group', 0, 'response-yes'),
+            Location('toast-group', 0, 'toast'),
+        ]
+        routing_path = [
+            Location('coffee-group', 0, 'coffee'),
+            Location('coffee-group', 0, 'response-yes'),
+            Location('toast-group', 0, 'toast'),
+        ]
+
+        progress = Completeness(
+            schema, AnswerStore(), completed_blocks, routing_path, metadata={})
+        self.assertTrue(progress.any_section_complete())
+
+    def test_repeating_skipped_group(self):
+        schema = load_schema_from_params('test', 'navigation_confirmation')
+
+        routing_path = [
+            Location('property-details', 0, 'insurance-type'),
+            Location('property-details', 0, 'insurance-address'),
+            Location('property-details', 0, 'property-interstitial'),
+            Location('house-details', 0, 'house-type'),
+            Location('multiple-questions-group', 0, 'household-composition'),
+            Location('repeating-group', 0, 'repeating-block-1'),
+            Location('repeating-group', 0, 'repeating-block-2'),
+            Location('extra-cover', 0, 'extra-cover-block'),
+            Location('extra-cover', 0, 'extra-cover-interstitial'),
+            Location('payment-details', 0, 'credit-card'),
+            Location('payment-details', 0, 'expiry-date'),
+            Location('payment-details', 0, 'security-code'),
+            Location('payment-details', 0, 'security-code-interstitial'),
+            Location('extra-cover-items-group', 0, 'extra-cover-items'),
+            Location('confirmation-group', 0, 'confirmation'),
+        ]
+
+        progress = Completeness(
+            schema, AnswerStore(), [], routing_path, metadata={})
+        progress_value = progress.get_state_for_group('repeating-group')
+        self.assertEqual(Completeness.SKIPPED, progress_value)
+
+    def test_repeating_skipped_section(self):
+        schema = load_schema_from_params('test', 'navigation_confirmation')
+
+        completed_blocks = [
+            Location('property-details', 0, 'insurance-type'),
+            Location('property-details', 0, 'insurance-address'),
+            Location('property-details', 0, 'property-interstitial'),
+            Location('house-details', 0, 'house-type'),
+            Location('multiple-questions-group', 0, 'household-composition'),
+            Location('repeating-group', 0, 'repeating-block-1'),
+            Location('repeating-group', 0, 'repeating-block-2'),
+            Location('extra-cover', 0, 'extra-cover-block'),
+            Location('extra-cover', 0, 'extra-cover-interstitial'),
+            Location('payment-details', 0, 'credit-card'),
+            Location('payment-details', 0, 'expiry-date'),
+            Location('payment-details', 0, 'security-code'),
+            Location('payment-details', 0, 'security-code-interstitial'),
+            Location('extra-cover-items-group', 0, 'extra-cover-items'),
+        ]
+
+        routing_path = [
+            Location('property-details', 0, 'insurance-type'),
+            Location('property-details', 0, 'insurance-address'),
+            Location('property-details', 0, 'property-interstitial'),
+            Location('house-details', 0, 'house-type'),
+            Location('multiple-questions-group', 0, 'household-composition'),
+            Location('repeating-group', 0, 'repeating-block-1'),
+            Location('repeating-group', 0, 'repeating-block-2'),
+            Location('extra-cover', 0, 'extra-cover-block'),
+            Location('extra-cover', 0, 'extra-cover-interstitial'),
+            Location('payment-details', 0, 'credit-card'),
+            Location('payment-details', 0, 'expiry-date'),
+            Location('payment-details', 0, 'security-code'),
+            Location('payment-details', 0, 'security-code-interstitial'),
+            Location('extra-cover-items-group', 0, 'extra-cover-items'),
+            Location('confirmation-group', 0, 'confirmation'),
+        ]
+
+
+        progress = Completeness(
+            schema, AnswerStore(), completed_blocks, routing_path, metadata={})
+        progress_value = progress.get_state_for_section(
+            'household-full-names-section')
+        self.assertEqual(Completeness.SKIPPED, progress_value)
+
+    def test_skipped_group(self):
+        schema = load_schema_from_params('test', 'navigation')
+
+        completed_blocks = [
+            Location('property-details', 0, 'insurance-type'),
+            Location('property-details', 0, 'insurance-address'),
+            Location('property-details', 0, 'property-interstitial'),
+            Location('house-details', 0, 'house-type'),
+            Location('multiple-questions-group', 0, 'household-composition'),
+            Location('repeating-group', 0, 'repeating-block-1'),
+            Location('repeating-group', 0, 'repeating-block-2'),
+            Location('extra-cover', 0, 'extra-cover-block'),
+            Location('extra-cover', 0, 'extra-cover-interstitial'),
+            Location('payment-details', 0, 'credit-card'),
+            Location('payment-details', 0, 'expiry-date'),
+            Location('payment-details', 0, 'security-code'),
+            Location('payment-details', 0, 'security-code-interstitial'),
+            Location('extra-cover-items-group', 0, 'extra-cover-items'),
+        ]
+
+        routing_path = [
+            Location('property-details', 0, 'insurance-type'),
+            Location('property-details', 0, 'insurance-address'),
+            Location('property-details', 0, 'property-interstitial'),
+            Location('house-details', 0, 'house-type'),
+            Location('multiple-questions-group', 0, 'household-composition'),
+            Location('repeating-group', 0, 'repeating-block-1'),
+            Location('repeating-group', 0, 'repeating-block-2'),
+            Location('payment-details', 0, 'credit-card'),
+            Location('payment-details', 0, 'expiry-date'),
+            Location('payment-details', 0, 'security-code'),
+            Location('payment-details', 0, 'security-code-interstitial'),
+            Location('extra-cover', 0, 'extra-cover-block'),
+            Location('extra-cover', 0, 'extra-cover-interstitial'),
+            Location('extra-cover-items-group', 0, 'extra-cover-items'),
+            Location('summary-group', 0, 'summary'),
+        ]
+
+        progress = Completeness(
+            schema, AnswerStore(), completed_blocks, routing_path, metadata={})
+        progress_value = progress.get_state_for_group('payment-details')
+        self.assertEqual(Completeness.SKIPPED, progress_value)
+
+    def test_only_question_blocks_counted_for_completeness(self):
+        schema_data = {
+            'sections': [{
+                'id': 'section_1',
+                'groups': [{
+                    'id': 'group_1',
+                    'blocks': [
+                        {
+                            'id': 'question-block',
+                            'type': 'Question',
+                            'questions': [{
+                                'id': 'question'
+                            }]
+                        },
+                        {
+                            'id': 'interstitial-block',
+                            'type': 'Interstitial',
+                            'questions': [{
+                                'id': 'interstitial-question',
+                            }]
+                        }
+                    ]
+                }]
+            }]
+        }
+        schema = QuestionnaireSchema(schema_data)
+
+        completed_blocks = [
+            Location('group_1', 0, 'question-block'),
+        ]
+
+        routing_path = [
+            Location('group_1', 0, 'question-block'),
+            Location('group_1', 0, 'interstitial-block'),
+        ]
+
+        progress = Completeness(
+            schema, AnswerStore(), completed_blocks, routing_path, metadata={})
+        self.assertEqual(Completeness.COMPLETED, progress.get_state_for_group('group_1'))
+        self.assertEqual(Completeness.COMPLETED, progress.get_state_for_section('section_1'))
+        self.assertTrue(progress.all_sections_complete())
+
+    def test_confirmation_questions_checked_for_completeness(self):
+        schema_data = {
+            'sections': [{
+                'id': 'section_1',
+                'groups': [{
+                    'id': 'group_1',
+                    'blocks': [
+                        {
+                            'id': 'question-block',
+                            'type': 'Question',
+                            'questions': [{
+                                'id': 'question'
+                            }]
+                        },
+                        {
+                            'id': 'confirm-question-block',
+                            'type': 'ConfirmationQuestion',
+                            'questions': [{
+                                'id': 'confirm-question'
+                            }]
+                        }
+                    ]
+                }]
+            }]
+        }
+        schema = QuestionnaireSchema(schema_data)
+
+        completed_blocks = [
+            Location('group_1', 0, 'question-block'),
+        ]
+
+        routing_path = [
+            Location('group_1', 0, 'question-block'),
+            Location('group_1', 0, 'confirm-question-block'),
+        ]
+
+        progress = Completeness(
+            schema, AnswerStore(), completed_blocks, routing_path, metadata={})
+        self.assertEqual(Completeness.STARTED, progress.get_state_for_group('group_1'))
+        self.assertEqual(Completeness.STARTED, progress.get_state_for_section('section_1'))
+
+    def test_get_first_incomplete_location_in_survey_not_started(self):
+        schema = load_schema_from_params('test', 'navigation_completeness')
+        expected_location = Location('coffee-group', 0, 'coffee')
+        routing_path = [
+            expected_location,
+            Location('coffee-group', 0, 'response-yes'),
+        ]
+
+        progress = Completeness(
+            schema, AnswerStore(), [], routing_path, metadata={})
+
+        invalid_location = progress.get_first_incomplete_location_in_survey()
+        self.assertEqual(expected_location, invalid_location)
+
+    def test_get_first_incomplete_location_in_survey_started(self):
+        schema = load_schema_from_params('test', 'navigation_completeness')
+        expected_location = Location('coffee-group', 0, 'response-yes')
+        completed_blocks = [
+            Location('coffee-group', 0, 'coffee'),
+        ]
+
+        routing_path = [
+            Location('coffee-group', 0, 'coffee'),
+            expected_location,
+        ]
+
+        progress = Completeness(
+            schema, AnswerStore(), completed_blocks, routing_path, metadata={})
+
+        invalid_location = progress.get_first_incomplete_location_in_survey()
+        self.assertEqual(expected_location, invalid_location)
+
+    def test_get_first_incomplete_location_in_survey_started_with_repeat(self):
+        schema = load_schema_from_params('test', 'navigation')
+
+        completed_blocks = [
+            Location('property-details', 0, 'insurance-type'),
+            Location('property-details', 0, 'insurance-address'),
+            Location('multiple-questions-group', 0, 'household-composition'),
+            Location('extra-cover', 1, 'extra-cover-block'),
+            Location('repeating-group', 0, 'repeating-block-1'),
+            Location('repeating-group', 1, 'repeating-block-1'),
+            Location('repeating-group', 0, 'repeating-block-2'),
+            Location('repeating-group', 1, 'repeating-block-2'),
+            Location('extra-cover', 0, 'extra-cover-block'),
+            Location('extra-cover-items-group', 0, 'extra-cover-items'),
+            Location('extra-cover-items-group', 0, 'extra-cover-items-radio'),
+        ]
+
+        expected_location = Location('extra-cover-items-group', 1, 'extra-cover-items')
+        routing_path = [
+            Location('multiple-questions-group', 0, 'household-composition'),
+            Location('repeating-group', 0, 'repeating-block-1'),
+            Location('repeating-group', 1, 'repeating-block-1'),
+            Location('repeating-group', 0, 'repeating-block-2'),
+            Location('repeating-group', 1, 'repeating-block-2'),
+            Location('extra-cover', 0, 'extra-cover-block'),
+            Location('extra-cover-items-group', 0, 'extra-cover-items'),
+            Location('extra-cover-items-group', 0, 'extra-cover-items-radio'),
+            expected_location,
+        ]
+
+        answer_store = AnswerStore()
+        answer_store.add(Answer(
+            answer_instance=0,
+            answer_id='first-name',
+            value='Person1'
+        ))
+        answer_store.add(Answer(
+            answer_instance=1,
+            answer_id='first-name',
+            value='Person2'
+        ))
+        answer_store.add(Answer(
+            answer_instance=0,
+            answer_id='extra-cover-answer',
+            value=2
+        ))
+
+        progress = Completeness(
+            schema, answer_store, completed_blocks, routing_path, metadata={})
+
+        invalid_location = progress.get_first_incomplete_location_in_survey()
+        self.assertEqual(expected_location, invalid_location)
+
+    def test_get_first_incomplete_location_in_survey_completed(self):
+        schema = load_schema_from_params('test', 'navigation')
+
+        # interstitial blocks have been removed
+        completed_blocks = [
+            Location('property-details', 0, 'insurance-type'),
+            Location('property-details', 0, 'insurance-address'),
+            Location('house-details', 0, 'house-type'),
+            Location('multiple-questions-group', 0, 'household-composition'),
+            Location('repeating-group', 0, 'repeating-block-1'),
+            Location('repeating-group', 0, 'repeating-block-2'),
+            Location('extra-cover', 0, 'extra-cover-block'),
+            Location('payment-details', 0, 'credit-card'),
+            Location('payment-details', 0, 'expiry-date'),
+            Location('payment-details', 0, 'security-code'),
+            Location('extra-cover-items-group', 0, 'extra-cover-items'),
+            Location('extra-cover-items-group', 0, 'extra-cover-items-radio'),
+            Location('skip-payment-group', 0, 'skip-payment'),
+        ]
+
+        routing_path = [
+            Location('property-details', 0, 'insurance-type'),
+            Location('property-details', 0, 'insurance-address'),
+            Location('property-details', 0, 'property-interstitial'),
+            Location('house-details', 0, 'house-type'),
+            Location('multiple-questions-group', 0, 'household-composition'),
+            Location('repeating-group', 0, 'repeating-block-1'),
+            Location('repeating-group', 0, 'repeating-block-2'),
+            Location('extra-cover', 0, 'extra-cover-block'),
+            Location('extra-cover', 0, 'extra-cover-interstitial'),
+            Location('payment-details', 0, 'credit-card'),
+            Location('payment-details', 0, 'expiry-date'),
+            Location('payment-details', 0, 'security-code'),
+            Location('payment-details', 0, 'security-code-interstitial'),
+            Location('extra-cover-items-group', 0, 'extra-cover-items'),
+            Location('extra-cover-items-group', 0, 'extra-cover-items-radio'),
+            Location('skip-payment-group', 0, 'skip-payment'),
+            Location('confirmation-group', 0, 'confirmation'),
+        ]
+        progress = Completeness(
+            schema, AnswerStore(), completed_blocks, routing_path, metadata={})
+        self.assertFalse(progress.get_first_incomplete_location_in_survey())
+
+    def test_get_latest_location_no_completed_blocks(self):
+        schema = load_schema_from_params('test', 'navigation')
+
+        routing_path = [
+            Location('property-details', 0, 'insurance-type'),
+        ]
+
+        progress = Completeness(
+            schema, AnswerStore(), [], routing_path, metadata={})
+        self.assertEqual(routing_path[0], progress.get_latest_location())
+
+    def test_get_latest_location_some_completed_blocks(self):
+        schema = load_schema_from_params('test', 'navigation')
+
+        completed_blocks = [
+            Location('property-details', 0, 'insurance-type'),
+        ]
+
+        routing_path = [
+            Location('property-details', 0, 'insurance-type'),
+            Location('property-details', 0, 'insurance-address'),
+        ]
+
+        progress = Completeness(
+            schema, AnswerStore(), completed_blocks, routing_path, metadata={})
+        self.assertEqual(routing_path[1], progress.get_latest_location())
+
+    def test_get_latest_location_survey_complete(self):
+        schema = load_schema_from_params('test', 'textarea')
+
+        completed_blocks = [
+            Location('textarea-group', 0, 'textarea-block'),
+        ]
+
+        routing_path = [
+            Location('textarea-group', 0, 'textarea-block'),
+            Location('textarea-group', 0, 'textarea-summary'),
+        ]
+
+        progress = Completeness(
+            schema, AnswerStore(), completed_blocks, routing_path, metadata={})
+        self.assertEqual(routing_path[-1], progress.get_latest_location())

--- a/tests/app/questionnaire/test_location.py
+++ b/tests/app/questionnaire/test_location.py
@@ -16,3 +16,8 @@ class TestLocation(AppContextTestCase):
         location_url = location.url(metadata)
 
         self.assertEqual(location_url, 'http://test/questionnaire/1/some_form/999/some-group/0/some-block')
+
+    def test_location_hash(self):
+        location = Location('some-group', 0, 'some-block')
+
+        self.assertEqual(hash(location), hash(location.__dict__.values()))

--- a/tests/app/questionnaire/test_path_finder.py
+++ b/tests/app/questionnaire/test_path_finder.py
@@ -873,43 +873,6 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         pytest.xfail(reason='Known bug when skipping last group due to summary bundled into it')
         self.assertEqual(path_finder.get_routing_path('should-skip-group'), expected_route)
 
-    def test_given_no_completed_blocks_when_get_latest_location_then_go_to_first_block(self):
-        # Given no completed blocks
-        schema = load_schema_from_params('test', 'repeating_household')
-        path_finder = PathFinder(schema, AnswerStore(), metadata={}, completed_blocks=[])
-        completed_block = []
-
-        # When go latest location
-        latest_location = path_finder.get_latest_location(completed_block)
-
-        # Then go to the first block
-        self.assertEqual(Location('multiple-questions-group', 0, 'introduction'), latest_location)
-
-    def test_given_some_completed_blocks_when_get_latest_location_then_go_to_next_uncompleted_block(self):
-        # Given no completed blocks
-        schema = load_schema_from_params('test', 'repeating_household')
-        path_finder = PathFinder(schema, AnswerStore(), metadata={}, completed_blocks=[])
-        completed_block = [Location('multiple-questions-group', 0, 'introduction')]
-
-        # When go latest location
-        latest_location = path_finder.get_latest_location(completed_block)
-
-        # Then go to the first block
-        self.assertEqual(Location('multiple-questions-group', 0, 'household-composition'), latest_location)
-
-    def test_given_completed_all_the_blocks_when_get_latest_location_then_go_to_last_block(self):
-        # Given no completed blocks
-        schema = load_schema_from_params('test', 'textarea')
-        path_finder = PathFinder(schema, AnswerStore(), metadata={}, completed_blocks=[])
-        completed_block = [Location('textarea-group', 0, 'textarea-block'),
-                           Location('textarea-group', 0, 'textarea-summary')]
-
-        # When go latest location
-        latest_location = path_finder.get_latest_location(completed_block)
-
-        # Then go to the first block
-        self.assertEqual(Location('textarea-group', 0, 'textarea-summary'), latest_location)
-
     def test_build_path_with_group_routing(self):
         # Given i have answered the routing question
         schema = load_schema_from_params('test', 'routing_group')

--- a/tests/app/questionnaire/test_questionnaire_schema.py
+++ b/tests/app/questionnaire/test_questionnaire_schema.py
@@ -204,3 +204,47 @@ class TestQuestionnaireSchema(AppContextTestCase):
         has_questions = schema.group_has_questions('non-question-group')
 
         self.assertFalse(has_questions)
+
+    def test_is_summary(self):
+        survey_json = {
+            'sections': [{
+                'id': 'section-1',
+                'groups': [{
+                    'id': 'group-1',
+                    'blocks': [
+                        {
+                            'id': 'block-1',
+                            'type': 'Summary'
+                        }
+                    ]
+                }]
+            }]
+        }
+
+        schema = QuestionnaireSchema(survey_json)
+        self.assertTrue(schema.is_summary_section(schema.get_section('section-1')))
+        self.assertTrue(schema.is_summary_group(schema.get_group('group-1')))
+        self.assertFalse(schema.is_confirmation_section(schema.get_section('section-1')))
+        self.assertFalse(schema.is_confirmation_group(schema.get_group('group-1')))
+
+    def test_is_confirmation(self):
+        survey_json = {
+            'sections': [{
+                'id': 'section-1',
+                'groups': [{
+                    'id': 'group-1',
+                    'blocks': [
+                        {
+                            'id': 'block-1',
+                            'type': 'Confirmation'
+                        }
+                    ]
+                }]
+            }]
+        }
+
+        schema = QuestionnaireSchema(survey_json)
+        self.assertTrue(schema.is_confirmation_section(schema.get_section('section-1')))
+        self.assertTrue(schema.is_confirmation_group(schema.get_group('group-1')))
+        self.assertFalse(schema.is_summary_section(schema.get_section('section-1')))
+        self.assertFalse(schema.is_summary_group(schema.get_group('group-1')))

--- a/tests/app/questionnaire/test_rules.py
+++ b/tests/app/questionnaire/test_rules.py
@@ -3,10 +3,9 @@ from datetime import datetime
 
 from app.data_model.answer_store import AnswerStore, Answer
 from app.questionnaire.location import Location
-from app.questionnaire.path_finder import PathFinder
 from app.questionnaire.questionnaire_schema import QuestionnaireSchema
 from app.questionnaire.rules import evaluate_rule, evaluate_date_rule, evaluate_goto, evaluate_repeat, \
-    evaluate_skip_conditions, evaluate_when_rules
+    evaluate_skip_conditions, evaluate_when_rules, get_answer_ids_on_routing_path
 
 
 class TestRules(TestCase):  # pylint: disable=too-many-public-methods
@@ -451,7 +450,7 @@ class TestRules(TestCase):  # pylint: disable=too-many-public-methods
         current_path = [Location('group-1', 0, 'block-1')]
 
         # When
-        answer_on_path = PathFinder.get_answer_ids_on_routing_path(schema, current_path)
+        answer_on_path = get_answer_ids_on_routing_path(schema, current_path)
         number_of_repeats = evaluate_repeat(repeat, answer_store, answer_on_path)
 
         self.assertEqual(number_of_repeats, 3)
@@ -498,7 +497,7 @@ class TestRules(TestCase):  # pylint: disable=too-many-public-methods
         current_path = [Location('group-1', 0, 'block-1')]
 
         # When
-        answer_on_path = PathFinder.get_answer_ids_on_routing_path(schema, current_path)
+        answer_on_path = get_answer_ids_on_routing_path(schema, current_path)
         number_of_repeats = evaluate_repeat(repeat, answer_store, answer_on_path)
 
         self.assertEqual(number_of_repeats, 2)
@@ -545,7 +544,7 @@ class TestRules(TestCase):  # pylint: disable=too-many-public-methods
         current_path = [Location('group-1', 0, 'block-1')]
 
         # When
-        answer_on_path = PathFinder.get_answer_ids_on_routing_path(schema, current_path)
+        answer_on_path = get_answer_ids_on_routing_path(schema, current_path)
         number_of_repeats = evaluate_repeat(repeat, answer_store, answer_on_path)
 
         self.assertEqual(number_of_repeats, 1)
@@ -592,7 +591,7 @@ class TestRules(TestCase):  # pylint: disable=too-many-public-methods
         current_path = [Location('group-1', 0, 'block-1')]
 
         # When
-        answer_on_path = PathFinder.get_answer_ids_on_routing_path(schema, current_path)
+        answer_on_path = get_answer_ids_on_routing_path(schema, current_path)
         number_of_repeats = evaluate_repeat(repeat, answer_store, answer_on_path)
 
         self.assertEqual(number_of_repeats, 24)

--- a/tests/functional/spec/navigation.spec.js
+++ b/tests/functional/spec/navigation.spec.js
@@ -200,7 +200,6 @@ describe('Navigation', function() {
     .click(SecurityCodePage.submit())
     .click(SkipInterstitialPage.no())
     .click(SkipInterstitialPage.submit())
-    .then(helpers.isSectionComplete('Payment Details')).should.eventually.be.false
     .click(SecurityCodeInterstitialPage.submit())
     .then(helpers.isSectionComplete('Payment Details')).should.eventually.be.true;
   }

--- a/tests/integration/mci/mci_test_urls.py
+++ b/tests/integration/mci/mci_test_urls.py
@@ -1,10 +1,10 @@
 MCI_0203_BASE = '/questionnaire/test/0203/789/mci/0/'
 MCI_0203_INTRODUCTION = MCI_0203_BASE + 'introduction'
-MCI_0203_SUMMARY = MCI_0203_BASE + 'summary'
+MCI_0203_SUMMARY = '/questionnaire/test/0203/789/mci/0/summary'
 MCI_0203_THANKYOU = '/questionnaire/test/0203/789/thank-you'
 
 MCI_0205_BASE = '/questionnaire/test/0205/789/mci/0/'
-MCI_0205_SUMMARY = MCI_0205_BASE + 'summary'
+MCI_0205_SUMMARY = '/questionnaire/test/0205/789/mci/0/summary'
 MCI_0205_INTRODUCTION = MCI_0205_BASE + 'introduction'
 MCI_0205_BLOCK1 = MCI_0205_BASE + 'reporting-period'
 MCI_0205_THANKYOU = '/questionnaire/test/0205/789/thank-you'

--- a/tests/integration/questionnaire/test_questionnaire_endpoint_redirects.py
+++ b/tests/integration/questionnaire/test_questionnaire_endpoint_redirects.py
@@ -34,7 +34,7 @@ class TestQuestionnaireEndpointRedirects(IntegrationTestCase):
         self.post(url=mci_test_urls.MCI_0205_SUMMARY)
 
         # Then
-        self.assertInUrl(mci_test_urls.MCI_0205_INTRODUCTION)
+        self.assertInUrl(mci_test_urls.MCI_0205_BLOCK1)
 
     def test_given_not_complete_questionnaire_when_get_thank_you_then_data_not_deleted(self):
         # Given we start a survey


### PR DESCRIPTION
### What is the context of this PR?
Delegates the logic for working how whether a section is not started, started, complete or skipped to a separate module. This is used by the navigation builder to work out which block to link to when a user clicks on a section link. It's also used to work out if a questionnaire has been completed and can be submitted.

- If a section has not been started the user should link to the first block.
- If it has been started then the user will link to the first incomplete block.
- If it has been completed and the final block is a summary or confirmation block then the user will link to the final block
- If it has been completed and the final block is not a summary or confirmation block then the user will link to the first block

### How to review 
- Test section navigation using surveys that make use of routing, skip conditions and repeated groups
