### PR TITLE
Uncomplete blocks dependent on an answer that changes

### DIFF
--- a/data/en/test_dependencies.json
+++ b/data/en/test_dependencies.json
@@ -1,0 +1,105 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "0",
+    "title": "A test schema to validate a sum of answers are Equal to a given total",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "description": "A survey that tests grouped and calculated answers against a total",
+    "navigation": {
+        "visible": true
+    },
+    "sections": [{
+            "id": "default-section",
+            "title": "Validate Sum Section",
+            "groups": [{
+                "id": "group",
+                "title": "Validate sum against total",
+                "blocks": [{
+                        "type": "Question",
+                        "title": "Target total",
+                        "id": "total-block",
+                        "description": "",
+                        "questions": [{
+                            "id": "total-question",
+                            "title": "Total",
+                            "type": "General",
+                            "answers": [{
+                                "id": "total-answer",
+                                "label": "Total",
+                                "mandatory": true,
+                                "type": "Number",
+                                "decimal_places": 2
+                            }]
+                        }]
+                    },
+                    {
+                        "type": "Question",
+                        "title": "Calculated total",
+                        "id": "breakdown-block",
+                        "questions": [{
+                            "id": "breakdown-question",
+                            "title": "Breakdown",
+                            "type": "Calculated",
+                            "calculations": [{
+                                "calculation_type": "sum",
+                                "answer_id": "total-answer",
+                                "answers_to_calculate": [
+                                    "breakdown-1",
+                                    "breakdown-2",
+                                    "breakdown-3",
+                                    "breakdown-4"
+                                ],
+                                "conditions": [
+                                    "equals"
+                                ]
+                            }],
+                            "answers": [{
+                                    "id": "breakdown-1",
+                                    "label": "Breakdown 1",
+                                    "mandatory": false,
+                                    "decimal_places": 2,
+                                    "type": "Number"
+                                },
+                                {
+                                    "id": "breakdown-2",
+                                    "label": "Breakdown 2",
+                                    "mandatory": false,
+                                    "decimal_places": 2,
+                                    "type": "Number"
+                                },
+                                {
+                                    "id": "breakdown-3",
+                                    "label": "Breakdown 3",
+                                    "mandatory": false,
+                                    "decimal_places": 2,
+                                    "type": "Number"
+                                },
+                                {
+                                    "id": "breakdown-4",
+                                    "label": "Breakdown 4",
+                                    "mandatory": false,
+                                    "decimal_places": 2,
+                                    "type": "Number"
+                                }
+                            ]
+                        }]
+                    }
+                ]
+            }]
+        },
+        {
+            "id": "summary-section",
+            "title": "Summary",
+            "groups": [{
+                "blocks": [{
+                    "type": "Summary",
+                    "id": "summary"
+                }],
+                "id": "summary-group",
+                "title": "Summary"
+            }]
+        }
+    ]
+}

