### PR TITLE
Add Confirmation Question

### DIFF
--- a/app/templates/confirmationquestion.html
+++ b/app/templates/confirmationquestion.html
@@ -1,0 +1,1 @@
+{% extends theme('question.html') %}

--- a/app/templating/view_context.py
+++ b/app/templating/view_context.py
@@ -20,7 +20,7 @@ def build_view_context(metadata, answer_store, schema_context, block, current_lo
 
         return build_view_context_for_summary(metadata, answer_store, schema_context, variables, form.csrf_token)
 
-    if block['type'] == 'Question':
+    if block['type'] in ('Question', 'ConfirmationQuestion'):
         if not form:
             form = get_form_for_location(g.schema, rendered_block, current_location, answer_store)
 

--- a/data/en/test_confirmation_question.json
+++ b/data/en/test_confirmation_question.json
@@ -1,0 +1,119 @@
+{
+    "legal_basis": "StatisticsOfTradeAct",
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "survey_id": "139",
+    "theme": "default",
+    "title": "Confirmation Question Test",
+    "data_version": "0.0.2",
+    "description": "Confirmation Question Test",
+    "view_submitted_response": {
+        "enabled": true,
+        "duration": 900
+    },
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "id": "confirmation-block",
+            "title": "Confirmation Question Test",
+            "blocks": [{
+                    "id": "number-of-employees-total-block",
+                    "questions": [{
+                        "answers": [{
+                            "id": "number-of-employees-total",
+                            "alias": "number_of_employees_total",
+                            "label": "Total number of employees",
+                            "mandatory": false,
+                            "type": "Number",
+                            "default": 0
+                        }],
+                        "id": "number-of-employees-total-question",
+                        "title": "How many employees work at {{respondent.trad_as_or_ru_name}}?",
+                        "type": "General"
+                    }],
+                    "type": "Question"
+                },
+                {
+                    "type": "ConfirmationQuestion",
+                    "title": "Employees",
+                    "id": "confirm-zero-employees-block",
+                    "skip_conditions": [{
+                        "when": [{
+                            "id": "number-of-employees-total",
+                            "condition": "greater than",
+                            "value": 0
+                        }]
+                    }],
+                    "questions": [{
+                        "type": "General",
+                        "answers": [{
+                            "type": "Radio",
+                            "id": "confirm-zero-employees-answer",
+                            "options": [{
+                                    "label": "Yes this is correct",
+                                    "value": "Yes"
+                                },
+                                {
+                                    "label": "No I need to change this",
+                                    "value": "No"
+                                }
+                            ],
+                            "mandatory": true
+                        }],
+                        "id": "confirm-zero-employees-question",
+                        "title": "The current number of employees for {{respondent.trad_as_or_ru_name}} is <em>0</em>, is this correct?"
+                    }],
+                    "routing_rules": [{
+                            "goto": {
+                                "when": [{
+                                    "value": "No",
+                                    "id": "confirm-zero-employees-answer",
+                                    "condition": "equals"
+                                }],
+                                "block": "number-of-employees-total-block"
+                            }
+                        },
+                        {
+                            "goto": {
+                                "block": "summary"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "number-of-employees-split-block",
+                    "type": "Question",
+                    "questions": [{
+                        "answers": [{
+                                "id": "number-of-employees-male-more-30-hours",
+                                "label": "Number of male employees working more than 30 hours per week",
+                                "mandatory": false,
+                                "type": "Number",
+                                "max_value": {
+                                    "answer_id": "number-of-employees-total"
+                                }
+                            },
+                            {
+                                "id": "number-of-employees-female-more-30-hours",
+                                "label": "Number of female employees working more than 30 hours per week",
+                                "mandatory": false,
+                                "type": "Number",
+                                "max_value": {
+                                    "answer_id": "number-of-employees-total"
+                                }
+                            }
+                        ],
+
+                        "id": "number-of-employees-split-question",
+                        "title": "Of the <em>{{answers.number_of_employees_total}}</em> total employees employed, how many male and female employees worked the following hours?",
+                        "type": "General"
+                    }]
+                },
+                {
+                    "type": "Summary",
+                    "id": "summary"
+                }
+            ]
+        }]
+    }]
+}

--- a/tests/functional/pages/features/confirmation_question/confirm-zero-employees-block.page.js
+++ b/tests/functional/pages/features/confirmation_question/confirm-zero-employees-block.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class ConfirmZeroEmployeesBlockPage extends QuestionPage {
+
+  constructor() {
+    super('confirm-zero-employees-block');
+  }
+
+  yes() {
+    return '#confirm-zero-employees-answer-0';
+  }
+
+  yesLabel() { return '#label-confirm-zero-employees-answer-0'; }
+
+  no() {
+    return '#confirm-zero-employees-answer-1';
+  }
+
+  noLabel() { return '#label-confirm-zero-employees-answer-1'; }
+
+}
+module.exports = new ConfirmZeroEmployeesBlockPage();

