### PR TITLE
Routing based on dates

### DIFF
--- a/data/en/test_routing_date_equals.json
+++ b/data/en/test_routing_date_equals.json
@@ -1,0 +1,199 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "001",
+    "title": "Test Routing Date Equals",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "description": "A test survey for routing based on equal dates",
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "blocks": [{
+                    "type": "Question",
+                    "id": "comparison-date-block",
+                    "description": "",
+                    "questions": [{
+                        "answers": [{
+                            "id": "comparison-date-answer",
+                            "alias": "comparison_date_answer",
+                            "label": "",
+                            "mandatory": true,
+                            "q_code": "11",
+                            "type": "Date"
+                        }],
+                        "description": "",
+                        "id": "comparison-date-question",
+                        "title": "",
+                        "type": "General",
+                        "guidance": {
+                            "content": [{
+                                "title": "If you enter 31/03/2018 the following dates will be valid",
+                                "list": [
+                                    "Yesterday 30/03/2018",
+                                    "Today 31/03/2018",
+                                    "Tomorrow 01/04/2018",
+                                    "Last Month 28/02/2018 (28th as no 31st February)",
+                                    "Next Month 30/04/2018 (30th as no 31st April)",
+                                    "Last Year 31/03/2017",
+                                    "Next Year 31/03/2019"
+                                ]
+                            }]
+                        }
+                    }],
+                    "title": "Date To Compare"
+                },
+                {
+                    "type": "Question",
+                    "id": "date-question",
+                    "description": "",
+                    "questions": [{
+                        "answers": [{
+                            "id": "single-date-answer",
+                            "label": "Today",
+                            "mandatory": true,
+                            "type": "Date"
+                        }],
+                        "description": "",
+                        "id": "date-questions",
+                        "title": "Enter {{ answers.comparison_date_answer|format_date }} or offset by one day, month or year in either direction",
+                        "type": "General"
+                    }],
+                    "title": "",
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "correct-answer",
+                                "when": [{
+                                    "id": "single-date-answer",
+                                    "condition": "equals",
+                                    "date_comparison": {
+                                        "id": "comparison-date-answer",
+                                        "offset_by": {
+                                            "days": -1
+                                        }
+                                    }
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "correct-answer",
+                                "when": [{
+                                    "id": "single-date-answer",
+                                    "condition": "equals",
+                                    "date_comparison": {
+                                        "id": "comparison-date-answer"
+                                    }
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "correct-answer",
+                                "when": [{
+                                    "id": "single-date-answer",
+                                    "condition": "equals",
+                                    "date_comparison": {
+                                        "id": "comparison-date-answer",
+                                        "offset_by": {
+                                            "days": 1
+                                        }
+                                    }
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "correct-answer",
+                                "when": [{
+                                    "id": "single-date-answer",
+                                    "condition": "equals",
+                                    "date_comparison": {
+                                        "id": "comparison-date-answer",
+                                        "offset_by": {
+                                            "months": -1
+                                        }
+                                    }
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "correct-answer",
+                                "when": [{
+                                    "id": "single-date-answer",
+                                    "condition": "equals",
+                                    "date_comparison": {
+                                        "id": "comparison-date-answer",
+                                        "offset_by": {
+                                            "months": 1
+                                        }
+                                    }
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "correct-answer",
+                                "when": [{
+                                    "id": "single-date-answer",
+                                    "condition": "equals",
+                                    "date_comparison": {
+                                        "id": "comparison-date-answer",
+                                        "offset_by": {
+                                            "years": -1
+                                        }
+                                    }
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "correct-answer",
+                                "when": [{
+                                    "id": "single-date-answer",
+                                    "condition": "equals",
+                                    "date_comparison": {
+                                        "id": "comparison-date-answer",
+                                        "offset_by": {
+                                            "years": 1
+                                        }
+                                    }
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "incorrect-answer"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Interstitial",
+                    "id": "incorrect-answer",
+                    "title": "Incorrect Date",
+                    "description": "You entered an incorrect date",
+                    "routing_rules": [{
+                        "goto": {
+                            "block": "summary"
+                        }
+                    }]
+                },
+                {
+                    "type": "Interstitial",
+                    "id": "correct-answer",
+                    "title": "Correct Date",
+                    "description": "You entered a correct date."
+                },
+                {
+                    "type": "Summary",
+                    "id": "summary"
+                }
+            ],
+            "id": "group",
+            "title": ""
+        }]
+    }]
+}

--- a/data/en/test_routing_date_greater_than.json
+++ b/data/en/test_routing_date_greater_than.json
@@ -1,0 +1,75 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "001",
+    "title": "Test Routing Date Greater Than",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "description": "A test survey for routing based on a date greater than",
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "blocks": [{
+                    "type": "Question",
+                    "id": "date-question",
+                    "description": "",
+                    "questions": [{
+                        "answers": [{
+                            "id": "single-date-answer",
+                            "label": "",
+                            "mandatory": true,
+                            "type": "MonthYearDate"
+                        }],
+                        "description": "",
+                        "id": "date-questions",
+                        "title": "Enter a date greater than Return date: {{ exercise.return_by|format_date('%B %Y') }}",
+                        "type": "General"
+                    }],
+                    "title": "",
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "correct-answer",
+                                "when": [{
+                                    "id": "single-date-answer",
+                                    "condition": "greater than",
+                                    "date_comparison": {
+                                        "meta": "return_by"
+                                    }
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "incorrect-answer"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Interstitial",
+                    "id": "incorrect-answer",
+                    "title": "Incorrect Date",
+                    "description": "You entered a return date earlier than {{ exercise.return_by|format_date('%B %Y') }}.",
+                    "routing_rules": [{
+                        "goto": {
+                            "block": "summary"
+                        }
+                    }]
+                },
+                {
+                    "type": "Interstitial",
+                    "id": "correct-answer",
+                    "title": "Correct Date",
+                    "description": "You entered a return date later than {{ exercise.return_by|format_date('%B %Y') }}."
+                },
+                {
+                    "type": "Summary",
+                    "id": "summary"
+                }
+            ],
+            "id": "group",
+            "title": ""
+        }]
+    }]
+}

--- a/data/en/test_routing_date_less_than.json
+++ b/data/en/test_routing_date_less_than.json
@@ -1,0 +1,75 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "001",
+    "title": "Test Routing Date Less Than",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "description": "A test survey for routing based on a Date less than",
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "blocks": [{
+                    "type": "Question",
+                    "id": "date-question",
+                    "description": "",
+                    "questions": [{
+                        "answers": [{
+                            "id": "single-date-answer",
+                            "label": "Today",
+                            "mandatory": true,
+                            "type": "Date"
+                        }],
+                        "description": "",
+                        "id": "date-questions",
+                        "title": "Enter a date less than today",
+                        "type": "General"
+                    }],
+                    "title": "",
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "correct-answer",
+                                "when": [{
+                                    "id": "single-date-answer",
+                                    "condition": "less than",
+                                    "date_comparison": {
+                                        "value": "now"
+                                    }
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "incorrect-answer"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Interstitial",
+                    "id": "incorrect-answer",
+                    "title": "Incorrect Date",
+                    "description": "You entered a date later than yesterday.",
+                    "routing_rules": [{
+                        "goto": {
+                            "block": "summary"
+                        }
+                    }]
+                },
+                {
+                    "type": "Interstitial",
+                    "id": "correct-answer",
+                    "title": "Correct Date",
+                    "description": "You entered a date older than today."
+                },
+                {
+                    "type": "Summary",
+                    "id": "summary"
+                }
+            ],
+            "id": "group",
+            "title": ""
+        }]
+    }]
+}

--- a/data/en/test_routing_date_not_equals.json
+++ b/data/en/test_routing_date_not_equals.json
@@ -1,0 +1,75 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "001",
+    "title": "Test Routing Date Not Equals",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "description": "A test survey for routing based on a date not equals",
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "blocks": [{
+                    "type": "Question",
+                    "id": "date-question",
+                    "description": "",
+                    "questions": [{
+                        "answers": [{
+                            "id": "single-date-answer",
+                            "label": "Today",
+                            "mandatory": true,
+                            "type": "Date"
+                        }],
+                        "description": "",
+                        "id": "date-questions",
+                        "title": "Enter a date other than 28 February 2018",
+                        "type": "General"
+                    }],
+                    "title": "",
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "correct-answer",
+                                "when": [{
+                                    "id": "single-date-answer",
+                                    "condition": "not equals",
+                                    "date_comparison": {
+                                        "value": "2018-02-28"
+                                    }
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "incorrect-answer"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Interstitial",
+                    "id": "incorrect-answer",
+                    "title": "Incorrect Date",
+                    "description": "You entered 28 February 2018.",
+                    "routing_rules": [{
+                        "goto": {
+                            "block": "summary"
+                        }
+                    }]
+                },
+                {
+                    "type": "Interstitial",
+                    "id": "correct-answer",
+                    "title": "Correct Date",
+                    "description": "You entered a date other than 28 February 2018."
+                },
+                {
+                    "type": "Summary",
+                    "id": "summary"
+                }
+            ],
+            "id": "group",
+            "title": ""
+        }]
+    }]
+}