--- a/data/en/test_dependencies_calculation.json
+++ b/data/en/test_dependencies_calculation.json
@@ -1,0 +1,103 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "0",
+    "title": "A test schema to validate a sum of answers are Equal to a given total",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "description": "A survey that tests grouped and calculated answers against a total",
+    "navigation": {
+        "visible": true
+    },
+    "sections": [{
+            "id": "default-section",
+            "title": "Validate Sum Section",
+            "groups": [{
+                "id": "group",
+                "title": "Validate sum against total",
+                "blocks": [{
+                        "type": "Question",
+                        "title": "Target total",
+                        "id": "total-block",
+                        "description": "",
+                        "questions": [{
+                            "id": "total-question",
+                            "title": "Total",
+                            "type": "General",
+                            "answers": [{
+                                "id": "total-answer",
+                                "label": "Total",
+                                "mandatory": true,
+                                "type": "Number"
+                            }]
+                        }]
+                    },
+                    {
+                        "type": "Question",
+                        "title": "Calculated total",
+                        "id": "breakdown-block",
+                        "questions": [{
+                            "id": "breakdown-question",
+                            "title": "Breakdown",
+                            "type": "Calculated",
+                            "calculations": [{
+                                "calculation_type": "sum",
+                                "answer_id": "total-answer",
+                                "answers_to_calculate": [
+                                    "breakdown-1",
+                                    "breakdown-2",
+                                    "breakdown-3",
+                                    "breakdown-4"
+                                ],
+                                "conditions": [
+                                    "equals"
+                                ]
+                            }],
+                            "answers": [{
+                                    "id": "breakdown-1",
+                                    "label": "Breakdown 1",
+                                    "mandatory": false,
+                                    "max_value": {
+                                        "answer_id": "total-answer"
+                                    },
+                                    "type": "Number"
+                                },
+                                {
+                                    "id": "breakdown-2",
+                                    "label": "Breakdown 2",
+                                    "mandatory": false,
+                                    "type": "Number"
+                                },
+                                {
+                                    "id": "breakdown-3",
+                                    "label": "Breakdown 3",
+                                    "mandatory": false,
+                                    "type": "Number"
+                                },
+                                {
+                                    "id": "breakdown-4",
+                                    "label": "Breakdown 4",
+                                    "mandatory": false,
+                                    "type": "Number"
+                                }
+                            ]
+                        }]
+                    }
+                ]
+            }]
+        },
+        {
+            "id": "summary-section",
+            "title": "Summary",
+            "groups": [{
+                "blocks": [{
+                    "type": "Summary",
+                    "id": "summary"
+                }],
+                "id": "summary-group",
+                "title": "Summary"
+            }]
+        }
+    ]
+}

--- a/data/en/test_dependencies_max_value.json
+++ b/data/en/test_dependencies_max_value.json
@@ -1,0 +1,71 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "0",
+    "title": "Maximum Answer Value Dependency Check",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "description": "A survey with an maximum validation dependency",
+    "navigation": {
+        "visible": true
+    },
+    "sections": [{
+            "id": "default-section",
+            "title": "Max Dependency",
+            "groups": [{
+                "id": "group",
+                "title": "Max Dependency Group",
+                "blocks": [{
+                        "type": "Question",
+                        "title": "Maximum Value Allowed",
+                        "id": "max-block",
+                        "description": "",
+                        "questions": [{
+                            "id": "max-question",
+                            "title": "max",
+                            "type": "General",
+                            "answers": [{
+                                "id": "max-answer",
+                                "label": "max",
+                                "mandatory": true,
+                                "type": "Number"
+                            }]
+                        }]
+                    },
+                    {
+                        "type": "Question",
+                        "title": "Calculated max",
+                        "id": "dependent-block",
+                        "questions": [{
+                            "id": "dependent-question",
+                            "title": "dependent",
+                            "type": "General",
+                            "answers": [{
+                                "id": "dependent-1",
+                                "label": "dependent",
+                                "mandatory": false,
+                                "type": "Number",
+                                "max_value": {
+                                    "answer_id": "max-answer"
+                                }
+                            }]
+                        }]
+                    }
+                ]
+            }]
+        },
+        {
+            "id": "summary-section",
+            "title": "Summary",
+            "groups": [{
+                "blocks": [{
+                    "type": "Summary",
+                    "id": "summary"
+                }],
+                "id": "summary-group",
+                "title": "Summary"
+            }]
+        }
+    ]
+}

