### PR TITLE
Date range validation

### DIFF
--- a/app/forms/date_form.py
+++ b/app/forms/date_form.py
@@ -1,20 +1,27 @@
 import logging
 import calendar
 
+from datetime import datetime
+
+from dateutil.relativedelta import relativedelta
+
 from wtforms import Form, SelectField, StringField
 
-from app.validation.validators import DateCheck, OptionalForm, DateRequired, MonthYearCheck
+from app.questionnaire.rules import get_metadata_value, get_answer_store_value, convert_to_datetime
+from app.validation.validators import DateCheck, OptionalForm, DateRequired, MonthYearCheck, SingleDatePeriodCheck
 
 logger = logging.getLogger(__name__)
 
 
-def get_date_form(answer=None, error_messages=None):
+def get_date_form(answer_store, metadata, answer=None, error_messages=None):
     """
     Returns a date form metaclass with appropriate validators. Used in both date and
     date range form creation.
 
     :param error_messages: The messages during validation
     :param answer: The answer on which to base this form
+    :param answer_store: The current answer store
+    :param metadata: metadata for reference meta dates
     :return: The generated DateForm metaclass
     """
     class DateForm(Form):
@@ -23,10 +30,10 @@ def get_date_form(answer=None, error_messages=None):
 
     validate_with = [OptionalForm()]
 
-    if not error_messages:
-        date_messages = {}
-    else:
+    if error_messages:
         date_messages = error_messages.copy()
+    else:
+        date_messages = {}
 
     if answer['mandatory'] is True:
         if 'validation' in answer and 'messages' in answer['validation'] \
@@ -39,7 +46,14 @@ def get_date_form(answer=None, error_messages=None):
             and 'INVALID_DATE' in answer['validation']['messages']:
         date_messages['INVALID_DATE'] = answer['validation']['messages']['INVALID_DATE']
 
-    validate_with += [DateCheck(date_messages['INVALID_DATE'])]
+    validate_with.append(DateCheck(date_messages['INVALID_DATE']))
+
+    if 'minimum' in answer or 'maximum' in answer:
+        messages = None
+        if 'validation' in answer:
+            messages = answer['validation'].get('messages')
+        minimum_date, maximum_date = get_dates_for_single_date_period_validation(answer, answer_store, metadata)
+        validate_with.append(SingleDatePeriodCheck(messages=messages, minimum_date=minimum_date, maximum_date=maximum_date))
 
     # Set up all the calendar month choices for select
     month_choices = [('', 'Select month')] + [(str(x), calendar.month_name[x]) for x in range(1, 13)]
@@ -84,3 +98,64 @@ def get_month_year_form(answer, error_messages):
     MonthYearDateForm.month = SelectField(choices=month_choices, default='', validators=validate_with)
 
     return MonthYearDateForm
+
+
+def get_dates_for_single_date_period_validation(answer, answer_store, metadata):
+    """
+    Gets attributes within a minimum or maximum of a date field and validates that the entered date
+    is valid.
+
+    :param answer: The answer which contains the minimum or maximum
+    :param answer_store: The current answer store
+    :param metadata: metadata for reference meta dates
+    :return: attributes
+    """
+    minimum_referenced_date, maximum_referenced_date = None, None
+
+    if 'minimum' in answer:
+        minimum_referenced_date = get_referenced_offset_value(answer['minimum'], answer_store, metadata)
+    if 'maximum' in answer:
+        maximum_referenced_date = get_referenced_offset_value(answer['maximum'], answer_store, metadata)
+
+    # Extra runtime validation that will catch invalid schemas
+    # Similar validation in schema validator
+    if minimum_referenced_date and maximum_referenced_date:
+        if minimum_referenced_date > maximum_referenced_date:
+            raise Exception('The minimum offset date is greater than the maximum offset date for {}.'.format(answer['id']))
+
+    return minimum_referenced_date, maximum_referenced_date
+
+
+def get_referenced_offset_value(answer_min_or_max, answer_store, metadata):
+    """
+    Gets value of the referenced date type, whether it is a value,
+    id of an answer or a meta date. Then adds/subtracts offset from that value and returns
+    the new offset value
+
+    :param answer_min_or_max: The minimum or maximum object which contains
+    the referenced value.
+    :param answer_store: The current answer store
+    :param metadata: metadata for reference meta dates
+    :return: date value
+    """
+    value = None
+
+    if 'value' in answer_min_or_max:
+        if answer_min_or_max['value'] == 'now':
+            value = datetime.utcnow().strftime('%Y-%m-%d')
+        else:
+            value = answer_min_or_max['value']
+    elif 'meta' in answer_min_or_max:
+        value = get_metadata_value(metadata, answer_min_or_max['meta'])
+    elif 'answer_id' in answer_min_or_max:
+        value = get_answer_store_value(answer_min_or_max['answer_id'], answer_store, group_instance=0)
+
+    value = convert_to_datetime(value)
+
+    if 'offset_by' in answer_min_or_max:
+        offset = answer_min_or_max['offset_by']
+        value += relativedelta(years=offset.get('years', 0),
+                               months=offset.get('months', 0),
+                               days=offset.get('days', 0))
+
+    return value

--- a/app/forms/fields.py
+++ b/app/forms/fields.py
@@ -15,16 +15,17 @@ MAX_DECIMAL_PLACES = 6
 logger = get_logger()
 
 
-def get_field(answer, label, error_messages, answer_store):
+def get_field(answer, label, error_messages, answer_store, metadata):
     guidance = answer.get('guidance', '')
 
     if answer['type'] in ['Number', 'Currency', 'Percentage', 'Unit']:
         field = get_number_field(answer, label, guidance, error_messages, answer_store)
+    elif answer['type'] == 'Date':
+        field = get_date_field(answer, label, guidance, error_messages, answer_store, metadata)
     else:
         field = {
             'Radio': get_select_field,
             'Checkbox': get_select_multiple_field,
-            'Date': get_date_field,
             'MonthYearDate': get_month_year_field,
             'TextArea': get_text_area_field,
             'TextField': get_string_field,
@@ -103,10 +104,10 @@ def get_text_area_field(answer, label, guidance, error_messages):
     )
 
 
-def get_date_field(answer, label, guidance, error_messages):
+def get_date_field(answer, label, guidance, error_messages, answer_store, metadata):
 
     return FormField(
-        get_date_form(answer, error_messages=error_messages),
+        get_date_form(answer_store=answer_store, metadata=metadata, answer=answer, error_messages=error_messages),
         label=label,
         description=guidance,
     )

--- a/app/forms/questionnaire_form.py
+++ b/app/forms/questionnaire_form.py
@@ -1,13 +1,17 @@
 import logging
+from datetime import datetime, timedelta
 
 from decimal import Decimal
 
 import itertools
+
+from dateutil.relativedelta import relativedelta
 from wtforms import validators
 from flask_wtf import FlaskForm
 from werkzeug.datastructures import MultiDict
 
 from app.forms.fields import get_field
+from app.forms.date_form import get_dates_for_single_date_period_validation
 from app.validation.validators import DateRangeCheck, SumCheck
 
 logger = logging.getLogger(__name__)
@@ -15,10 +19,11 @@ logger = logging.getLogger(__name__)
 
 class QuestionnaireForm(FlaskForm):
 
-    def __init__(self, schema, block_json, answer_store, formdata=None, **kwargs):
+    def __init__(self, schema, block_json, answer_store, metadata, formdata=None, **kwargs):
         self.schema = schema
         self.block_json = block_json
         self.answer_store = answer_store
+        self.metadata = metadata
         self.question_errors = {}
         self.options_with_children = {}
 
