### PR TITLE
Go to relevant Summary if available after edit

### DIFF
--- a/app/helpers/path_finder_helper.py
+++ b/app/helpers/path_finder_helper.py
@@ -4,7 +4,7 @@ from flask import g
 from flask_login import current_user, login_required
 from werkzeug.local import LocalProxy
 
-from app.globals import get_answer_store, get_metadata
+from app.globals import get_answer_store, get_metadata, get_completed_blocks
 from app.questionnaire.path_finder import PathFinder
 
 
@@ -15,7 +15,8 @@ def get_path_finder():
     if finder is None:
         metadata = get_metadata(current_user)
         answer_store = get_answer_store(current_user)
-        finder = PathFinder(g.schema, answer_store, metadata)
+        completed_blocks = get_completed_blocks(current_user)
+        finder = PathFinder(g.schema, answer_store, metadata, completed_blocks)
         g.path_finder = finder
 
     return finder

--- a/app/questionnaire/questionnaire_schema.py
+++ b/app/questionnaire/questionnaire_schema.py
@@ -47,7 +47,10 @@ class QuestionnaireSchema(object):  # pylint: disable=too-many-public-methods
         return self._answer_dependencies.get(answer_id, [])
 
     def get_group_and_block_id_by_answer_id(self, answer_id):
-        return self._answer_with_block_and_group_ids.get(answer_id)
+        return self._answer_with_block_and_group_id.get(answer_id)
+
+    def get_section_and_group_id_by_block_id(self, block_id):
+        return self._block_with_group_and_section_id.get(block_id)
 
     def get_groups_that_repeat_with_answer_id(self, answer_id):
         for group in self.groups:
@@ -145,7 +148,8 @@ class QuestionnaireSchema(object):  # pylint: disable=too-many-public-methods
         self.error_messages = self._get_error_messages()
         self.aliases = self._get_aliases()
         self._answer_dependencies = self._get_answer_dependencies()