--- a/scripts/test_schemas.sh
+++ b/scripts/test_schemas.sh
@@ -28,7 +28,7 @@ until [ "$checks" == 0 ]; do
         (( checks=0 ))
     fi
 
-done  
+done
 
 exit=0
 

--- a/tests/app/questionnaire/test_rules.py
+++ b/tests/app/questionnaire/test_rules.py
@@ -1,11 +1,12 @@
 from unittest import TestCase
+from datetime import datetime
 
 from app.data_model.answer_store import AnswerStore, Answer
 from app.questionnaire.location import Location
 from app.questionnaire.path_finder import PathFinder
 from app.questionnaire.questionnaire_schema import QuestionnaireSchema
-from app.questionnaire.rules import evaluate_rule, evaluate_goto, evaluate_repeat, evaluate_skip_conditions, \
-    evaluate_when_rules
+from app.questionnaire.rules import evaluate_rule, evaluate_date_rule, evaluate_goto, evaluate_repeat, \
+    evaluate_skip_conditions, evaluate_when_rules
 
 
 class TestRules(TestCase):  # pylint: disable=too-many-public-methods
@@ -629,3 +630,135 @@ class TestRules(TestCase):  # pylint: disable=too-many-public-methods
         with self.assertRaises(Exception) as err:
             evaluate_when_rules(when['when'], None, answer_store, 0)
         self.assertEqual('Multiple answers (2) found evaluating when rule for answer (my_answers)', str(err.exception))