--- a/tests/functional/pages/features/confirmation_question/number-of-employees-split-block.page.js
+++ b/tests/functional/pages/features/confirmation_question/number-of-employees-split-block.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class NumberOfEmployeesSplitBlockPage extends QuestionPage {
+
+  constructor() {
+    super('number-of-employees-split-block');
+  }
+
+  numberOfEmployeesMaleMore30Hours() {
+    return '#number-of-employees-male-more-30-hours';
+  }
+
+  numberOfEmployeesMaleMore30HoursLabel() { return '#label-number-of-employees-male-more-30-hours'; }
+
+  numberOfEmployeesFemaleMore30Hours() {
+    return '#number-of-employees-female-more-30-hours';
+  }
+
+  numberOfEmployeesFemaleMore30HoursLabel() { return '#label-number-of-employees-female-more-30-hours'; }
+
+}
+module.exports = new NumberOfEmployeesSplitBlockPage();

--- a/tests/functional/pages/features/confirmation_question/number-of-employees-total-block.page.js
+++ b/tests/functional/pages/features/confirmation_question/number-of-employees-total-block.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class NumberOfEmployeesTotalBlockPage extends QuestionPage {
+
+  constructor() {
+    super('number-of-employees-total-block');
+  }
+
+  answer() {
+    return '#number-of-employees-total';
+  }
+
+  answerLabel() { return '#label-number-of-employees-total'; }
+
+}
+module.exports = new NumberOfEmployeesTotalBlockPage();

--- a/tests/functional/pages/features/confirmation_question/summary.page.js
+++ b/tests/functional/pages/features/confirmation_question/summary.page.js
@@ -1,0 +1,29 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  numberOfEmployeesTotal() { return '#number-of-employees-total-answer'; }
+
+  numberOfEmployeesTotalEdit() { return '[data-qa="number-of-employees-total-edit"]'; }
+
+  confirmZeroEmployeesAnswer() { return '#confirm-zero-employees-answer-answer'; }
+
+  confirmZeroEmployeesAnswerEdit() { return '[data-qa="confirm-zero-employees-answer-edit"]'; }
+
+  numberOfEmployeesMaleMore30Hours() { return '#number-of-employees-male-more-30-hours-answer'; }
+
+  numberOfEmployeesMaleMore30HoursEdit() { return '[data-qa="number-of-employees-male-more-30-hours-edit"]'; }
+
+  numberOfEmployeesFemaleMore30Hours() { return '#number-of-employees-female-more-30-hours-answer'; }
+
+  numberOfEmployeesFemaleMore30HoursEdit() { return '[data-qa="number-of-employees-female-more-30-hours-edit"]'; }
+
+  confirmationBlockTitle() { return '#confirmation-block'; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/spec/features/confirmation_question.spec.js
+++ b/tests/functional/spec/features/confirmation_question.spec.js
@@ -1,0 +1,40 @@
+const helpers = require('../../helpers');
+
+const NumberOfEmployeesTotalBlockPage = require('../../pages/features/confirmation_question/number-of-employees-total-block.page.js');
+const ConfirmZeroEmployeesBlockPage = require('../../pages/features/confirmation_question/confirm-zero-employees-block.page.js');
+const SummaryPage = require('../../pages/features/confirmation_question/summary.page.js');
+const ThankYouPage = require('../../pages/thank-you.page.js');
+
+describe('Feature: Confirmation Question', function() {
+
+  describe('Given I have a confirmation Question', function() {
+
+    before('Get to summary', function () {
+      return helpers.openQuestionnaire('test_confirmation_question.json').then(() => {
+        return browser
+          .setValue(NumberOfEmployeesTotalBlockPage.answer(), 0)
+          .click(NumberOfEmployeesTotalBlockPage.submit())
+          .click(ConfirmZeroEmployeesBlockPage.yes())
+          .click(ConfirmZeroEmployeesBlockPage.submit())
+          .getUrl().should.eventually.contain(SummaryPage.pageName);
+      });
+    });
+
+    it('When I view the summary, Then the confirmation question should not be displayed', function () {
+      return browser
+        .getText(SummaryPage.numberOfEmployeesTotal()).should.eventually.contain('0')
+        .elements(SummaryPage.confirmZeroEmployeesAnswer()).then(result => result.value).should.eventually.be.empty;
+    });
+
+    it('When I view my responses, Then the confirmation question should not be displayed', function () {
+      return browser
+        .click(SummaryPage.submit())
+        .click(ThankYouPage.viewSubmitted())
+        .getUrl().should.eventually.contain('view-submission')
+        .getText(SummaryPage.numberOfEmployeesTotal()).should.eventually.contain('0')
+        .elements(SummaryPage.confirmZeroEmployeesAnswer()).then(result => result.value).should.eventually.be.empty;
+    });
+
+  });
+});
+


### PR DESCRIPTION
Treat confirmation questions as their own block type.
This way we can not show them on the summary as they are not "Questions" that make up the answers of the questionnaire