@@ -33,19 +38,43 @@ class QuestionnaireForm(FlaskForm):
         :return:
         """
         valid_fields = FlaskForm.validate(self)
-        valid_form = True
+        valid_date_range_form = True
+        valid_calculated_form = True
 
         for question in self.schema.get_questions_for_block(self.block_json):
             if question['type'] == 'DateRange':
-                period_from_id = question['answers'][0]['id']
-                period_to_id = question['answers'][1]['id']
-                if not (self.answers_all_valid([period_from_id, period_to_id]) and
-                        self._validate_date_range_question(question['id'], period_from_id, period_to_id)):
-                    valid_form = False
+                valid_date_range_form = self.validate_date_range_question(question)
             elif question['type'] == 'Calculated':
-                valid_form = self.validate_calculated_question(question)
+                valid_calculated_form = self.validate_calculated_question(question)
 
-        return valid_form and valid_fields
+        return valid_calculated_form and valid_date_range_form and valid_fields
+
+    def validate_date_range_question(self, question):
+        date_from = question['answers'][0]
+        date_to = question['answers'][1]
+        if self._has_min_and_max_single_dates(date_from, date_to):
+            # Work out the largest possible range, for date range question
+            period_range = self._get_period_range_for_single_date(date_from, date_to)
+            if 'period_limits' in question:
+                self.validate_date_range_with_period_limits_and_single_date_limits(question['id'],
+                                                                                   question['period_limits'],
+                                                                                   period_range)
+            else:
+                # Check every field on each form has populated data
+                if self.is_date_form_populated(getattr(self, date_from['id']), getattr(self, date_to['id'])):
+                    self.validate_date_range_with_single_date_limits(question['id'], period_range)
+        period_from_id = date_from['id']
+        period_to_id = date_to['id']
+        messages = None
+        if 'validation' in question:
+            messages = question['validation'].get('messages')
+        if not (
+                self.answers_all_valid([period_from_id, period_to_id]) and
+                self._validate_date_range_question(question['id'], period_from_id, period_to_id, messages,
+                                                   question.get('period_limits'))):
+            return False
+
+        return True
 
     def validate_calculated_question(self, question):
         for calculation in question['calculations']:
@@ -66,15 +95,36 @@ class QuestionnaireForm(FlaskForm):
         target_answer = self.schema.get_answer(calculation['answer_id'])
         return self.answer_store.filter(answer_ids=[target_answer['id']]).values()[0], target_answer.get('currency')
 
-    def _validate_date_range_question(self, question_id, period_from_id, period_to_id):
+    def validate_date_range_with_period_limits_and_single_date_limits(self, question_id, period_limits, period_range):
+        # Get period_limits from question
+        period_min, period_max = self._get_period_limits(period_limits)
+
+        # Exception to be raised if range from answers are smaller than
+        # minimum or larger than maximum period_limits
+        exception = 'The schema has invalid period_limits for {}'.format(question_id)
+
+        if period_min and period_range < self._get_offset_value(period_min):
+            raise Exception(exception)
+        if period_max and period_range > self._get_offset_value(period_max):
+            raise Exception(exception)
+
+    @staticmethod
+    def validate_date_range_with_single_date_limits(question_id, period_range):
+        # Exception to be raised if range from answers are smaller than
+        # minimum or larger than maximum period_limits
+        exception = 'The schema has invalid date answer limits for {}'.format(question_id)
+
+        if period_range < timedelta(0):
+            raise Exception(exception)
+
+    def _validate_date_range_question(self, question_id, period_from_id, period_to_id, messages, period_limits):
         period_from = getattr(self, period_from_id)
         period_to = getattr(self, period_to_id)
-        validator = DateRangeCheck()
+        period_min, period_max = self._get_period_limits(period_limits)
+        validator = DateRangeCheck(messages=messages, period_min=period_min, period_max=period_max)
 
         # Check every field on each form has populated data
-        populated = all(field.data for field in itertools.chain(period_from, period_to))
-
-        if populated:
+        if self.is_date_form_populated(period_from, period_to):
             try:
                 validator(self, period_from, period_to)
             except validators.ValidationError as e:
@@ -104,6 +154,49 @@ class QuestionnaireForm(FlaskForm):
             return False
 
         return True
+
+    def _get_period_range_for_single_date(self, date_from, date_to):
+        from_min_period_date, from_max_period_date = get_dates_for_single_date_period_validation(date_from,
+                                                                                                 self.answer_store,
+                                                                                                 self.metadata)
+        to_min_period_date, to_max_period_date = get_dates_for_single_date_period_validation(date_to,
+                                                                                             self.answer_store,
+                                                                                             self.metadata)
+
+        min_period_date = from_min_period_date or from_max_period_date
+        max_period_date = to_max_period_date or to_min_period_date
+
+        # Work out the largest possible range, for date range question
+        period_range = max_period_date - min_period_date
+
+        return period_range
+
+    @staticmethod
+    def is_date_form_populated(date_from, date_to):
+        return all(field.data for field in itertools.chain(date_from, date_to))
+
+    @staticmethod
+    def _has_min_and_max_single_dates(date_from, date_to):
+        return ('minimum' in date_from or 'maximum' in date_from) and ('minimum' in date_to or 'maximum' in date_to)
+
+    @staticmethod
+    def _get_offset_value(period_object):
+        now = datetime.now()
+        delta = relativedelta(years=period_object.get('years', 0),
+                              months=period_object.get('months', 0),
+                              days=period_object.get('days', 0))
+
+        return now + delta - now
+
+    @staticmethod
+    def _get_period_limits(limits):
+        minimum, maximum = None, None
+        if limits:
+            if 'minimum' in limits:
+                minimum = limits['minimum']
+            if 'maximum' in limits:
+                maximum = limits['maximum']
+        return minimum, maximum
 
     @staticmethod
     def _get_calculation_type(calculation_type):
@@ -164,7 +257,7 @@ class QuestionnaireForm(FlaskForm):
         return None
 
 
-def get_answer_fields(question, data, error_messages, answer_store):
+def get_answer_fields(question, data, error_messages, answer_store, metadata):
     answer_fields = {}
     for answer in question['answers']:
         if 'parent_answer_id' in answer and answer['parent_answer_id'] in data and \
@@ -173,7 +266,7 @@ def get_answer_fields(question, data, error_messages, answer_store):
                 next(a['mandatory'] for a in question['answers'] if a['id'] == answer['parent_answer_id'])
 
         name = answer.get('label') or question.get('title')
-        answer_fields[answer['id']] = get_field(answer, name, error_messages, answer_store)
+        answer_fields[answer['id']] = get_field(answer, name, error_messages, answer_store, metadata)
     return answer_fields
 
 
@@ -203,19 +296,19 @@ def map_child_option_errors(errors, answer_json):
     return child_errors
 
 
-def generate_form(schema, block_json, data, answer_store):
+def generate_form(schema, block_json, data, answer_store, metadata):
     answer_fields = {}
 
     class DynamicForm(QuestionnaireForm):
         for question in schema.get_questions_for_block(block_json):
-            answer_fields.update(get_answer_fields(question, data, schema.error_messages, answer_store))
+            answer_fields.update(get_answer_fields(question, data, schema.error_messages, answer_store, metadata))
 
     for answer_id, field in answer_fields.items():
         setattr(DynamicForm, answer_id, field)
 
     if data:
-        form = DynamicForm(schema, block_json, answer_store, MultiDict(data))
+        form = DynamicForm(schema, block_json, answer_store, metadata, MultiDict(data))
     else:
-        form = DynamicForm(schema, block_json, answer_store)
+        form = DynamicForm(schema, block_json, answer_store, metadata)
 
     return form

--- a/app/helpers/form_helper.py
+++ b/app/helpers/form_helper.py
@@ -11,14 +11,15 @@ from app.forms.questionnaire_form import generate_form
 logger = get_logger()
 
 
-def get_form_for_location(schema, block_json, location, answer_store, disable_mandatory=False):
+def get_form_for_location(schema, block_json, location, answer_store, metadata, disable_mandatory=False):  # pylint: disable=too-many-locals
     """
     Returns the form necessary for the location given a get request, plus any template arguments
 
+    :param schema: schema
     :param block_json: The block json
     :param location: The location which this form is for
     :param answer_store: The current answer store
-    :param error_messages: The default error messages to use within the form
+    :param metadata: metadata
     :param disable_mandatory: Make mandatory answers optional
     :return: form, template_args A tuple containing the form for this location and any additional template arguments
     """
@@ -62,16 +63,17 @@ def get_form_for_location(schema, block_json, location, answer_store, disable_ma
 
     mapped_answers = deserialise_dates(schema, location.block_id, mapped_answers)
 
-    return generate_form(schema, block_json, mapped_answers, answer_store)
+    return generate_form(schema, block_json, mapped_answers, answer_store, metadata)
 
 
-def post_form_for_location(schema, block_json, location, answer_store, request_form, disable_mandatory=False):
+def post_form_for_location(schema, block_json, location, answer_store, metadata, request_form, disable_mandatory=False):
     """
     Returns the form necessary for the location given a post request, plus any template arguments
 
     :param block_json: The block json
     :param location: The location which this form is for
     :param answer_store: The current answer store
+    :param metadata: metadata
     :param request_form: form, template_args A tuple containing the form for this location and any additional template arguments
     :param error_messages: The default error messages to use within the form
     :param disable_mandatory: Make mandatory answers optional
@@ -89,7 +91,7 @@ def post_form_for_location(schema, block_json, location, answer_store, request_f
         return form
 
     data = clear_other_text_field(request_form, schema.get_questions_for_block(block_json))
-    return generate_form(schema, block_json, data, answer_store)
+    return generate_form(schema, block_json, data, answer_store, metadata)
 
 
 def disable_mandatory_answers(block_json):

--- a/app/templating/view_context.py
+++ b/app/templating/view_context.py
@@ -23,7 +23,7 @@ def build_view_context(metadata, answer_store, schema_context, block, current_lo
 
     if block['type'] in ('Question', 'ConfirmationQuestion'):
         if not form:
-            form = get_form_for_location(g.schema, rendered_block, current_location, answer_store)
+            form = get_form_for_location(g.schema, rendered_block, current_location, answer_store, metadata)
 
         return build_view_context_for_question(current_location, variables, rendered_block, form)
 

--- a/app/validation/error_messages.py
+++ b/app/validation/error_messages.py
@@ -22,4 +22,8 @@ error_messages = {
     'MAX_LENGTH_EXCEEDED': 'Your answer is too long, it has to be less than %(max)d characters.',
     'INVALID_DATE': 'Enter a valid date.',
     'INVALID_DATE_RANGE': "Enter a 'period to' date later than the 'period from' date.",
+    'DATE_PERIOD_TOO_SMALL': 'Enter a reporting period greater than or equal to %(min)s.',
+    'DATE_PERIOD_TOO_LARGE': 'Enter a reporting period less than or equal to %(max)s.',
+    'SINGLE_DATE_PERIOD_TOO_EARLY': 'Enter a date after %(min)s.',
+    'SINGLE_DATE_PERIOD_TOO_LATE': 'Enter a date before %(max)s.',
 }

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -176,8 +176,8 @@ def post_household_composition(routing_path, **kwargs):
 
     block = _get_block_json(current_location)
 
-    form = post_form_for_location(g.schema, block, current_location, answer_store, request.form,
-                                  disable_mandatory=disable_mandatory)
+    form = post_form_for_location(g.schema, block, current_location, answer_store, get_metadata(current_user),
+                                  request.form, disable_mandatory=disable_mandatory)
 
     if 'action[add_answer]' in request.form:
         form.household.append_entry()
@@ -319,6 +319,7 @@ def _generate_wtf_form(form, block, location):
         block,
         location,
         get_answer_store(current_user),
+        get_metadata(current_user),
         request.form,
         disable_mandatory)
 

--- a/data/en/test_date_range_period_validation.json
+++ b/data/en/test_date_range_period_validation.json
@@ -1,0 +1,58 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "023",
+    "title": "Date formats",
+    "description": "A test schema for different date formats",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "variables": {
+        "period": "{{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}"
+    },
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "id": "dates",
+            "title": "Date Range Validation",
+            "blocks": [{
+                    "type": "Question",
+                    "id": "date-range-block",
+                    "title": "Date Range",
+                    "questions": [{
+                        "id": "date-range-question",
+                        "title": "Enter Date Range",
+                        "type": "DateRange",
+                        "description": "Enter a date range that is at least 23 days apart and at most 1 month 23 days apart",
+                        "period_limits": {
+                            "minimum": {
+                                "days": 23
+                            },
+                            "maximum": {
+                                "months": 1,
+                                "days": 20
+                            }
+                        },
+                        "answers": [{
+                                "id": "date-range-from",
+                                "label": "Period from",
+                                "mandatory": true,
+                                "type": "Date"
+                            },
+                            {
+                                "id": "date-range-to",
+                                "label": "Period to",
+                                "mandatory": true,
+                                "type": "Date"
+                            }
+                        ]
+                    }]
+                },
+                {
+                    "type": "Summary",
+                    "id": "summary"
+                }
+            ]
+        }]
+    }]
+}