-        self._answer_with_block_and_group_ids = self._get_answer_block_group_ids()
+        self._answer_with_block_and_group_id = self._get_answer_block_group_ids()
+        self._block_with_group_and_section_id = self._get_block_section_group_ids()
 
     def _get_sections_by_id(self):
         return OrderedDict(
@@ -210,6 +214,20 @@ class QuestionnaireSchema(object):  # pylint: disable=too-many-public-methods
                     answers_blocks_groups[answer_id] = block_group
 
         return answers_blocks_groups
+
+    def _get_block_section_group_ids(self):
+        block_section_groups = {}
+        for section in self.sections:
+            for group in section['groups']:
+                section_group = {
+                    'section': section['id'],
+                    'group': group['id']
+                }
+                block_ids = (block['id'] for block in group['blocks'])
+                for block_id in block_ids:
+                    block_section_groups[block_id] = section_group
+
+        return block_section_groups
 
 
 def get_nested_schema_objects(parent_object, list_key):

--- a/app/templating/summary_context.py
+++ b/app/templating/summary_context.py
@@ -13,7 +13,7 @@ def build_summary_rendering_context(schema, sections, answer_store, metadata):
     :param metadata: all of the metadata
     :return: questionnaire summary context
     """
-    navigator = PathFinder(schema, answer_store, metadata)
+    navigator = PathFinder(schema, answer_store, metadata, [])
     path = navigator.get_full_routing_path()
     groups = []
 

--- a/app/views/dump.py
+++ b/app/views/dump.py
@@ -4,7 +4,7 @@ from flask import Blueprint, jsonify
 
 
 from app.authentication.roles import role_required
-from app.globals import get_answer_store, get_metadata
+from app.globals import get_answer_store, get_metadata, get_completed_blocks
 from app.submitter.converter import convert_answers
 from app.utilities.schema import load_schema_from_metadata
 from app.questionnaire.path_finder import PathFinder
@@ -28,6 +28,7 @@ def dump_submission():
     answer_store = get_answer_store(current_user)
     metadata = get_metadata(current_user)
     schema = load_schema_from_metadata(metadata)
-    routing_path = PathFinder(schema, answer_store, metadata).get_full_routing_path()
+    completed_blocks = get_completed_blocks(current_user)
+    routing_path = PathFinder(schema, answer_store, metadata, completed_blocks).get_full_routing_path()
     response = {'submission': convert_answers(metadata, schema, answer_store, routing_path)}
     return jsonify(response), 200

--- a/app/views/flush.py
+++ b/app/views/flush.py
@@ -4,7 +4,7 @@ from sdc.crypto.decrypter import decrypt
 
 
 from app.authentication.user import User
-from app.globals import get_answer_store, get_metadata, get_questionnaire_store
+from app.globals import get_answer_store, get_metadata, get_questionnaire_store, get_completed_blocks
 from app.questionnaire.path_finder import PathFinder
 from app.keys import KEY_PURPOSE_AUTHENTICATION, KEY_PURPOSE_SUBMISSION
 from app.submitter.converter import convert_answers
@@ -47,7 +47,8 @@ def _submit_data(user):
     if answer_store.answers:
         metadata = get_metadata(user)
         schema = load_schema_from_metadata(metadata)
-        routing_path = PathFinder(schema, answer_store, metadata).get_full_routing_path()
+        completed_blocks = get_completed_blocks(user)
+        routing_path = PathFinder(schema, answer_store, metadata, completed_blocks).get_full_routing_path()
 
         message = convert_answers(metadata, schema, answer_store, routing_path, flushed=True)
         encrypted_message = encrypt(message, current_app.eq['key_store'], KEY_PURPOSE_SUBMISSION)

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -260,7 +260,7 @@ def get_view_submission(eq_id, form_type):  # pylint: disable=unused-argument
 
             metadata = submitted_data.get('metadata')
 
-            routing_path = PathFinder(g.schema, answer_store, metadata).get_full_routing_path()
+            routing_path = PathFinder(g.schema, answer_store, metadata, []).get_full_routing_path()
 
             schema_context = _get_schema_context(routing_path, 0, metadata, answer_store)
             rendered_schema = renderer.render(g.schema.json, **schema_context)

--- a/app/views/session.py
+++ b/app/views/session.py
@@ -75,8 +75,9 @@ def login():
     if 'account_service_url' in metadata and metadata.get('account_service_url'):
         cookie_session[ACCOUNT_URL] = metadata.get('account_service_url')
 
-    navigator = PathFinder(g.schema, get_answer_store(current_user), metadata)
-    current_location = navigator.get_latest_location(get_completed_blocks(current_user))
+    completed_blocks = get_completed_blocks(current_user)
+    navigator = PathFinder(g.schema, get_answer_store(current_user), metadata, completed_blocks)
+    current_location = navigator.get_latest_location(completed_blocks)
 
     return redirect(current_location.url(metadata))
 

--- a/tests/app/confirmation_page/test_confirmation_page.py
+++ b/tests/app/confirmation_page/test_confirmation_page.py
@@ -16,7 +16,7 @@ class TestConfirmationPage(AppContextTestCase):
         answer_store.add(answer)
 
         schema = load_schema_from_params('0', 'rogue_one')
-        navigator = PathFinder(schema, answer_store, {})
+        navigator = PathFinder(schema, answer_store, {}, [])
         next_location = navigator.get_next_location(Location('rogue-one', 0, 'film-takings'))
 
         self.assertEqual('summary', next_location.block_id)

--- a/tests/app/helpers/test_path_finder_helper.py
+++ b/tests/app/helpers/test_path_finder_helper.py
@@ -9,11 +9,12 @@ from tests.app.app_context_test_case import AppContextTestCase
 @patch('app.helpers.path_finder_helper.PathFinder')
 @patch('app.helpers.path_finder_helper.get_metadata')
 @patch('app.helpers.path_finder_helper.get_answer_store')
+@patch('app.helpers.path_finder_helper.get_completed_blocks')
 class TestPathFinderHelper(AppContextTestCase):
 
     LOGIN_DISABLED = True
 
-    def test_path_finder_instantiated_once(self, mock_path_finder, _, __):
+    def test_path_finder_instantiated_once(self, mock_path_finder, _, __, ___):
         g.schema = QuestionnaireSchema({})
 
         # Werkzeug LocalProxy only instantiates an object on

--- a/tests/app/questionnaire/test_path_finder.py
+++ b/tests/app/questionnaire/test_path_finder.py
@@ -24,7 +24,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
             group_instance=0
         )
 
-        path_finder = PathFinder(schema, AnswerStore(), metadata={})
+        path_finder = PathFinder(schema, AnswerStore(), metadata={}, completed_blocks=[])
         self.assertEqual(path_finder.get_next_location(current_location=current_location), next_location)
 
     def test_previous_block(self):
@@ -42,13 +42,13 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
             group_instance=0
         )
 
-        path_finder = PathFinder(schema, AnswerStore(), metadata={})
+        path_finder = PathFinder(schema, AnswerStore(), metadata={}, completed_blocks=[])
         self.assertEqual(path_finder.get_previous_location(current_location=current_location), previous_location)
 
     def test_introduction_in_path_when_in_schema(self):
         schema = load_schema_from_params('test', '0102')
 
-        path_finder = PathFinder(schema, AnswerStore(), metadata={})
+        path_finder = PathFinder(schema, AnswerStore(), metadata={}, completed_blocks=[])
 
         blocks = [b.block_id for b in path_finder.get_full_routing_path()]
 
@@ -57,7 +57,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
     def test_introduction_not_in_path_when_not_in_schema(self):
         schema = load_schema_from_params('census', 'individual')
 
-        path_finder = PathFinder(schema, AnswerStore(), metadata={})
+        path_finder = PathFinder(schema, AnswerStore(), metadata={}, completed_blocks=[])
 
         blocks = [b.block_id for b in path_finder.get_full_routing_path()]
 
@@ -91,13 +91,24 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         current_location = expected_path[1]
         expected_next_location = expected_path[2]
 
-        path_finder = PathFinder(schema, answer_store=answers, metadata={})
+        completed_blocks = [
+            expected_path[0],
+            expected_path[1]
+        ]
+
+        path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=completed_blocks)
         actual_next_block = path_finder.get_next_location(current_location=current_location)
 
         self.assertEqual(actual_next_block, expected_next_location)
 
         current_location = expected_path[2]
         expected_next_location = expected_path[3]
+
+        path_finder.completed_blocks = [
+            expected_path[0],
+            expected_path[1],
+            expected_path[2]
+        ]
 
         actual_next_block = path_finder.get_next_location(current_location=current_location)
 
@@ -117,7 +128,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
             Location('rsi', 0, 'summary')
         ]
 
-        path_finder = PathFinder(schema, AnswerStore(), metadata={})
+        path_finder = PathFinder(schema, AnswerStore(), metadata={}, completed_blocks=[])
         routing_path = path_finder.get_full_routing_path()
 
         self.assertEqual(routing_path, expected_path)
@@ -149,7 +160,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         answers.add(answer_1)
         answers.add(answer_2)
 
-        path_finder = PathFinder(schema, answer_store=answers, metadata={})
+        path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
         routing_path = path_finder.get_full_routing_path()
 
         self.assertEqual(routing_path, expected_path)
@@ -157,9 +168,9 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
     def test_get_next_location_introduction(self):
         schema = load_schema_from_params('0', 'star_wars')
 
-        path_finder = PathFinder(schema, AnswerStore(), {})
-
         introduction = Location('star-wars', 0, 'introduction')
+
+        path_finder = PathFinder(schema, AnswerStore(), {}, [introduction])
 
         next_location = path_finder.get_next_location(current_location=introduction)
 
@@ -181,7 +192,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         answers.add(answer_1)
         answers.add(answer_2)
 
-        path_finder = PathFinder(schema, answer_store=answers, metadata={})
+        path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
         current_location = Location('star-wars', 0, 'star-wars-trivia-part-2')
 
@@ -202,7 +213,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
     def test_get_previous_location_introduction(self):
         schema = load_schema_from_params('0', 'star_wars')
 
-        path_finder = PathFinder(schema, AnswerStore(), metadata={})
+        path_finder = PathFinder(schema, AnswerStore(), metadata={}, completed_blocks=[])
 
         first_location = Location('star-wars', 0, 'choose-your-side-block')
 
@@ -238,7 +249,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         current_location = expected_path[3]
         expected_previous_location = expected_path[2]
 
-        path_finder = PathFinder(schema, answer_store=answers, metadata={})
+        path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
         actual_previous_block = path_finder.get_previous_location(current_location=current_location)
 
         self.assertEqual(actual_previous_block, expected_previous_location)
@@ -277,7 +288,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         answers.add(answer_1)
         answers.add(answer_2)
 
-        path_finder = PathFinder(schema, answer_store=answers, metadata={})
+        path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
         self.assertEqual(path_finder.get_previous_location(current_location=current_location),
                          expected_previous_location)
@@ -298,7 +309,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         )
         answers = AnswerStore()
         answers.add(answer)
-        path_finder = PathFinder(schema, answer_store=answers, metadata={})
+        path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
         current_location = expected_path[1]
         expected_next_location = expected_path[2]
@@ -330,7 +341,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         answers.add(answer_1)
         answers.add(answer_2)
 
-        path_finder = PathFinder(schema, answer_store=answers, metadata={})
+        path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
         current_location = expected_path[1]
         expected_next_location = expected_path[2]
@@ -350,7 +361,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         answers = AnswerStore()
         answers.add(answer)
 
-        path_finder = PathFinder(schema, answer_store=answers, metadata={})
+        path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
         self.assertFalse(Location('star-wars', 0, 'summary') in path_finder.get_full_routing_path())
 
@@ -378,7 +389,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         answers = AnswerStore()
         answers.add(answer)
 
-        path_finder = PathFinder(schema, answer_store=answers, metadata={})
+        path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
         self.assertEqual(expected_path, path_finder.get_full_routing_path())
 
@@ -401,7 +412,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         )
         answers = AnswerStore()
         answers.add(answer)
-        path_finder = PathFinder(schema, answer_store=answers, metadata={})
+        path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
         self.assertEqual(expected_path, path_finder.get_full_routing_path())
 
     def test_repeating_groups_no_of_answers(self):
@@ -446,7 +457,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         answers.add(answer_2)
         answers.add(answer_3)
 
-        path_finder = PathFinder(schema, answer_store=answers, metadata={})
+        path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
         self.assertEqual(expected_path, path_finder.get_full_routing_path())
 
@@ -483,7 +494,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         answers.add(answer)
         answers.add(answer_2)
 
-        path_finder = PathFinder(schema, answer_store=answers, metadata={})
+        path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
         self.assertEqual(expected_path, path_finder.get_full_routing_path())
 
@@ -494,7 +505,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
             Location('who-lives-here', 0, 'overnight-visitors'),
             Location('who-lives-here-relationship', 0, 'household-relationships'),
         ]
-        path_finder = PathFinder(schema, AnswerStore(), metadata={})
+        path_finder = PathFinder(schema, AnswerStore(), metadata={}, completed_blocks=[])
         self.assertEqual(path_finder.get_previous_location(current_location=expected_path[1]), expected_path[0])
 
     def test_repeating_groups_previous_location_second_instance(self):
@@ -504,7 +515,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
             Location('who-lives-here-relationship', 0, 'household-relationships'),
             Location('who-lives-here-relationship', 1, 'household-relationships'),
         ]
-        path_finder = PathFinder(schema, AnswerStore(), metadata={})
+        path_finder = PathFinder(schema, AnswerStore(), metadata={}, completed_blocks=[])
         self.assertEqual(path_finder.get_previous_location(current_location=expected_path[1]), expected_path[0])
 
     def test_repeating_groups_previous_location(self):
@@ -539,7 +550,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         answers.add(answer)
         answers.add(answer_2)
 
-        path_finder = PathFinder(schema, answer_store=answers, metadata={})
+        path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
         self.assertEqual(expected_previous_location,
                          path_finder.get_previous_location(current_location=current_location))
@@ -573,7 +584,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         answers.add(answer)
         answers.add(answer_2)
 
-        path_finder = PathFinder(schema, answer_store=answers, metadata={})
+        path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
         summary_location = Location('summary-group', 0, 'summary')
 
@@ -615,7 +626,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         answers.add(answer_2)
         answers.add(answer_3)
 
-        path_finder = PathFinder(schema, answer_store=answers, metadata={})
+        path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
         self.assertEqual(expected_path, path_finder.get_full_routing_path())
 
@@ -636,7 +647,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
                 value='Shoe Size Only'
             ))
 
-        path_finder = PathFinder(schema, answer_store=answers, metadata={})
+        path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
         self.assertEqual('summary', path_finder.get_full_routing_path().pop().block_id)
 
@@ -658,7 +669,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
             }
         }
 
-        path_finder = PathFinder(schema, AnswerStore(), metadata=metadata)
+        path_finder = PathFinder(schema, AnswerStore(), metadata=metadata, completed_blocks=[])
 
         self.assertEqual(expected_next_location, path_finder.get_next_location(current_location=current_location))
 
@@ -679,7 +690,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
             }
         }
 
-        path_finder = PathFinder(schema, AnswerStore(), metadata=metadata)
+        path_finder = PathFinder(schema, AnswerStore(), metadata=metadata, completed_blocks=[])
 
         self.assertEqual(expected_next_location, path_finder.get_next_location(current_location=current_location))
 
@@ -724,7 +735,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         answers.add(answer_2)
         answers.add(answer_3)
 
-        path_finder = PathFinder(schema, answer_store=answers, metadata={})
+        path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
         self.assertEqual(expected_next_location, path_finder.get_next_location(current_location=current_location))
 
@@ -769,7 +780,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         answers.add(answer_2)
         answers.add(answer_3)
 
-        path_finder = PathFinder(schema, answer_store=answers, metadata={})
+        path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
         self.assertEqual(expected_next_location, path_finder.get_next_location(current_location=current_location))
 
@@ -782,7 +793,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
                                 value='Yes'))
 
         # When
-        path_finder = PathFinder(schema, answer_store=answer_store, metadata={})
+        path_finder = PathFinder(schema, answer_store=answer_store, metadata={}, completed_blocks=[])
 
         # Then
         expected_next_location = Location('summary-group', 0, 'summary')
@@ -798,7 +809,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
                                 value='Yes'))
 
         # When
-        path_finder = PathFinder(schema, answer_store=answer_store, metadata={})
+        path_finder = PathFinder(schema, answer_store=answer_store, metadata={}, completed_blocks=[])
 
         # Then
         expected_next_location = Location('last-group', 0, 'last-group-block')
@@ -814,7 +825,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
                                 value='No'))
 
         # When
-        path_finder = PathFinder(schema, answer_store=answer_store, metadata={})
+        path_finder = PathFinder(schema, answer_store=answer_store, metadata={}, completed_blocks=[])
 
         # Then
         expected_location = Location('should-skip-group', 0, 'should-skip')
@@ -828,7 +839,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         answer_store = AnswerStore()
 
         # When
-        path_finder = PathFinder(schema, answer_store=answer_store, metadata={})
+        path_finder = PathFinder(schema, answer_store=answer_store, metadata={}, completed_blocks=[])
 
         # Then
         expected_location = Location('should-skip-group', 0, 'should-skip')
@@ -843,7 +854,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
                                 value='Yes'))
 
         # When
-        path_finder = PathFinder(schema, answer_store=answer_store, metadata={})
+        path_finder = PathFinder(schema, answer_store=answer_store, metadata={}, completed_blocks=[])
 
         # Then
         expected_route = [
@@ -865,7 +876,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
     def test_given_no_completed_blocks_when_get_latest_location_then_go_to_first_block(self):
         # Given no completed blocks
         schema = load_schema_from_params('test', 'repeating_household')
-        path_finder = PathFinder(schema, AnswerStore(), metadata={})
+        path_finder = PathFinder(schema, AnswerStore(), metadata={}, completed_blocks=[])
         completed_block = []
 
         # When go latest location
@@ -877,7 +888,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
     def test_given_some_completed_blocks_when_get_latest_location_then_go_to_next_uncompleted_block(self):
         # Given no completed blocks
         schema = load_schema_from_params('test', 'repeating_household')
-        path_finder = PathFinder(schema, AnswerStore(), metadata={})
+        path_finder = PathFinder(schema, AnswerStore(), metadata={}, completed_blocks=[])
         completed_block = [Location('multiple-questions-group', 0, 'introduction')]
 
         # When go latest location
@@ -889,7 +900,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
     def test_given_completed_all_the_blocks_when_get_latest_location_then_go_to_last_block(self):
         # Given no completed blocks
         schema = load_schema_from_params('test', 'textarea')
-        path_finder = PathFinder(schema, AnswerStore(), metadata={})
+        path_finder = PathFinder(schema, AnswerStore(), metadata={}, completed_blocks=[])
         completed_block = [Location('textarea-group', 0, 'textarea-block'),
                            Location('textarea-group', 0, 'textarea-summary')]
 
@@ -908,10 +919,74 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
                                 value='group2'))
 
         # When i build the path
-        path_finder = PathFinder(schema, answer_store=answer_store, metadata={})
+        path_finder = PathFinder(schema, answer_store=answer_store, metadata={}, completed_blocks=[])
 
         path = path_finder.build_path()
 
         # Then it should route me straight to Group2 and not Group1
         self.assertNotIn(Location('group1', 0, 'group1-block'), path)
         self.assertIn(Location('group2', 0, 'group2-block'), path)
+
+    def test_return_to_summary_if_complete(self):
+        schema = load_schema_from_params('test', 'summary')
+
+        # All blocks completed
+        completed_blocks = [
+            Location('summary-group', 0, 'radio'),
+            Location('summary-group', 0, 'test-number-block'),
+            Location('dessert-group', 0, 'dessert-block')
+        ]
+
+        answer_store = AnswerStore()
+        answer_store.add(Answer(answer_id='radio-answer', value='Bacon'))
+        answer_store.add(Answer(answer_id='test-currency', value='123'))
+        answer_store.add(Answer(answer_id='dessert', value='Cake'))
+
+        summary_location = Location('dessert-group', 0, 'summary')
+
+        path_finder = PathFinder(schema, answer_store, metadata={}, completed_blocks=completed_blocks)
+
+        self.assertEqual(path_finder.get_next_location(current_location=completed_blocks[0]), summary_location)
+
+    def test_return_to_section_summary_if_section_complete(self):
+        schema = load_schema_from_params('test', 'section_summary')
+
+        # All blocks completed
+        completed_blocks = [
+            Location('property-details', 0, 'insurance-type'),
+            Location('property-details', 0, 'insurance-address'),
+            Location('address-length', 0, 'address-duration')
+        ]
+
+        answer_store = AnswerStore()
+        answer_store.add(Answer(answer_id='insurance-type-answer', value='Contents'))
+        answer_store.add(Answer(answer_id='insurance-address-answer', value='123 Test Road'))
+        answer_store.add(Answer(answer_id='address-duration-answer', value='No'))
+
+        summary_location = Location('address-length', 0, 'property-details-summary')
+
+        path_finder = PathFinder(schema, answer_store, metadata={}, completed_blocks=completed_blocks)
+
+        self.assertEqual(path_finder.get_next_location(current_location=completed_blocks[0]), summary_location)
+
+    def test_go_to_next_section_after_section_summary(self):
+        schema = load_schema_from_params('test', 'section_summary')
+
+        # All blocks completed
+        completed_blocks = [
+            Location('property-details', 0, 'insurance-type'),
+            Location('property-details', 0, 'insurance-address'),
+            Location('address-length', 0, 'address-duration'),
+            Location('address-length', 0, 'property-details-summary')
+        ]
+
+        answer_store = AnswerStore()
+        answer_store.add(Answer(answer_id='insurance-type-answer', value='Both'))
+        answer_store.add(Answer(answer_id='insurance-address-answer', value='123 Test Road'))
+        answer_store.add(Answer(answer_id='address-duration-answer', value='No'))
+
+        second_section_location = Location('house-details', 0, 'house-type')
+
+        path_finder = PathFinder(schema, answer_store, metadata={}, completed_blocks=completed_blocks)
+
+        self.assertEqual(path_finder.get_next_location(current_location=completed_blocks[3]), second_section_location)

--- a/tests/functional/pages/surveys/section_summary/final-summary.page.js
+++ b/tests/functional/pages/surveys/section_summary/final-summary.page.js
@@ -1,0 +1,45 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class PropertyDetailsSummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  insuranceTypeAnswer() { return '#insurance-type-answer-answer'; }
+
+  insuranceTypeAnswerEdit() { return '[data-qa="insurance-type-answer-edit"]'; }
+
+  insuranceAddressAnswer() { return '#insurance-address-answer-answer'; }
+
+  insuranceAddressAnswerEdit() { return '[data-qa="insurance-address-answer-edit"]'; }
+
+  propertyDetailsTitle() { return '#property-details'; }
+
+  addressDurationAnswer() { return '#address-duration-answer-answer'; }
+
+  addressDurationAnswerEdit() { return '[data-qa="address-duration-answer-edit"]'; }
+
+  addressLengthTitle() { return '#address-length'; }
+
+  propertyDetailsSectionSummaryTitle() { return '#property-details-section-summary'; }
+
+  houseTypeAnswer() { return '#house-type-answer-answer'; }
+
+  houseTypeAnswerEdit() { return '[data-qa="house-type-answer-edit"]'; }
+
+  houseDetailsTitle() { return '#house-details'; }
+
+  householdDetailsSectionSummaryTitle() { return '#household-details-section-summary'; }
+
+  lastName() { return '#last-name-answer'; }
+
+  lastNameEdit() { return '[data-qa="last-name-edit"]'; }
+
+  multipleQuestionsGroupTitle() { return '#multiple-questions-group'; }
+
+  summaryGroupTitle() { return '#summary-group'; }
+
+}
+module.exports = new PropertyDetailsSummaryPage();

--- a/tests/functional/pages/surveys/section_summary/household-composition.page.js
+++ b/tests/functional/pages/surveys/section_summary/household-composition.page.js
@@ -1,0 +1,39 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class HouseholdCompositionPage extends QuestionPage {
+
+  constructor() {
+    super('household-composition');
+  }
+
+  addPerson() {
+    return 'button[name="action[add_answer]"]';
+  }
+
+  removePerson(index = 2) {
+    return 'div:nth-child(' + index + ') > h3 > small > button';
+  }
+
+  numRemoveButtons() {
+    return '[class="btn btn--link pluto"]';
+  }
+
+  firstName(index = '') {
+    return '#household-0-first-name' + index ;
+  }
+
+  middleNames(index = '') {
+    return '#household-0-middle-names' + index;
+  }
+
+  lastName(index = '') {
+    return '#household-0-last-name' + index;
+  }
+
+  personLegend(index = 1) {
+    return 'div:nth-child(' + index + ') > fieldset > legend';
+  }
+
+}
+module.exports = new HouseholdCompositionPage();

--- a/tests/functional/spec/section_summary.spec.js
+++ b/tests/functional/spec/section_summary.spec.js
@@ -4,55 +4,72 @@ const InsuranceAddressPage = require('../pages/surveys/section_summary/insurance
 const InsuranceTypePage = require('../pages/surveys/section_summary/insurance-type.page.js');
 const AddressDurationPage = require('../pages/surveys/section_summary/address-duration.page.js');
 const PropertyDetailsSummaryPage = require('../pages/surveys/section_summary/property-details-summary.page.js');
+const HouseHoldCompositionPage = require('../pages/surveys/section_summary/household-composition.page.js');
+const FinalSummaryPage = require('../pages/surveys/section_summary/final-summary.page.js');
 
 describe('Section Summary', function() {
-  describe('Given I start a Test Section Summary survey', function() {
 
-    const schema = 'test_section_summary.json';
+  describe('Given I start a Test Section Summary survey and complete to Section Summary', function() {
 
-    it('When I have selected a set of answers , Then the selected option should be displayed on the section summary', function() {
-      return helpers.openQuestionnaire(schema)
-        .then(() => {
-          return browser
-           .click(InsuranceTypePage.buildings())
-           .click(InsuranceTypePage.submit())
-           .click(InsuranceAddressPage.submit())
-           .click(AddressDurationPage.yes())
-           .click(AddressDurationPage.submit())
-           .getText(PropertyDetailsSummaryPage.insuranceTypeAnswer()).should.eventually.contain('Buildings');
+    beforeEach(function() {
+      return helpers.openQuestionnaire('test_section_summary.json').then(() => {
+        return browser
+          .click(InsuranceTypePage.contents())
+          .click(InsuranceTypePage.submit())
+          .click(InsuranceAddressPage.submit())
+          .click(AddressDurationPage.submit())
+          .getText(PropertyDetailsSummaryPage.insuranceTypeAnswer()).should.eventually.contain('Contents');
       });
     });
 
-  it('When I have selected an answer , And want to change that answer on the section summary, Then the selected option should be displayed on the section summary', function() {
-      return helpers.openQuestionnaire(schema)
-        .then(() => {
-         return browser
-           .click(InsuranceTypePage.buildings())
-           .click(InsuranceTypePage.submit())
-           .click(InsuranceAddressPage.submit())
-           .click(AddressDurationPage.submit())
-           .getText(PropertyDetailsSummaryPage.insuranceTypeAnswer()).should.eventually.contain('Buildings')
-           .click(PropertyDetailsSummaryPage.insuranceTypeAnswerEdit())
-           .click(InsuranceTypePage.contents())
-           .click(InsuranceTypePage.submit())
-           .click(InsuranceAddressPage.submit())
-           .click(AddressDurationPage.submit())
-           .getText(PropertyDetailsSummaryPage.insuranceTypeAnswer()).should.eventually.contain('Contents');
+    it('When I have selected an answer to edit and edit it, Then I should return to the section summary with new value displayed', function() {
+      return browser
+        .click(PropertyDetailsSummaryPage.insuranceTypeAnswerEdit())
+        .click(InsuranceTypePage.buildings())
+        .click(InsuranceTypePage.submit())
+        .getText(PropertyDetailsSummaryPage.insuranceTypeAnswer()).should.eventually.contain('Buildings');
+    });
+
+    it('When I continue on the section summary page, Then I should be taken to the next section', function() {
+      return browser
+        .click(PropertyDetailsSummaryPage.submit())
+        .getUrl().should.eventually.contain(HouseHoldCompositionPage.pageName);
+    });
+
+  });
+
+  describe('Given I start a Test Section Summary survey and complete to Final Summary', function() {
+
+    beforeEach(function() {
+      return helpers.openQuestionnaire('test_section_summary.json').then(() => {
+        return browser
+          .click(InsuranceTypePage.contents())
+          .click(InsuranceTypePage.submit())
+          .click(InsuranceAddressPage.submit())
+          .click(AddressDurationPage.submit())
+          .click(PropertyDetailsSummaryPage.submit())
+          .setValue(HouseHoldCompositionPage.firstName(), 'John')
+          .click(HouseHoldCompositionPage.submit())
+          .getUrl().should.eventually.contain(FinalSummaryPage.pageName);
       });
     });
 
-   it('When I have selected an answer , And decide to continue on the section summary page, Then I should be taken to the next section', function() {
-      return helpers.openQuestionnaire(schema)
-        .then(() => {
-         return browser
-           .click(InsuranceTypePage.buildings())
-           .click(InsuranceTypePage.submit())
-           .click(InsuranceAddressPage.submit())
-           .click(AddressDurationPage.submit())
-           .click(PropertyDetailsSummaryPage.submit())
-           .getUrl().should.eventually.contain(HouseTypePage.pageName);
-        });
+    it('When I select edit from Final Summary, Then I should be taken back to the Final Summary', function() {
+      return browser
+        .click(FinalSummaryPage.addressDurationAnswerEdit())
+        .click(AddressDurationPage.no())
+        .click(AddressDurationPage.submit())
+        .getUrl().should.eventually.contain(FinalSummaryPage.pageName);
     });
+
+    it('When I edit from Final Summary but change routing, Then I should be taken back to the Section Summary', function() {
+      return browser
+        .click(FinalSummaryPage.insuranceTypeAnswerEdit())
+        .click(InsuranceTypePage.buildings())
+        .click(InsuranceTypePage.submit())
+        .getUrl().should.eventually.contain(PropertyDetailsSummaryPage.pageName);
+    });
+
   });
 
 });

--- a/tests/functional/spec/summary_screen.spec.js
+++ b/tests/functional/spec/summary_screen.spec.js
@@ -41,6 +41,18 @@ describe('Summary Screen', function() {
       });
   });
 
+  it('Given a survey has been completed when a summary page edit link is clicked then it should return to that question then back to summary', function() {
+  return helpers.openQuestionnaire('test_summary.json')
+    .then(completeAllQuestions)
+    .then(() => {
+      return browser
+        .click(SummaryPage.radioAnswerEdit())
+        .click(RadioPage.sausage())
+        .click(RadioPage.submit())
+        .getText(SummaryPage.radioAnswer()).should.eventually.contain('Sausage');
+      });
+  });
+
   it('Given the edit link is used when a question is updated then the summary screen should show the new answer', function() {
   return helpers.openQuestionnaire('test_summary.json')
     .then(completeAllQuestions)
@@ -51,7 +63,6 @@ describe('Summary Screen', function() {
         .hasFocus(TestNumberPage.squareKilometres())
         .setValue(TestNumberPage.squareKilometres(), '654321')
         .click(TestNumberPage.submit())
-        .click(DessertBlockPage.submit())
         .getText(SummaryPage.squareKilometres()).should.eventually.contain('654,321 km²');
       });
   });


### PR DESCRIPTION
### What is the context of this PR?
Upon returning to a question in any fashion (via edit link, using back buttons or entering question url) when submitting that question if a Summary page (Final or Section) is still available (no change in routing or dependencies) for it then it should return to the summary page.

### How to review 
Use existing test_section_summary.json for testing of returns to both section and final summaries. Final summary can be made unavailable with a change of routing.
Use test_dependencies schemas to show behaviour when summary is unavailable due to a dependency change.
