### PR TITLE
Revert Validator to latest

### DIFF
--- a/scripts/test_schemas.sh
+++ b/scripts/test_schemas.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-docker pull onsdigital/eq-schema-validator:eq-1947-date-range-validation
-validator="$(docker run -d -p 5001:5000 onsdigital/eq-schema-validator:eq-1947-date-range-validation)"
+docker pull onsdigital/eq-schema-validator
+validator="$(docker run -d -p 5001:5000 onsdigital/eq-schema-validator)"
 
 sleep 3
 


### PR DESCRIPTION
### What is the context of this PR?
An earlier merge overwrote the validator to a specific branch. Revert to pick up latest.