--- a/data/en/test_single_date_period_validation.json
+++ b/data/en/test_single_date_period_validation.json
@@ -1,0 +1,85 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "023",
+    "title": "Date formats",
+    "description": "A test schema for single date period validation",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "variables": {
+        "period": "{{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}"
+    },
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "id": "dates",
+            "title": "Date Range Validation",
+            "blocks": [{
+                    "type": "Question",
+                    "id": "date-block",
+                    "title": "Date",
+                    "description": "Enter a date after 1 July 2017. Entering a date before will result in a 5xx on the next page as this will invalidate the schema",
+                    "questions": [{
+                        "id": "date-question",
+                        "title": "Enter Date",
+                        "type": "General",
+                        "answers": [{
+                            "id": "date",
+                            "label": "Enter date",
+                            "mandatory": true,
+                            "type": "Date"
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "date-range-block",
+                    "title": "Date Range",
+                    "questions": [{
+                        "id": "date-range-question",
+                        "title": "Enter Date Range",
+                        "type": "DateRange",
+                        "description": "Enter any 'period from' 19 days before exercise start date and 1 July 2017. Then enter any 'period to', at least 1 month and 10 days after your previous answer on the last question",
+                        "answers": [{
+                                "id": "date-range-from",
+                                "label": "Period from",
+                                "mandatory": true,
+                                "type": "Date",
+                                "minimum": {
+                                    "meta": "ref_p_start_date",
+                                    "offset_by": {
+                                      "days": -19
+                                    }
+                                },
+                                "maximum": {
+                                  "value": "2017-06-11",
+                                  "offset_by": {
+                                      "days": 20
+                                    }
+                                }
+                            },
+                            {
+                                "id": "date-range-to",
+                                "label": "Period to",
+                                "mandatory": true,
+                                "type": "Date",
+                                "minimum": {
+                                    "answer_id": "date",
+                                    "offset_by": {
+                                      "months": 1,
+                                      "days": 10
+                                    }
+                                }
+                            }
+                        ]
+                    }]
+                },
+                {
+                    "type": "Summary",
+                    "id": "summary"
+                }
+            ]
+        }]
+    }]
+}

--- a/scripts/test_schemas.sh
+++ b/scripts/test_schemas.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-docker pull onsdigital/eq-schema-validator
-validator="$(docker run -d -p 5001:5000 onsdigital/eq-schema-validator)"
+docker pull onsdigital/eq-schema-validator:eq-1947-date-range-validation
+validator="$(docker run -d -p 5001:5000 onsdigital/eq-schema-validator:eq-1947-date-range-validation)"
 
 sleep 3
 

--- a/tests/app/forms/test_date_form.py
+++ b/tests/app/forms/test_date_form.py
@@ -1,4 +1,12 @@
-from app.forms.date_form import get_date_form, get_month_year_form
+from datetime import datetime
+
+from dateutil.relativedelta import relativedelta
+from mock import patch
+
+from app.data_model.answer_store import AnswerStore, Answer
+from app.forms.date_form import get_date_form, get_month_year_form, get_referenced_offset_value, \
+    get_dates_for_single_date_period_validation
+from app.questionnaire.rules import convert_to_datetime
 from app.utilities.schema import load_schema_from_params
 from tests.app.app_context_test_case import AppContextTestCase
 
@@ -11,7 +19,7 @@ class TestDateForm(AppContextTestCase):
 
         answers = schema.get_answers_by_id_for_block('date-block')
 
-        form = get_date_form(answers['single-date-answer'], error_messages=error_messages)
+        form = get_date_form(AnswerStore(), {}, answers['single-date-answer'], error_messages=error_messages)
 
         self.assertTrue(hasattr(form, 'day'))
         self.assertTrue(hasattr(form, 'month'))
@@ -28,3 +36,169 @@ class TestDateForm(AppContextTestCase):
         self.assertFalse(hasattr(form, 'day'))
         self.assertTrue(hasattr(form, 'month'))
         self.assertTrue(hasattr(form, 'year'))
+
+    def test_generate_date_form_validates_single_date_period(self):
+        schema = load_schema_from_params('test', 'single_date_period_validation')
+        error_messages = schema.error_messages
+        test_metadata = {'ref_p_start_date': '2017-02-20'}
+
+        answers = schema.get_answers_by_id_for_block('date-range-block')
+
+        form = get_date_form(AnswerStore(), test_metadata, answers['date-range-from'], error_messages=error_messages)
+
+        self.assertTrue(hasattr(form, 'day'))
+        self.assertTrue(hasattr(form, 'month'))
+        self.assertTrue(hasattr(form, 'year'))
+
+    def test_generate_date_form_validates_single_date_period_with_bespoke_message(self):
+        schema = load_schema_from_params('test', 'single_date_period_validation')
+        error_messages = schema.error_messages
+        answer = {
+            'id': 'date-range-from',
+            'mandatory': True,
+            'label': 'Period from',
+            'type': 'Date',
+            'maximum': {
+                'value': '2017-06-11',
+                'offset_by': {
+                    'days': 20
+                }
+            },
+            'validation': {
+                'messages': {
+                    'SINGLE_DATE_PERIOD_TOO_LATE': 'Test Message'
+                }
+            }
+        }
+
+        with patch('app.questionnaire.questionnaire_schema.QuestionnaireSchema.get_answers_by_id_for_block',
+                   return_value=[answer]):
+            form = get_date_form(AnswerStore(), {}, answer, error_messages=error_messages)
+
+            self.assertTrue(hasattr(form, 'day'))
+            self.assertTrue(hasattr(form, 'month'))
+            self.assertTrue(hasattr(form, 'year'))
+
+    def test_get_referenced_offset_value_for_value(self):
+        answer_minimum = {
+            'value': '2017-06-11',
+            'offset_by': {
+                'days': 10
+            }
+        }
+
+        value = get_referenced_offset_value(answer_minimum, AnswerStore(), {})
+
+        self.assertEqual(value, convert_to_datetime('2017-06-21'))
+
+    def test_get_referenced_offset_value_for_now_value(self):
+        answer_minimum = {
+            'value': 'now',
+            'offset_by': {
+                'days': 10
+            }
+        }
+
+        value = get_referenced_offset_value(answer_minimum, AnswerStore(), {})
+
+        self.assertEqual(datetime.date(value), (datetime.now().date() + relativedelta(days=10)))
+
+    def test_get_referenced_offset_value_for_meta(self):
+        test_metadata = {'date': '2018-02-20'}
+        answer_minimum = {
+            'meta': 'date',
+            'offset_by': {
+                'days': -10
+            }
+        }
+
+        value = get_referenced_offset_value(answer_minimum, AnswerStore(), test_metadata)
+
+        self.assertEqual(value, convert_to_datetime('2018-02-10'))
+
+    def test_get_referenced_offset_value_for_answer_id(self):
+        store = AnswerStore()
+
+        test_answer_id = Answer(
+            answer_id='date',
+            answer_instance=1,
+            group_instance=0,
+            value='2018-03-20',
+        )
+        store.add(test_answer_id)
+
+        answer_maximum = {
+            'answer_id': 'date',
+            'offset_by': {
+                'months': 1
+            }
+        }
+
+        value = get_referenced_offset_value(answer_maximum, store, {})
+
+        self.assertEqual(value, convert_to_datetime('2018-04-20'))
+
+    def test_get_referenced_offset_value_with_no_offset(self):
+        answer_minimum = {
+            'value': '2017-06-11',
+        }
+
+        value = get_referenced_offset_value(answer_minimum, AnswerStore(), {})
+
+        self.assertEqual(value, convert_to_datetime('2017-06-11'))
+
+    def test_minimum_and_maximum_offset_dates(self):
+        test_metadata = {'date': '2018-02-20'}
+        store = AnswerStore()
+
+        test_answer_id = Answer(
+            answer_id='date',
+            answer_instance=1,
+            group_instance=0,
+            value='2018-03-20',
+        )
+        store.add(test_answer_id)
+
+        answer = {
+            'id': 'date_answer',
+            'type': 'Date',
+            'minimum': {
+                'meta': 'date',
+                'offset_by': {
+                    'days': -10
+                }
+            },
+            'maximum': {
+                'answer_id': 'date',
+                'offset_by': {
+                    'years': 1
+                }
+            }
+        }
+
+        offset_dates = get_dates_for_single_date_period_validation(answer, store, metadata=test_metadata)
+
+        self.assertEqual(offset_dates, (convert_to_datetime('2018-02-10'), convert_to_datetime('2019-03-20')))
+
+    def test_greater_minimum_date_than_maximum_date(self):
+        answer = {
+            'id': 'date_answer',
+            'type': 'Date',
+            'minimum': {
+                'value': '2018-02-15',
+                'offset_by': {
+                    'days': -10
+                }
+            },
+            'maximum': {
+                'value': '2018-01-15',
+                'offset_by': {
+                    'days': 10
+                }
+            }
+        }
+
+        with self.assertRaises(Exception) as ite:
+            get_dates_for_single_date_period_validation(answer, AnswerStore(), {})
+            self.assertEqual('The minimum offset date is greater than the maximum offset date for date-answer.',
+                             str(ite.exception))

--- a/tests/app/forms/test_fields.py
+++ b/tests/app/forms/test_fields.py
@@ -4,6 +4,7 @@ from wtforms import validators, StringField, FormField, SelectField, SelectMulti
 
 from app.forms.custom_fields import MaxTextAreaField
 from app.forms.fields import CustomIntegerField, CustomDecimalField, get_field, get_mandatory_validator, get_length_validator, _coerce_str_unless_none
