### PR TITLE
Don't render an empty header in the summary

### DIFF
--- a/app/templates/partials/summary/summary.html
+++ b/app/templates/partials/summary/summary.html
@@ -5,7 +5,9 @@
 
     {% for group in content.summary.groups %}
 
+      {% if group.title %}
       <h2 class="summary__title saturn" id="{{group.id}}">{{group.title}}</h2>
+      {% endif %}
 
       <div class="summary__block">
 

--- a/data/en/test_summary.json
+++ b/data/en/test_summary.json
@@ -99,14 +99,39 @@
                         "type": "General"
                     }],
                     "title": ""
+                }
+            ],
+            "id": "summary-group",
+            "title": ""
+        },
+        {
+            "blocks": [
+                {
+                    "description": "",
+                    "type": "Question",
+                    "id": "dessert-block",
+                    "questions": [{
+                        "id": "test-dessert-question",
+                        "title": "",
+                        "type": "General",
+                        "answers": [
+                            {
+                                "id": "dessert",
+                                "label": "What is your favourite dessert?",
+                                "mandatory": false,
+                                "q_code": "30",
+                                "type": "TextField"
+                            }
+                        ]
+                    }]
                 },
                 {
                     "type": "Summary",
                     "id": "summary"
                 }
             ],
-            "id": "summary-group",
-            "title": ""
+            "id": "dessert-group",
+            "title": "Dessert"
         }]
     }]
 }

--- a/tests/functional/generate_pages.py
+++ b/tests/functional/generate_pages.py
@@ -87,6 +87,10 @@ SUMMARY_ANSWER_EDIT_GETTER = Template(r"""  ${answerName}Edit() { return '[data-
 
 """)
 
+SUMMARY_TITLE_GETTER = Template(r"""  ${group_id_camel}Title() { return '#${group_id}'; }
+
+""")
+
 CONSTRUCTOR = Template(r"""  constructor() {
     super('${block_id}');
   }
@@ -203,6 +207,13 @@ def process_summary(schema_data, page_spec):
                         }
                         page_spec.write(SUMMARY_ANSWER_GETTER.substitute(answer_context))
                         page_spec.write(SUMMARY_ANSWER_EDIT_GETTER.substitute(answer_context))
+
+            group_context = {
+                'group_id_camel': camel_case(generate_pascal_case_from_id(group['id'])),
+                'group_id': group['id']
+            }
+            page_spec.write(
+                SUMMARY_TITLE_GETTER.substitute(group_context))
 
 
 def long_names_required(question, num_questions):

--- a/tests/functional/pages/surveys/summary_screen/dessert-block.page.js
+++ b/tests/functional/pages/surveys/summary_screen/dessert-block.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class DessertBlockPage extends QuestionPage {
+
+  constructor() {
+    super('dessert-block');
+  }
+
+  answer() {
+    return '#dessert';
+  }
+
+  answerLabel() { return '#label-dessert'; }
+
+}
+module.exports = new DessertBlockPage();

--- a/tests/functional/pages/surveys/summary_screen/summary.page.js
+++ b/tests/functional/pages/surveys/summary_screen/summary.page.js
@@ -27,5 +27,13 @@ class SummaryPage extends QuestionPage {
 
   testDecimalEdit() { return '[data-qa="test-decimal-edit"]'; }
 
+  summaryGroupTitle() { return '#summary-group'; }
+
+  dessert() { return '#dessert-answer'; }
+
+  dessertEdit() { return '[data-qa="dessert-edit"]'; }
+
+  dessertGroupTitle() { return '#dessert-group'; }
+
 }
 module.exports = new SummaryPage();

--- a/tests/functional/spec/summary_screen.spec.js
+++ b/tests/functional/spec/summary_screen.spec.js
@@ -2,6 +2,7 @@ const helpers = require('../helpers');
 
 const RadioPage = require('../pages/surveys/summary_screen/radio.page.js');
 const TestNumberPage = require('../pages/surveys/summary_screen/test-number-block.page.js');
+const DessertBlockPage = require('../pages/surveys/summary_screen/dessert-block.page.js');
 const SummaryPage = require('../pages/surveys/summary_screen/summary.page.js');
 
 describe('Summary Screen', function() {
@@ -14,7 +15,9 @@ describe('Summary Screen', function() {
         .getText(SummaryPage.radioAnswer()).should.eventually.contain('Bacon')
         .getText(SummaryPage.testCurrency()).should.eventually.contain('£1,234.00')
         .getText(SummaryPage.squareKilometres()).should.eventually.contain('123,456 km²')
-        .getText(SummaryPage.testDecimal()).should.eventually.contain('123,456.78');
+        .getText(SummaryPage.testDecimal()).should.eventually.contain('123,456.78')
+        .getText(SummaryPage.dessertGroupTitle()).should.eventually.contain('Dessert')
+        .elements(SummaryPage.summaryGroupTitle()).then(result => result.value).should.eventually.be.empty;
       });
   });
 
@@ -48,6 +51,7 @@ describe('Summary Screen', function() {
         .hasFocus(TestNumberPage.squareKilometres())
         .setValue(TestNumberPage.squareKilometres(), '654321')
         .click(TestNumberPage.submit())
+        .click(DessertBlockPage.submit())
         .getText(SummaryPage.squareKilometres()).should.eventually.contain('654,321 km²');
       });
   });
@@ -58,6 +62,7 @@ describe('Summary Screen', function() {
       .click(RadioPage.submit())
       .setValue(TestNumberPage.testCurrency(), '0')
       .click(TestNumberPage.submit())
+      .click(DessertBlockPage.submit())
       .getUrl().should.eventually.contain(SummaryPage.pageName)
       .getText(SummaryPage.testCurrency()).should.eventually.contain('£0.00');
      });
@@ -68,6 +73,7 @@ describe('Summary Screen', function() {
     return browser
       .click(RadioPage.submit())
       .click(TestNumberPage.submit())
+      .click(DessertBlockPage.submit())
       .getUrl().should.eventually.contain(SummaryPage.pageName)
       .getText(SummaryPage.testCurrency()).should.eventually.contain('No answer provided');
      });
@@ -82,6 +88,8 @@ describe('Summary Screen', function() {
       .setValue(TestNumberPage.squareKilometres(), '123456')
       .setValue(TestNumberPage.testDecimal(), '123456.78')
       .click(TestNumberPage.submit())
+      .setValue(DessertBlockPage.answer(), 'Crème Brûlée')
+      .click(DessertBlockPage.submit())
       .getUrl().should.eventually.contain(SummaryPage.pageName);
   }
 


### PR DESCRIPTION
### What is the context of this PR?
Removes empty `<h2>`s that get rendered on the summary page if any groups don't have titles. 

### How to review 
Complete the 1_0102 questionnaire. Verify that no empty h2 gets rendered.