+
+class TestDateRules(TestCase):
+
+    def test_evaluate_date_rule_equals_with_value_now(self):
+
+        when = {
+            'id': 'date-answer',
+            'condition': 'equals',
+            'date_comparison': {
+                'value': 'now'
+            }
+        }
+
+        answer_value = datetime.utcnow().strftime('%Y-%m-%d')
+        result = evaluate_date_rule(when, None, 0, None, answer_value)
+        self.assertTrue(result)
+
+        answer_value = '2000-01-01'
+        result = evaluate_date_rule(when, None, 0, None, answer_value)
+        self.assertFalse(result)
+
+    def test_evaluate_date_rule_equals_with_with_offset(self):
+
+        when = {
+            'id': 'date-answer',
+            'condition': 'equals',
+            'date_comparison': {
+                'value': '2019-03-31',
+                'offset_by': {
+                    'days': 1,
+                    'months': 1,
+                    'years': 1
+                }
+            }
+        }
+
+        answer_value = '2020-05-01'
+        result = evaluate_date_rule(when, None, 0, None, answer_value)
+        self.assertTrue(result)
+
+        when = {
+            'id': 'date-answer',
+            'condition': 'equals',
+            'date_comparison': {
+                'value': '2021-04-01',
+                'offset_by': {
+                    'days': -1,
+                    'months': -1,
+                    'years': -1
+                }
+            }
+        }
+
+        answer_value = '2020-02-29'
+        result = evaluate_date_rule(when, None, 0, None, answer_value)
+        self.assertTrue(result)
+
+    def test_evaluate_date_rule_not_equals_with_value_year_month(self):
+
+        when = {
+            'id': 'date-answer',
+            'condition': 'not equals',
+            'date_comparison': {
+                'value': '2018-01'
+            }
+        }
+
+        answer_value = '2018-02'
+        result = evaluate_date_rule(when, None, 0, None, answer_value)
+        self.assertTrue(result)
+
+        answer_value = '2018-01'
+        result = evaluate_date_rule(when, None, 0, None, answer_value)
+        self.assertFalse(result)
+
+    def test_evaluate_date_rule_less_than_meta(self):
+
+        metadata = {'return_by': '2016-06-12'}
+        when = {
+            'id': 'date-answer',
+            'condition': 'less than',
+            'date_comparison': {
+                'meta': 'return_by'
+            }
+        }
+
+        answer_value = '2016-06-11'
+        result = evaluate_date_rule(when, None, 0, metadata, answer_value)
+        self.assertTrue(result)
+
+        answer_value = '2016-06-12'
+        result = evaluate_date_rule(when, None, 0, metadata, answer_value)
+        self.assertFalse(result)
+
+    def test_evaluate_date_rule_greater_than_with_id(self):
+
+        when = {
+            'id': 'date-answer',
+            'condition': 'greater than',
+            'date_comparison': {
+                'id': 'compare_date_answer'
+            }
+        }
+
+        answer_store = AnswerStore({})
+        answer_store.add(Answer(answer_id='compare_date_answer', value='2018-02-03'))
+
+        answer_value = '2018-02-04'
+        result = evaluate_date_rule(when, answer_store, 0, None, answer_value)
+        self.assertTrue(result)
+
+        answer_value = '2018-02-03'
+        result = evaluate_date_rule(when, answer_store, 0, None, answer_value)
+        self.assertFalse(result)
+
+    def test_do_not_go_to_next_question_for_date_answer(self):
+
+        goto_rule = {
+            'id': 'next-question',
+            'when': [{
+                'id': 'date-answer',
+                'condition': 'equals',
+                'date_comparison': {
+                    'value': '2018-01'
+                }
+            }]
+        }
+
+        answer_store = AnswerStore({})
+        answer_store.add(Answer(answer_id='date_answer', value='2018-02-01'))
+
+        self.assertFalse(evaluate_goto(goto_rule, {}, answer_store, 0))