+from app.storage.metadata_parser import parse_metadata
 from app.validation.error_messages import error_messages
 from app.validation.validators import ResponseRequired
 from app.data_model.answer_store import AnswerStore
@@ -14,9 +15,25 @@ class TestFields(unittest.TestCase):
 
     def setUp(self):
         self.answer_store = AnswerStore()
+        self.metadata = parse_metadata({
+            'user_id': '789473423',
+            'form_type': '0205',
+            'collection_exercise_sid': 'test-sid',
+            'eq_id': '1',
+            'period_id': '2016-02-01',
+            'period_str': '2016-01-01',
+            'ref_p_start_date': '2016-02-02',
+            'ref_p_end_date': '2016-03-03',
+            'ru_ref': '432423423423',
+            'ru_name': 'Apple',
+            'return_by': '2016-07-07',
+            'case_id': '1234567890',
+            'case_ref': '1000000000000001'
+        })
 
     def tearDown(self):
         self.answer_store.clear()
+        self.metadata.clear()
 
     def test_get_mandatory_validator_optional(self):
         answer = {
@@ -94,7 +111,8 @@ class TestFields(unittest.TestCase):
             'guidance': '<p>Please enter your job title in the space provided.</p>',
             'type': 'TextField'
         }
-        unbound_field = get_field(textfield_json, textfield_json['label'], error_messages, self.answer_store)
+        unbound_field = get_field(textfield_json, textfield_json['label'], error_messages, self.answer_store,
+                                  self.metadata)
 
         self.assertTrue(unbound_field.field_class == StringField)
         self.assertEqual(unbound_field.kwargs['label'], textfield_json['label'])
@@ -110,7 +128,8 @@ class TestFields(unittest.TestCase):
             'type': 'TextArea'
         }
 
-        unbound_field = get_field(textarea_json, textarea_json['label'], error_messages, self.answer_store)
+        unbound_field = get_field(textarea_json, textarea_json['label'], error_messages, self.answer_store,
+                                  self.metadata)
 
         self.assertTrue(unbound_field.field_class == MaxTextAreaField)
         self.assertEqual(unbound_field.kwargs['label'], textarea_json['label'])
@@ -131,7 +150,8 @@ class TestFields(unittest.TestCase):
             }
         }
 
-        unbound_field = get_field(date_json, date_json['label'], error_messages, self.answer_store)
+        unbound_field = get_field(date_json, date_json['label'], error_messages, self.answer_store,
+                                  self.metadata)
 
         self.assertTrue(unbound_field.field_class == FormField)
         self.assertEqual(unbound_field.kwargs['label'], date_json['label'])
@@ -154,7 +174,8 @@ class TestFields(unittest.TestCase):
             }
         }
 
-        unbound_field = get_field(date_json, date_json['label'], error_messages, self.answer_store)
+        unbound_field = get_field(date_json, date_json['label'], error_messages, self.answer_store,
+                                  self.metadata)
 
         self.assertTrue(unbound_field.field_class == FormField)
         self.assertEqual(unbound_field.kwargs['label'], date_json['label'])
@@ -190,7 +211,8 @@ class TestFields(unittest.TestCase):
             'type': 'Radio'
         }
 
-        unbound_field = get_field(radio_json, radio_json['label'], error_messages, self.answer_store)
+        unbound_field = get_field(radio_json, radio_json['label'], error_messages, self.answer_store,
+                                  self.metadata)
 
         expected_choices = [(option['label'], option['value']) for option in radio_json['options']]
 
@@ -223,7 +245,8 @@ class TestFields(unittest.TestCase):
             ]
         }
 
-        unbound_field = get_field(dropdown_json, dropdown_json['label'], error_messages, self.answer_store)
+        unbound_field = get_field(dropdown_json, dropdown_json['label'], error_messages, self.answer_store,
+                                  self.metadata)
 
         expected_choices = [('', 'Select an answer')] + \
                            [(option['label'], option['value']) for option in dropdown_json['options']]
@@ -279,7 +302,8 @@ class TestFields(unittest.TestCase):
             'type': 'Checkbox'
         }
 
-        unbound_field = get_field(checkbox_json, checkbox_json['label'], error_messages, self.answer_store)
+        unbound_field = get_field(checkbox_json, checkbox_json['label'], error_messages, self.answer_store,
+                                  self.metadata)
 
         expected_choices = [(option['label'], option['value']) for option in checkbox_json['options']]
 
@@ -306,7 +330,7 @@ class TestFields(unittest.TestCase):
             }
         }
 
-        unbound_field = get_field(integer_json, integer_json['label'], error_messages, self.answer_store)
+        unbound_field = get_field(integer_json, integer_json['label'], error_messages, self.answer_store, self.metadata)
 
         self.assertTrue(unbound_field.field_class == CustomIntegerField)
         self.assertEqual(unbound_field.kwargs['label'], integer_json['label'])
@@ -329,7 +353,7 @@ class TestFields(unittest.TestCase):
             }
         }
 
-        unbound_field = get_field(decimal_json, decimal_json['label'], error_messages, self.answer_store)
+        unbound_field = get_field(decimal_json, decimal_json['label'], error_messages, self.answer_store, self.metadata)
 
         self.assertTrue(unbound_field.field_class == CustomDecimalField)
         self.assertEqual(unbound_field.kwargs['label'], decimal_json['label'])
@@ -352,7 +376,8 @@ class TestFields(unittest.TestCase):
             }
         }
 
-        unbound_field = get_field(currency_json, currency_json['label'], error_messages, self.answer_store)
+        unbound_field = get_field(currency_json, currency_json['label'], error_messages, self.answer_store,
+                                  self.metadata)
 
         self.assertTrue(unbound_field.field_class == CustomIntegerField)
         self.assertEqual(unbound_field.kwargs['label'], currency_json['label'])
@@ -378,7 +403,8 @@ class TestFields(unittest.TestCase):
             }
         }
 
-        unbound_field = get_field(percentage_json, percentage_json['label'], error_messages, self.answer_store)
+        unbound_field = get_field(percentage_json, percentage_json['label'], error_messages, self.answer_store,
+                                  self.metadata)
 
         self.assertTrue(unbound_field.field_class == CustomIntegerField)
         self.assertEqual(unbound_field.kwargs['label'], percentage_json['label'])

--- a/tests/app/forms/test_questionnaire_form.py
+++ b/tests/app/forms/test_questionnaire_form.py
@@ -9,7 +9,7 @@ from app.data_model.answer_store import AnswerStore, Answer
 from tests.app.app_context_test_case import AppContextTestCase
 
 
-class TestQuestionnaireForm(AppContextTestCase):
+class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=too-many-public-methods
 
     @staticmethod
     def _error_exists(answer_id, msg, mapped_errors):
@@ -21,7 +21,7 @@ class TestQuestionnaireForm(AppContextTestCase):
 
             block_json = schema.get_block('reporting-period')
 
-            form = generate_form(schema, block_json, {}, AnswerStore())
+            form = generate_form(schema, block_json, {}, AnswerStore(), metadata=None)
 
             for answer in schema.get_answers_for_block('reporting-period'):
                 self.assertTrue(hasattr(form, answer['id']))
@@ -46,7 +46,7 @@ class TestQuestionnaireForm(AppContextTestCase):
                 'period-from': {'day': '01', 'month': '3', 'year': '2016'},
                 'period-to': {'day': '31', 'month': '3', 'year': '2016'}
             }
-            form = generate_form(schema, block_json, data, AnswerStore())
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None)
 
             self.assertEqual(form.data, expected_form_data)
 
@@ -70,7 +70,7 @@ class TestQuestionnaireForm(AppContextTestCase):
                 'period-from': {'day': '25', 'month': '12', 'year': '2016'},
                 'period-to': {'day': '25', 'month': '12', 'year': '2016'}
             }
-            form = generate_form(schema, block_json, data, AnswerStore())
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -97,12 +97,311 @@ class TestQuestionnaireForm(AppContextTestCase):
                 'period-from': {'day': '25', 'month': '12', 'year': '2016'},
                 'period-to': {'day': '24', 'month': '12', 'year': '2016'}
             }
-            form = generate_form(schema, block_json, data, AnswerStore())
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
             self.assertEqual(form.question_errors['reporting-period-question'], schema.error_messages
                              ['INVALID_DATE_RANGE'], AnswerStore())
