### PR TITLE
Removes completed block if routing sends you backwards

### DIFF
--- a/app/questionnaire/path_finder.py
+++ b/app/questionnaire/path_finder.py
@@ -142,12 +142,12 @@ class PathFinder:
         next_precedes_current = next_block_index is not None and next_block_index < block_index
 
         if next_precedes_current:
-            self._remove_rule_answers(rule['goto'])
+            self._remove_rule_answers(rule['goto'], this_location)
             path.append(next_location)
 
         return next_location
 
-    def _remove_rule_answers(self, goto_rule):
+    def _remove_rule_answers(self, goto_rule, this_location):
         # We're jumping backwards, so need to delete all answers from which
         # route is derived. Need to filter out conditions that don't use answers
         if 'when' in goto_rule.keys():
@@ -155,6 +155,9 @@ class PathFinder:
                 if 'meta' not in condition.keys():
                     self.answer_store.remove(answer_ids=[condition['id']],
                                              answer_instance=0,)
+
+        if this_location in self.completed_blocks:
+            self.completed_blocks.remove(this_location)
 
     def get_routing_path(self, group_id, group_instance=0):
         """

--- a/data/en/test_confirmation_question.json
+++ b/data/en/test_confirmation_question.json
@@ -5,115 +5,132 @@
     "survey_id": "139",
     "theme": "default",
     "title": "Confirmation Question Test",
-    "data_version": "0.0.2",
+    "data_version": "0.0.1",
     "description": "Confirmation Question Test",
     "view_submitted_response": {
         "enabled": true,
         "duration": 900
     },
+    "navigation": {
+        "visible": true
+    },
     "sections": [{
-        "id": "default-section",
-        "groups": [{
-            "id": "confirmation-block",
-            "title": "Confirmation Question Test",
-            "blocks": [{
-                    "id": "number-of-employees-total-block",
-                    "questions": [{
-                        "answers": [{
-                            "id": "number-of-employees-total",
-                            "alias": "number_of_employees_total",
-                            "label": "Total number of employees",
-                            "mandatory": false,
-                            "type": "Number",
-                            "default": 0
-                        }],
-                        "id": "number-of-employees-total-question",
-                        "title": "How many employees work at {{respondent.trad_as_or_ru_name}}?",
-                        "type": "General"
-                    }],
-                    "type": "Question"
-                },
-                {
-                    "type": "ConfirmationQuestion",
-                    "title": "Employees",
-                    "id": "confirm-zero-employees-block",
-                    "skip_conditions": [{
-                        "when": [{
-                            "id": "number-of-employees-total",
-                            "condition": "greater than",
-                            "value": 0
-                        }]
-                    }],
-                    "questions": [{
-                        "type": "General",
-                        "answers": [{
-                            "type": "Radio",
-                            "id": "confirm-zero-employees-answer",
-                            "options": [{
-                                    "label": "Yes this is correct",
-                                    "value": "Yes"
-                                },
-                                {
-                                    "label": "No I need to change this",
-                                    "value": "No"
-                                }
-                            ],
-                            "mandatory": true
-                        }],
-                        "id": "confirm-zero-employees-question",
-                        "title": "The current number of employees for {{respondent.trad_as_or_ru_name}} is <em>0</em>, is this correct?"
-                    }],
-                    "routing_rules": [{
-                            "goto": {
-                                "when": [{
-                                    "value": "No",
-                                    "id": "confirm-zero-employees-answer",
-                                    "condition": "equals"
-                                }],
-                                "block": "number-of-employees-total-block"
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "summary"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "id": "number-of-employees-split-block",
-                    "type": "Question",
-                    "questions": [{
-                        "answers": [{
-                                "id": "number-of-employees-male-more-30-hours",
-                                "label": "Number of male employees working more than 30 hours per week",
+            "id": "default-section",
+            "title": "Questions",
+            "groups": [{
+                "id": "confirmation-block",
+                "title": "Confirmation Question Test",
+                "blocks": [{
+                        "id": "number-of-employees-total-block",
+                        "questions": [{
+                            "answers": [{
+                                "id": "number-of-employees-total",
+                                "q_code": "50",
+                                "alias": "number_of_employees_total",
+                                "label": "Total number of employees",
                                 "mandatory": false,
                                 "type": "Number",
-                                "max_value": {
-                                    "answer_id": "number-of-employees-total"
+                                "default": 0
+                            }],
+                            "id": "number-of-employees-total-question",
+                            "title": "How many employees work at {{respondent.trad_as_or_ru_name}}?",
+                            "type": "General"
+                        }],
+                        "type": "Question"
+                    },
+                    {
+                        "type": "ConfirmationQuestion",
+                        "title": "Employees",
+                        "id": "confirm-zero-employees-block",
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "number-of-employees-total",
+                                "condition": "greater than",
+                                "value": 0
+                            }]
+                        }],
+                        "questions": [{
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "confirm-zero-employees-answer",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true,
+                                "q_code": "d50"
+                            }],
+                            "id": "confirm-zero-employees-question",
+                            "title": "The current number of employees for {{respondent.trad_as_or_ru_name}} is <em>0</em>, is this correct?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "value": "No",
+                                        "id": "confirm-zero-employees-answer",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "number-of-employees-total-block"
                                 }
                             },
                             {
-                                "id": "number-of-employees-female-more-30-hours",
-                                "label": "Number of female employees working more than 30 hours per week",
-                                "mandatory": false,
-                                "type": "Number",
-                                "max_value": {
-                                    "answer_id": "number-of-employees-total"
+                                "goto": {
+                                    "group": "summary-group"
                                 }
                             }
-                        ],
+                        ]
+                    },
+                    {
+                        "id": "number-of-employees-split-block",
+                        "type": "Question",
+                        "questions": [{
+                            "answers": [{
+                                    "id": "number-of-employees-male-more-30-hours",
+                                    "label": "Number of male employees working more than 30 hours per week",
+                                    "mandatory": false,
+                                    "q_code": "51",
+                                    "type": "Number",
+                                    "max_value": {
+                                        "answer_id": "number-of-employees-total"
+                                    }
+                                },
+                                {
+                                    "id": "number-of-employees-female-more-30-hours",
+                                    "label": "Number of female employees working more than 30 hours per week",
+                                    "mandatory": false,
+                                    "q_code": "52",
+                                    "type": "Number",
+                                    "max_value": {
+                                        "answer_id": "number-of-employees-total"
+                                    }
+                                }
+                            ],
 
-                        "id": "number-of-employees-split-question",
-                        "title": "Of the <em>{{answers.number_of_employees_total}}</em> total employees employed, how many male and female employees worked the following hours?",
-                        "type": "General"
-                    }]
-                },
-                {
-                    "type": "Summary",
-                    "id": "summary"
-                }
-            ]
-        }]
-    }]
+                            "id": "number-of-employees-split-question",
+                            "title": "Of the <em>{{answers.number_of_employees_total}}</em> total employees employed, how many male and female employees worked the following hours?",
+                            "type": "General"
+                        }]
+                    }
+                ]
+            }]
+        },
+        {
+            "id": "summary-section",
+            "title": "Summary",
+            "groups": [{
+                "blocks": [{
+                    "id": "summary",
+                    "type": "Summary"
+                }],
+                "id": "summary-group",
+                "title": "Summary"
+            }]
+        }
+    ]
 }

--- a/tests/app/questionnaire/test_path_finder.py
+++ b/tests/app/questionnaire/test_path_finder.py
@@ -990,3 +990,27 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         path_finder = PathFinder(schema, answer_store, metadata={}, completed_blocks=completed_blocks)
 
         self.assertEqual(path_finder.get_next_location(current_location=completed_blocks[3]), second_section_location)
+
+    def test_remove_answer_and_block_if_routing_backwards(self):
+        schema = load_schema_from_params('test', 'confirmation_question')
+
+        # All blocks completed
+        completed_blocks = [
+            Location('confirmation-block', 0, 'number-of-employees-total-block'),
+            Location('confirmation-block', 0, 'confirm-zero-employees-block')
+        ]
+
+        answer_store = AnswerStore()
+        number_of_employees_answer = Answer(answer_id='number-of-employees-total', value=0)
+        confirm_zero_answer = Answer(answer_id='confirm-zero-employees-answer', value='No')
+        answer_store.add(number_of_employees_answer)
+        answer_store.add(confirm_zero_answer)
+
+        path_finder = PathFinder(schema, answer_store, metadata={}, completed_blocks=completed_blocks)
+        self.assertEqual(len(path_finder.completed_blocks), 2)
+        self.assertEqual(len(path_finder.answer_store.answers), 2)
+
+        self.assertEqual(path_finder.get_next_location(current_location=completed_blocks[1]), completed_blocks[0])
+
+        self.assertEqual(path_finder.completed_blocks, [completed_blocks[0]])
+        self.assertEqual(len(path_finder.answer_store.answers), 1)

--- a/tests/functional/spec/features/routing/removes_completed_block.spec.js
+++ b/tests/functional/spec/features/routing/removes_completed_block.spec.js
@@ -1,0 +1,32 @@
+const helpers = require('../../../helpers');
+
+const NumberOfEmployeesTotalBlockPage = require('../../../pages/features/confirmation_question/number-of-employees-total-block.page.js');
+const ConfirmZeroEmployeesBlockPage = require('../../../pages/features/confirmation_question/confirm-zero-employees-block.page.js');
+const SummaryPage = require('../../../pages/features/confirmation_question/summary.page.js');
+
+describe('Feature: Routing incompletes block if routing backwards', function() {
+
+  describe('Given I have a confirmation Question', function() {
+
+    before('Get to summary', function () {
+      return helpers.openQuestionnaire('test_confirmation_question.json').then(() => {
+        return browser
+          .setValue(NumberOfEmployeesTotalBlockPage.answer(), 0)
+          .click(NumberOfEmployeesTotalBlockPage.submit())
+          .click(ConfirmZeroEmployeesBlockPage.yes())
+          .click(ConfirmZeroEmployeesBlockPage.submit())
+          .getUrl().should.eventually.contain(SummaryPage.pageName);
+      });
+    });
+
+    it('When I use browser back button and change confirmation to no then Summary should not be available', function () {
+      return browser
+        .back()
+        .isVisible(helpers.navigationLink('Summary')).should.eventually.be.true
+        .click(ConfirmZeroEmployeesBlockPage.no())
+        .click(ConfirmZeroEmployeesBlockPage.submit())
+        .isVisible(helpers.navigationLink('Summary')).should.eventually.be.false;
+    });
+
+  });
+});


### PR DESCRIPTION
### What is the context of this PR?
We have an issue where in MBS (will affect other surveys) if you select a routing option that routes you back to a previous block both blocks are still marked as complete. This means the summary could still be accessible (via browser back buttons/direct url only) and incorrect data can be submitted. By invalidating the block you're being routed from will mean that the summary is no longer available and the routing path will have to be revalidated.

### How to review 
Try to break MBS 
`test_confirmation_question.json` is essentially MBS with Navigation so you can see Summary availability.