--- a/data/en/test_dependencies_min_value.json
+++ b/data/en/test_dependencies_min_value.json
@@ -1,0 +1,71 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "0",
+    "title": "Minimum Answer Value Dependency Check",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "description": "A survey with an minimum validation dependency",
+    "navigation": {
+        "visible": true
+    },
+    "sections": [{
+            "id": "default-section",
+            "title": "Min Dependency",
+            "groups": [{
+                "id": "group",
+                "title": "Min Dependency Group",
+                "blocks": [{
+                        "type": "Question",
+                        "title": "Minimum Value Allowed",
+                        "id": "min-block",
+                        "description": "",
+                        "questions": [{
+                            "id": "min-question",
+                            "title": "min",
+                            "type": "General",
+                            "answers": [{
+                                "id": "min-answer",
+                                "label": "min",
+                                "mandatory": true,
+                                "type": "Number"
+                            }]
+                        }]
+                    },
+                    {
+                        "type": "Question",
+                        "title": "Calculated min",
+                        "id": "dependent-block",
+                        "questions": [{
+                            "id": "dependent-question",
+                            "title": "dependent",
+                            "type": "General",
+                            "answers": [{
+                                "id": "dependent-1",
+                                "label": "dependent",
+                                "mandatory": false,
+                                "type": "Number",
+                                "min_value": {
+                                    "answer_id": "min-answer"
+                                }
+                            }]
+                        }]
+                    }
+                ]
+            }]
+        },
+        {
+            "id": "summary-section",
+            "title": "Summary",
+            "groups": [{
+                "blocks": [{
+                    "type": "Summary",
+                    "id": "summary"
+                }],
+                "id": "summary-group",
+                "title": "Summary"
+            }]
+        }
+    ]
+}

--- a/tests/functional/pages/features/dependencies/calculation/breakdown-block.page.js
+++ b/tests/functional/pages/features/dependencies/calculation/breakdown-block.page.js
@@ -1,0 +1,35 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class BreakdownBlockPage extends QuestionPage {
+
+  constructor() {
+    super('breakdown-block');
+  }
+
+  breakdown1() {
+    return '#breakdown-1';
+  }
+
+  breakdown1Label() { return '#label-breakdown-1'; }
+
+  breakdown2() {
+    return '#breakdown-2';
+  }
+
+  breakdown2Label() { return '#label-breakdown-2'; }
+
+  breakdown3() {
+    return '#breakdown-3';
+  }
+
+  breakdown3Label() { return '#label-breakdown-3'; }
+
+  breakdown4() {
+    return '#breakdown-4';
+  }
+
+  breakdown4Label() { return '#label-breakdown-4'; }
+
+}
+module.exports = new BreakdownBlockPage();