--- a/tests/functional/pages/features/routing/date/correct-answer.page.js
+++ b/tests/functional/pages/features/routing/date/correct-answer.page.js
@@ -1,0 +1,11 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class CorrectAnswerPage extends QuestionPage {
+
+  constructor() {
+    super('correct-answer');
+  }
+
+}
+module.exports = new CorrectAnswerPage();

--- a/tests/functional/pages/features/routing/date/equals/comparison-date-block.page.js
+++ b/tests/functional/pages/features/routing/date/equals/comparison-date-block.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../../surveys/question.page');
+
+class ComparisonDateBlockPage extends QuestionPage {
+
+  constructor() {
+    super('comparison-date-block');
+  }
+
+  day() {
+    return '#comparison-date-answer-day';
+  }
+
+  month() {
+    return '#comparison-date-answer-month';
+  }
+
+  year() {
+    return '#comparison-date-answer-year';
+  }
+
+}
+module.exports = new ComparisonDateBlockPage();

--- a/tests/functional/pages/features/routing/date/equals/date-question.page.js
+++ b/tests/functional/pages/features/routing/date/equals/date-question.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../../surveys/question.page');
+
+class DateQuestionPage extends QuestionPage {
+
+  constructor() {
+    super('date-question');
+  }
+
+  day() {
+    return '#single-date-answer-day';
+  }
+
+  month() {
+    return '#single-date-answer-month';
+  }
+
+  year() {
+    return '#single-date-answer-year';
+  }
+
+}
+module.exports = new DateQuestionPage();

