### PR TITLE
Removing timezone and just display the localised time

### DIFF
--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -82,11 +82,9 @@ def format_month_year_date(value, date_format='%B %Y'):
 
 @blueprint.app_template_filter()
 def format_datetime(value, date_format='%d %B %Y at %H:%M'):
-    london = datetime.strptime(value, '%Y-%m-%dT%H:%M:%S.%f').replace(tzinfo=tz.gettz('UTC'))\
+    london_date_time = datetime.strptime(value, '%Y-%m-%dT%H:%M:%S.%f').replace(tzinfo=tz.gettz('UTC'))\
         .astimezone(tz.gettz('Europe/London'))
-    date_time = london.strftime(date_format)
-    timezone = '(GMT+1)' if london.dst() else '(GMT)'
-    return "<span class='date'>{date} {timezone}</span>".format(date=date_time, timezone=timezone)
+    return "<span class='date'>{date}</span>".format(date=london_date_time.strftime(date_format))
 
 
 @blueprint.app_template_filter()

--- a/tests/app/test_jinja_filters.py
+++ b/tests/app/test_jinja_filters.py
@@ -138,7 +138,7 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         format_value = format_datetime(date_time, date_format)
 
         # Then
-        self.assertEqual(format_value, "<span class='date'>29 March 2018 at 12:59 (GMT+1)</span>")
+        self.assertEqual(format_value, "<span class='date'>29 March 2018 at 12:59</span>")
 
     def test_format_date_time_in_gmt(self):
         # Given
@@ -149,7 +149,7 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         format_value = format_datetime(date_time, date_format)
 
         # Then
-        self.assertEqual(format_value, "<span class='date'>28 October 2018 at 11:59 (GMT)</span>")
+        self.assertEqual(format_value, "<span class='date'>28 October 2018 at 11:59</span>")
 
     def test_format_conditional_date_not_date(self):
         # Given       no test for integers this check was removed from jinja_filters


### PR DESCRIPTION
### What is the context of this PR?
Now it does not display the UTC(timezone) and just displays the localised time on the submission pages etc.
Card: https://trello.com/c/zYD6SlAX/1983-provide-locale-specific-time-for-users-when-server-response-is-in-utc-s

### How to review 
Check in `test_view_submitted_response` to view this change.