+
+    def test_date_range_too_large_period_raises_question_error(self):
+        with self.test_request_context():
+            schema = load_schema_from_params('test', 'date_range_period_validation')
+
+            block_json = schema.get_block('date-range-block')
+
+            data = {
+                'date-range-from-day': '25',
+                'date-range-from-month': '12',
+                'date-range-from-year': '2016',
+                'date-range-to-day': '24',
+                'date-range-to-month': '12',
+                'date-range-to-year': '2017'
+            }
+
+            expected_form_data = {
+                'csrf_token': '',
+                'date-range-from': {'day': '25', 'month': '12', 'year': '2016'},
+                'date-range-to': {'day': '24', 'month': '12', 'year': '2017'}
+            }
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None)
+
+            form.validate()
+            self.assertEqual(form.data, expected_form_data)
+            self.assertEqual(form.question_errors['date-range-question'], schema.error_messages
+                             ['DATE_PERIOD_TOO_LARGE'] % dict(max='1 month, 20 days'), AnswerStore())
+
+    def test_date_range_too_small_period_raises_question_error(self):
+        with self.test_request_context():
+            schema = load_schema_from_params('test', 'date_range_period_validation')
+
+            block_json = schema.get_block('date-range-block')
+
+            data = {
+                'date-range-from-day': '25',
+                'date-range-from-month': '12',
+                'date-range-from-year': '2016',
+                'date-range-to-day': '26',
+                'date-range-to-month': '12',
+                'date-range-to-year': '2016'
+            }
+
+            expected_form_data = {
+                'csrf_token': '',
+                'date-range-from': {'day': '25', 'month': '12', 'year': '2016'},
+                'date-range-to': {'day': '26', 'month': '12', 'year': '2016'}
+            }
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None)
+
+            form.validate()
+            self.assertEqual(form.data, expected_form_data)
+            self.assertEqual(form.question_errors['date-range-question'], schema.error_messages
+                             ['DATE_PERIOD_TOO_SMALL'] % dict(min='23 days'), AnswerStore())
+
+    def test_date_range_valid_period(self):
+        with self.test_request_context():
+            schema = load_schema_from_params('test', 'date_range_period_validation')
+
+            block_json = schema.get_block('date-range-block')
+
+            data = {
+                'date-range-from-day': '25',
+                'date-range-from-month': '12',
+                'date-range-from-year': '2016',
+                'date-range-to-day': '26',
+                'date-range-to-month': '01',
+                'date-range-to-year': '2017'
+            }
+
+            expected_form_data = {
+                'csrf_token': '',
+                'date-range-from': {'day': '25', 'month': '12', 'year': '2016'},
+                'date-range-to': {'day': '26', 'month': '01', 'year': '2017'}
+            }
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None)
+
+            form.validate()
+            self.assertEqual(form.data, expected_form_data)
+
+    def test_bespoke_message_for_date_range_period_validation(self):
+        with self.test_request_context():
+            schema = load_schema_from_params('test', 'date_range_period_validation')
+
+            block_json = schema.get_block('date-range-block')
+
+            question_json = {
+                'id': 'date-range-question',
+                'type': 'DateRange',
+                'validation': {
+                    'messages': {
+                        'DATE_PERIOD_TOO_SMALL': 'Test Message'
+                    }
+                },
+                'period_limits': {
+                    'minimum': {
+                        'days': 20
+                    }
+                },
+                'answers': [{
+                    'id': 'date-range-from',
+                    'label': 'Period from',
+                    'mandatory': True,
+                    'type': 'Date'
+                }, {
+                    'id': 'date-range-to',
+                    'label': 'Period to',
+                    'mandatory': True,
+                    'type': 'Date'
+                }]
+            }
+
+            data = {
+                'date-range-from-day': '25',
+                'date-range-from-month': '1',
+                'date-range-from-year': '2018',
+                'date-range-to-day': '26',
+                'date-range-to-month': '1',
+                'date-range-to-year': '2018'
+            }
+
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None)
+
+            with patch('app.questionnaire.questionnaire_schema.QuestionnaireSchema.get_questions_for_block',
+                       return_value=[question_json]):
+                form.validate()
+                self.assertIn(form.question_errors['date-range-question'], 'Test Message')
+
+    def test_invalid_minimum_period_limit_and_single_date_periods(self):
+        with self.test_request_context():
+            schema = load_schema_from_params('test', 'date_range_period_validation')
+
+            block_json = schema.get_block('date-range-block')
+
+            question_json = {
+                'id': 'date-range-question',
+                'type': 'DateRange',
+                'period_limits': {
+                    'minimum': {
+                        'months': 2
+                    }
+                },
+                'answers': [{
+                    'id': 'date-range-from',
+                    'label': 'Period from',
+                    'mandatory': True,
+                    'type': 'Date',
+                    'minimum': {
+                        'value': '2018-01-10',
+                        'offset_by': {
+                            'days': -5
+                        }
+                    }
+                }, {
+                    'id': 'date-range-to',
+                    'label': 'Period to',
+                    'mandatory': True,
+                    'type': 'Date',
+                    'maximum': {
+                        'value': '2018-01-10',
+                        'offset_by': {
+                            'days': 5
+                        }
+                    }
+                }]
+            }
+
+            data = {
+                'date-range-from-day': '8',
+                'date-range-from-month': '1',
+                'date-range-from-year': '2018',
+                'date-range-to-day': '13',
+                'date-range-to-month': '1',
+                'date-range-to-year': '2018'
+            }
+
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None)
+
+            with self.assertRaises(Exception) as ite:
+                with patch('app.questionnaire.questionnaire_schema.QuestionnaireSchema.get_questions_for_block',
+                           return_value=[question_json]):
+                    form.validate()
+                    self.assertEqual('The schema has invalid period_limits for date-range-question', str(ite.exception))
+
+    def test_invalid_maximum_period_limit_and_single_date_periods(self):
+        with self.test_request_context():
+            schema = load_schema_from_params('test', 'date_range_period_validation')
+
+            block_json = schema.get_block('date-range-block')
+
+            question_json = {
+                'id': 'date-range-question',
+                'type': 'DateRange',
+                'period_limits': {
+                    'maximum': {
+                        'days': 8
+                    }
+                },
+                'answers': [{
+                    'id': 'date-range-from',
+                    'label': 'Period from',
+                    'mandatory': True,
+                    'type': 'Date',
+                    'minimum': {
+                        'value': '2018-01-10',
+                        'offset_by': {
+                            'days': -5
+                        }
+                    }
+                }, {
+                    'id': 'date-range-to',
+                    'label': 'Period to',
+                    'mandatory': True,
+                    'type': 'Date',
+                    'maximum': {
+                        'value': '2018-01-10',
+                        'offset_by': {
+                            'days': 5
+                        }
+                    }
+                }]
+            }
+
+            data = {
+                'date-range-from-day': '6',
+                'date-range-from-month': '1',
+                'date-range-from-year': '2018',
+                'date-range-to-day': '15',
+                'date-range-to-month': '1',
+                'date-range-to-year': '2018'
+            }
+
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None)
+
+            with self.assertRaises(Exception) as ite:
+                with patch('app.questionnaire.questionnaire_schema.QuestionnaireSchema.get_questions_for_block',
+                           return_value=[question_json]):
+                    form.validate()
+                    self.assertEqual('The schema has invalid period_limits for date-range-question', str(ite.exception))
+
+    def test_invalid_date_range_and_single_date_periods(self):
+        with self.test_request_context():
+            store = AnswerStore()
+            test_answer_id = Answer(
+                answer_id='date',
+                answer_instance=1,
+                group_instance=0,
+                value='2017-03-20',
+            )
+            store.add(test_answer_id)
+
+            schema = load_schema_from_params('test', 'date_range_period_validation')
+
+            block_json = schema.get_block('date-range-block')
+
+            question_json = {
+                'id': 'date-range-question',
+                'type': 'DateRange',
+                'answers': [{
+                    'id': 'date-range-from',
+                    'label': 'Period from',
+                    'mandatory': True,
+                    'type': 'Date',
+                    'minimum': {
+                        'value': '2018-01-10',
+                        'offset_by': {
+                            'days': -5
+                        }
+                    }
+                }, {
+                    'id': 'date-range-to',
+                    'label': 'Period to',
+                    'mandatory': True,
+                    'type': 'Date',
+                    'maximum': {
+                        'answer_id': 'date',
+                        'offset_by': {
+                            'days': 5
+                        }
+                    }
+                }]
+            }
+
+            data = {
+                'date-range-from-day': '6',
+                'date-range-from-month': '1',
+                'date-range-from-year': '2018',
+                'date-range-to-day': '15',
+                'date-range-to-month': '1',
+                'date-range-to-year': '2018'
+            }
+
+            form = generate_form(schema, block_json, data, store, metadata=None)
+
+            with self.assertRaises(Exception) as ite:
+                with patch('app.questionnaire.questionnaire_schema.QuestionnaireSchema.get_questions_for_block',
+                           return_value=[question_json]):
+                    form.validate()
+                    self.assertEqual('The schema has invalid date answer limits for date-range-question', str(ite.exception))
 
     def test_invalid_calculation_type(self):
         store = AnswerStore()
@@ -151,7 +450,7 @@ class TestQuestionnaireForm(AppContextTestCase):
                 'breakdown-2': '5',
             }
 
-            form = generate_form(schema, block_json, data, store)
+            form = generate_form(schema, block_json, data, store, metadata=None)
 
             with self.assertRaises(Exception) as ite:
                 with patch('app.questionnaire.questionnaire_schema.QuestionnaireSchema.get_questions_for_block',
@@ -211,7 +510,7 @@ class TestQuestionnaireForm(AppContextTestCase):
                 'breakdown-2': '5',
             }
 
-            form = generate_form(schema, block_json, data, store)
+            form = generate_form(schema, block_json, data, store, metadata=None)
 
             with patch('app.questionnaire.questionnaire_schema.QuestionnaireSchema.get_questions_for_block',
                        return_value=[question_json]):
@@ -249,7 +548,7 @@ class TestQuestionnaireForm(AppContextTestCase):
                 'breakdown-3': Decimal('4'),
                 'breakdown-4': None
             }
-            form = generate_form(schema, block_json, data, store)
+            form = generate_form(schema, block_json, data, store, metadata=None)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -287,7 +586,7 @@ class TestQuestionnaireForm(AppContextTestCase):
                 'breakdown-3': Decimal('4'),
                 'breakdown-4': Decimal('1')
             }
-            form = generate_form(schema, block_json, data, store)
+            form = generate_form(schema, block_json, data, store, metadata=None)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -323,7 +622,7 @@ class TestQuestionnaireForm(AppContextTestCase):
                 'breakdown-3': None,
                 'breakdown-4': None
             }
-            form = generate_form(schema, block_json, data, store)
+            form = generate_form(schema, block_json, data, store, metadata=None)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -355,7 +654,7 @@ class TestQuestionnaireForm(AppContextTestCase):
             }
 
             # With no answers question validation should pass
-            form = generate_form(schema, block_json, data, store)
+            form = generate_form(schema, block_json, data, store, metadata=None)
             form.validate()
 
             self.assertEqual(len(form.question_errors), 0)
@@ -363,7 +662,7 @@ class TestQuestionnaireForm(AppContextTestCase):
             # With the data equaling the total question validation should pass
             data['breakdown-1'] = '10'
 
-            form = generate_form(schema, block_json, data, store)
+            form = generate_form(schema, block_json, data, store, metadata=None)
             form.validate()
 
             self.assertEqual(len(form.question_errors), 0)
@@ -371,12 +670,11 @@ class TestQuestionnaireForm(AppContextTestCase):
             # With the data not equaling zero or the total, question validation should fail
             data['breakdown-1'] = '1'
 
-            form = generate_form(schema, block_json, data, store)
+            form = generate_form(schema, block_json, data, store, metadata=None)
             form.validate()
 
             self.assertEqual(form.question_errors['breakdown-question'],
                              schema.error_messages['TOTAL_SUM_NOT_EQUALS'] % dict(total='10'))