--- a/tests/functional/pages/features/routing/date/greater_than/date-question.page.js
+++ b/tests/functional/pages/features/routing/date/greater_than/date-question.page.js
@@ -1,0 +1,19 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../../surveys/question.page');
+
+class DateQuestionPage extends QuestionPage {
+
+  constructor() {
+    super('date-question');
+  }
+
+  month() {
+    return '#single-date-answer-month';
+  }
+
+  year() {
+    return '#single-date-answer-year';
+  }
+
+}
+module.exports = new DateQuestionPage();

--- a/tests/functional/pages/features/routing/date/incorrect-answer.page.js
+++ b/tests/functional/pages/features/routing/date/incorrect-answer.page.js
@@ -1,0 +1,11 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class IncorrectAnswerPage extends QuestionPage {
+
+  constructor() {
+    super('incorrect-answer');
+  }
+
+}
+module.exports = new IncorrectAnswerPage();

--- a/tests/functional/pages/features/routing/date/less_than/date-question.page.js
+++ b/tests/functional/pages/features/routing/date/less_than/date-question.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../../surveys/question.page');
+
+class DateQuestionPage extends QuestionPage {
+
+  constructor() {
+    super('date-question');
+  }
+
+  day() {
+    return '#single-date-answer-day';
+  }
+
+  month() {
+    return '#single-date-answer-month';
+  }
+
+  year() {
+    return '#single-date-answer-year';
+  }
+
+}
+module.exports = new DateQuestionPage();

--- a/tests/functional/pages/features/routing/date/not_equals/date-question.page.js
+++ b/tests/functional/pages/features/routing/date/not_equals/date-question.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../../surveys/question.page');
+
+class DateQuestionPage extends QuestionPage {
+
+  constructor() {
+    super('date-question');
+  }
+
+  day() {
+    return '#single-date-answer-day';
+  }
+
+  month() {
+    return '#single-date-answer-month';
+  }
+
+  year() {
+    return '#single-date-answer-year';
+  }
+
+}
+module.exports = new DateQuestionPage();

