### PR TITLE
Apply breakdown sum validation to QBS

### DIFF
--- a/data/en/2_0001.json
+++ b/data/en/2_0001.json
@@ -154,7 +154,23 @@
                 },
                 {
                     "id": "number-of-employees-split-block",
+                    "title": "Quarterly Business Survey",
+                    "type": "Question",
                     "questions": [{
+                        "calculated": {
+                            "calculated_type": "sum",
+                            "answer_id": "number-of-employees-total",
+                            "answers_to_calculate": [
+                                "number-of-employees-male-more-30-hours",
+                                "number-of-employees-male-less-30-hours",
+                                "number-of-employees-female-more-30-hours",
+                                "number-of-employees-female-less-30-hours"
+                            ],
+                            "conditions": [
+                                "less than",
+                                "equals"
+                            ]
+                        },
                         "answers": [{
                                 "id": "number-of-employees-male-more-30-hours",
                                 "label": "Number of male employees working more than 30 hours per week",
@@ -218,10 +234,8 @@
                         },
                         "id": "number-of-employees-split-question",
                         "title": "Of the <em>{{answers.number_of_employees_total}}</em> total employees employed on {{exercise.start_date|format_date}}, how many male and female employees worked the following hours?",
-                        "type": "General"
-                    }],
-                    "title": "Quarterly Business Survey",
-                    "type": "Question"
+                        "type": "Calculated"
+                    }]
                 },
                 {
                     "type": "Summary",

--- a/tests/integration/qbs/test_qbs_submission_data.py
+++ b/tests/integration/qbs/test_qbs_submission_data.py
@@ -21,7 +21,7 @@ class TestQbsSubmissionData(IntegrationTestCase):
         self.assertInPage('>Continue<')
 
         # When I submit answers
-        self.post(post_data={'number-of-employees-total': '5'})
+        self.post(post_data={'number-of-employees-total': '10'})
 
         self.post(post_data={'number-of-employees-male-more-30-hours': '1',
                              'number-of-employees-male-less-30-hours': '2',
@@ -51,7 +51,7 @@ class TestQbsSubmissionData(IntegrationTestCase):
                 'flushed': False,
                 'tx_id': actual['submission']['tx_id'],
                 'data': {
-                    '50': '5',
+                    '50': '10',
                     '51': '1',
                     '52': '2',
                     '53': '3',


### PR DESCRIPTION
### What is the context of this PR?
As a respondent
I want my answers validated before I submit
So that ONS does not contact me after submission

### How to review 
Enter a value for total number of employees.
The sum of the breakdown answers must then total less than or equal to that value. Otherwise a correct error message should be displayed.