### PR TITLE
Don't show radios as a list on summary

### DIFF
--- a/app/templates/partials/summary/radio.html
+++ b/app/templates/partials/summary/radio.html
@@ -1,18 +1,14 @@
 {% set not_answered = 'No answer provided' %}
-<ul class="u-m-no">
-    <li>{{answer.value}}
-    {%- if answer.child_answer_value is not none -%}
-        <ul>
-            <li>
-                {%- if answer.child_answer_value == ''  -%}
-                    {{not_answered}}
-                {%- else -%}
-                    {{ answer.child_answer_value }}
-                {%- endif -%}
-            </li>
-        </ul>
-        {%- endif -%}
-    </li>
-</ul>
-
+{{answer.value}}
+{%- if answer.child_answer_value is not none -%}
+    <ul>
+        <li>
+            {%- if answer.child_answer_value == ''  -%}
+                {{not_answered}}
+            {%- else -%}
+                {{ answer.child_answer_value }}
+            {%- endif -%}
+        </li>
+    </ul>
+{%- endif -%}
 


### PR DESCRIPTION
### What is the context of this PR?
Single answer radios are no longer showed as lists on the summary