--- a/tests/functional/pages/features/dependencies/calculation/summary.page.js
+++ b/tests/functional/pages/features/dependencies/calculation/summary.page.js
@@ -1,0 +1,35 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  totalAnswer() { return '#total-answer-answer'; }
+
+  totalAnswerEdit() { return '[data-qa="total-answer-edit"]'; }
+
+  breakdown1() { return '#breakdown-1-answer'; }
+
+  breakdown1Edit() { return '[data-qa="breakdown-1-edit"]'; }
+
+  breakdown2() { return '#breakdown-2-answer'; }
+
+  breakdown2Edit() { return '[data-qa="breakdown-2-edit"]'; }
+
+  breakdown3() { return '#breakdown-3-answer'; }
+
+  breakdown3Edit() { return '[data-qa="breakdown-3-edit"]'; }
+
+  breakdown4() { return '#breakdown-4-answer'; }
+
+  breakdown4Edit() { return '[data-qa="breakdown-4-edit"]'; }
+
+  groupTitle() { return '#group'; }
+
+  summaryGroupTitle() { return '#summary-group'; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/pages/features/dependencies/calculation/total-block.page.js
+++ b/tests/functional/pages/features/dependencies/calculation/total-block.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class TotalBlockPage extends QuestionPage {
+
+  constructor() {
+    super('total-block');
+  }
+
+  answer() {
+    return '#total-answer';
+  }
+
+  answerLabel() { return '#label-total-answer'; }
+
+}
+module.exports = new TotalBlockPage();

--- a/tests/functional/pages/features/dependencies/max/dependent-block.page.js
+++ b/tests/functional/pages/features/dependencies/max/dependent-block.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class DependentBlockPage extends QuestionPage {
+
+  constructor() {
+    super('dependent-block');
+  }
+
+  answer() {
+    return '#dependent-1';
+  }
+
+  answerLabel() { return '#label-dependent-1'; }
+
+}
+module.exports = new DependentBlockPage();

--- a/tests/functional/pages/features/dependencies/max/max-block.page.js
+++ b/tests/functional/pages/features/dependencies/max/max-block.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class MaxBlockPage extends QuestionPage {
+
+  constructor() {
+    super('max-block');
+  }
+
+  answer() {
+    return '#max-answer';
+  }
+
+  answerLabel() { return '#label-max-answer'; }
+
+}
+module.exports = new MaxBlockPage();

--- a/tests/functional/pages/features/dependencies/max/summary.page.js
+++ b/tests/functional/pages/features/dependencies/max/summary.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  maxAnswer() { return '#max-answer-answer'; }
+
+  maxAnswerEdit() { return '[data-qa="max-answer-edit"]'; }
+
+  dependent1() { return '#dependent-1-answer'; }
+
+  dependent1Edit() { return '[data-qa="dependent-1-edit"]'; }
+
+  groupTitle() { return '#group'; }
+
+  summaryGroupTitle() { return '#summary-group'; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/pages/features/dependencies/min/dependent-block.page.js
+++ b/tests/functional/pages/features/dependencies/min/dependent-block.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class DependentBlockPage extends QuestionPage {
+
+  constructor() {
+    super('dependent-block');
+  }
+
+  answer() {
+    return '#dependent-1';
+  }
+
+  answerLabel() { return '#label-dependent-1'; }
+
+}
+module.exports = new DependentBlockPage();

--- a/tests/functional/pages/features/dependencies/min/min-block.page.js
+++ b/tests/functional/pages/features/dependencies/min/min-block.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class MinBlockPage extends QuestionPage {
+
+  constructor() {
+    super('min-block');
+  }
+
+  answer() {
+    return '#min-answer';
+  }
+
+  answerLabel() { return '#label-min-answer'; }
+
+}
+module.exports = new MinBlockPage();

--- a/tests/functional/pages/features/dependencies/min/summary.page.js
+++ b/tests/functional/pages/features/dependencies/min/summary.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  minAnswer() { return '#min-answer-answer'; }
+
+  minAnswerEdit() { return '[data-qa="min-answer-edit"]'; }
+
+  dependent1() { return '#dependent-1-answer'; }
+
+  dependent1Edit() { return '[data-qa="dependent-1-edit"]'; }
+
+  groupTitle() { return '#group'; }
+
+  summaryGroupTitle() { return '#summary-group'; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/spec/features/dependencies.spec.js
+++ b/tests/functional/spec/features/dependencies.spec.js
@@ -1,0 +1,119 @@
+const helpers = require('../../helpers');
+
+describe('Feature: Dependencies', function() {
+
+  describe('Calculation', function () {
+
+    var TotalBlockPage = require('../../pages/features/dependencies/calculation/total-block.page.js');
+    var BreakdownBlockPage = require('../../pages/features/dependencies/calculation/breakdown-block.page.js');
+    var CalculationSummary = require('../../pages/features/dependencies/calculation/summary.page.js');
+
+    describe('Given I complete the test_dependencies_calculation schema', function() {
+
+      beforeEach(function() {
+         return helpers.openQuestionnaire('test_dependencies_calculation.json').then(() => {
+          return browser
+            .setValue(TotalBlockPage.answer(),100)
+            .click(TotalBlockPage.submit())
+            .setValue(BreakdownBlockPage.breakdown1(),10)
+            .setValue(BreakdownBlockPage.breakdown2(),20)
+            .setValue(BreakdownBlockPage.breakdown3(),30)
+            .setValue(BreakdownBlockPage.breakdown4(),40)
+            .click(BreakdownBlockPage.submit())
+            .click(CalculationSummary.totalAnswerEdit())
+            .getUrl().should.eventually.contain(TotalBlockPage.pageName);
+         });
+      });
+
+      it('When I go back and change the total answer Then breakdown block becomes incomplete', function() {
+        return browser
+          .setValue(TotalBlockPage.answer(),99)
+          .click(TotalBlockPage.submit())
+          .isVisible(helpers.navigationLink('Summary')).should.eventually.be.false;
+      });
+
+      it('When I go back and do not change the total answer Then breakdown block remains complete', function() {
+        return browser
+          .click(TotalBlockPage.submit())
+          .isVisible(helpers.navigationLink('Summary')).should.eventually.be.true;
+      });
+
+    });
+
+  });
+
+  describe('Min', function () {
+
+    var MinBlockPage = require('../../pages/features/dependencies/min/min-block.page.js');
+    var MinDependentBlockPage = require('../../pages/features/dependencies/min/dependent-block.page.js');
+    var MinSummary = require('../../pages/features/dependencies/min/summary.page.js');
+
+    describe('Given I complete the test_dependencies_min_value schema', function() {
+
+      beforeEach(function() {
+         return helpers.openQuestionnaire('test_dependencies_min_value.json').then(() => {
+          return browser
+            .setValue(MinBlockPage.answer(),10)
+            .click(MinBlockPage.submit())
+            .setValue(MinDependentBlockPage.answer(),10)
+            .click(MinDependentBlockPage.submit())
+            .click(MinSummary.minAnswerEdit())
+            .getUrl().should.eventually.contain(MinBlockPage.pageName);
+         });
+      });
+
+      it('When I go back and change the minimum answer Then dependent block becomes incomplete', function() {
+        return browser
+          .setValue(MinBlockPage.answer(),9)
+          .click(MinBlockPage.submit())
+          .isVisible(helpers.navigationLink('Summary')).should.eventually.be.false;
+      });
+
+      it('When I go back and do not change the minimum answer Then dependent block remains complete', function() {
+        return browser
+          .click(MinBlockPage.submit())
+          .isVisible(helpers.navigationLink('Summary')).should.eventually.be.true;
+      });
+
+    });
+
+  });
+
+  describe('Max', function () {
+
+    var MaxBlockPage = require('../../pages/features/dependencies/max/max-block.page.js');
+    var MaxDependentBlockPage = require('../../pages/features/dependencies/max/dependent-block.page.js');
+    var MaxSummary = require('../../pages/features/dependencies/max/summary.page.js');
+
+    describe('Given I complete the test_dependencies_max_value schema', function() {
+
+      beforeEach(function() {
+         return helpers.openQuestionnaire('test_dependencies_max_value.json').then(() => {
+          return browser
+            .setValue(MaxBlockPage.answer(),10)
+            .click(MaxBlockPage.submit())
+            .setValue(MaxDependentBlockPage.answer(),10)
+            .click(MaxDependentBlockPage.submit())
+            .click(MaxSummary.maxAnswerEdit())
+            .getUrl().should.eventually.contain(MaxBlockPage.pageName);
+         });
+      });
+
+      it('When I go back and change the maximum answer Then dependent block becomes incomplete', function() {
+        return browser
+          .setValue(MaxBlockPage.answer(),9)
+          .click(MaxBlockPage.submit())
+          .isVisible(helpers.navigationLink('Summary')).should.eventually.be.false;
+      });
+
+      it('When I go back and do not change the maximum answer Then dependent block remains complete', function() {
+        return browser
+          .click(MaxBlockPage.submit())
+          .isVisible(helpers.navigationLink('Summary')).should.eventually.be.true;
+      });
+
+    });
+
+  });
+
+});

--- a/tests/integration/views/test_questionnaire.py
+++ b/tests/integration/views/test_questionnaire.py
@@ -433,3 +433,105 @@ class TestQuestionnaire(IntegrationTestCase):
 
         # Then
         self.assertEqual(page_title, 'How is … related to the people below? - 2017 Census Test')
+
+    def test_updating_questionnaire_store_removes_completed_block_for_min_dependencies(self):
+
+        g.schema = load_schema_from_params('test', 'dependencies_min_value')
+
+        min_answer_location = Location('group', 0, 'min-block')
+        dependent_location = Location('group', 0, 'dependent-block')
+
+        min_answer_data = {
+            'min-answer': '10',
+        }
+
+        dependent_data = {
+            'dependent-1': '10',
+        }
+
+        with self._application.test_request_context():
+            update_questionnaire_store_with_form_data(self.question_store, min_answer_location, min_answer_data)
+
+        with self._application.test_request_context():
+            update_questionnaire_store_with_form_data(self.question_store, dependent_location, dependent_data)
+
+        self.assertIn(min_answer_location, self.question_store.completed_blocks)
+        self.assertIn(dependent_location, self.question_store.completed_blocks)
+
+        min_answer_data = {
+            'min-answer': '9',
+        }
+
+        with self._application.test_request_context():
+            update_questionnaire_store_with_form_data(self.question_store, min_answer_location, min_answer_data)
+
+        self.assertNotIn(dependent_location, self.question_store.completed_blocks)
+
+    def test_updating_questionnaire_store_removes_completed_block_for_max_dependencies(self):
+
+        g.schema = load_schema_from_params('test', 'dependencies_max_value')
+
+        max_answer_location = Location('group', 0, 'max-block')
+        dependent_location = Location('group', 0, 'dependent-block')
+
+        max_answer_data = {
+            'max-answer': '10',
+        }
+
+        dependent_data = {
+            'dependent-1': '10',
+        }
+
+        with self._application.test_request_context():
+            update_questionnaire_store_with_form_data(self.question_store, max_answer_location, max_answer_data)
+
+        with self._application.test_request_context():
+            update_questionnaire_store_with_form_data(self.question_store, dependent_location, dependent_data)
+
+        self.assertIn(max_answer_location, self.question_store.completed_blocks)
+        self.assertIn(dependent_location, self.question_store.completed_blocks)
+
+        max_answer_data = {
+            'max-answer': '11',
+        }
+
+        with self._application.test_request_context():
+            update_questionnaire_store_with_form_data(self.question_store, max_answer_location, max_answer_data)
+
+        self.assertNotIn(dependent_location, self.question_store.completed_blocks)
+
+    def test_updating_questionnaire_store_removes_completed_block_for_calculation_dependencies(self):
+
+        g.schema = load_schema_from_params('test', 'dependencies_calculation')
+
+        calculation_answer_location = Location('group', 0, 'total-block')
+        dependent_location = Location('group', 0, 'breakdown-block')
+
+        calculation_answer_data = {
+            'total-answer': '100',
+        }
+
+        dependent_data = {
+            'breakdown-1': '10',
+            'breakdown-2': '20',
+            'breakdown-3': '30',
+            'breakdown-4': '40'
+        }
+
+        with self._application.test_request_context():
+            update_questionnaire_store_with_form_data(self.question_store, calculation_answer_location, calculation_answer_data)
+
+        with self._application.test_request_context():
+            update_questionnaire_store_with_form_data(self.question_store, dependent_location, dependent_data)
+
+        self.assertIn(calculation_answer_location, self.question_store.completed_blocks)
+        self.assertIn(dependent_location, self.question_store.completed_blocks)
+
+        calculation_answer_data = {
+            'total-answer': '99',
+        }
+
+        with self._application.test_request_context():
+            update_questionnaire_store_with_form_data(self.question_store, calculation_answer_location, calculation_answer_data)
+
+        self.assertNotIn(dependent_location, self.question_store.completed_blocks)


### PR DESCRIPTION
### What is the context of this PR?
If I answer the 1st question as 100 and then the 2nd page questions with appropriate answers, if i go back and edit the 1st question to 1 and jump back to the summary page.
I am able to submit the answers in an invalid state.
I think if we modify an answer that is depended on by validation then we should invalidate the answers for the dependent block.