### PR TITLE
Superseded by  1535.- Employees per period mandate to non zero and change error message 

### DIFF
--- a/data/en/1_0005.json
+++ b/data/en/1_0005.json
@@ -302,7 +302,10 @@
                                 "label": "Total number of weekly paid employees",
                                 "mandatory": true,
                                 "q_code": "40",
-                                "type": "Number"
+                                "type": "Number",
+                                "min_value": {
+                                    "value": 1
+                                }
                             }],
                             "description": "<p>If the last week of the month is affected by holidays please use a more representative week.</p>",
                             "guidance": {
@@ -716,7 +719,10 @@
                                 "label": "Total number of fortnightly paid employees",
                                 "mandatory": true,
                                 "q_code": "40f",
-                                "type": "Number"
+                                "type": "Number",
+                                "min_value": {
+                                    "value": 1
+                                }
                             }],
                             "description": "<p>If the last week of the month is affected by holidays please use a more representative week.</p>",
                             "guidance": {
@@ -1130,7 +1136,10 @@
                                 "label": "Total number of calendar monthly paid employees",
                                 "mandatory": true,
                                 "q_code": "140m",
-                                "type": "Number"
+                                "type": "Number",
+                                "min_value": {
+                                    "value": 1
+                                }
                             }],
                             "description": "<p>If there are two pay days in the same month only give details for one.</p>",
                             "guidance": {
@@ -1236,7 +1245,7 @@
                                 "mandatory": true
                             }],
                             "id": "confirm-calendar-monthly-pay-gross-pay-question",
-                            "title": "The <em>total gross calendar monthly pay</em> paid to employees in the last week of {{exercise.period_str}} was <em>£0</em>, is this correct?"
+                            "title": "The <em>total gross calendar monthly pay</em> paid to employees in {{exercise.period_str}} was <em>£0</em>, is this correct?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -1531,7 +1540,10 @@
                                 "label": "Total number of four weekly paid employees",
                                 "mandatory": true,
                                 "q_code": "140w4",
-                                "type": "Number"
+                                "type": "Number",
+                                "min_value": {
+                                    "value": 1
+                                }
                             }],
                             "description": "<p>If there are two pay days in the same month only give details for one.</p>",
                             "guidance": {
@@ -1637,7 +1649,7 @@
                                 "mandatory": true
                             }],
                             "id": "confirm-four-weekly-gross-pay-question",
-                            "title": "The <em>total gross four weekly pay</em> paid to employees in the last week of {{exercise.period_str}} was <em>£0</em>, is this correct?"
+                            "title": "The <em>total gross four weekly pay</em> paid to employees in {{exercise.period_str}} was <em>£0</em>, is this correct?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -1939,7 +1951,10 @@
                                 "label": "Total number of five weekly paid employees",
                                 "mandatory": true,
                                 "q_code": "140w5",
-                                "type": "Number"
+                                "type": "Number",
+                                "min_value": {
+                                    "value": 1
+                                }
                             }],
                             "description": "<p>If there are two pay dates in the same month only give details for one.</p>",
                             "guidance": {
@@ -2046,7 +2061,7 @@
                                 "mandatory": true
                             }],
                             "id": "confirm-five-weekly-gross-pay-question",
-                            "title": "The <em>total gross five weekly pay</em> paid to employees in the last week of {{exercise.period_str}} was <em>£0</em>, is this correct?"
+                            "title": "The <em>total gross five weekly pay</em> paid to employees {{exercise.period_str}} was <em>£0</em>, is this correct?"
                         }],
                         "routing_rules": [{
                                 "goto": {


### PR DESCRIPTION
Superseded by  1535.

MWSS - (1_005)

Would allow a pay period to have zero employees. Added a min_value of 1 to the schema so that if a pay period is selected it must have non zero employees .
If no entry or zero pounds chosen for the pay period the question in the confirmation page always referred to the last week of the period. This was changed to match the slides for monthly, 4 weekly and 5 weekly periods
How to review
Run an mwss survey . And validate that zero employees is not valid and that the confirmation question is correct .
