### PR TITLE
Question error message should focus on first input  when clicked

### DIFF
--- a/app/templates/partials/questions/errors.html
+++ b/app/templates/partials/questions/errors.html
@@ -1,5 +1,5 @@
 {% import 'macros/helpers.html' as helpers %}
-<div class="panel panel--simple panel--error" data-qa="error">
+<div class="panel panel--simple panel--error" data-qa="error" id="container-{{question.id}}">
   <div class="panel__header">
     {% if form.question_errors[question.id] is not none %}
     <ul class="list list--bare list--errors">

--- a/tests/functional/spec/dates.spec.js
+++ b/tests/functional/spec/dates.spec.js
@@ -57,7 +57,11 @@ describe('Date checks', function() {
           .click(DatesPage.submit())
 
           // Then an error message is shown
-          .getText(DatesPage.errorNumber(1)).should.eventually.contain('Enter a \'period to\' date later than the \'period from\' date.');
+          .getText(DatesPage.errorNumber(1)).should.eventually.contain('Enter a \'period to\' date later than the \'period from\' date.')
+
+          // Then clicking error should focus on first input field
+          .click(DatesPage.errorNumber(1))
+          .hasFocus(DatesPage.dateRangeFromday());
     });
   });
 


### PR DESCRIPTION
Fixes #1241

### How to review 
Complete a dateRange question (test_dates.json) and enter a To Date earlier than the From Date.
When clicking the error message the focus should go to the From Date day field.