-
 
     def test_form_errors_are_correctly_mapped(self):
         with self.test_request_context():
@@ -384,7 +682,7 @@ class TestQuestionnaireForm(AppContextTestCase):
 
             block_json = schema.get_block('total-retail-turnover')
 
-            form = generate_form(schema, block_json, {}, AnswerStore())
+            form = generate_form(schema, block_json, {}, AnswerStore(), metadata=None)
 
             form.validate()
             mapped_errors = form.map_errors()
@@ -398,7 +696,7 @@ class TestQuestionnaireForm(AppContextTestCase):
 
             block_json = schema.get_block('reporting-period')
 
-            form = generate_form(schema, block_json, {}, AnswerStore())
+            form = generate_form(schema, block_json, {}, AnswerStore(), metadata=None)
 
             form.validate()
             mapped_errors = form.map_errors()
@@ -414,7 +712,7 @@ class TestQuestionnaireForm(AppContextTestCase):
 
             form = generate_form(schema, block_json, {
                 'radio-mandatory-answer': 'Other'
-            }, AnswerStore())
+            }, AnswerStore(), metadata=None)
 
             child_field = getattr(form, 'other-answer-mandatory')
 
@@ -428,7 +726,7 @@ class TestQuestionnaireForm(AppContextTestCase):
 
             form = generate_form(schema, block_json, {
                 'radio-mandatory-answer': 'Other'
-            }, AnswerStore())
+            }, AnswerStore(), metadata=None)
 
             form.validate()
             mapped_errors = form.map_errors()
@@ -446,7 +744,7 @@ class TestQuestionnaireForm(AppContextTestCase):
 
             form = generate_form(schema, block_json, {
                 'total-number-employees': '-1'
-            }, AnswerStore())
+            }, AnswerStore(), metadata=None)
 
             form.validate()
             answer_errors = form.answer_errors('total-number-employees')
@@ -457,7 +755,7 @@ class TestQuestionnaireForm(AppContextTestCase):
             schema = load_schema_from_params('test', 'checkbox')
             block_json = schema.get_block('mandatory-checkbox')
 
-            form = generate_form(schema, block_json, {}, AnswerStore())
+            form = generate_form(schema, block_json, {}, AnswerStore(), metadata=None)
 
             self.assertFalse(form.option_has_other('mandatory-checkbox-answer', 1))
             self.assertTrue(form.option_has_other('mandatory-checkbox-answer', 6))
@@ -469,7 +767,7 @@ class TestQuestionnaireForm(AppContextTestCase):
 
             form = generate_form(schema, block_json, {
                 'other-answer-mandatory': 'Some data'
-            }, AnswerStore())
+            }, AnswerStore(), metadata=None)
 
             field = form.get_other_answer('mandatory-checkbox-answer', 6)
 
@@ -482,7 +780,7 @@ class TestQuestionnaireForm(AppContextTestCase):
 
             form = generate_form(schema, block_json, {
                 'other-answer-mandatory': 'Some data'
-            }, AnswerStore())
+            }, AnswerStore(), metadata=None)
 
             field = form.get_other_answer('mandatory-checkbox-answer', 4)
 

--- a/tests/app/helpers/test_form_helper.py
+++ b/tests/app/helpers/test_form_helper.py
@@ -21,7 +21,7 @@ class TestFormHelper(AppContextTestCase):
                                 group_instance=0,
                                 block_id='introduction')
 
-            form = get_form_for_location(schema, block_json, location, AnswerStore())
+            form = get_form_for_location(schema, block_json, location, AnswerStore(), metadata=None)
 
             self.assertTrue(hasattr(form, 'period-to'))
             self.assertTrue(hasattr(form, 'period-from'))
@@ -42,7 +42,7 @@ class TestFormHelper(AppContextTestCase):
                                 block_id='introduction')
 
             form = get_form_for_location(schema, block_json, location,
-                                         AnswerStore(), disable_mandatory=True)
+                                         AnswerStore(), metadata=None, disable_mandatory=True)
 
             self.assertTrue(hasattr(form, 'period-from'))
             self.assertTrue(hasattr(form, 'period-to'))
@@ -72,7 +72,7 @@ class TestFormHelper(AppContextTestCase):
                     'value': '2017-09-01',
                     'answer_instance': 0,
                 }
-            ]))
+            ]), metadata=None)
 
             self.assertTrue(hasattr(form, 'period-to'))
             self.assertTrue(hasattr(form, 'period-from'))
@@ -158,7 +158,7 @@ class TestFormHelper(AppContextTestCase):
                                 group_instance=0,
                                 block_id='introduction')
 
