### PR TITLE
Remove edit links from Answers after submission

### DIFF
--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -268,11 +268,10 @@ def get_view_submission(eq_id, form_type):  # pylint: disable=unused-argument
             context = {
                 'summary': {
                     'groups': summary_rendered_context,
-                    'answers_are_editable': True,
+                    'answers_are_editable': False,
                     'is_view_submission_response_enabled': is_view_submitted_response_enabled(g.schema.json),
                 },
-                'variables': None,
-                'answers_are_editable': False
+                'variables': None
             }
 
             return render_theme_template(g.schema.json['theme'],

--- a/tests/integration/views/test_view_submission.py
+++ b/tests/integration/views/test_view_submission.py
@@ -71,6 +71,9 @@ class TestViewSubmission(IntegrationTestCase):
         self.assertInPage('345')
         self.assertInPage('67.89')
 
+        # check edit links are not on page
+        self.assertNotInPage('data-ga-action="Edit click"')
+
     def test_try_view_submission_when_not_available(self):
         self.launchSurvey('test', 'currency')
 


### PR DESCRIPTION
### What is the context of this PR?
The edit links were appearing on the answers after submission screen

### How to review 
Do the edit links appear on the answers after submission screen? They shouldn't.