--- a/tests/functional/spec/features/routing/date.spec.js
+++ b/tests/functional/spec/features/routing/date.spec.js
@@ -1,0 +1,201 @@
+const helpers = require('../../../helpers');
+
+const IncorrectAnswerPage = require('../../../pages/features/routing/date/incorrect-answer.page.js');
+const CorrectAnswerPage = require('../../../pages/features/routing/date/correct-answer.page.js');
+
+describe('Feature: Routing on a Date', function () {
+
+  describe('Equals', function () {
+    describe('Given I start date routing equals survey', function () {
+
+      var ComparisonDateQuestionPage = require('../../../pages/features/routing/date/equals/comparison-date-block.page');
+      var DateQuestionPage = require('../../../pages/features/routing/date/equals/date-question.page');
+
+      beforeEach(function() {
+        return helpers.openQuestionnaire('test_routing_date_equals.json').then(() => {
+          return browser
+            .setValue(ComparisonDateQuestionPage.day(), 31)
+            .selectByValue(ComparisonDateQuestionPage.month(), 3)
+            .setValue(ComparisonDateQuestionPage.year(), 2020)
+            .click(ComparisonDateQuestionPage.submit())
+            .getUrl().should.eventually.contain(DateQuestionPage.pageName);
+        });
+      });
+
+      it('When I enter the same date, Then I should be routed to the correct page', function () {
+        return browser
+          .setValue(DateQuestionPage.day(), 31)
+          .selectByValue(DateQuestionPage.month(), 3)
+          .setValue(DateQuestionPage.year(), 2020)
+          .click(DateQuestionPage.submit())
+          .getUrl().should.eventually.contain(CorrectAnswerPage.pageName);
+      });
+
+      it('When I enter the yesterday date, Then I should be routed to the correct page', function () {
+        return browser
+          .setValue(DateQuestionPage.day(), 30)
+          .selectByValue(DateQuestionPage.month(), 3)
+          .setValue(DateQuestionPage.year(), 2020)
+          .click(DateQuestionPage.submit())
+          .getUrl().should.eventually.contain(CorrectAnswerPage.pageName);
+      });
+
+      it('When I enter the tomorrow date, Then I should be routed to the correct page', function () {
+        return browser
+          .setValue(DateQuestionPage.day(), 1)
+          .selectByValue(DateQuestionPage.month(), 4)
+          .setValue(DateQuestionPage.year(), 2020)
+          .click(DateQuestionPage.submit())
+          .getUrl().should.eventually.contain(CorrectAnswerPage.pageName);
+      });
+
+      it('When I enter the last month date, Then I should be routed to the correct page', function () {
+        return browser
+          .setValue(DateQuestionPage.day(), 29)
+          .selectByValue(DateQuestionPage.month(), 2)
+          .setValue(DateQuestionPage.year(), 2020)
+          .click(DateQuestionPage.submit())
+          .getUrl().should.eventually.contain(CorrectAnswerPage.pageName);
+      });
+
+      it('When I enter the next month date, Then I should be routed to the correct page', function () {
+        return browser
+          .setValue(DateQuestionPage.day(), 30)
+          .selectByValue(DateQuestionPage.month(), 4)
+          .setValue(DateQuestionPage.year(), 2020)
+          .click(DateQuestionPage.submit())
+          .getUrl().should.eventually.contain(CorrectAnswerPage.pageName);
+      });
+
+      it('When I enter the last year date, Then I should be routed to the correct page', function () {
+        return browser
+          .setValue(DateQuestionPage.day(), 31)
+          .selectByValue(DateQuestionPage.month(), 3)
+          .setValue(DateQuestionPage.year(), 2019)
+          .click(DateQuestionPage.submit())
+          .getUrl().should.eventually.contain(CorrectAnswerPage.pageName);
+      });
+
+      it('When I enter the next year date, Then I should be routed to the correct page', function () {
+        return browser
+          .setValue(DateQuestionPage.day(), 31)
+          .selectByValue(DateQuestionPage.month(), 3)
+          .setValue(DateQuestionPage.year(), 2021)
+          .click(DateQuestionPage.submit())
+          .getUrl().should.eventually.contain(CorrectAnswerPage.pageName);
+      });
+
+      it('When I enter an incorrect date, Then I should be routed to the incorrect page', function () {
+        return browser
+          .setValue(DateQuestionPage.day(), 1)
+          .selectByValue(DateQuestionPage.month(), 3)
+          .setValue(DateQuestionPage.year(), 2020)
+          .click(ComparisonDateQuestionPage.submit())
+          .getUrl().should.eventually.contain(CorrectAnswerPage.pageName);
+      });
+    });
+  });
+
+  describe('Not Equals', function () {
+    describe('Given I start date routing not equals survey', function () {
+
+      var DateQuestionPage = require('../../../pages/features/routing/date/not_equals/date-question.page');
+
+      beforeEach(function() {
+        return helpers.openQuestionnaire('test_routing_date_not_equals.json').then(() => {
+          return browser
+            .getUrl().should.eventually.contain(DateQuestionPage.pageName);
+        });
+      });
+
+      it('When I enter a different date to 28/02/2018, Then I should be routed to the correct page', function () {
+        return browser
+          .setValue(DateQuestionPage.day(), 27)
+          .selectByValue(DateQuestionPage.month(), 2)
+          .setValue(DateQuestionPage.year(), 2018)
+          .click(DateQuestionPage.submit())
+          .getUrl().should.eventually.contain(CorrectAnswerPage.pageName);
+      });
+
+      it('When I enter 28/02/2018, Then I should be routed to the incorrect page', function () {
+        return browser
+          .setValue(DateQuestionPage.day(), 28)
+          .selectByValue(DateQuestionPage.month(), 2)
+          .setValue(DateQuestionPage.year(), 2018)
+          .click(DateQuestionPage.submit())
+          .getUrl().should.eventually.contain(IncorrectAnswerPage.pageName);
+      });
+
+    });
+  });
+
+  describe('Greater Than', function () {
+    describe('Given I start number routing not equals survey', function () {
+
+      var DateQuestionPage = require('../../../pages/features/routing/date/greater_than/date-question.page');
+
+      beforeEach(function() {
+        return helpers.openQuestionnaire('test_routing_date_greater_than.json').then(() => {
+          return browser
+            .getUrl().should.eventually.contain(DateQuestionPage.pageName);
+        });
+      });
+
+      it('When I enter a date greater than March 2017, Then I should be routed to the correct page', function () {
+        return browser
+          .selectByValue(DateQuestionPage.month(), 4)
+          .setValue(DateQuestionPage.year(), 2017)
+          .click(DateQuestionPage.submit())
+          .getUrl().should.eventually.contain(CorrectAnswerPage.pageName);
+      });
+
+      it('When I enter a date less than or equal to March 2017, Then I should be routed to the incorrect page', function () {
+        return browser
+          .selectByValue(DateQuestionPage.month(), 3)
+          .setValue(DateQuestionPage.year(), 2017)
+          .click(DateQuestionPage.submit())
+          .getUrl().should.eventually.contain(IncorrectAnswerPage.pageName);
+      });
+
+    });
+  });
+
+  describe('Less Than', function () {
+    describe('Given I start number routing not equals survey', function () {
+
+      var DateQuestionPage = require('../../../pages/features/routing/date/less_than/date-question.page');
+      var today = new Date();
+      var dd_today = today.getDate(); // today
+      var dd_yesterday = today.getDate()-1; // yesterday
+      var mm = today.getMonth()+1; //January is 0!
+      var yyyy = today.getFullYear();
+
+      beforeEach(function() {
+        return helpers.openQuestionnaire('test_routing_date_less_than.json').then(() => {
+          return browser
+            .getUrl().should.eventually.contain(DateQuestionPage.pageName);
+        });
+      });
+
+      it('When I enter a date less than today, Then I should be routed to the correct page', function () {
+        return browser
+          .setValue(DateQuestionPage.day(), dd_yesterday)
+          .selectByValue(DateQuestionPage.month(), mm)
+          .setValue(DateQuestionPage.year(), yyyy)
+          .click(DateQuestionPage.submit())
+          .getUrl().should.eventually.contain(CorrectAnswerPage.pageName);
+      });
+
+      it('When I enter a date greater than or equal to today, Then I should be routed to the incorrect page', function () {
+        return browser
+          .setValue(DateQuestionPage.day(), dd_today)
+          .selectByValue(DateQuestionPage.month(), mm)
+          .setValue(DateQuestionPage.year(), yyyy)
+          .click(DateQuestionPage.submit())
+          .getUrl().should.eventually.contain(IncorrectAnswerPage.pageName);
+      });
+
+    });
+  });
+
+});


### PR DESCRIPTION
### What is the context of this PR?
As a user
I want to only answer questions which are applicable to me based on a date I have provided
So that I can skip any questions to reduce burden and to ensure I am able to answer them

Date compared with previous answer, metadata or hard coded date including today.
Offset_by allows for you to compare against a date in the past or future. Offset must allow for days, months and years.

### How to review 
test schemas:
test_routing_date_equals.json
test_routing_date_greater_than.json
test_routing_date_less_than.json
test_routing_date_not_equals.json