### PR TITLE
Removed logic from templates

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -51,17 +51,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:8db0b63e0bdf0b188803a4a793a0779369d7b08e45758d0fe0ac610d124bc019",
-                "sha256:0591da93d0c5e8fda7f032cd3e175e93ab0baf7b5174e07aee92b48baeb5582f"
+                "sha256:247dc574d96775faa7891ad8fabcc6b7f8fc2b3ab89b55598d2ab252869da886",
+                "sha256:d0308aa58e53fb255fa6041a636ced9a0bbd35b3ab3c2c7206207af2f147580f"
             ],
-            "version": "==1.5.32"
+            "version": "==1.6.5"
         },
         "botocore": {
             "hashes": [
-                "sha256:52bc09d2f4439bb89ec9606ad652dedeb5bfe2c4db56f27417f4d2e5e50e4e79",
-                "sha256:d798b9aa32e070f6483a9723fb3296da546a2d9d09f17bb62adc57eb5771aaa6"
+                "sha256:2d879f09594ea740bb6768c8bdcfe11f2c0d8d53b6c8ff128995f9ae880ca81f",
+                "sha256:550f95b2cf66a9089480fd37ca82d49126826dcc62a47f5c4fa4c364b5467920"
             ],
-            "version": "==1.8.46"
+            "version": "==1.9.5"
         },
         "certifi": {
             "hashes": [
@@ -72,35 +72,35 @@
         },
         "cffi": {
             "hashes": [
-                "sha256:5d0d7023b72794ea847725680e2156d1d01bc698a9007fccce46d03c904fe093",
-                "sha256:86903c0afab4a3390170aca61f753f5adad8ffff947030719ee44dedc5b68403",
-                "sha256:7d35678a54da0d3f1bc30e3a58a232043753d57c691875b5a75e4e062793bc9a",
-                "sha256:824cac33906be5c8e976f0d950924d88ec058989ef9cd2f77f5cd53cec417635",
-                "sha256:6ca52651f6bd4b8647cb7dee15c82619de3e13490f8e0bc0620830a2245b51d1",
-                "sha256:a183959a4b1e01d6172aeed356e2523ec8682596075aa6cf0003fe08da959a49",
-                "sha256:9532c5bc0108bd0fe43c0eb3faa2ef98a2db60fc0d4019f106b88d46803dd663",
-                "sha256:96652215ef328262b5f1d5647632bd342ac6b31dfbc495b21f1ab27cb06d621d",
-                "sha256:6c99d19225e3135f6190a3bfce2a614cae8eaa5dcaf9e0705d4ccb79a3959a3f",
-                "sha256:12cbf4c04c1ad07124bfc9e928c01e282feac9ec7dd72a18042d4fc56456289a",
-                "sha256:69c37089ccf10692361c8d14dbf4138b00b46741ffe9628755054499f06ed548",
-                "sha256:b8d1454ef627098dc76ccfd6211a08065e6f84efe3754d8d112049fec3768e71",
-                "sha256:cd13f347235410c592f6e36395ee1c136a64b66534f10173bfa4df1dc88f47d0",
-                "sha256:0640f12f04f257c4467075a804a4920a5d07ef91e11c525fc65d715c08231c81",
-                "sha256:89a8d05b96bdeca8fdc89c5fa9469a357d30f6c066262e92c0c8d2e4d3c53cae",
-                "sha256:a67c430a9bde73ae85b0c885fcf41b556760e42ea74c16dc70431a349989b448",
-                "sha256:7a831170b621e98f45ed1d5758325be19619a593924127a0a47af9a72a117319",
-                "sha256:796d0379102e6da5215acfcd20e8e69cca9d97309215b4ce088fe175b1c2f586",
-                "sha256:0fe3b3d571543a4065059d1d3d6d39f4ca6da0f2207ad13547094522e32ead46",
-                "sha256:678135090c311780382b1dd3f828f715583ea8a69687ed053c047d3cec6625d6",
-                "sha256:f4992cd7b4c867f453d44c213ee29e8fd484cf81cfece4b6e836d0982b6fa1cf",
-                "sha256:6d191fb20138fe1948727b20e7b96582b7b7e676135eabf72d910e10bf7bfa65",
-                "sha256:ec208ca16e57904dd7f4c7568665f80b1f7eb7e3214be014560c28def219060d",
-                "sha256:b3653644d6411bf4bd64c1f2ca3cb1b093f98c68439ade5cef328609bbfabf8c",
-                "sha256:f4719d0bafc5f0a67b2ec432086d40f653840698d41fa6e9afa679403dea9d78",
-                "sha256:87f837459c3c78d75cb4f5aadf08a7104db15e8c7618a5c732e60f252279c7a6",
-                "sha256:df9083a992b17a28cd4251a3f5c879e0198bb26c9e808c4647e0a18739f1d11d"
+                "sha256:1b0493c091a1898f1136e3f4f991a784437fac3673780ff9de3bcf46c80b6b50",
+                "sha256:87f37fe5130574ff76c17cab61e7d2538a16f843bb7bca8ebbc4b12de3078596",
+                "sha256:1553d1e99f035ace1c0544050622b7bc963374a00c467edafac50ad7bd276aef",
+                "sha256:151b7eefd035c56b2b2e1eb9963c90c6302dc15fbd8c1c0a83a163ff2c7d7743",
+                "sha256:edabd457cd23a02965166026fd9bfd196f4324fe6032e866d0f3bd0301cd486f",
+                "sha256:ba5e697569f84b13640c9e193170e89c13c6244c24400fc57e88724ef610cd31",
+                "sha256:79f9b6f7c46ae1f8ded75f68cf8ad50e5729ed4d590c74840471fc2823457d04",
+                "sha256:b0f7d4a3df8f06cf49f9f121bead236e328074de6449866515cea4907bbc63d6",
+                "sha256:4c91af6e967c2015729d3e69c2e51d92f9898c330d6a851bf8f121236f3defd3",
+                "sha256:7a33145e04d44ce95bcd71e522b478d282ad0eafaf34fe1ec5bbd73e662f22b6",
+                "sha256:95d5251e4b5ca00061f9d9f3d6fe537247e145a8524ae9fd30a2f8fbce993b5b",
+                "sha256:b75110fb114fa366b29a027d0c9be3709579602ae111ff61674d28c93606acca",
+                "sha256:ae5e35a2c189d397b91034642cb0eab0e346f776ec2eb44a49a459e6615d6e2e",
+                "sha256:fdf1c1dc5bafc32bc5d08b054f94d659422b05aba244d6be4ddc1c72d9aa70fb",
+                "sha256:9d1d3e63a4afdc29bd76ce6aa9d58c771cd1599fbba8cf5057e7860b203710dd",
+                "sha256:be2a9b390f77fd7676d80bc3cdc4f8edb940d8c198ed2d8c0be1319018c778e1",
+                "sha256:ed01918d545a38998bfa5902c7c00e0fee90e957ce036a4000a88e3fe2264917",
+                "sha256:857959354ae3a6fa3da6651b966d13b0a8bed6bbc87a0de7b38a549db1d2a359",
+                "sha256:2ba8a45822b7aee805ab49abfe7eec16b90587f7f26df20c71dd89e45a97076f",
+                "sha256:a36c5c154f9d42ec176e6e620cb0dd275744aa1d804786a71ac37dc3661a5e95",
+                "sha256:e55e22ac0a30023426564b1059b035973ec82186ddddbac867078435801c7801",
+                "sha256:3eb6434197633b7748cea30bf0ba9f66727cdce45117a712b29a443943733257",
+                "sha256:ecbb7b01409e9b782df5ded849c178a0aa7c906cf8c5a67368047daab282b184",
+                "sha256:770f3782b31f50b68627e22f91cb182c48c47c02eb405fd689472aa7b7aa16dc",
+                "sha256:d5d8555d9bfc3f02385c1c37e9f998e2011f0db4f90e250e5bc0c0a85a813085",
+                "sha256:3c85641778460581c42924384f5e68076d724ceac0f267d66c757f7535069c93",
+                "sha256:e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4"
             ],
-            "version": "==1.11.4"
+            "version": "==1.11.5"
         },
         "chardet": {
             "hashes": [
@@ -325,9 +325,9 @@
         },
         "newrelic": {
             "hashes": [
-                "sha256:b01ecb7ca6cd2ae1fab1c462a29b8534a1ff896959d9950248f7a44164e69724"
+                "sha256:0594dd63d7883d30c560e292d063a8dbc7b2ae11b889bec1e8eb9d0f11ab73a6"
             ],
-            "version": "==2.102.0.85"
+            "version": "==2.106.1.88"
         },
         "pika": {
             "hashes": [
@@ -470,9 +470,9 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:9e9ec143e2e246f385cfb2de8daa89d2fa466279addcb7be9e102988fdf33d24"
+                "sha256:249000654107a420a40200f1e0b555a79dfd4eff235b2ff60bc77714bd045f2d"
             ],
-            "version": "==1.2.3"
+            "version": "==1.2.5"
         },
         "structlog": {
             "hashes": [

--- a/app/helpers/form_helper.py
+++ b/app/helpers/form_helper.py
@@ -31,7 +31,7 @@ def get_form_for_location(schema, block_json, location, answer_store, disable_ma
 
         data = deserialise_composition_answers(answers)
 
-        return generate_household_composition_form(schema, block_json, data), None
+        return generate_household_composition_form(schema, block_json, data)
 
     elif location.block_id in ['relationships', 'household-relationships']:
         answer_ids = schema.get_answer_ids_for_block(location.block_id)
@@ -39,11 +39,11 @@ def get_form_for_location(schema, block_json, location, answer_store, disable_ma
 
         data = deserialise_relationship_answers(answers)
 
-        choices = build_relationship_choices(answer_store, location.group_instance)
+        relationship_choices = build_relationship_choices(answer_store, location.group_instance)
 
-        form = generate_relationship_form(schema, block_json, len(choices), data)
+        form = generate_relationship_form(schema, block_json, relationship_choices, data)
 
-        return form, {'relation_instances': choices}
+        return form
 
     mapped_answers = get_mapped_answers(
         schema,
@@ -62,7 +62,7 @@ def get_form_for_location(schema, block_json, location, answer_store, disable_ma
 
     mapped_answers = deserialise_dates(schema, location.block_id, mapped_answers)
 
-    return generate_form(schema, block_json, mapped_answers, answer_store), None
+    return generate_form(schema, block_json, mapped_answers, answer_store)
 
 
 def post_form_for_location(schema, block_json, location, answer_store, request_form, disable_mandatory=False):
@@ -80,16 +80,16 @@ def post_form_for_location(schema, block_json, location, answer_store, request_f
         block_json = disable_mandatory_answers(block_json)
 
     if location.block_id == 'household-composition':
-        return generate_household_composition_form(schema, block_json, request_form), None
+        return generate_household_composition_form(schema, block_json, request_form)
 
     elif location.block_id in ['relationships', 'household-relationships']:
-        choices = build_relationship_choices(answer_store, location.group_instance)
-        form = generate_relationship_form(schema, block_json, len(choices), request_form)
+        relationship_choices = build_relationship_choices(answer_store, location.group_instance)
+        form = generate_relationship_form(schema, block_json, relationship_choices, request_form)
 
-        return form, {'relation_instances': choices}
+        return form
 
     data = clear_other_text_field(request_form, schema.get_questions_for_block(block_json))
-    return generate_form(schema, block_json, data, answer_store), None
+    return generate_form(schema, block_json, data, answer_store)
 
 
 def disable_mandatory_answers(block_json):

--- a/app/templates/layouts/_questionnaire.html
+++ b/app/templates/layouts/_questionnaire.html
@@ -23,7 +23,7 @@
     {% block form_errors %}{% endblock %}
 
     <form class="form qa-questionnaire-form" role="form" method="POST" autocomplete="off" novalidate>
-      {{ form.csrf_token }}
+      {{ content.csrf_token }}
 
       {% block form_content %}
         <div class="group" id="{{current_location.group_id}}">

--- a/app/templates/partials/answer.html
+++ b/app/templates/partials/answer.html
@@ -1,6 +1,6 @@
 {% import 'macros/helpers.html' as helpers %}
 {% set form = content.form %}
-{% set invalid = form.answer_errors(answer.id) | length > 0 %}
+{% set invalid = form.answer_errors[answer.id] | length > 0 %}
 
 <div class="answer answer--{{answer.type|lower}} {{'js-has-errors' if invalid}} {{'answer--calculated' if answer.calculated}}" id="container-{{answer.id}}">
 
@@ -34,7 +34,7 @@
     <aside class="panel panel--simple panel--error" data-qa="error">
       <div class="panel__header">
         <ul class="list list--bare list--errors">
-          {% for field_error in form.answer_errors(answer_id) %}
+          {% for field_error in form.answer_errors[answer_id] %}
             <li class="list__item mars" {{helpers.track('error', 'Error', field_error, question.id)}}>{{ field_error }}</li>
           {% endfor %}
         </ul>

--- a/app/templates/partials/answers/checkbox.html
+++ b/app/templates/partials/answers/checkbox.html
@@ -1,5 +1,5 @@
 {% set widget_type = "checkbox" %}
-{% set input = form[answer['id']] %}
+{% set input = form.fields[answer['id']] %}
 
 <div class="field field--checkbox field--multiplechoice {{'field--cols' if use_grid}}">
   {% include 'partials/widgets/multiple_choice_widget.html' %}

--- a/app/templates/partials/answers/currency.html
+++ b/app/templates/partials/answers/currency.html
@@ -12,9 +12,9 @@
       <span class="input-type__type" id="{{answer.id}}-type">{{ get_currency_symbol(answer.currency) }}</span>
 
         {% if form.errors or form.question_errors %}
-            {% set data_input = form.get_data(answer['id']) %}
+            {% set data_input = form.data[answer['id']] %}
          {% else %}
-            {% set data_input = format_currency_for_input(form.get_data(answer['id']), answer.get('decimal_places')) %}
+            {% set data_input = format_currency_for_input(form.data[answer['id']], answer.get('decimal_places')) %}
         {% endif %}
 
         {% set input = {

--- a/app/templates/partials/answers/date.html
+++ b/app/templates/partials/answers/date.html
@@ -1,25 +1,25 @@
 {% set subfields %}
   <div class="fieldgroup__fields">
-    {% if form[answer['id']]['day'] %}
+    {% if form.fields[answer['id']]['day'] %}
     <div class="field field--input field--day">
       <label class="label mercury" for="{{answer['id']}}-day" id="label-{{answer['id']}}-day" data-qa="label-day">Day</label>
-      {% set input = form[answer['id']]['day'] %}
+      {% set input = form.fields[answer['id']]['day'] %}
       {% set input_placeholder = "DD" %}
       {% include 'partials/forms/input.html' %}
     </div>
     {% endif %}
-    {% if form[answer['id']]['month'] %}
+    {% if form.fields[answer['id']]['month'] %}
     <div class="field field--select field--month">
       <label class="label mercury" for="{{answer['id']}}-month" id="label-{{answer['id']}}-month" data-qa="label-month">Month</label>
-      {% set select = form[answer['id']]['month'] %}
+      {% set select = form.fields[answer['id']]['month'] %}
 
       {% include 'partials/forms/select.html' %}
     </div>
     {% endif %}
-    {% if form[answer['id']]['year'] %}
+    {% if form.fields[answer['id']]['year'] %}
     <div class="field field--input field--year">
       <label class="label mercury" for="{{answer['id']}}-year" id="label-{{answer['id']}}-year" data-qa="label-year">Year</label>
-      {% set input = form[answer['id']]['year'] %}
+      {% set input = form.fields[answer['id']]['year'] %}
       {% set input_placeholder = "YYYY" %}
       {% include 'partials/forms/input.html' %}
     </div>

--- a/app/templates/partials/answers/dropdown.html
+++ b/app/templates/partials/answers/dropdown.html
@@ -1,4 +1,4 @@
-{% set select = form[answer['id']] %}
+{% set select = form.fields[answer['id']] %}
 
 <div class="field field--select">
     {% set label = {

--- a/app/templates/partials/answers/number.html
+++ b/app/templates/partials/answers/number.html
@@ -7,9 +7,9 @@
     {% include 'partials/forms/label.html' %}
 
     {% if form.errors or form.question_errors %}
-        {% set data_input = form.get_data(answer['id']) %}
+        {% set data_input = form.data[answer['id']] %}
     {% else %}
-        {% set data_input = format_number(form.get_data(answer['id'])) %}
+        {% set data_input = format_number(form.data[answer['id']]) %}
     {% endif %}
 
     {% set input = {

--- a/app/templates/partials/answers/percentage.html
+++ b/app/templates/partials/answers/percentage.html
@@ -1,4 +1,4 @@
-{% set input = form[answer['id']] %}
+{% set input = form.fields[answer['id']] %}
 
 <div class="field">
   {% include 'partials/widgets/percentage_widget.html' %}

--- a/app/templates/partials/answers/radio.html
+++ b/app/templates/partials/answers/radio.html
@@ -1,5 +1,5 @@
 {% set widget_type = "radio" %}
-{% set input = form[answer['id']] %}
+{% set input = form.fields[answer['id']] %}
 
 <div class="field field--radio field--multiplechoice {{'field--cols' if use_grid}}">
   {% include 'partials/widgets/multiple_choice_widget.html' %}

--- a/app/templates/partials/answers/textarea.html
+++ b/app/templates/partials/answers/textarea.html
@@ -6,7 +6,7 @@
 
     {% include 'partials/forms/label.html' %}
 
-    {% set input = form[answer['id']] %}
+    {% set input = form.fields[answer['id']] %}
 
     {% set attr = {
       "class": "input input--textarea js-charlimit-input",
@@ -21,7 +21,7 @@
 
     {% set answer_helper = answer.name ~ "-helper" %}
 
-    <textarea {{attr|xmlattr}}>{{ form.get_data(answer['id']) }}</textarea>
+    <textarea {{attr|xmlattr}}>{{ form.data[answer['id']] }}</textarea>
 
     {% set remainingAttr = {
       "id": answer.id ~ "-remaining",

--- a/app/templates/partials/answers/textfield.html
+++ b/app/templates/partials/answers/textfield.html
@@ -1,4 +1,4 @@
-{% set input = form[answer.id] if input is undefined else input %}
+{% set input = form.fields[answer.id] if input is undefined else input %}
 
 <div class="field">
     {% set label = {

--- a/app/templates/partials/answers/unit.html
+++ b/app/templates/partials/answers/unit.html
@@ -1,4 +1,4 @@
-{% set input = form[answer['id']] %}
+{% set input = form.fields[answer['id']] %}
 <div class="field">
     {% set label = {
     'for': answer.id,
@@ -15,9 +15,9 @@
     <div class="input-type input-type--unit">
 
         {% if form.errors or form.question_errors %}
-            {% set data_input = form.get_data(answer['id']) %}
+            {% set data_input = form.data[answer['id']] %}
         {% else %}
-            {% set data_input = format_number(form.get_data(answer['id'])) %}
+            {% set data_input = format_number(form.data[answer['id']]) %}
         {% endif %}
 
         {% set input = {

--- a/app/templates/partials/feedback_form.html
+++ b/app/templates/partials/feedback_form.html
@@ -1,5 +1,5 @@
 <form id="feedback-form" method="POST" class="feedback__form">
-    {{ form.csrf_token }}
+    {{ content.csrf_token }}
     <div class="group">
         <div class="feedback__field">
             <label id="feedback-message-label" class="label venus" for="feedback-message">How can we improve this survey?</label>

--- a/app/templates/partials/introduction/start-survey.html
+++ b/app/templates/partials/introduction/start-survey.html
@@ -1,6 +1,6 @@
 {% set form = content.form %}
 
     <form class="form" method="POST" autocomplete="off" novalidate>
-        {{ form.csrf_token }}
+        {{ content.csrf_token }}
         <button class="btn btn--primary btn--lg qa-btn-get-started" type="submit" name="action[start_questionnaire]">Start survey</button>
     </form>

--- a/app/templates/partials/questions/relationship.html
+++ b/app/templates/partials/questions/relationship.html
@@ -14,9 +14,8 @@
       {{question_title}}
     </legend>
     <div class="question__answers">
-        {% for current_person, other_person in content.relation_instances %}
-          {% set answer = question.answers[0] %}
-          {% set relation_instance = loop.index0 %}
+        {% set answer = question.answers[0] %}
+        {% for field in form.fields[answer['id']] %}
           {% include 'partials/widgets/relationship_widget.html' %}
         {%- endfor -%}
     </div>

--- a/app/templates/partials/summary/summary.html
+++ b/app/templates/partials/summary/summary.html
@@ -3,7 +3,7 @@
 <div>
   <div class="summary">
 
-    {% for group in content.summary %}
+    {% for group in content.summary.groups %}
 
       <h2 class="summary__title saturn" id="{{group.id}}">{{group.title}}</h2>
 
@@ -35,7 +35,7 @@
                      {%- endif -%}
                    </div>
 
-                  {% if content.answers_are_editable %}
+                  {% if content.summary.answers_are_editable %}
                     <div class="summary__edit">
                       <a href="{{ block.link }}#{{answer.id}}" class="summary__edit-link" aria-describedby="{{answer.id}} {{answer.id}}-answer" data-qa="{{answer.id}}-edit" {{helpers.track('click', 'Summary', 'Edit click')}}>Edit <span class="u-vh">your answer</span></a>
                     </div>

--- a/app/templates/partials/topbar.html
+++ b/app/templates/partials/topbar.html
@@ -5,7 +5,7 @@
             {% if meta and meta.respondent.name %}
                 for&nbsp;<span>{{ meta.respondent.name }}</span>
             {% endif %}
-            {% if content and content.variables.period %}
+            {% if content and content.variables and content.variables.period %}
                 <p class="u-mb-no pluto">Period:
                     <span>{{ content.variables.period }}</span>
                 </p>

--- a/app/templates/partials/widgets/multiple_choice_widget.html
+++ b/app/templates/partials/widgets/multiple_choice_widget.html
@@ -14,7 +14,7 @@
     <div class="field__label mars">Select all that apply:</div>
   {% endif %}
 
-  {% for option in form[answer.id] %}
+  {% for option in form.fields[answer.id] %}
     {% set input = {
       "class": "input input--" ~ widget_type ~ " js-focusable",
       "type": widget_type,
@@ -22,7 +22,7 @@
       "name": option.name,
       "id": option.id,
       "checked": "checked" if option['checked'],
-      "data-qa": "has-other-option" if form.option_has_other(answer.id, loop.index0)
+      "data-qa": "has-other-option" if answer.id in form.other_answer and form.other_answer[answer.id][loop.index0] != None
     } %}
 
     {% set label = {
@@ -30,8 +30,8 @@
       "for": option.id,
       "id": "label-" ~ option.id
     } %}
-    
-    
+
+
     <div class="field__item js-focusable-box">
       <input {{input|xmlattr}}>
       <label {{label|xmlattr}}>
@@ -42,8 +42,8 @@
         {% endif %}
       </label>
 
-      {% if form.option_has_other(answer.id, loop.index0) %}
-        {% set other_answer = form.get_other_answer(answer.id, loop.index0) %}
+      {% if answer.id in form.other_answer and form.other_answer[answer.id][loop.index0] != None %}
+        {% set other_answer = form.other_answer[answer.id][loop.index0] %}
 
         {% set other_label = {
           "class": "label mercury",

--- a/app/templates/partials/widgets/percentage_widget.html
+++ b/app/templates/partials/widgets/percentage_widget.html
@@ -19,7 +19,7 @@
         'type': 'number',
         'classes': input_classes,
         'hasType': true,
-        'data': form.get_data(answer['id'])|e,
+        'data': form.data[answer['id']]|e,
         'name': input.name,
         'id': answer.id
     } %}

--- a/app/templates/partials/widgets/relationship_widget.html
+++ b/app/templates/partials/widgets/relationship_widget.html
@@ -1,21 +1,20 @@
-{% set select_option = form[answer.id][relation_instance] %}
 <div class="question__answer">
   <div class="answer">
     <div class="answer__fields">
       <div class="field field--select">
         {% set label = {
           "class": "label venus",
-          "for": select_option.id
+          "for": field.id
         } %}
         <label {{label|xmlattr}}>
-          {{current_person}} is {{other_person}}'s
+          {{field.label.text}}
         </label>
         {% set select = {
           "class": "input input--select",
-          "name": select_option.id,
-          "id": "input-" ~ form[answer.id].id,
-          "choices": select_option.choices,
-          "data": form[answer['id']].data[relation_instance],
+          "name": field.id,
+          "id": "input-" ~ field.id,
+          "choices": field.choices,
+          "data": field.data,
           "flags": {
             "required": answer.mandatory
           }

--- a/app/templates/partials/widgets/text_widget.html
+++ b/app/templates/partials/widgets/text_widget.html
@@ -7,7 +7,7 @@
 
 {% set input = {
   'type': 'text',
-  'value': form.get_data(answer['id'])|e,
+  'value': form.data[answer['id']]|e,
   'name': answer.name,
   'id': answer.id,
   'placeholder': answer.placeholder

--- a/app/templates/question.html
+++ b/app/templates/question.html
@@ -3,16 +3,15 @@
 
 {% block form_errors %}
   {% if form and (form.errors or form.question_errors) %}
-    {% set mapped_errors = form.map_errors() %}
 
     <div class="panel panel--error u-mb-s" data-qa="error">
       <div class="panel__header">
-        <h1 class="panel__title venus">This page has {{ ngettext('an error', '%(num)s errors', mapped_errors|length) }}</h1>
+        <h1 class="panel__title venus">This page has {{ ngettext('an error', '%(num)s errors', form.mapped_errors|length) }}</h1>
       </div>
       <div class="panel__body" data-qa="error-body">
-        <p class="mars">{{ ngettext('This', 'These', mapped_errors|length) }} <strong>must be corrected</strong> to continue.</p>
+        <p class="mars">{{ ngettext('This', 'These', form.mapped_errors|length) }} <strong>must be corrected</strong> to continue.</p>
         <ul class="list list--bare">
-          {% for answer_id, error in mapped_errors %}
+          {% for answer_id, error in form.mapped_errors %}
             <li class="list__item mars">
               {{loop.index}}) <a class="js-inpagelink" href="#container-{{answer_id}}">{{ error }}</a>
             </li>

--- a/app/templating/summary/answer.py
+++ b/app/templating/summary/answer.py
@@ -9,3 +9,15 @@ class Answer:
         self.parent_answer_id = answer_schema.get('parent_answer_id')
         self.child_answer_value = child_answer_value
         self.currency = answer_schema.get('currency')
+
+    def serialize(self):
+        return {
+            'id': self.id,
+            'label': self.label,
+            'value': self.value,
+            'type': self.type,
+            'unit': self.unit,
+            'parent_answer_id': self.parent_answer_id,
+            'child_answer_value': self.child_answer_value,
+            'currency': self.currency
+        }

--- a/app/templating/summary/block.py
+++ b/app/templating/summary/block.py
@@ -1,18 +1,21 @@
+from flask import url_for
+
+from app.questionnaire.rules import evaluate_skip_conditions
 from app.templating.summary.question import Question
 
 
 class Block:
 
-    def __init__(self, block_schema, group_id, answer_store, metadata, url_for):
+    def __init__(self, block_schema, group_id, answer_store, metadata):
         self.id = block_schema['id']
         self.title = block_schema.get('title')
         self.number = block_schema.get('number')
-        self.link = self._build_link(block_schema, group_id, metadata, url_for)
+        self.link = self._build_link(block_schema, group_id, metadata)
         self.questions = self._build_questions(block_schema, answer_store, metadata)
 
     @staticmethod
-    def _build_link(block_schema, group_id, metadata, url_for):
-        link = url_for('questionnaire.get_block',
+    def _build_link(block_schema, group_id, metadata):
+        return url_for('questionnaire.get_block',
                        eq_id=metadata['eq_id'],
                        form_type=metadata['form_type'],
                        collection_id=metadata['collection_exercise_sid'],
@@ -20,13 +23,21 @@ class Block:
                        group_instance=0,
                        block_id=block_schema['id'])
 
-        return link
-
     @staticmethod
     def _build_questions(block_schema, answer_store, metadata):
         questions = []
         for question_schema in block_schema.get('questions', []):
-            question = Question(question_schema, answer_store, metadata)
-            if not question.is_skipped:
+            is_skipped = evaluate_skip_conditions(question_schema.get('skip_conditions'), metadata, answer_store)
+            if not is_skipped:
+                question = Question(question_schema, answer_store).serialize()
                 questions.append(question)
         return questions
+
+    def serialize(self):
+        return {
+            'id': self.id,
+            'title': self.title,
+            'number': self.number,
+            'link': self.link,
+            'questions': self.questions
+        }

--- a/app/templating/summary/group.py
+++ b/app/templating/summary/group.py
@@ -3,18 +3,27 @@ from app.templating.summary.block import Block
 
 class Group:
 
-    def __init__(self, group_schema, path, answer_store, metadata, url_for):
+    def __init__(self, group_schema, path, answer_store, metadata):
         self.id = group_schema['id']
         self.title = group_schema['title']
-        self.blocks = self._build_blocks(group_schema, path, answer_store, metadata, url_for)
+        self.blocks = self._build_blocks(group_schema, path, answer_store, metadata)
 
     @staticmethod
-    def _build_blocks(group_schema, path, answer_store, metadata, url_for):
+    def _build_blocks(group_schema, path, answer_store, metadata):
         blocks = []
 
+        block_ids_on_path = [location.block_id for location in path]
+
         for block in group_schema['blocks']:
-            if block['id'] in [location.block_id for location in path] and \
+            if block['id'] in block_ids_on_path and \
                     block['type'] == 'Question':
-                blocks.extend([Block(block, group_schema['id'], answer_store, metadata, url_for)])
+                blocks.extend([Block(block, group_schema['id'], answer_store, metadata).serialize()])
 
         return blocks
+
+    def serialize(self):
+        return {
+            'id': self.id,
+            'title': self.title,
+            'blocks': self.blocks
+        }

--- a/app/templating/summary/question.py
+++ b/app/templating/summary/question.py
@@ -1,62 +1,59 @@
 import collections
 
 from app.templating.summary.answer import Answer
-from app.questionnaire.rules import evaluate_skip_conditions
 
 
 class Question:
 
-    def __init__(self, question_schema, answer_store, metadata):
+    def __init__(self, question_schema, answer_store):
         self.id = question_schema['id']
         self.type = question_schema['type']
-        self.skip_conditions = question_schema.get('skip_conditions')
-        answer_schema = question_schema['answers']
-        self.title = question_schema['title'] or answer_schema[0]['label']
+
+        answer_schemas = iter(question_schema['answers'])
+        self.title = question_schema['title'] or question_schema['answers'][0]['label']
         self.number = question_schema.get('number', None)
-        self._answer_store = answer_store
-        self._answer_schemas = iter(answer_schema)
-        self.answers = self._build_answers(question_schema)
-        self.is_skipped = evaluate_skip_conditions(self.skip_conditions, metadata, answer_store)
+        self.answers = self._build_answers(answer_store, question_schema, answer_schemas)
 
-    def _get_answers(self, answer_id):
-        return self._answer_store.filter(answer_ids=[answer_id]).escaped().values()
+    @staticmethod
+    def _get_answers(answer_store, answer_id):
+        return answer_store.filter(answer_ids=[answer_id]).escaped().values()
 
-    def _get_answer(self, answer_id):
+    def _get_answer(self, answer_store, answer_id):
         try:
-            return self._get_answers(answer_id)[0]
+            return self._get_answers(answer_store, answer_id)[0]
         except IndexError:
             return None
 
-    def _build_answers(self, question_schema):
+    def _build_answers(self, answer_store, question_schema, answer_schemas):
         summary_answers = []
-        for answer_schema in self._answer_schemas:
+        for answer_schema in answer_schemas:
             if 'parent_answer_id' in answer_schema:
                 continue
             if question_schema['type'] == 'RepeatingAnswer':
-                for answer_value in self._get_answers(answer_schema['id']):
-                    answer = self._build_answer(question_schema, answer_schema, answer_value)
+                for answer_value in self._get_answers(answer_store, answer_schema['id']):
+                    answer = self._build_answer(answer_store, question_schema, answer_schema, answer_schemas, answer_value)
                     summary_answers.append(Answer(answer_schema, answer))
             else:
-                answer_value = self._get_answer(answer_schema['id'])
-                answer = self._build_answer(question_schema, answer_schema, answer_value)
-                child_answer_value = self._find_other_value_in_answers(answer_schema, answer)
-                summary_answers.append(Answer(answer_schema, answer, child_answer_value))
+                answer_value = self._get_answer(answer_store, answer_schema['id'])
+                answer = self._build_answer(answer_store, question_schema, answer_schema, answer_schemas, answer_value)
+                child_answer_value = self._find_other_value_in_answers(answer_store, answer_schema, answer)
+                summary_answers.append(Answer(answer_schema, answer, child_answer_value).serialize())
         return summary_answers
 
-    def _find_other_value_in_answers(self, answer_schema, answer):
+    def _find_other_value_in_answers(self, answer_store, answer_schema, answer):
         if answer is not None and 'options' in answer_schema:
             options = answer_schema['options']
             for option in options:
                 if option['label'] in [a[0] for a in answer] or option['label'] == answer:
                     if 'child_answer_id' in option:
-                        return self._get_answer(option['child_answer_id'])
+                        return self._get_answer(answer_store, option['child_answer_id'])
         return None
 
-    def _build_answer(self, question_schema, answer_schema, answer_value=None):
+    def _build_answer(self, answer_store, question_schema, answer_schema, answer_schemas, answer_value=None):
         if answer_value is None:
             return None
         elif question_schema['type'] == 'DateRange':
-            return self._build_date_range_answer(answer_value)
+            return self._build_date_range_answer(answer_store, answer_value, answer_schemas)
         elif answer_schema['type'] == 'Checkbox':
             checkbox_answers = self._build_checkbox_answers(answer_value, answer_schema)
             return checkbox_answers or None
@@ -81,9 +78,9 @@ class Question:
                                                                   should_display_other=False))
         return multiple_answers
 
-    def _build_date_range_answer(self, answer):
-        next_answer = next(self._answer_schemas)
-        to_date = self._get_answer(next_answer['id'])
+    def _build_date_range_answer(self, answer_store, answer, answer_schemas):
+        next_answer = next(answer_schemas)
+        to_date = self._get_answer(answer_store, next_answer['id'])
         return {
             'from': answer,
             'to': to_date,
@@ -102,3 +99,12 @@ class Question:
         for option in answer_schema['options']:
             if answer == option['value']:
                 return option['label']
+
+    def serialize(self):
+        return {
+            'id': self.id,
+            'type': self.type,
+            'title': self.title,
+            'number': self.number,
+            'answers': self.answers,
+        }

--- a/app/templating/summary_context.py
+++ b/app/templating/summary_context.py
@@ -1,10 +1,10 @@
 import itertools
-from flask import url_for
+
 from app.questionnaire.path_finder import PathFinder
 from app.templating.summary.group import Group
 
 
-def build_summary_rendering_context(schema, schema_json, answer_store, metadata):
+def build_summary_rendering_context(schema, sections, answer_store, metadata):
     """
     Build questionnaire summary context containing metadata and content from the answers of the questionnaire
     :param schema: schema of the current questionnaire
@@ -18,12 +18,14 @@ def build_summary_rendering_context(schema, schema_json, answer_store, metadata)
 
     group_lists = (
         section['groups']
-        for section in schema_json['sections']
+        for section in sections
     )
 
+    group_ids_on_path = [location.group_id for location in path]
+
     for group in itertools.chain.from_iterable(group_lists):
-        if group['id'] in [location.group_id for location in path] \
+        if group['id'] in group_ids_on_path \
                 and schema.group_has_questions(group['id']):
-            groups.extend([Group(group, path, answer_store, metadata, url_for)])
+            groups.extend([Group(group, path, answer_store, metadata).serialize()])
 
     return groups

--- a/app/templating/view_context.py
+++ b/app/templating/view_context.py
@@ -1,0 +1,111 @@
+from flask import current_app, g
+from flask_wtf import FlaskForm
+
+from app.helpers.form_helper import get_form_for_location
+from app.templating.summary_context import build_summary_rendering_context
+from app.templating.template_renderer import renderer
+
+
+def build_view_context(metadata, answer_store, schema_context, block, current_location, form):
+
+    variables = None
+    if g.schema.json.get('variables'):
+        variables = renderer.render(g.schema.json.get('variables'), **schema_context)
+
+    rendered_block = renderer.render(block, **schema_context)
+
+    if block['type'] in ('Summary', 'SectionSummary'):
+        form = form or FlaskForm()
+
+        return build_view_context_for_summary(metadata, answer_store, schema_context, variables, form.csrf_token)
+
+    if block['type'] == 'Question':
+        if not form:
+            form = get_form_for_location(g.schema, rendered_block, current_location, answer_store)
+
+        return build_view_context_for_question(current_location, variables, rendered_block, form)
+
+    if block['type'] in ('Introduction', 'Interstitial', 'Confirmation'):
+        form = form or FlaskForm()
+        return build_view_context_for_non_question(variables, form.csrf_token, rendered_block)
+
+
+def build_view_context_for_non_question(variables, csrf_token, rendered_block):
+    return {
+        'variables': variables,
+        'block': rendered_block,
+        'csrf_token': csrf_token,
+    }
+
+
+def build_view_context_for_question(current_location, variables, rendered_block, form):  # noqa: C901  pylint: disable=too-complex
+
+    context = {
+        'variables': variables,
+        'block': rendered_block,
+        'csrf_token': form.csrf_token,
+        'form': {
+            'errors': form.errors,
+            'question_errors': form.question_errors,
+            'mapped_errors': form.map_errors(),
+            'answer_errors': {},
+            'data': {},
+            'other_answer': {},
+            'fields': {}
+        }
+    }
+
+    answer_ids = []
+    for question in rendered_block.get('questions'):
+        for answer in question['answers']:
+            if current_location.block_id == 'household-composition':
+                for repeated_form in form.household:
+                    answer_ids.append(repeated_form.form[answer['id']].id)
+            else:
+                answer_ids.append(answer['id'])
+
+            if answer['type'] in ('Checkbox', 'Radio'):
+                options = answer['options']
+                context['form']['other_answer'][answer['id']] = []
+                for index in range(len(options)):
+                    context['form']['other_answer'][answer['id']].append(form.get_other_answer(answer['id'], index))
+
+    for answer_id in answer_ids:
+        context['form']['answer_errors'][answer_id] = form.answer_errors(answer_id)
+
+        if hasattr(form, 'get_data'):
+            context['form']['data'][answer_id] = form.get_data(answer_id)
+
+        if answer_id in form:
+            context['form']['fields'][answer_id] = form[answer_id]
+
+    if current_location.block_id in ['household-composition']:
+        context['form']['household'] = form.household
+
+    return context
+
+
+def build_view_context_for_summary(metadata, answer_store, schema_context, variables, csrf_token):
+    rendered_schema_json = renderer.render(g.schema.json, **schema_context)
+    summary_rendered_context = build_summary_rendering_context(g.schema, rendered_schema_json['sections'],
+                                                               answer_store, metadata)
+
+    context = {
+        'csrf_token': csrf_token,
+        'summary': {
+            'groups': summary_rendered_context,
+            'answers_are_editable': True,
+            'is_view_submission_response_enabled': is_view_submitted_response_enabled(g.schema.json),
+        },
+        'variables': variables,
+    }
+    return context
+
+
+def is_view_submitted_response_enabled(schema):
+    if 'submitted_responses' in current_app.eq:
+        view_submitted_response = schema.get('view_submitted_response')
+        if view_submitted_response:
+            return view_submitted_response['enabled']
+
+    return False

--- a/app/themes/census/templates/introduction.html
+++ b/app/themes/census/templates/introduction.html
@@ -16,7 +16,7 @@
 services in your community - services like GPs, hospitals, schools and
 public transport. </p>
 <p>Everyone must be included on a Census form. </p>
- 
+
   <div class="panel panel--info panel--spacious panel--simple u-mb-l">
     <h3 class="neptune">Start or continue to fill in the Census</h3>
     <h4 class="venus"> Enter your 20 digit unique access code </h4>
@@ -25,7 +25,7 @@ public transport. </p>
     <a href="http://www.ons.gov.uk/census/help" target="_blank" >{{_('Help finding your access code')}}</a>
   </div>
   <form action="" class="form" role="form" method="POST" autocomplete="off" novalidate>
-    {{ form.csrf_token }}
+    {{ content.csrf_token }}
     <button class="btn btn--lg qa-btn-get-started" type="submit" name="action[start_questionnaire]">Start survey</button>
   </form>
  <!-- <div class="lock u-mb-s u-mb-m@s"> -->
@@ -34,9 +34,9 @@ public transport. </p>
     <p class="mars">You could be fined if you do not participate or if you supply false information. </p>
     <p>Your personal information is protected by law. Census information is kept confidential for 100 years.</p>
     <p>Census information helps government check that services are fair to everyone. This is called equality monitoring.</p>
-  
+
     <a href="http://www.ons.gov.uk/census/help" target="_blank" >{{_('Need help? More information about the Census')}}</a>
   </div>
-  
+
 </div>
 {% endblock main %}

--- a/app/views/feedback.py
+++ b/app/views/feedback.py
@@ -40,7 +40,10 @@ def before_request():
 @login_required
 def get_form():
     form = FeedbackForm()
-    return _render_template('feedback', form=form)
+    content = {
+        'csrf_token': form.csrf_token
+    }
+    return _render_template('feedback', content=content)
 
 
 @feedback_blueprint.route('', methods=['POST'])

--- a/data/en/census_household.json
+++ b/data/en/census_household.json
@@ -397,7 +397,7 @@
                             "type": "Relationship",
                             "answers": [{
                                 "id": "household-relationships-answer",
-                                "label": "%(current_person)s is %(other_person)s",
+                                "label": "%(current_person)s is %(other_person)s's",
                                 "mandatory": false,
                                 "options": [{
                                         "label": "Husband or wife",

--- a/tests/app/forms/test_household_relationship_form.py
+++ b/tests/app/forms/test_household_relationship_form.py
@@ -71,7 +71,9 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
 
             answer = schema.get_answers_for_block('relationships')[0]
 
-            form = generate_relationship_form(schema, block_json, 3, {})
+            relationship_choices = [['a', 'b'], ['c', 'd'], ['e', 'f']]
+
+            form = generate_relationship_form(schema, block_json, relationship_choices, {})
 
             self.assertTrue(hasattr(form, answer['id']))
             self.assertEqual(len(form.data[answer['id']]), 3)
@@ -83,7 +85,9 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
 
             answer = schema.get_answers_for_block('relationships')[0]
 
-            form = generate_relationship_form(schema, block_json, 3, {
+            relationship_choices = [['a', 'b'], ['c', 'd'], ['e', 'f']]
+
+            form = generate_relationship_form(schema, block_json, relationship_choices, {
                 '{answer_id}-0'.format(answer_id=answer['id']): 'Husband or Wife',
                 '{answer_id}-1'.format(answer_id=answer['id']): 'Brother or Sister',
                 '{answer_id}-2'.format(answer_id=answer['id']): 'Relation - other',
@@ -101,9 +105,11 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
 
             answer = schema.get_answers_for_block('relationships')[0]
 
-            generated_form = generate_relationship_form(schema, block_json, 3, None)
+            relationship_choices = [['a', 'b'], ['c', 'd'], ['e', 'f']]
 
-            form = generate_relationship_form(schema, block_json, 3, {
+            generated_form = generate_relationship_form(schema, block_json, relationship_choices, None)
+
+            form = generate_relationship_form(schema, block_json, relationship_choices, {
                 'csrf_token': generated_form.csrf_token.current_token,
                 '{answer_id}-0'.format(answer_id=answer['id']): '1',
                 '{answer_id}-1'.format(answer_id=answer['id']): '3',

--- a/tests/app/helpers/test_form_helper.py
+++ b/tests/app/helpers/test_form_helper.py
@@ -21,7 +21,7 @@ class TestFormHelper(AppContextTestCase):
                                 group_instance=0,
                                 block_id='introduction')
 
-            form, _ = get_form_for_location(schema, block_json, location, AnswerStore())
+            form = get_form_for_location(schema, block_json, location, AnswerStore())
 
             self.assertTrue(hasattr(form, 'period-to'))
             self.assertTrue(hasattr(form, 'period-from'))
@@ -41,8 +41,8 @@ class TestFormHelper(AppContextTestCase):
                                 group_instance=0,
                                 block_id='introduction')
 
-            form, _ = get_form_for_location(schema, block_json, location,
-                                            AnswerStore(), disable_mandatory=True)
+            form = get_form_for_location(schema, block_json, location,
+                                         AnswerStore(), disable_mandatory=True)
 
             self.assertTrue(hasattr(form, 'period-from'))
             self.assertTrue(hasattr(form, 'period-to'))
@@ -60,7 +60,7 @@ class TestFormHelper(AppContextTestCase):
             block_json = schema.get_block('reporting-period')
             location = Location('rsi', 0, 'reporting-period')
 
-            form, _ = get_form_for_location(schema, block_json, location, AnswerStore([
+            form = get_form_for_location(schema, block_json, location, AnswerStore([
                 {
                     'answer_id': 'period-from',
                     'group_instance': 0,
@@ -101,7 +101,7 @@ class TestFormHelper(AppContextTestCase):
                                 block_id='date-block')
             error_messages = schema.error_messages
 
-            form, _ = get_form_for_location(schema, block_json, location, AnswerStore([
+            form = get_form_for_location(schema, block_json, location, AnswerStore([
                 {
                     'answer_id': 'month-year-answer',
                     'group_id': 'dates',
@@ -132,7 +132,7 @@ class TestFormHelper(AppContextTestCase):
 
             error_messages = schema.error_messages
 
-            form, _ = get_form_for_location(schema, block_json, location, AnswerStore([
+            form = get_form_for_location(schema, block_json, location, AnswerStore([
                 {
                     'answer_id': 'mandatory-checkbox-answer',
                     'group_id': 'checkboxes',
@@ -158,7 +158,7 @@ class TestFormHelper(AppContextTestCase):
                                 group_instance=0,
                                 block_id='introduction')
 
-            form, _ = post_form_for_location(schema, block_json, location, AnswerStore(), {
+            form = post_form_for_location(schema, block_json, location, AnswerStore(), {
                 'period-from-day': '1',
                 'period-from-month': '05',
                 'period-from-year': '2015',
@@ -196,7 +196,7 @@ class TestFormHelper(AppContextTestCase):
                                 group_instance=0,
                                 block_id='introduction')
 
-            form, _ = post_form_for_location(schema, block_json, location, AnswerStore(), {
+            form = post_form_for_location(schema, block_json, location, AnswerStore(), {
             }, disable_mandatory=True)
 
             self.assertTrue(hasattr(form, 'period-from'))
@@ -216,7 +216,7 @@ class TestFormHelper(AppContextTestCase):
             location = Location('who-lives-here', 0, 'household-composition')
             error_messages = schema.error_messages
 
-            form, _ = get_form_for_location(schema, block_json, location, AnswerStore(), error_messages)
+            form = get_form_for_location(schema, block_json, location, AnswerStore(), error_messages)
 
             self.assertTrue(hasattr(form, 'household'))
             self.assertEqual(len(form.household.entries), 1)
@@ -234,7 +234,7 @@ class TestFormHelper(AppContextTestCase):
             block_json = schema.get_block('household-composition')
             location = Location('who-lives-here', 0, 'household-composition')
 
-            form, _ = post_form_for_location(schema, block_json, location, AnswerStore(), {
+            form = post_form_for_location(schema, block_json, location, AnswerStore(), {
                 'household-0-first-name': 'Joe',
                 'household-0-last-name': '',
                 'household-1-first-name': 'Bob',
@@ -292,7 +292,7 @@ class TestFormHelper(AppContextTestCase):
                     'answer_instance': 1,
                 }
             ])
-            form, _ = get_form_for_location(schema, block_json, location, answer_store, error_messages)
+            form = get_form_for_location(schema, block_json, location, answer_store, error_messages)
 
             answer = schema.get_answers_for_block('household-relationships')[0]
 
@@ -336,7 +336,7 @@ class TestFormHelper(AppContextTestCase):
 
             answer = schema.get_answers_for_block('household-relationships')[0]
 
-            form, _ = post_form_for_location(schema, block_json, location, answer_store, MultiDict({
+            form = post_form_for_location(schema, block_json, location, answer_store, MultiDict({
                 '{answer_id}-0'.format(answer_id=answer['id']): '3'
             }))
 
@@ -372,7 +372,7 @@ class TestFormHelper(AppContextTestCase):
                 }
             ])
 
-            form, _ = post_form_for_location(schema, block_json, location, answer_store, MultiDict({
+            form = post_form_for_location(schema, block_json, location, answer_store, MultiDict({
                 'radio-mandatory-answer': 'Bacon',
                 'other-answer-mandatory': 'Old other text'
             }))
@@ -407,7 +407,7 @@ class TestFormHelper(AppContextTestCase):
             radio_answer = schema.get_answers_for_block('radio-mandatory')[0]
             text_answer = 'other-answer-mandatory'
 
-            form, _ = post_form_for_location(schema, block_json, location, answer_store, MultiDict({
+            form = post_form_for_location(schema, block_json, location, answer_store, MultiDict({
                 '{answer_id}'.format(answer_id=radio_answer['id']): 'Other',
                 '{answer_id}'.format(answer_id=text_answer): 'Other text field value',
             }))

--- a/tests/app/templating/summary/test_block.py
+++ b/tests/app/templating/summary/test_block.py
@@ -1,8 +1,8 @@
-from unittest import TestCase
+from mock import MagicMock
 
-import mock
-
+from app.data_model.answer_store import Answer, AnswerStore
 from app.templating.summary.block import Block
+from tests.app.app_context_test_case import AppContextTestCase
 
 
 def build_block_schema(question_schema):
@@ -19,20 +19,19 @@ def build_question_schema(_id, answer_schemas):
     return {'id': _id, 'answers': answer_schemas, 'skipped': False, 'title': 'title', 'type': 'GENERAL'}
 
 
-class TestSection(TestCase):
+class TestSection(AppContextTestCase):
 
     def test_create_block(self):
         # Given
 
-        answer_schema = mock.MagicMock()
+        answer_schema = MagicMock()
         question_schema = build_question_schema('question_id', [answer_schema])
         block_schema = build_block_schema([question_schema])
-        answer_store = mock.MagicMock()
-        metadata = mock.MagicMock()
-        url_for = mock.MagicMock()
+        answer_store = MagicMock()
+        metadata = MagicMock()
 
         # When
-        block = Block(block_schema, 'group_id', answer_store, metadata, url_for)
+        block = Block(block_schema, 'group_id', answer_store, metadata)
 
         # Then
         self.assertEqual(block.id, 'block_id')
@@ -42,17 +41,55 @@ class TestSection(TestCase):
 
     def test_create_section_with_multiple_questions(self):
         # Given
-        first_answer_schema = mock.MagicMock()
-        second_answer_schema = mock.MagicMock()
+        first_answer_schema = MagicMock()
+        second_answer_schema = MagicMock()
         first_question_schema = build_question_schema('question_1', [first_answer_schema])
         second_question_schema = build_question_schema('question_2', [second_answer_schema])
         block_schema = build_block_schema([first_question_schema, second_question_schema])
-        answer_store = mock.MagicMock()
-        metadata = mock.MagicMock()
-        url_for = mock.MagicMock()
+        answer_store = MagicMock()
+        metadata = MagicMock()
 
         # When
-        block = Block(block_schema, 'group_id', answer_store, metadata, url_for)
+        block = Block(block_schema, 'group_id', answer_store, metadata)
 
         # Then
         self.assertEqual(len(block.questions), 2)
+
+    def test_question_should_be_skipped(self):
+        # Given
+        answer = Answer(
+            answer_id='answer_1',
+            value='skip me',
+        )
+        answer_store = AnswerStore()
+        answer_store.add(answer)
+        metadata = MagicMock()
+        answer_schema = {'id': 'answer_1', 'title': '', 'type': '', 'label': ''}
+        skip_conditions = [{'when': [{'id': 'answer_1', 'condition': 'equals', 'value': 'skip me'}]}]
+        question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema],
+                           'skip_conditions': skip_conditions}
+        second_question_schema = build_question_schema('question_2', [MagicMock()])
+        block_schema = build_block_schema([question_schema, second_question_schema])
+
+        # When
+        block = Block(block_schema, 'group_id', answer_store, metadata)
+
+        # Then
+        self.assertTrue(len(block.questions) == 1)
+
+    def test_question_with_no_answers_should_not_be_skipped(self):
+        # Given
+        answer_store = AnswerStore()
+        metadata = MagicMock()
+        answer_schema = {'id': 'answer_1', 'title': '', 'type': '', 'label': ''}
+        skip_conditions = [{'when': [{'id': 'answer_1', 'condition': 'equals', 'value': 'skip me'}]}]
+        question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema],
+                           'skip_conditions': skip_conditions}
+        second_question_schema = build_question_schema('question_2', [MagicMock()])
+        block_schema = build_block_schema([question_schema, second_question_schema])
+
+        # When
+        block = Block(block_schema, 'group_id', answer_store, metadata)
+
+        # Then
+        self.assertTrue(len(block.questions) == 2)

--- a/tests/app/templating/summary/test_question.py
+++ b/tests/app/templating/summary/test_question.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 import mock
 
 from app.templating.summary.question import Question
-from app.data_model.answer_store import Answer, AnswerStore
+from app.data_model.answer_store import AnswerStore
 
 
 class TestQuestion(TestCase):
@@ -12,11 +12,10 @@ class TestQuestion(TestCase):
         # Given
         answer_schema = mock.MagicMock()
         answer_store = AnswerStore()
-        metadata = mock.MagicMock()
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store, metadata)
+        question = Question(question_schema, answer_store)
 
         # Then
         self.assertEqual(question.id, 'question_id')
@@ -27,11 +26,10 @@ class TestQuestion(TestCase):
         # Given
         answer_schema = mock.MagicMock()
         answer_store = AnswerStore()
-        metadata = mock.MagicMock()
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store, metadata)
+        question = Question(question_schema, answer_store)
 
         # Then
         self.assertEqual(question.id, 'question_id')
@@ -51,19 +49,18 @@ class TestQuestion(TestCase):
             'value': 'Solo',
             'answer_instance': 0,
         }])
-        metadata = mock.MagicMock()
         first_answer_schema = {'id': 'answer_1', 'label': 'First name', 'type': 'text'}
         second_answer_schema = {'id': 'answer_2', 'label': 'Surname', 'type': 'text'}
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL',
                            'answers': [first_answer_schema, second_answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store, metadata)
+        question = Question(question_schema, answer_store)
 
         # Then
         self.assertEqual(len(question.answers), 2)
-        self.assertEqual(question.answers[0].value, 'Han')
-        self.assertEqual(question.answers[1].value, 'Solo')
+        self.assertEqual(question.answers[0]['value'], 'Han')
+        self.assertEqual(question.answers[1]['value'], 'Solo')
 
     def test_merge_date_range_answers(self):
         # Given
@@ -78,19 +75,18 @@ class TestQuestion(TestCase):
             'value': '13/09/2016',
             'answer_instance': 0,
         }])
-        metadata = mock.MagicMock()
         first_date_answer_schema = {'id': 'answer_1', 'label': 'From', 'type': 'date'}
         second_date_answer_schema = {'id': 'answer_2', 'label': 'To', 'type': 'date'}
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'DateRange',
                            'answers': [first_date_answer_schema, second_date_answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store, metadata)
+        question = Question(question_schema, answer_store)
 
         # Then
         self.assertEqual(len(question.answers), 1)
-        self.assertEqual(question.answers[0].value['from'], '13/02/2016')
-        self.assertEqual(question.answers[0].value['to'], '13/09/2016', '%d/%m/%Y')
+        self.assertEqual(question.answers[0]['value']['from'], '13/02/2016')
+        self.assertEqual(question.answers[0]['value']['to'], '13/09/2016', '%d/%m/%Y')
 
     def test_merge_multiple_date_range_answers(self):
         # Given
@@ -115,7 +111,6 @@ class TestQuestion(TestCase):
             'value': '13/10/2016',
             'answer_instance': 0,
         }])
-        metadata = mock.MagicMock()
         first_date_answer_schema = {'id': 'answer_1', 'label': 'From', 'type': 'date'}
         second_date_answer_schema = {'id': 'answer_2', 'label': 'To', 'type': 'date'}
         third_date_answer_schema = {'id': 'answer_3', 'label': 'First period', 'type': 'date'}
@@ -124,14 +119,14 @@ class TestQuestion(TestCase):
                            [first_date_answer_schema, second_date_answer_schema, third_date_answer_schema, fourth_date_answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store, metadata)
+        question = Question(question_schema, answer_store)
 
         # Then
         self.assertEqual(len(question.answers), 2)
-        self.assertEqual(question.answers[0].value['from'], '13/02/2016')
-        self.assertEqual(question.answers[0].value['to'], '13/09/2016', '%d/%m/%Y')
-        self.assertEqual(question.answers[1].value['from'], '13/03/2016', '%d/%m/%Y')
-        self.assertEqual(question.answers[1].value['to'], '13/10/2016', '%d/%m/%Y')
+        self.assertEqual(question.answers[0]['value']['from'], '13/02/2016')
+        self.assertEqual(question.answers[0]['value']['to'], '13/09/2016', '%d/%m/%Y')
+        self.assertEqual(question.answers[1]['value']['from'], '13/03/2016', '%d/%m/%Y')
+        self.assertEqual(question.answers[1]['value']['to'], '13/10/2016', '%d/%m/%Y')
 
     def test_checkbox_button_options(self):
         # Given
@@ -149,17 +144,16 @@ class TestQuestion(TestCase):
             'label': 'Dark Side',
             'value': 'Dark Side',
         }]
-        metadata = mock.MagicMock()
         answer_schema = {'id': 'answer_1', 'label': 'Which side?', 'type': 'Checkbox', 'options': options}
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store, metadata)
+        question = Question(question_schema, answer_store)
 
         # Then
-        self.assertEqual(len(question.answers[0].value), 2)
-        self.assertEqual(question.answers[0].value[0].label, 'Light Side')
-        self.assertEqual(question.answers[0].value[1].label, 'Dark Side')
+        self.assertEqual(len(question.answers[0]['value']), 2)
+        self.assertEqual(question.answers[0]['value'][0].label, 'Light Side')
+        self.assertEqual(question.answers[0]['value'][1].label, 'Dark Side')
 
     def test_checkbox_button_other_option_empty(self):
         # Given
@@ -169,7 +163,6 @@ class TestQuestion(TestCase):
             'value': ['other', ''],
             'answer_instance': 0,
         }])
-        metadata = mock.MagicMock()
         options = [{
             'label': 'Light Side',
             'value': 'Light Side',
@@ -184,12 +177,12 @@ class TestQuestion(TestCase):
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store, metadata)
+        question = Question(question_schema, answer_store)
 
         # Then
-        self.assertEqual(len(question.answers[0].value), 1)
-        self.assertEqual(question.answers[0].value[0].label, 'Other option label')
-        self.assertEqual(question.answers[0].value[0].should_display_other, True)
+        self.assertEqual(len(question.answers[0]['value']), 1)
+        self.assertEqual(question.answers[0]['value'][0].label, 'Other option label')
+        self.assertEqual(question.answers[0]['value'][0].should_display_other, True)
 
     def test_checkbox_answer_with_other_value_returns_the_value(self):
         # Given
@@ -204,7 +197,6 @@ class TestQuestion(TestCase):
             'value': 'Test',
             'answer_instance': 0,
         }])
-        metadata = mock.MagicMock()
         options = [{
             'label': 'Light Side',
             'value': 'Light Side',
@@ -227,11 +219,11 @@ class TestQuestion(TestCase):
                            'answers': answer_schema}
 
         # When
-        question = Question(question_schema, answer_store, metadata)
+        question = Question(question_schema, answer_store)
 
         # Then
-        self.assertEqual(len(question.answers[0].value), 2)
-        self.assertEqual(question.answers[0].child_answer_value, 'Test')
+        self.assertEqual(len(question.answers[0]['value']), 2)
+        self.assertEqual(question.answers[0]['child_answer_value'], 'Test')
 
     def test_checkbox_button_other_option_text(self):
         # Given
@@ -246,7 +238,6 @@ class TestQuestion(TestCase):
             'value': 'Neither',
             'answer_instance': 0,
         }])
-        metadata = mock.MagicMock()
         options = [{
             'label': 'Light Side',
             'value': 'Light Side',
@@ -259,12 +250,12 @@ class TestQuestion(TestCase):
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store, metadata)
+        question = Question(question_schema, answer_store)
 
         # Then
-        self.assertEqual(len(question.answers[0].value), 2)
-        self.assertEqual(question.answers[0].value[0].label, 'Light Side')
-        self.assertEqual(question.answers[0].child_answer_value, 'Neither')
+        self.assertEqual(len(question.answers[0]['value']), 2)
+        self.assertEqual(question.answers[0]['value'][0].label, 'Light Side')
+        self.assertEqual(question.answers[0]['child_answer_value'], 'Neither')
 
     def test_checkbox_button_none_selected_should_be_none(self):
         # Given
@@ -274,7 +265,6 @@ class TestQuestion(TestCase):
             'value': [],
             'answer_instance': 0,
         }])
-        metadata = mock.MagicMock()
         options = [{
             'label': 'Light Side',
             'value': 'Light Side',
@@ -283,10 +273,10 @@ class TestQuestion(TestCase):
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store, metadata)
+        question = Question(question_schema, answer_store)
 
         # Then
-        self.assertEqual(question.answers[0].value, None)
+        self.assertEqual(question.answers[0]['value'], None)
 
     def test_radio_button_other_option_empty(self):
         # Given
@@ -296,7 +286,6 @@ class TestQuestion(TestCase):
             'value': '',
             'answer_instance': 0,
         }])
-        metadata = mock.MagicMock()
         options = [{
             'label': 'Light Side',
             'value': 'Light Side',
@@ -311,10 +300,10 @@ class TestQuestion(TestCase):
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store, metadata)
+        question = Question(question_schema, answer_store)
 
         # Then
-        self.assertEqual(question.answers[0].value, 'Other option label')
+        self.assertEqual(question.answers[0]['value'], 'Other option label')
 
     def test_radio_button_other_option_text(self):
         # Given
@@ -324,7 +313,6 @@ class TestQuestion(TestCase):
             'value': 'I want to be on the dark side',
             'answer_instance': 0,
         }])
-        metadata = mock.MagicMock()
         options = [{
             'label': 'Light Side',
             'value': 'Light Side',
@@ -339,10 +327,10 @@ class TestQuestion(TestCase):
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store, metadata)
+        question = Question(question_schema, answer_store)
 
         # Then
-        self.assertEqual(question.answers[0].value, 'I want to be on the dark side')
+        self.assertEqual(question.answers[0]['value'], 'I want to be on the dark side')
 
     def test_radio_button_none_selected_should_be_none(self):
         # Given
@@ -352,7 +340,6 @@ class TestQuestion(TestCase):
             'value': None,
             'answer_instance': 0,
         }])
-        metadata = mock.MagicMock()
         options = [{
             'label': 'Light Side',
             'value': 'Light Side',
@@ -361,10 +348,10 @@ class TestQuestion(TestCase):
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store, metadata)
+        question = Question(question_schema, answer_store)
 
         # Then
-        self.assertEqual(question.answers[0].value, None)
+        self.assertEqual(question.answers[0]['value'], None)
 
     def test_radio_answer_with_other_value_returns_the_value(self):
         # Given
@@ -379,7 +366,6 @@ class TestQuestion(TestCase):
             'value': 'Test',
             'answer_instance': 0,
         }])
-        metadata = mock.MagicMock()
         options = [{
             'label': 'Other',
             'value': 'Other',
@@ -399,45 +385,10 @@ class TestQuestion(TestCase):
                            'answers': answer_schema}
 
         # When
-        question = Question(question_schema, answer_store, metadata)
+        question = Question(question_schema, answer_store)
 
         # Then
-        self.assertEqual(question.answers[0].child_answer_value, 'Test')
-
-    def test_question_should_be_skipped(self):
-        # Given
-        metadata = mock.MagicMock()
-        answer = Answer(
-            answer_id='answer_1',
-            value='skip me',
-        )
-        answer_store = AnswerStore()
-        answer_store.add(answer)
-        answer_schema = {'id': 'answer_1', 'title': '', 'type': '', 'label': ''}
-        skip_conditions = [{'when': [{'id': 'answer_1', 'condition': 'equals', 'value': 'skip me'}]}]
-        question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema],
-                           'skip_conditions': skip_conditions}
-
-        # When
-        question = Question(question_schema, answer_store, metadata)
-
-        # Then
-        self.assertTrue(question.is_skipped)
-
-    def test_question_with_no_answers_should_not_be_skipped(self):
-        # Given
-        metadata = mock.MagicMock()
-        answer_store = AnswerStore()
-        answer_schema = {'id': 'answer_1', 'title': '', 'type': '', 'label': ''}
-        skip_conditions = [{'when': [{'id': 'answer_1', 'condition': 'equals', 'value': 'skip me'}]}]
-        question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema],
-                           'skip_conditions': skip_conditions}
-
-        # When
-        question = Question(question_schema, answer_store, metadata)
-
-        # Then
-        self.assertFalse(question.is_skipped)
+        self.assertEqual(question.answers[0]['child_answer_value'], 'Test')
 
     def test_build_answers_repeating_answers(self):
         # Given
@@ -457,13 +408,12 @@ class TestQuestion(TestCase):
             'value': 'value2',
             'answer_instance': 0,
         }])
-        metadata = mock.MagicMock()
         answer_schema = {'id': 'answer', 'title': '', 'type': '', 'label': ''}
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'RepeatingAnswer',
                            'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store, metadata)
+        question = Question(question_schema, answer_store)
 
         # Then
         self.assertEqual(len(question.answers), 3)

--- a/tests/app/templating/test_summary_context.py
+++ b/tests/app/templating/test_summary_context.py
@@ -40,7 +40,7 @@ class TestSummaryContext(AppContextTestCase):
         navigator.get_full_routing_path = Mock(return_value=routing_path)
 
         with patch('app.templating.summary_context.PathFinder', return_value=navigator):
-            context = build_summary_rendering_context(self.schema, self.schema.json, answer_store, self.metadata)
+            context = build_summary_rendering_context(self.schema, self.schema.json['sections'], answer_store, self.metadata)
 
         self.assertEqual(len(context), 1)
 
@@ -61,7 +61,7 @@ class TestSummaryContext(AppContextTestCase):
         navigator.get_full_routing_path = Mock(return_value=routing_path)
 
         with patch('app.templating.summary_context.PathFinder', return_value=navigator):
-            context = build_summary_rendering_context(self.schema, self.schema.json, answer_store, self.metadata)
+            context = build_summary_rendering_context(self.schema, self.schema.json['sections'], answer_store, self.metadata)
 
-        answer = context[0].blocks[0].questions[0].answers[0]
-        self.assertEqual(answer.value, '&lt;&gt;&#34;&#39;&amp;')
+        answer = context[0]['blocks'][0]['questions'][0]['answers'][0]
+        self.assertEqual(answer['value'], '&lt;&gt;&#34;&#39;&amp;')

--- a/tests/integration/views/test_view_submission.py
+++ b/tests/integration/views/test_view_submission.py
@@ -65,6 +65,7 @@ class TestViewSubmission(IntegrationTestCase):
         self.assertInPage('Submitted answers')
 
         # check answers are on page
+        self.assertStatusOK()
         self.assertInPage('Bacon')
         self.assertInPage('12')
         self.assertInPage('345')


### PR DESCRIPTION
Constructed a view model will all information required to render the page

### What is the context of this PR?
The model passed to the templates is now a dict and contains all of the information required to render the page.
Also implemented is the ability to get to json back from any questionnaire endpoint, by only specifying in the request that the client accepts json

### How to review 
Does everything continue to work.
When adding the accepts `application/json` header then all of the context is returned as json