### PR TITLE
Add ability to change routing within first section of test_section_su…

### DIFF
--- a/data/en/test_section_summary.json
+++ b/data/en/test_section_summary.json
@@ -92,14 +92,25 @@
                                         }
                                     ]
                                 }]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "insurance-type-answer",
+                                    "condition": "equals",
+                                    "value": "Both"
+                                }]
                             }]
-                        },
-                        {
-                            "id": "property-details-summary",
-                            "type": "SectionSummary"
                         }
                     ]
 
+                },
+                {
+                    "id": "property-details-summary-group",
+                    "title": "Property Details Summary",
+                    "blocks": [{
+                            "id": "property-details-summary",
+                            "type": "SectionSummary"
+                    }]
                 }
 
             ]
@@ -111,19 +122,18 @@
                 "id": "house-details",
                 "title": "House Details",
                 "skip_conditions": [{
-                        "when": [{
-                            "id": "insurance-type-answer",
-                            "condition": "equals",
-                            "value": "Contents"
-                        }]
-                    },
-                    {
-                        "when": [{
-                            "id": "insurance-type-answer",
-                            "condition": "not set"
-                        }]
-                    }
-                ],
+                    "when": [{
+                        "id": "insurance-type-answer",
+                        "condition": "equals",
+                        "value": "Contents"
+                    }]
+                },
+                {
+                    "when": [{
+                        "id": "insurance-type-answer",
+                        "condition": "not set"
+                    }]
+                }],
                 "blocks": [{
                         "id": "house-type",
                         "title": "House Details",
@@ -152,13 +162,30 @@
                                 ]
                             }]
                         }]
-                    },
-                    {
-                        "id": "household-details-summary",
-                        "type": "SectionSummary"
                     }
 
                 ]
+            },
+            {
+                "id": "household-details-summary-group",
+                "title": "Household Details Summary",
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "insurance-type-answer",
+                        "condition": "equals",
+                        "value": "Contents"
+                    }]
+                },
+                {
+                    "when": [{
+                        "id": "insurance-type-answer",
+                        "condition": "not set"
+                    }]
+                }],
+                "blocks": [{
+                        "id": "household-details-summary",
+                        "type": "SectionSummary"
+                }]
             }]
         },
         {
@@ -215,12 +242,12 @@
             "id": "summary-section",
             "title": "Summary",
             "groups": [{
+                "id": "summary-group",
+                "title": "Summary",
                 "blocks": [{
                     "id": "summary",
                     "type": "Summary"
-                }],
-                "id": "summary-group",
-                "title": "Summary"
+                }]
             }]
         }
     ]

--- a/tests/app/questionnaire/test_path_finder.py
+++ b/tests/app/questionnaire/test_path_finder.py
@@ -918,7 +918,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         completed_blocks = [
             Location('property-details', 0, 'insurance-type'),
             Location('property-details', 0, 'insurance-address'),
-            Location('address-length', 0, 'address-duration')
+            Location('address-length', 0, 'address-duration'),
         ]
 
         answer_store = AnswerStore()
@@ -926,7 +926,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         answer_store.add(Answer(answer_id='insurance-address-answer', value='123 Test Road'))
         answer_store.add(Answer(answer_id='address-duration-answer', value='No'))
 
-        summary_location = Location('address-length', 0, 'property-details-summary')
+        summary_location = Location('property-details-summary-group', 0, 'property-details-summary')
 
         path_finder = PathFinder(schema, answer_store, metadata={}, completed_blocks=completed_blocks)
 
@@ -940,7 +940,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
             Location('property-details', 0, 'insurance-type'),
             Location('property-details', 0, 'insurance-address'),
             Location('address-length', 0, 'address-duration'),
-            Location('address-length', 0, 'property-details-summary')
+            Location('property-details-summary-group', 0, 'property-details-summary')
         ]
 
         answer_store = AnswerStore()

--- a/tests/functional/spec/section_summary.spec.js
+++ b/tests/functional/spec/section_summary.spec.js
@@ -35,7 +35,6 @@ describe('Section Summary', function() {
         .click(PropertyDetailsSummaryPage.submit())
         .getUrl().should.eventually.contain(HouseHoldCompositionPage.pageName);
     });
-
   });
 
   describe('Given I start a Test Section Summary survey and complete to Final Summary', function() {
@@ -69,7 +68,21 @@ describe('Section Summary', function() {
         .click(InsuranceTypePage.submit())
         .getUrl().should.eventually.contain(PropertyDetailsSummaryPage.pageName);
     });
+  });
 
+  describe('Given I start a Test Section Summary survey and complete to the first Section Summary', function() {
+    it('When I select edit from Section Summary but change routing, Then I should be stepped through the section', function() {
+      return helpers.openQuestionnaire('test_section_summary.json').then(() => {
+        return browser
+          .click(InsuranceTypePage.both())
+          .click(InsuranceTypePage.submit())
+          .click(InsuranceAddressPage.submit())
+          .click(PropertyDetailsSummaryPage.insuranceTypeAnswerEdit())
+          .click(InsuranceTypePage.contents())
+          .click(InsuranceTypePage.submit())
+          .getUrl().should.eventually.contain(InsuranceAddressPage.pageName);
+      });
+    });
   });
 
 });


### PR DESCRIPTION
…mmary

### What is the context of this PR?
Just added a skip condition in the first section so we can test a change of routing within a section also

### How to review 
Run `test_section_summary.json` click `Both` option on the insurance type page, then in the section summary edit that question and change to either `Contents` or `Buildings` and user should be stepped through the section again as routing has changed