### PR TITLE
Modified filter to output correct time  with UTC

### DIFF
--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -1,15 +1,15 @@
 # coding: utf-8
-
 import re
 import string
 
 from datetime import datetime
+from dateutil import relativedelta, tz
 
-from dateutil import relativedelta
 import flask
 
 from jinja2 import Markup, escape, evalcontextfilter
 from babel import units, numbers
+
 
 from app.settings import DEFAULT_LOCALE
 from app.questionnaire.rules import convert_to_datetime
@@ -82,7 +82,11 @@ def format_month_year_date(value, date_format='%B %Y'):
 
 @blueprint.app_template_filter()
 def format_datetime(value, date_format='%d %B %Y at %H:%M'):
-    return "<span class='date'>{date}</span>".format(date=datetime.strptime(value, '%Y-%m-%dT%H:%M:%S.%f').strftime(date_format))
+    london = datetime.strptime(value, '%Y-%m-%dT%H:%M:%S.%f').replace(tzinfo=tz.gettz('UTC'))\
+        .astimezone(tz.gettz('Europe/London'))
+    date_time = london.strftime(date_format)
+    timezone = '(GMT+1)' if london.dst() else '(GMT)'
+    return "<span class='date'>{date} {timezone}</span>".format(date=date_time, timezone=timezone)
 
 
 @blueprint.app_template_filter()

--- a/tests/app/test_jinja_filters.py
+++ b/tests/app/test_jinja_filters.py
@@ -9,9 +9,9 @@ from mock import Mock
 
 from app.jinja_filters import format_date, format_conditional_date, format_currency, get_currency_symbol, \
     format_multilined_string, format_percentage, format_date_range, format_household_member_name, \
-    format_month_year_date, format_number_to_alphabetic_letter, \
-    format_unit, format_currency_for_input, format_number, format_unordered_list, format_household_member_name_possessive, \
-    concatenated_list, calculate_years_difference
+    format_month_year_date, format_datetime, format_number_to_alphabetic_letter, \
+    format_unit, format_currency_for_input, format_number, format_unordered_list, \
+    format_household_member_name_possessive, concatenated_list, calculate_years_difference
 
 
 class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
@@ -128,6 +128,28 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
 
         # Then
         self.assertEqual(format_value, "<span class='date'>January 2017</span>")
+
+    def test_format_date_time_in_bst(self):
+        # Given
+        date_time = '2018-03-29T11:59:13.528680'
+        date_format = '%d %B %Y at %H:%M'
+
+        # When
+        format_value = format_datetime(date_time, date_format)
+
+        # Then
+        self.assertEqual(format_value, "<span class='date'>29 March 2018 at 12:59 (GMT+1)</span>")
+
+    def test_format_date_time_in_gmt(self):
+        # Given
+        date_time = '2018-10-28T11:59:13.528680'
+        date_format = '%d %B %Y at %H:%M'
+
+        # When
+        format_value = format_datetime(date_time, date_format)
+
+        # Then
+        self.assertEqual(format_value, "<span class='date'>28 October 2018 at 11:59 (GMT)</span>")
 
     def test_format_conditional_date_not_date(self):
         # Given       no test for integers this check was removed from jinja_filters


### PR DESCRIPTION
### What is the context of this PR?
Problem displaying times as UTC so now displaying as GMT with the +1

Card: https://trello.com/c/zYD6SlAX/1983-provide-locale-specific-time-for-users-when-server-response-is-in-utc-s

### How to review 
Check that on the view submission page and the after submission page show GMT(+1) on any survey/test surveys.