-            form = post_form_for_location(schema, block_json, location, AnswerStore(), {
+            form = post_form_for_location(schema, block_json, location, AnswerStore(), metadata=None, request_form={
                 'period-from-day': '1',
                 'period-from-month': '05',
                 'period-from-year': '2015',
@@ -196,7 +196,7 @@ class TestFormHelper(AppContextTestCase):
                                 group_instance=0,
                                 block_id='introduction')
 
-            form = post_form_for_location(schema, block_json, location, AnswerStore(), {
+            form = post_form_for_location(schema, block_json, location, AnswerStore(), metadata=None, request_form={
             }, disable_mandatory=True)
 
             self.assertTrue(hasattr(form, 'period-from'))
@@ -234,7 +234,7 @@ class TestFormHelper(AppContextTestCase):
             block_json = schema.get_block('household-composition')
             location = Location('who-lives-here', 0, 'household-composition')
 
-            form = post_form_for_location(schema, block_json, location, AnswerStore(), {
+            form = post_form_for_location(schema, block_json, location, AnswerStore(), metadata=None, request_form={
                 'household-0-first-name': 'Joe',
                 'household-0-last-name': '',
                 'household-1-first-name': 'Bob',
@@ -336,9 +336,8 @@ class TestFormHelper(AppContextTestCase):
 
             answer = schema.get_answers_for_block('household-relationships')[0]
 
-            form = post_form_for_location(schema, block_json, location, answer_store, MultiDict({
-                '{answer_id}-0'.format(answer_id=answer['id']): '3'
-            }))
+            form = post_form_for_location(schema, block_json, location, answer_store, metadata=None,
+                                          request_form=MultiDict({'{answer_id}-0'.format(answer_id=answer['id']): '3'}))
 
             self.assertTrue(hasattr(form, answer['id']))
 
@@ -372,10 +371,9 @@ class TestFormHelper(AppContextTestCase):
                 }
             ])
 
-            form = post_form_for_location(schema, block_json, location, answer_store, MultiDict({
-                'radio-mandatory-answer': 'Bacon',
-                'other-answer-mandatory': 'Old other text'
-            }))
+            form = post_form_for_location(schema, block_json, location, answer_store, metadata=None,
+                                          request_form=MultiDict({'radio-mandatory-answer': 'Bacon',
+                                                                  'other-answer-mandatory': 'Old other text'}))
 
             self.assertTrue(hasattr(form, 'radio-mandatory-answer'))
 
@@ -407,7 +405,7 @@ class TestFormHelper(AppContextTestCase):
             radio_answer = schema.get_answers_for_block('radio-mandatory')[0]
             text_answer = 'other-answer-mandatory'
 
-            form = post_form_for_location(schema, block_json, location, answer_store, MultiDict({
+            form = post_form_for_location(schema, block_json, location, answer_store, metadata=None, request_form=MultiDict({
                 '{answer_id}'.format(answer_id=radio_answer['id']): 'Other',
                 '{answer_id}'.format(answer_id=text_answer): 'Other text field value',
             }))

--- a/tests/app/validation/test_date_check_validator.py
+++ b/tests/app/validation/test_date_check_validator.py
@@ -11,9 +11,11 @@ class TestDateCheckValidator(unittest.TestCase):
         validator = DateCheck()
 
         mock_form = Mock()
-        mock_form.day.data = None
-        mock_form.month.data = None
-        mock_form.year.data = None
+        mock_form.data = {
+            'day': '',
+            'month': '',
+            'year': ''
+        }
 
         mock_field = Mock()
 
@@ -26,9 +28,11 @@ class TestDateCheckValidator(unittest.TestCase):
         validator = DateCheck()
 
         mock_form = Mock()
-        mock_form.day.data = ''
-        mock_form.month.data = ''
-        mock_form.year.data = ''
+        mock_form.data = {
+            'day': '',
+            'month': '',
+            'year': ''
+        }
 
         mock_field = Mock()
 
@@ -41,9 +45,11 @@ class TestDateCheckValidator(unittest.TestCase):
         validator = DateCheck()
 
         mock_form = Mock()
-        mock_form.day.data = ''
-        mock_form.month.data = '12'
-        mock_form.year.data = '2016'
+        mock_form.data = {
+            'day': '',
+            'month': '12',
+            'year': '2016'
+        }
 
         mock_field = Mock()
 
@@ -56,9 +62,11 @@ class TestDateCheckValidator(unittest.TestCase):
         validator = DateCheck()
 
         mock_form = Mock()
-        mock_form.day.data = '01'
-        mock_form.month.data = ''
-        mock_form.year.data = '2016'
+        mock_form.data = {
+            'day': '03',
+            'month': '',
+            'year': '2016'
+        }
 
         mock_field = Mock()
 
@@ -71,9 +79,11 @@ class TestDateCheckValidator(unittest.TestCase):
         validator = DateCheck()
 
         mock_form = Mock()
-        mock_form.day.data = '01'
-        mock_form.month.data = '12'
-        mock_form.year.data = ''
+        mock_form.data = {
+            'day': '03',
+            'month': '12',
+            'year': ''
+        }
 
         mock_field = Mock()
 
@@ -86,9 +96,11 @@ class TestDateCheckValidator(unittest.TestCase):
         validator = DateCheck()
 
         mock_form = Mock()
-        mock_form.day.data = '40'
-        mock_form.month.data = '12'
-        mock_form.year.data = '2016'
+        mock_form.data = {
+            'day': '40',
+            'month': '12',
+            'year': '2016'
+        }
 
         mock_field = Mock()
 
@@ -101,9 +113,11 @@ class TestDateCheckValidator(unittest.TestCase):
         validator = DateCheck()
 
         mock_form = Mock()
-        mock_form.day.data = '01'
-        mock_form.month.data = '13'
-        mock_form.year.data = '2016'
+        mock_form.data = {
+            'day': '20',
+            'month': '13',
+            'year': '2016'
+        }
 
         mock_field = Mock()
 
@@ -116,9 +130,11 @@ class TestDateCheckValidator(unittest.TestCase):
         validator = DateCheck()
 
         mock_form = Mock()
-        mock_form.day.data = '01'
-        mock_form.month.data = '1'
-        mock_form.year.data = '16'
+        mock_form.data = {
+            'day': '20',
+            'month': '12',
+            'year': '16'
+        }
 
         mock_field = Mock()
 
@@ -133,9 +149,11 @@ class TestDateCheckValidator(unittest.TestCase):
 
         # 2015 was not a leap year
         mock_form = Mock()
-        mock_form.day.data = '29'
-        mock_form.month.data = '02'
-        mock_form.year.data = '2015'
+        mock_form.data = {
+            'day': '29',
+            'month': '02',
+            'year': '2015'
+        }
 
         mock_field = Mock()
 
@@ -144,58 +162,51 @@ class TestDateCheckValidator(unittest.TestCase):
 
         self.assertEqual(error_messages['INVALID_DATE'], str(ite.exception))
 
-    def test_date_type_validator_valid_leap_year(self):
+    @staticmethod
+    def test_date_type_validator_valid_leap_year():
         validator = DateCheck()
 
         # 2016 WAS a leap year
         mock_form = Mock()
-        mock_form.day.data = '29'
-        mock_form.month.data = '02'
-        mock_form.year.data = '2016'
+        mock_form.data = {
+            'day': '29',
+            'month': '02',
+            'year': '2016'
+        }
 
         mock_field = Mock()
+        validator(mock_form, mock_field)
 
-        try:
-            validator(mock_form, mock_field)
-        except StopValidation:
-            self.fail('Valid date raised StopValidation')
-
-    def test_date_type_validator_valid_dates(self):
-
+    @staticmethod
+    def test_date_type_validator_valid_dates():
         validator = DateCheck()
 
         mock_form = Mock()
-        mock_form.day.data = '01'
-        mock_form.month.data = '01'
-        mock_form.year.data = '2016'
+        mock_form.data = {
+            'day': '29',
+            'month': '01',
+            'year': '2016'
+        }
 
         mock_field = Mock()
-
-        try:
-            validator(mock_form, mock_field)
-        except StopValidation:
-            self.fail('Valid date raised StopValidation')
+        validator(mock_form, mock_field)
 
         mock_form = Mock()
-        mock_form.day.data = '1'
-        mock_form.month.data = '12'
-        mock_form.year.data = '2016'
+        mock_form.data = {
+            'day': '01',
+            'month': '12',
+            'year': '2016'
+        }
 
         mock_field = Mock()
-
-        try:
-            validator(mock_form, mock_field)
-        except StopValidation:
-            self.fail('Valid date raised StopValidation')
+        validator(mock_form, mock_field)
 
         mock_form = Mock()
-        mock_form.day.data = '01'
-        mock_form.month.data = '03'
-        mock_form.year.data = '2016'
+        mock_form.data = {
+            'day': '03',
+            'month': '03',
+            'year': '2016'
+        }
 
         mock_field = Mock()
-
-        try:
-            validator(mock_form, mock_field)
-        except StopValidation:
-            self.fail('Valid date raised StopValidation')
+        validator(mock_form, mock_field)

--- a/tests/app/validation/test_single_date_range_validator.py
+++ b/tests/app/validation/test_single_date_range_validator.py
@@ -1,0 +1,83 @@
+import unittest
+from unittest.mock import Mock
+from wtforms.validators import ValidationError
+
+from app.questionnaire.rules import convert_to_datetime
+from app.validation.error_messages import error_messages
+from app.validation.validators import SingleDatePeriodCheck
+
+
+class TestDateRangeValidator(unittest.TestCase):
+
+    def test_invalid_single_date_period_minimum_date(self):
+        minimum_date = convert_to_datetime('2016-03-31')
+        validator = SingleDatePeriodCheck(minimum_date=minimum_date)
+
+        mock_form = Mock()
+        mock_form.data = {
+            'day': '29',
+            'month': '01',
+            'year': '2016'
+        }
+
+        mock_field = Mock()
+
+        with self.assertRaises(ValidationError) as ite:
+            validator(mock_form, mock_field)
+
+        self.assertEqual(error_messages['SINGLE_DATE_PERIOD_TOO_EARLY'] % dict(min='30 March 2016'), str(ite.exception))
+
+    def test_invalid_single_date_period_maximum_date(self):
+        maximum_date = convert_to_datetime('2016-03-31')
+        validator = SingleDatePeriodCheck(maximum_date=maximum_date)
+
+        mock_form = Mock()
+        mock_form.data = {
+            'day': '29',
+            'month': '04',
+            'year': '2016'
+        }
+
+        mock_field = Mock()
+
+        with self.assertRaises(ValidationError) as ite:
+            validator(mock_form, mock_field)
+
+        self.assertEqual(error_messages['SINGLE_DATE_PERIOD_TOO_LATE'] % dict(max='1 April 2016'),
+                         str(ite.exception))
+
+    def test_invalid_single_date_period_with_bespoke_message(self):
+        maximum_date = convert_to_datetime('2016-03-31')
+        message = {'SINGLE_DATE_PERIOD_TOO_LATE': 'Test %(max)s'}
+        validator = SingleDatePeriodCheck(messages=message, maximum_date=maximum_date)
+
+        mock_form = Mock()
+        mock_form.data = {
+            'day': '29',
+            'month': '04',
+            'year': '2016'
+        }
+
+        mock_field = Mock()
+
+        with self.assertRaises(ValidationError) as ite:
+            validator(mock_form, mock_field)
+
+        self.assertEqual('Test 1 April 2016', str(ite.exception))
+
+    @staticmethod
+    def test_valid_single_date_period():
+        minimum_date = convert_to_datetime('2016-03-20')
+        maximum_date = convert_to_datetime('2016-03-31')
+        validator = SingleDatePeriodCheck(minimum_date=minimum_date, maximum_date=maximum_date)
+
+        mock_form = Mock()
+        mock_form.data = {
+            'day': '26',
+            'month': '03',
+            'year': '2016'
+        }
+
+        mock_field = Mock()
+
+        validator(mock_form, mock_field)

--- a/tests/functional/pages/features/grouped_validation/date-range/date-range-block.page.js
+++ b/tests/functional/pages/features/grouped_validation/date-range/date-range-block.page.js
@@ -1,0 +1,35 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class DateRangeBlockPage extends QuestionPage {
+
+  constructor() {
+    super('date-range-block');
+  }
+
+  dateRangeFromday() {
+    return '#date-range-from-day';
+  }
+
+  dateRangeFrommonth() {
+    return '#date-range-from-month';
+  }
+
+  dateRangeFromyear() {
+    return '#date-range-from-year';
+  }
+
+  dateRangeToday() {
+    return '#date-range-to-day';
+  }
+
+  dateRangeTomonth() {
+    return '#date-range-to-month';
+  }
+
+  dateRangeToyear() {
+    return '#date-range-to-year';
+  }
+
+}
+module.exports = new DateRangeBlockPage();

--- a/tests/functional/pages/features/grouped_validation/date-range/summary.page.js
+++ b/tests/functional/pages/features/grouped_validation/date-range/summary.page.js
@@ -1,0 +1,21 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  dateRangeFrom() { return '#date-range-from-answer'; }
+
+  dateRangeFromEdit() { return '[data-qa="date-range-from-edit"]'; }
+
+  dateRangeTo() { return '#date-range-to-answer'; }
+
+  dateRangeToEdit() { return '[data-qa="date-range-to-edit"]'; }
+
+  datesTitle() { return '#dates'; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/pages/features/validation/date-validation/date-period-validation/date-block.page.js
+++ b/tests/functional/pages/features/validation/date-validation/date-period-validation/date-block.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../../surveys/question.page');
+
+class DateBlockPage extends QuestionPage {
+
+  constructor() {
+    super('date-block');
+  }
+
+  day() {
+    return '#date-day';
+  }
+
+  month() {
+    return '#date-month';
+  }
+
+  year() {
+    return '#date-year';
+  }
+
+}
+module.exports = new DateBlockPage();

--- a/tests/functional/pages/features/validation/date-validation/date-period-validation/date-range-block.page.js
+++ b/tests/functional/pages/features/validation/date-validation/date-period-validation/date-range-block.page.js
@@ -1,0 +1,35 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../../surveys/question.page');
+
+class DateRangeBlockPage extends QuestionPage {
+
+  constructor() {
+    super('date-range-block');
+  }
+
+  dateRangeFromday() {
+    return '#date-range-from-day';
+  }
+
+  dateRangeFrommonth() {
+    return '#date-range-from-month';
+  }
+
+  dateRangeFromyear() {
+    return '#date-range-from-year';
+  }
+
+  dateRangeToday() {
+    return '#date-range-to-day';
+  }
+
+  dateRangeTomonth() {
+    return '#date-range-to-month';
+  }
+
+  dateRangeToyear() {
+    return '#date-range-to-year';
+  }
+
+}
+module.exports = new DateRangeBlockPage();

--- a/tests/functional/pages/features/validation/date-validation/date-period-validation/summary.page.js
+++ b/tests/functional/pages/features/validation/date-validation/date-period-validation/summary.page.js
@@ -1,0 +1,21 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../../surveys/question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  date() { return '#date-answer'; }
+
+  dateEdit() { return '[data-qa="date-edit"]'; }
+
+  dateRangeTo() { return '#date-range-to-answer'; }
+
+  dateRangeToEdit() { return '[data-qa="date-range-to-edit"]'; }
+
+  datesTitle() { return '#dates'; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/spec/features/grouped_validation/date-range/date-range-question-validation.spec.js
+++ b/tests/functional/spec/features/grouped_validation/date-range/date-range-question-validation.spec.js
@@ -1,0 +1,104 @@
+const helpers = require('../../../../helpers');
+
+describe('Feature: Question level validation for date ranges', function() {
+  var DateRangePage = require('../../../../pages/features/grouped_validation/date-range/date-range-block.page');
+  var SummaryPage = require('../../../../pages/features/grouped_validation/date-range/summary.page');
+
+  beforeEach(function() {
+        return helpers.openQuestionnaire('test_date_range_period_validation.json');
+  });
+
+  describe('Period Validation', function () {
+    describe('Given I enter a date period greater than the max period limit', function() {
+      it('When I continue, Then I should see a period validation error', function() {
+        return browser
+         .setValue(DateRangePage.dateRangeFromday(), 1)
+         .selectByValue(DateRangePage.dateRangeFrommonth(), 1)
+         .setValue(DateRangePage.dateRangeFromyear(), 2018)
+
+         .setValue(DateRangePage.dateRangeToday(), 3)
+         .selectByValue(DateRangePage.dateRangeTomonth(), 3)
+         .setValue(DateRangePage.dateRangeToyear(), 2018)
+         .click(DateRangePage.submit())
+         .getText(DateRangePage.errorNumber(1)).should.eventually.contain('Enter a reporting period less than or equal to 1 month, 20 days.');
+       });
+    });
+
+    describe('Given I enter a date period less than the min period limit', function() {
+      it('When I continue, Then I should see a period validation error', function() {
+        return browser
+         .setValue(DateRangePage.dateRangeFromday(), 1)
+         .selectByValue(DateRangePage.dateRangeFrommonth(), 1)
+         .setValue(DateRangePage.dateRangeFromyear(), 2018)
+
+         .setValue(DateRangePage.dateRangeToday(), 3)
+         .selectByValue(DateRangePage.dateRangeTomonth(), 1)
+         .setValue(DateRangePage.dateRangeToyear(), 2018)
+         .click(DateRangePage.submit())
+         .getText(DateRangePage.errorNumber(1)).should.eventually.contain('Enter a reporting period greater than or equal to 23 days.');
+       });
+    });
+
+    describe('Given I enter a date period within the set period limits', function() {
+      it('When I continue, Then I should be able to reach the summary', function() {
+        return browser
+         .setValue(DateRangePage.dateRangeFromday(), 1)
+         .selectByValue(DateRangePage.dateRangeFrommonth(), 1)
+         .setValue(DateRangePage.dateRangeFromyear(), 2018)
+
+         .setValue(DateRangePage.dateRangeToday(), 3)
+         .selectByValue(DateRangePage.dateRangeTomonth(), 2)
+         .setValue(DateRangePage.dateRangeToyear(), 2018)
+         .click(DateRangePage.submit())
+         .getUrl().should.eventually.contain(SummaryPage.pageName);
+       });
+    });
+  });
+
+  describe('Date Range Validation', function () {
+    describe('Given I enter a "to date" which is earlier than the "from date"', function() {
+      it('When I continue, Then I should see a validation error', function() {
+        return browser
+         .setValue(DateRangePage.dateRangeFromday(), 1)
+         .selectByValue(DateRangePage.dateRangeFrommonth(), 2)
+         .setValue(DateRangePage.dateRangeFromyear(), 2018)
+
+         .setValue(DateRangePage.dateRangeToday(), 3)
+         .selectByValue(DateRangePage.dateRangeTomonth(), 1)
+         .setValue(DateRangePage.dateRangeToyear(), 2018)
+         .click(DateRangePage.submit())
+         .getText(DateRangePage.errorNumber(1)).should.eventually.contain('Enter a \'period to\' date later than the \'period from\' date.');
+       });
+    });
+
+    describe('Given I enter matching dates for the "from" and "to" dates', function() {
+      it('When I continue, Then I should see a validation error', function() {
+        return browser
+         .setValue(DateRangePage.dateRangeFromday(), 1)
+         .selectByValue(DateRangePage.dateRangeFrommonth(), 1)
+         .setValue(DateRangePage.dateRangeFromyear(), 2018)
+
+         .setValue(DateRangePage.dateRangeToday(), 1)
+         .selectByValue(DateRangePage.dateRangeTomonth(), 1)
+         .setValue(DateRangePage.dateRangeToyear(), 2018)
+         .click(DateRangePage.submit())
+         .getText(DateRangePage.errorNumber(1)).should.eventually.contain('Enter a \'period to\' date later than the \'period from\' date.');
+       });
+    });
+
+    describe('Given I enter a valid date range', function() {
+      it('When I continue, Then I should be able to reach the summary', function() {
+        return browser
+         .setValue(DateRangePage.dateRangeFromday(), 1)
+         .selectByValue(DateRangePage.dateRangeFrommonth(), 1)
+         .setValue(DateRangePage.dateRangeFromyear(), 2018)
+
+         .setValue(DateRangePage.dateRangeToday(), 3)
+         .selectByValue(DateRangePage.dateRangeTomonth(), 2)
+         .setValue(DateRangePage.dateRangeToyear(), 2018)
+         .click(DateRangePage.submit())
+         .getUrl().should.eventually.contain(SummaryPage.pageName);
+       });
+    });
+  });
+});

--- a/tests/functional/spec/features/validation/date_validation/single-date-period-validation.spec.js
+++ b/tests/functional/spec/features/validation/date_validation/single-date-period-validation.spec.js
@@ -1,0 +1,87 @@
+const helpers = require('../../../../helpers');
+
+describe('Feature: Validation for single date periods', function() {
+  var DatePage = require('../../../../pages/features/validation/date-validation/date-period-validation/date-block.page');
+  var DatePeriodPage = require('../../../../pages/features/validation/date-validation/date-period-validation/date-range-block.page');
+  var SummaryPage = require('../../../../pages/features/validation/date-validation/date-period-validation/summary.page');
+
+  beforeEach(function() {
+     return helpers.openQuestionnaire('test_single_date_period_validation.json')
+      .then(completeFirstDatePage)
+      .then(() => {
+      });
+  });
+
+  describe('Given I enter a date before the minimum offset meta date', function() {
+    it('When I continue, Then I should see a period validation error', function() {
+      return browser
+       .setValue(DatePeriodPage.dateRangeFromday(), 13)
+       .selectByValue(DatePeriodPage.dateRangeFrommonth(), 2)
+       .setValue(DatePeriodPage.dateRangeFromyear(), 2016)
+       .click(DatePeriodPage.submit())
+
+       .setValue(DatePeriodPage.dateRangeToday(), 3)
+       .selectByValue(DatePeriodPage.dateRangeTomonth(), 3)
+       .setValue(DatePeriodPage.dateRangeToyear(), 2018)
+       .click(DatePeriodPage.submit())
+       .getText(DatePeriodPage.errorNumber(1)).should.eventually.contain('Enter a date after 12 December 2016.');
+     });
+  });
+
+  describe('Given I enter a date after the maximum offset value date', function() {
+    it('When I continue, Then I should see a period validation error', function() {
+      return browser
+       .setValue(DatePeriodPage.dateRangeFromday(), 13)
+       .selectByValue(DatePeriodPage.dateRangeFrommonth(), 7)
+       .setValue(DatePeriodPage.dateRangeFromyear(), 2017)
+       .click(DatePeriodPage.submit())
+
+       .setValue(DatePeriodPage.dateRangeToday(), 3)
+       .selectByValue(DatePeriodPage.dateRangeTomonth(), 3)
+       .setValue(DatePeriodPage.dateRangeToyear(), 2018)
+       .click(DatePeriodPage.submit())
+       .getText(DatePeriodPage.errorNumber(1)).should.eventually.contain('Enter a date before 2 July 2017.');
+     });
+  });
+
+  describe('Given I enter a date before the minimum offset answer id date', function() {
+    it('When I continue, Then I should see a period validation error', function() {
+      return browser
+       .setValue(DatePeriodPage.dateRangeFromday(), 13)
+       .selectByValue(DatePeriodPage.dateRangeFrommonth(), 11)
+       .setValue(DatePeriodPage.dateRangeFromyear(), 2016)
+       .click(DatePeriodPage.submit())
+
+       .setValue(DatePeriodPage.dateRangeToday(), 13)
+       .selectByValue(DatePeriodPage.dateRangeTomonth(), 1)
+       .setValue(DatePeriodPage.dateRangeToyear(), 2018)
+       .click(DatePeriodPage.submit())
+       .getText(DatePeriodPage.errorNumber(2)).should.eventually.contain('Enter a date after 10 February 2018.');
+     });
+  });
+
+  describe('Given I enter a date in between the minimum offset meta date and the maximum offset value date', function() {
+    it('When I continue, Then I should be able to reach the summary', function() {
+      return browser
+       .setValue(DatePeriodPage.dateRangeFromday(), 13)
+       .selectByValue(DatePeriodPage.dateRangeFrommonth(), 12)
+       .setValue(DatePeriodPage.dateRangeFromyear(), 2016)
+       .click(DatePeriodPage.submit())
+
+       .setValue(DatePeriodPage.dateRangeToday(), 11)
+       .selectByValue(DatePeriodPage.dateRangeTomonth(), 2)
+       .setValue(DatePeriodPage.dateRangeToyear(), 2018)
+       .click(DatePeriodPage.submit())
+       .getUrl().should.eventually.contain(SummaryPage.pageName);
+     });
+  });
+
+  function completeFirstDatePage() {
+    return browser
+     .setValue(DatePage.day(), 1)
+     .selectByValue(DatePage.month(), 1)
+     .setValue(DatePage.year(), 2018)
+     .click(DatePage.submit());
+  }
+
+});


### PR DESCRIPTION
### What is the context of this PR?
- Added date range validation for a period between to dates, allows for a minimum limit or/and a maximum limit to be set 
- Added period validation given a referenced date for single dates
- Runtime validation for invalid schemas with date ranges

### How to review 
- open `test_date_range_period_validation.json` and test out the question level validation
- also open `test_single_date_period_validation.json` and test out single date period validation
- Schema-validator PR: https://github.com/ONSdigital/eq-schema-validator/pull/44