### PR TITLE
Empty Total Routing RSI/MCI

### DIFF
--- a/data/en/1_0102.json
+++ b/data/en/1_0102.json
@@ -196,7 +196,7 @@
                 {
                     "type": "Question",
                     "title": "Retail Turnover",
-                    "id": "confirm-zero-block",
+                    "id": "confirm-zero-turnover-block",
                     "skip_conditions": [{
                         "when": [{
                             "id": "total-retail-turnover-answer",
@@ -208,7 +208,8 @@
                         "type": "General",
                         "answers": [{
                             "type": "Radio",
-                            "id": "confirm-zero-answer",
+                            "id": "confirm-zero-turnover-answer",
+                            "q_code": "d20",
                             "options": [{
                                     "label": "Yes this is correct",
                                     "value": "Yes"
@@ -220,14 +221,14 @@
                             ],
                             "mandatory": true
                         }],
-                        "id": "confirm-zero-question",
+                        "id": "confirm-zero-turnover-question",
                         "title": "For the period {{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}, the value of the total retail turnover was <em>£0</em>, is this correct?"
                     }],
                     "routing_rules": [{
                             "goto": {
                                 "when": [{
                                     "value": "No",
-                                    "id": "confirm-zero-answer",
+                                    "id": "confirm-zero-turnover-answer",
                                     "condition": "equals"
                                 }],
                                 "block": "total-retail-turnover-block"

--- a/data/en/1_0112.json
+++ b/data/en/1_0112.json
@@ -240,7 +240,7 @@
                 {
                     "type": "Question",
                     "title": "Retail Turnover",
-                    "id": "confirm-zero-block",
+                    "id": "confirm-zero-turnover-block",
                     "skip_conditions": [{
                         "when": [{
                             "id": "total-retail-turnover-answer",
@@ -252,7 +252,8 @@
                         "type": "General",
                         "answers": [{
                             "type": "Radio",
-                            "id": "confirm-zero-answer",
+                            "id": "confirm-zero-turnover-answer",
+                            "q_code": "d20",
                             "options": [{
                                     "label": "Yes this is correct",
                                     "value": "Yes"
@@ -264,14 +265,14 @@
                             ],
                             "mandatory": true
                         }],
-                        "id": "confirm-zero-question",
+                        "id": "confirm-zero-turnover-question",
                         "title": "For the period {{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}, the value of the total retail turnover was <em>£0</em>, is this correct?"
                     }],
                     "routing_rules": [{
                             "goto": {
                                 "when": [{
                                     "value": "No",
-                                    "id": "confirm-zero-answer",
+                                    "id": "confirm-zero-turnover-answer",
                                     "condition": "equals"
                                 }],
                                 "block": "total-retail-turnover-block"
@@ -484,9 +485,10 @@
                             "id": "total-number-employees",
                             "alias": "employee_count",
                             "label": "Total number of employees",
-                            "mandatory": true,
+                            "mandatory": false,
                             "q_code": "50",
-                            "type": "Number"
+                            "type": "Number",
+                            "default": 0
                         }],
                         "description": "<p>An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.</p>",
                         "id": "total-number-employees-question",
@@ -494,6 +496,54 @@
                         "type": "General"
                     }],
                     "title": "Employees"
+                },
+                {
+                    "type": "Question",
+                    "title": "Employees",
+                    "id": "confirm-zero-employees-block",
+                    "skip_conditions": [{
+                        "when": [{
+                            "id": "total-number-employees",
+                            "condition": "greater than",
+                            "value": 0
+                        }]
+                    }],
+                    "questions": [{
+                        "type": "General",
+                        "answers": [{
+                            "type": "Radio",
+                            "id": "confirm-zero-employees-answer",
+                            "q_code": "d50",
+                            "options": [{
+                                    "label": "Yes this is correct",
+                                    "value": "Yes"
+                                },
+                                {
+                                    "label": "No I need to change this",
+                                    "value": "No"
+                                }
+                            ],
+                            "mandatory": true
+                        }],
+                        "id": "confirm-zero-employees-question",
+                        "title": "On {{exercise.employment_date|format_date}}, the number of employees for {{respondent.trad_as_or_ru_name}} was <em>0</em>, is this correct?"
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "when": [{
+                                    "value": "No",
+                                    "id": "confirm-zero-employees-answer",
+                                    "condition": "equals"
+                                }],
+                                "block": "total-employees"
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "changes-in-employees"
+                            }
+                        }
+                    ]
                 },
                 {
                     "type": "Question",

--- a/data/en/1_0203.json
+++ b/data/en/1_0203.json
@@ -290,7 +290,7 @@
                 {
                     "type": "Question",
                     "title": "Retail Turnover",
-                    "id": "confirm-zero-block",
+                    "id": "confirm-zero-turnover-block",
                     "skip_conditions": [{
                         "when": [{
                             "id": "total-retail-turnover",
@@ -302,7 +302,8 @@
                         "type": "General",
                         "answers": [{
                             "type": "Radio",
-                            "id": "confirm-zero-answer",
+                            "id": "confirm-zero-turnover-answer",
+                            "q_code": "d20",
                             "options": [{
                                     "label": "Yes this is correct",
                                     "value": "Yes"
@@ -314,14 +315,14 @@
                             ],
                             "mandatory": true
                         }],
-                        "id": "confirm-zero-question",
+                        "id": "confirm-zero-turnover-question",
                         "title": "For the period {{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}, the value of the total retail turnover was <em>£0</em>, is this correct?"
                     }],
                     "routing_rules": [{
                             "goto": {
                                 "when": [{
                                     "value": "No",
-                                    "id": "confirm-zero-answer",
+                                    "id": "confirm-zero-turnover-answer",
                                     "condition": "equals"
                                 }],
                                 "block": "total-retail-turnover-block"

--- a/data/en/1_0205.json
+++ b/data/en/1_0205.json
@@ -307,7 +307,7 @@
                 {
                     "type": "Question",
                     "title": "Retail Turnover",
-                    "id": "confirm-zero-block",
+                    "id": "confirm-zero-turnover-block",
                     "skip_conditions": [{
                         "when": [{
                             "id": "total-retail-turnover",
@@ -319,7 +319,8 @@
                         "type": "General",
                         "answers": [{
                             "type": "Radio",
-                            "id": "confirm-zero-answer",
+                            "id": "confirm-zero-turnover-answer",
+                            "q_code": "d20",
                             "options": [{
                                     "label": "Yes this is correct",
                                     "value": "Yes"
@@ -331,14 +332,14 @@
                             ],
                             "mandatory": true
                         }],
-                        "id": "confirm-zero-question",
+                        "id": "confirm-zero-turnover-question",
                         "title": "For the period {{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}, the value of the total retail turnover was <em>£0</em>, is this correct?"
                     }],
                     "routing_rules": [{
                             "goto": {
                                 "when": [{
                                     "value": "No",
-                                    "id": "confirm-zero-answer",
+                                    "id": "confirm-zero-turnover-answer",
                                     "condition": "equals"
                                 }],
                                 "block": "total-retail-turnover-block"

--- a/data/en/1_0213.json
+++ b/data/en/1_0213.json
@@ -332,7 +332,7 @@
                 {
                     "type": "Question",
                     "title": "Retail Turnover",
-                    "id": "confirm-zero-block",
+                    "id": "confirm-zero-turnover-block",
                     "skip_conditions": [{
                         "when": [{
                             "id": "total-retail-turnover",
@@ -344,7 +344,8 @@
                         "type": "General",
                         "answers": [{
                             "type": "Radio",
-                            "id": "confirm-zero-answer",
+                            "id": "confirm-zero-turnover-answer",
+                            "q_code": "d20",
                             "options": [{
                                     "label": "Yes this is correct",
                                     "value": "Yes"
@@ -356,14 +357,14 @@
                             ],
                             "mandatory": true
                         }],
-                        "id": "confirm-zero-question",
+                        "id": "confirm-zero-turnover-question",
                         "title": "For the period {{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}, the value of the total retail turnover was <em>£0</em>, is this correct?"
                     }],
                     "routing_rules": [{
                             "goto": {
                                 "when": [{
                                     "value": "No",
-                                    "id": "confirm-zero-answer",
+                                    "id": "confirm-zero-turnover-answer",
                                     "condition": "equals"
                                 }],
                                 "block": "total-retail-turnover-block"
@@ -784,9 +785,10 @@
                             "id": "total-number-employees",
                             "alias": "employee_count",
                             "label": "Total number of employees",
-                            "mandatory": true,
+                            "mandatory": false,
                             "q_code": "50",
-                            "type": "Number"
+                            "type": "Number",
+                            "default": 0
                         }],
                         "description": "<p>An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.</p>",
                         "id": "total-number-employees-question",
@@ -794,6 +796,54 @@
                         "type": "General"
                     }],
                     "title": "Employees"
+                },
+                {
+                    "type": "Question",
+                    "title": "Employees",
+                    "id": "confirm-zero-employees-block",
+                    "skip_conditions": [{
+                        "when": [{
+                            "id": "total-number-employees",
+                            "condition": "greater than",
+                            "value": 0
+                        }]
+                    }],
+                    "questions": [{
+                        "type": "General",
+                        "answers": [{
+                            "type": "Radio",
+                            "id": "confirm-zero-employees-answer",
+                            "q_code": "d50",
+                            "options": [{
+                                    "label": "Yes this is correct",
+                                    "value": "Yes"
+                                },
+                                {
+                                    "label": "No I need to change this",
+                                    "value": "No"
+                                }
+                            ],
+                            "mandatory": true
+                        }],
+                        "id": "confirm-zero-employees-question",
+                        "title": "On {{exercise.employment_date|format_date}}, the number of employees for {{respondent.trad_as_or_ru_name}} was <em>0</em>, is this correct?"
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "when": [{
+                                    "value": "No",
+                                    "id": "confirm-zero-employees-answer",
+                                    "condition": "equals"
+                                }],
+                                "block": "total-employees"
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "summary"
+                            }
+                        }
+                    ]
                 },
                 {
                     "type": "Question",

--- a/data/en/1_0215.json
+++ b/data/en/1_0215.json
@@ -351,7 +351,7 @@
                 {
                     "type": "Question",
                     "title": "Retail Turnover",
-                    "id": "confirm-zero-block",
+                    "id": "confirm-zero-turnover-block",
                     "skip_conditions": [{
                         "when": [{
                             "id": "total-retail-turnover",
@@ -363,7 +363,8 @@
                         "type": "General",
                         "answers": [{
                             "type": "Radio",
-                            "id": "confirm-zero-answer",
+                            "id": "confirm-zero-turnover-answer",
+                            "q_code": "d20",
                             "options": [{
                                     "label": "Yes this is correct",
                                     "value": "Yes"
@@ -375,14 +376,14 @@
                             ],
                             "mandatory": true
                         }],
-                        "id": "confirm-zero-question",
+                        "id": "confirm-zero-turnover-question",
                         "title": "For the period {{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}, the value of the total retail turnover was <em>£0</em>, is this correct?"
                     }],
                     "routing_rules": [{
                             "goto": {
                                 "when": [{
                                     "value": "No",
-                                    "id": "confirm-zero-answer",
+                                    "id": "confirm-zero-turnover-answer",
                                     "condition": "equals"
                                 }],
                                 "block": "total-retail-turnover-block"
@@ -856,9 +857,10 @@
                             "id": "total-number-employees",
                             "alias": "employee_count",
                             "label": "Total number of employees",
-                            "mandatory": true,
+                            "mandatory": false,
                             "q_code": "50",
-                            "type": "Number"
+                            "type": "Number",
+                            "default": 0
                         }],
                         "description": "<p>An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.</p>",
                         "id": "total-number-employees-question",
@@ -866,6 +868,54 @@
                         "type": "General"
                     }],
                     "title": "Employees"
+                },
+                {
+                    "type": "Question",
+                    "title": "Employees",
+                    "id": "confirm-zero-employees-block",
+                    "skip_conditions": [{
+                        "when": [{
+                            "id": "total-number-employees",
+                            "condition": "greater than",
+                            "value": 0
+                        }]
+                    }],
+                    "questions": [{
+                        "type": "General",
+                        "answers": [{
+                            "type": "Radio",
+                            "id": "confirm-zero-employees-answer",
+                            "q_code": "d50",
+                            "options": [{
+                                    "label": "Yes this is correct",
+                                    "value": "Yes"
+                                },
+                                {
+                                    "label": "No I need to change this",
+                                    "value": "No"
+                                }
+                            ],
+                            "mandatory": true
+                        }],
+                        "id": "confirm-zero-employees-question",
+                        "title": "On {{exercise.employment_date|format_date}}, the number of employees for {{respondent.trad_as_or_ru_name}} was <em>0</em>, is this correct?"
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "when": [{
+                                    "value": "No",
+                                    "id": "confirm-zero-employees-answer",
+                                    "condition": "equals"
+                                }],
+                                "block": "total-employees"
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "summary"
+                            }
+                        }
+                    ]
                 },
                 {
                     "type": "Question",

--- a/data/en/test_default.json
+++ b/data/en/test_default.json
@@ -1,0 +1,40 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "001",
+    "title": "Test Routing Number Equals",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "description": "A test survey for routing based on an number equals",
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "blocks": [{
+                    "type": "Question",
+                    "id": "number-question",
+                    "description": "",
+                    "questions": [{
+                        "answers": [{
+                            "id": "answer",
+                            "mandatory": false,
+                            "alias": "answer",
+                            "type": "Number",
+                            "default": 0
+                        }],
+                        "id": "question",
+                        "title": "Don't enter an answer. Zero will be shown on summary",
+                        "type": "General"
+                    }],
+                    "title": "Zero Default"
+                },
+                {
+                    "type": "Summary",
+                    "id": "summary"
+                }
+            ],
+            "id": "group",
+            "title": ""
+        }]
+    }]
+}

--- a/tests/functional/pages/features/default_value/number-question.page.js
+++ b/tests/functional/pages/features/default_value/number-question.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class NumberQuestionPage extends QuestionPage {
+
+  constructor() {
+    super('number-question');
+  }
+
+  answer() {
+    return '#answer';
+  }
+
+  answerLabel() { return '#label-answer'; }
+
+}
+module.exports = new NumberQuestionPage();

--- a/tests/functional/pages/features/default_value/summary.page.js
+++ b/tests/functional/pages/features/default_value/summary.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  answer() { return '#answer-answer'; }
+
+  answerEdit() { return '[data-qa="answer-edit"]'; }
+
+  groupTitle() { return '#group'; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/spec/features/default_value/default_value.spec.js
+++ b/tests/functional/spec/features/default_value/default_value.spec.js
@@ -1,0 +1,19 @@
+const helpers = require('../../../helpers');
+
+const QuestionPage = require('../../../pages/features/default_value/number-question.page.js');
+const Summary = require('../../../pages/features/default_value/summary.page.js');
+
+describe('Feature: Default Value', function() {
+
+  it('Given I start default schema, When I do not give a value, Then the default value will be stored', function() {
+    return helpers.openQuestionnaire('test_default.json').then(() => {
+      return browser
+        .click(QuestionPage.submit())
+          .getUrl().should.eventually.contain(Summary.pageName)
+          .getText(Summary.answer()).should.eventually.contain('0')
+          .click(Summary.previous())
+          .getUrl().should.eventually.contain(QuestionPage.pageName)
+          .getValue(QuestionPage.answer()).should.eventually.contain('0');
+    });
+  });
+});

--- a/tests/integration/views/test_questionnaire.py
+++ b/tests/integration/views/test_questionnaire.py
@@ -56,6 +56,31 @@ class TestQuestionnaire(IntegrationTestCase):
             'block_id': 'total-retail-turnover'
         }, self.question_store.answer_store.answers)
 
+    def test_update_questionnaire_store_with_default_value(self):
+
+        g.schema = load_schema_from_params('test', 'default')
+
+        location = Location('group', 0, 'number-question')
+
+        # No answer given so will use schema defined default
+        form_data = {
+            'answer': None
+        }
+
+        with self._application.test_request_context():
+            update_questionnaire_store_with_form_data(self.question_store, location, form_data)
+
+        self.assertEqual(self.question_store.completed_blocks, [location])
+
+        self.assertIn({
+            'group_instance': 0,
+            'answer_id': 'answer',
+            'answer_instance': 0,
+            'value': 0,
+            'group_id': 'group',
+            'block_id': 'number-question'
+        }, self.question_store.answer_store.answers)
+
     def test_update_questionnaire_store_with_date_form_data(self):
 
         g.schema = load_schema_from_params('test', 'dates')


### PR DESCRIPTION
Zero or empty routing for Total Retail Turnover and Employment questions for schemas:
1_0102, 1_0112, 1_0203, 1_0205, 1_0213 and 1_0215

Completion of https://github.com/ONSdigital/eq-survey-runner/pull/1509 that was merged early.