### PR TITLE
Pipe difference between two dates

### DIFF
--- a/app/questionnaire/rules.py
+++ b/app/questionnaire/rules.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 MAX_REPEATS = 25
@@ -79,9 +80,9 @@ def get_date_match_value(date_comparison, answer_store, group_instance, metadata
 
 
 def convert_to_datetime(value):
-    date_format = '%Y-%m-%d'
-    if value and len(value) == 7:
-        date_format = '%Y-%m'
+    date_format = '%Y-%m'
+    if value and re.match(r'\d{4}-\d{2}-\d{2}', value):
+        date_format = '%Y-%m-%d'
 
     return datetime.strptime(value, date_format) if value else None
 

--- a/app/templates/partials/summary/monthyeardate.html
+++ b/app/templates/partials/summary/monthyeardate.html
@@ -1,1 +1,5 @@
-{{answer.value|format_month_year_date}}
+{% if question.type == 'DateRange' %}
+    {{format_date_range(answer.value.from, answer.value.to)}}
+{% else %}
+    {{answer.value|format_month_year_date}}
+{% endif %}

--- a/app/templating/template_renderer.py
+++ b/app/templating/template_renderer.py
@@ -7,7 +7,7 @@ from jinja2 import Environment
 
 from app.jinja_filters import format_date, format_household_member_name, format_currency, format_number,\
     get_currency_symbol, format_household_summary, format_conditional_date, format_unordered_list, \
-    format_date_range, format_household_member_name_possessive, concatenated_list
+    format_date_range, format_household_member_name_possessive, concatenated_list, calculate_years_difference
 
 
 class TemplateRenderer:
@@ -25,6 +25,7 @@ class TemplateRenderer:
         self.environment.filters['get_currency_symbol'] = get_currency_symbol
         self.environment.globals['format_date_range'] = format_date_range
         self.environment.filters['concatenated_list'] = concatenated_list
+        self.environment.globals['calculate_years_difference'] = calculate_years_difference
 
     def render(self, renderable, **context):
         """

--- a/app/validation/validators.py
+++ b/app/validation/validators.py
@@ -8,6 +8,7 @@ from structlog import get_logger
 from app.jinja_filters import format_number, format_currency
 from app.settings import DEFAULT_LOCALE
 from app.validation.error_messages import error_messages
+from app.questionnaire.rules import convert_to_datetime
 
 logger = get_logger()
 
@@ -219,16 +220,19 @@ class DateRangeCheck(object):
 
     def __call__(self, form, from_field, to_field):
 
-        from_date_str = '{}-{:02d}-{:02d}'.format(int(from_field.year.data or 0),
-                                                  int(from_field.month.data or 0),
-                                                  int(from_field.day.data or 0))
+        from_day = int(from_field.day.data) if 'day' in from_field.data else 1
+        to_day = int(to_field.day.data) if 'day' in to_field.data else 1
 
-        to_date_str = '{}-{:02d}-{:02d}'.format(int(to_field.year.data or 0),
-                                                int(to_field.month.data or 0),
-                                                int(to_field.day.data or 0))
+        from_date_str = '{}-{:02d}-{:02d}'.format(int(from_field.year.data),
+                                                  int(from_field.month.data),
+                                                  from_day)
 
-        from_date = datetime.strptime(from_date_str, '%Y-%m-%d')
-        to_date = datetime.strptime(to_date_str, '%Y-%m-%d')
+        to_date_str = '{}-{:02d}-{:02d}'.format(int(to_field.year.data),
+                                                int(to_field.month.data),
+                                                to_day)
+
+        from_date = convert_to_datetime(from_date_str)
+        to_date = convert_to_datetime(to_date_str)
 
         if from_date == to_date or from_date > to_date:
             raise validators.ValidationError(self.messages['INVALID_DATE_RANGE'])

--- a/data/en/test_difference_in_years.json
+++ b/data/en/test_difference_in_years.json
@@ -1,0 +1,85 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "023",
+    "title": "Difference between two dates",
+    "description": "A test schema for calculate age from date",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "id": "dates",
+            "title": "Date Difference",
+            "blocks": [{
+                    "type": "Question",
+                    "id": "age-block",
+                    "title": "Calculate Age",
+                    "questions": [{
+                        "id": "date-pipe-question",
+                        "title": "What is your date of birth?",
+                        "type": "General",
+                        "answers": [{
+                            "alias": "date_dob",
+                            "id": "date-dob",
+                            "label": "For example 20 March 1990",
+                            "mandatory": true,
+                            "type": "Date"
+                        }]
+                    }]
+                },
+                {
+                    "type": "ConfirmationQuestion",
+                    "id": "age-test",
+                    "title": "Confirm Your Age",
+                    "questions": [{
+                        "id": "confirm-dob-question",
+                        "title": "You are {{ calculate_years_difference (answers.date_dob, 'now') }} old. Is this correct?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "date-test-answer",
+                            "label": "Piped dates",
+                            "mandatory": true,
+                            "type": "Radio",
+                            "options": [{
+                                    "label": "Yes",
+                                    "value": "Yes"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "No"
+                                }
+                            ]
+                        }]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "age-block",
+                                "when": [{
+                                    "id": "date-test-answer",
+                                    "condition": "equals",
+                                    "value": "No"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "summary",
+                                "when": [{
+                                    "id": "date-test-answer",
+                                    "condition": "equals",
+                                    "value": "Yes"
+                                }]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Summary",
+                    "id": "summary"
+                }
+            ]
+        }]
+    }]
+}

--- a/data/en/test_difference_in_years_month_year.json
+++ b/data/en/test_difference_in_years_month_year.json
@@ -1,0 +1,85 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "023",
+    "title": "Difference between two dates",
+    "description": "A test schema for calculate age from date",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "id": "dates",
+            "title": "Date Difference",
+            "blocks": [{
+                    "type": "Question",
+                    "id": "age-block",
+                    "title": "Calculate Difference",
+                    "questions": [{
+                        "id": "date-pipe-question",
+                        "title": "When did you last go on holiday?",
+                        "type": "General",
+                        "answers": [{
+                            "alias": "date_dob",
+                            "id": "date-dob",
+                            "label": "For example March 1990",
+                            "mandatory": true,
+                            "type": "MonthYearDate"
+                        }]
+                    }]
+                },
+                {
+                    "type": "ConfirmationQuestion",
+                    "id": "age-test",
+                    "title": "Confirm Duration",
+                    "questions": [{
+                        "id": "confirm-dob-question",
+                        "title": "It has been {{ calculate_years_difference (answers.date_dob, 'now') }} since you last went on holiday. Is this correct?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "date-test-answer",
+                            "label": "Piped dates",
+                            "mandatory": true,
+                            "type": "Radio",
+                            "options": [{
+                                    "label": "Yes",
+                                    "value": "Yes"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "No"
+                                }
+                            ]
+                        }]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "age-block",
+                                "when": [{
+                                    "id": "date-test-answer",
+                                    "condition": "equals",
+                                    "value": "No"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "summary",
+                                "when": [{
+                                    "id": "date-test-answer",
+                                    "condition": "equals",
+                                    "value": "Yes"
+                                }]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Summary",
+                    "id": "summary"
+                }
+            ]
+        }]
+    }]
+}

--- a/data/en/test_difference_in_years_month_year_range.json
+++ b/data/en/test_difference_in_years_month_year_range.json
@@ -1,0 +1,93 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "023",
+    "title": "Difference between two dates",
+    "description": "A test schema for calculate age from date",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "id": "dates",
+            "title": "Date Difference",
+            "blocks": [{
+                    "type": "Question",
+                    "id": "date-block",
+                    "title": "Calculate Difference Between Two Dates",
+                    "questions": [{
+                        "id": "date-pipe-question",
+                        "title": "How long were you outside the UK?",
+                        "type": "DateRange",
+                        "answers": [{
+                                "mandatory": true,
+                                "label": "From",
+                                "id": "period-from",
+                                "alias": "period_from",
+                                "type": "MonthYearDate"
+                            },
+                            {
+                                "mandatory": true,
+                                "label": "To",
+                                "id": "period-to",
+                                "alias": "period_to",
+                                "type": "MonthYearDate"
+                            }
+                        ]
+                    }]
+                },
+                {
+                    "type": "ConfirmationQuestion",
+                    "id": "age-test",
+                    "title": "Confirm Dates",
+                    "questions": [{
+                        "id": "confirm-dob-question",
+                        "title": "You were out of the UK for {{ calculate_years_difference (answers.period_from, answers.period_to) }}. Is this correct?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "date-test-answer",
+                            "label": "Piped dates",
+                            "mandatory": true,
+                            "type": "Radio",
+                            "options": [{
+                                    "label": "Yes",
+                                    "value": "Yes"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "No"
+                                }
+                            ]
+                        }]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "date-block",
+                                "when": [{
+                                    "id": "date-test-answer",
+                                    "condition": "equals",
+                                    "value": "No"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "summary",
+                                "when": [{
+                                    "id": "date-test-answer",
+                                    "condition": "equals",
+                                    "value": "Yes"
+                                }]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Summary",
+                    "id": "summary"
+                }
+            ]
+        }]
+    }]
+}

--- a/data/en/test_difference_in_years_range.json
+++ b/data/en/test_difference_in_years_range.json
@@ -1,0 +1,93 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "023",
+    "title": "Difference between two dates",
+    "description": "A test schema for calculate age from date",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "id": "dates",
+            "title": "Date Difference",
+            "blocks": [{
+                    "type": "Question",
+                    "id": "date-block",
+                    "title": "Calculate Difference Between Two Dates",
+                    "questions": [{
+                        "id": "date-pipe-question",
+                        "title": "How long were you outside the UK?",
+                        "type": "DateRange",
+                        "answers": [{
+                                "mandatory": true,
+                                "label": "From",
+                                "id": "period-from",
+                                "alias": "period_from",
+                                "type": "Date"
+                            },
+                            {
+                                "mandatory": true,
+                                "label": "To",
+                                "id": "period-to",
+                                "alias": "period_to",
+                                "type": "Date"
+                            }
+                        ]
+                    }]
+                },
+                {
+                    "type": "ConfirmationQuestion",
+                    "id": "age-test",
+                    "title": "Confirm Dates",
+                    "questions": [{
+                        "id": "confirm-dob-question",
+                        "title": "You were out of the UK for {{ calculate_years_difference (answers.period_from, answers.period_to) }}. Is this correct?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "date-test-answer",
+                            "label": "Piped dates",
+                            "mandatory": true,
+                            "type": "Radio",
+                            "options": [{
+                                    "label": "Yes",
+                                    "value": "Yes"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "No"
+                                }
+                            ]
+                        }]
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "block": "date-block",
+                                "when": [{
+                                    "id": "date-test-answer",
+                                    "condition": "equals",
+                                    "value": "No"
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "summary",
+                                "when": [{
+                                    "id": "date-test-answer",
+                                    "condition": "equals",
+                                    "value": "Yes"
+                                }]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Summary",
+                    "id": "summary"
+                }
+            ]
+        }]
+    }]
+}

--- a/data/en/test_routing_date_greater_than.json
+++ b/data/en/test_routing_date_greater_than.json
@@ -23,7 +23,7 @@
                         }],
                         "description": "",
                         "id": "date-questions",
-                        "title": "Enter a date greater than Return date: {{ exercise.return_by|format_date('%B %Y') }}",
+                        "title": "Enter a date greater than Return date: {{ exercise.return_by|format_date }}",
                         "type": "General"
                     }],
                     "title": "",
@@ -50,7 +50,7 @@
                     "type": "Interstitial",
                     "id": "incorrect-answer",
                     "title": "Incorrect Date",
-                    "description": "You entered a return date earlier than {{ exercise.return_by|format_date('%B %Y') }}.",
+                    "description": "You entered a return date earlier than {{ exercise.return_by|format_date }}.",
                     "routing_rules": [{
                         "goto": {
                             "block": "summary"
@@ -61,7 +61,7 @@
                     "type": "Interstitial",
                     "id": "correct-answer",
                     "title": "Correct Date",
-                    "description": "You entered a return date later than {{ exercise.return_by|format_date('%B %Y') }}."
+                    "description": "You entered a return date later than {{ exercise.return_by|format_date }}."
                 },
                 {
                     "type": "Summary",

--- a/tests/app/validation/test_date_range_validator.py
+++ b/tests/app/validation/test_date_range_validator.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock
+from unittest.mock import MagicMock
 from wtforms.validators import ValidationError
 
 from app.validation.error_messages import error_messages
@@ -16,17 +16,17 @@ class TestDateRangeValidator(unittest.TestCase):
 
         validator = DateRangeCheck()
 
-        period_from = Mock()
+        period_from = MagicMock()
         period_from.day.data = '01'
         period_from.month.data = '01'
         period_from.year.data = '2016'
 
-        period_to = Mock()
+        period_to = MagicMock()
         period_to.day.data = '01'
         period_to.month.data = '01'
         period_to.year.data = '2016'
 
-        mock_form = Mock()
+        mock_form = MagicMock()
 
         with self.assertRaises(ValidationError) as ite:
             validator(mock_form, period_from, period_to)
@@ -37,17 +37,17 @@ class TestDateRangeValidator(unittest.TestCase):
 
         validator = DateRangeCheck()
 
-        period_from = Mock()
+        period_from = MagicMock()
         period_from.day.data = '20'
         period_from.month.data = '01'
         period_from.year.data = '2018'
 
-        period_to = Mock()
+        period_to = MagicMock()
         period_to.day.data = '20'
         period_to.month.data = '01'
         period_to.year.data = '2016'
 
-        mock_form = Mock()
+        mock_form = MagicMock()
 
         with self.assertRaises(ValidationError) as ite:
             validator(mock_form, period_from, period_to)
@@ -58,17 +58,17 @@ class TestDateRangeValidator(unittest.TestCase):
 
         validator = DateRangeCheck()
 
-        period_from = Mock()
+        period_from = MagicMock()
         period_from.day.data = '01'
         period_from.month.data = '01'
         period_from.year.data = '2016'
 
-        period_to = Mock()
+        period_to = MagicMock()
         period_to.day.data = '01'
         period_to.month.data = '01'
         period_to.year.data = '2017'
 
-        mock_form = Mock()
+        mock_form = MagicMock()
 
         try:
             validator(mock_form, period_from, period_to)


### PR DESCRIPTION
### What is the context of this PR?
Added new Jinja filters to calculate and pipe the difference between two dates.
Now also supports `MonthYearDate` ranges.
[Trello Card](https://trello.com/c/iUoHqZDx/1931-pipe-difference-between-two-dates)

### How to review
1. For the new schemas, ensure the playback value for the difference in years is valid.

Schemas:
```
test_difference_in_years.json
test_difference_in_years_month_year.json
test_difference_in_years_month_year_range.jso
test_difference_in_years_range.json
```

Ensure that all tests pass and validate all the schemas are correct and the structure is valid.