### PR TITLE
Validate employment breakdown total

### DIFF
--- a/data/en/1_0112.json
+++ b/data/en/1_0112.json
@@ -549,6 +549,33 @@
                     "type": "Question",
                     "id": "employees-breakdown",
                     "questions": [{
+                        "calculations": [{
+                                "calculation_type": "sum",
+                                "value": 0,
+                                "answers_to_calculate": [
+                                    "male-employees-over-30-hours",
+                                    "male-employees-under-30-hours",
+                                    "female-employees-over-30-hours",
+                                    "female-employees-under-30-hours"
+                                ],
+                                "conditions": [
+                                    "equals"
+                                ]
+                            },
+                            {
+                                "calculation_type": "sum",
+                                "answer_id": "total-number-employees",
+                                "answers_to_calculate": [
+                                    "male-employees-over-30-hours",
+                                    "male-employees-under-30-hours",
+                                    "female-employees-over-30-hours",
+                                    "female-employees-under-30-hours"
+                                ],
+                                "conditions": [
+                                    "equals"
+                                ]
+                            }
+                        ],
                         "guidance": {
                             "content": [{
                                     "title": "Include",
@@ -612,7 +639,7 @@
                         ],
                         "id": "employee-breakdown-questions",
                         "title": "Of the <em>{{answers.employee_count|format_number}}</em> total employees employed on {{exercise.employment_date|format_date}}, please specify the number of:",
-                        "type": "General"
+                        "type": "Calculated"
                     }],
                     "title": "Employees"
                 },

--- a/data/en/1_0213.json
+++ b/data/en/1_0213.json
@@ -849,6 +849,33 @@
                     "type": "Question",
                     "id": "employees-breakdown",
                     "questions": [{
+                        "calculations": [{
+                                "calculation_type": "sum",
+                                "value": 0,
+                                "answers_to_calculate": [
+                                    "number-male-employees-over-30-hours",
+                                    "number-male-employees-under-30-hours",
+                                    "number-female-employees-over-30-hours",
+                                    "number-female-employees-under-30-hours"
+                                ],
+                                "conditions": [
+                                    "equals"
+                                ]
+                            },
+                            {
+                                "calculation_type": "sum",
+                                "answer_id": "total-number-employees",
+                                "answers_to_calculate": [
+                                    "number-male-employees-over-30-hours",
+                                    "number-male-employees-under-30-hours",
+                                    "number-female-employees-over-30-hours",
+                                    "number-female-employees-under-30-hours"
+                                ],
+                                "conditions": [
+                                    "equals"
+                                ]
+                            }
+                        ],
                         "guidance": {
                             "content": [{
                                     "title": "Include",
@@ -912,7 +939,7 @@
                         ],
                         "id": "employee-breakdown-questions",
                         "title": "Of the <em>{{answers.employee_count|format_number}}</em> total employees employed on {{exercise.employment_date|format_date}}, please specify the number of:",
-                        "type": "General"
+                        "type": "Calculated"
                     }],
                     "title": "Employees"
                 },

--- a/data/en/1_0215.json
+++ b/data/en/1_0215.json
@@ -921,6 +921,33 @@
                     "type": "Question",
                     "id": "employees-breakdown",
                     "questions": [{
+                        "calculations": [{
+                                "calculation_type": "sum",
+                                "value": 0,
+                                "answers_to_calculate": [
+                                    "number-male-employees-over-30-hours",
+                                    "number-male-employees-under-30-hours",
+                                    "number-female-employees-over-30-hours",
+                                    "number-female-employees-under-30-hours"
+                                ],
+                                "conditions": [
+                                    "equals"
+                                ]
+                            },
+                            {
+                                "calculation_type": "sum",
+                                "answer_id": "total-number-employees",
+                                "answers_to_calculate": [
+                                    "number-male-employees-over-30-hours",
+                                    "number-male-employees-under-30-hours",
+                                    "number-female-employees-over-30-hours",
+                                    "number-female-employees-under-30-hours"
+                                ],
+                                "conditions": [
+                                    "equals"
+                                ]
+                            }
+                        ],
                         "guidance": {
                             "content": [{
                                     "title": "Include",
@@ -985,7 +1012,7 @@
                         ],
                         "id": "employee-breakdown-questions",
                         "title": "Of the <em>{{answers.employee_count|format_number}}</em> total employees employed on {{exercise.employment_date|format_date}}, please specify the number of:",
-                        "type": "General"
+                        "type": "Calculated"
                     }],
                     "title": "Employees"
                 },


### PR DESCRIPTION
### What is the context of this PR?
On RSI MCI (1_0112, 1_0213, 1_0215) a respondent if they give a total number of employees can
either give zero or no figures for all employee breakdown OR sum of breakdown figures must EQUAL the total
