### PR TITLE
Specify metadata in survey JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Python temp file
 *.py[cod]
 __pycache__
+.pytest_cache
 
 # C extensions
 *.so
@@ -50,6 +51,9 @@ venv
 *.iml
 *.iws
 
+# VS Code
+.vscode
+
 .DS_Store
 
 node_modules/
@@ -83,3 +87,5 @@ keys.yml
 secrets.yml
 
 requirements.txt
+
+.screenshots

--- a/app/authentication/authenticator.py
+++ b/app/authentication/authenticator.py
@@ -3,7 +3,6 @@ from uuid import uuid4
 from blinker import ANY
 from flask import session as cookie_session, current_app
 from flask_login import LoginManager, user_logged_out
-from sdc.crypto.exceptions import InvalidTokenException
 from sdc.crypto.decrypter import decrypt
 from structlog import get_logger
 
@@ -12,7 +11,7 @@ from app.authentication.user import User
 from app.data_model.session_data import SessionData
 from app.globals import get_questionnaire_store, get_session_store, create_session_store
 from app.keys import KEY_PURPOSE_AUTHENTICATION
-from app.storage.metadata_parser import is_valid_metadata
+
 from app.settings import EQ_SESSION_ID, USER_IK
 
 logger = get_logger()
@@ -114,18 +113,14 @@ def store_session(metadata):
 
 
 def decrypt_token(encrypted_token):
-    logger.debug('decrypting token')
-    if not encrypted_token or encrypted_token is None:
+    if not encrypted_token:
         raise NoTokenException('Please provide a token')
 
+    logger.debug('decrypting token')
     decrypted_token = decrypt(token=encrypted_token,
                               key_store=current_app.eq['key_store'],
                               key_purpose=KEY_PURPOSE_AUTHENTICATION,
                               leeway=current_app.config['EQ_JWT_LEEWAY_IN_SECONDS'])
-
-    valid, field = is_valid_metadata(decrypted_token)
-    if not valid:
-        raise InvalidTokenException('Missing value {}'.format(field))
 
     logger.debug('token decrypted')
     return decrypted_token

--- a/app/helpers/template_helper.py
+++ b/app/helpers/template_helper.py
@@ -36,7 +36,7 @@ def with_metadata(func):
         metadata = get_metadata(current_user)
         metadata_context = build_metadata_context(metadata)
 
-        return func(*args, meta=metadata_context, **kwargs)
+        return func(*args, metadata=metadata_context, **kwargs)
 
     return metadata_wrapper
 
@@ -52,12 +52,11 @@ def with_questionnaire_url_prefix(func):
     def url_prefix_wrapper(*args, **kwargs):
         metadata = get_metadata(current_user)
         metadata_context = build_metadata_context(metadata)
-        survey_data = metadata_context['survey']
 
         url_prefix = '/questionnaire/{}/{}/{}'.format(
-            survey_data['eq_id'],
-            survey_data['form_type'],
-            survey_data['collection_id'],
+            metadata_context['eq_id'],
+            metadata_context['form_type'],
+            metadata_context['collection_id'],
         )
 
         return func(*args, url_prefix=url_prefix, **kwargs)

--- a/app/submitter/converter.py
+++ b/app/submitter/converter.py
@@ -85,8 +85,10 @@ def _build_metadata(metadata):
     downstream_metadata = {
         'user_id': metadata['user_id'],
         'ru_ref': metadata['ru_ref'],
-        'ref_period_start_date': metadata['ref_p_start_date'],
     }
+
+    if metadata.get('ref_p_start_date'):
+        downstream_metadata['ref_period_start_date'] = metadata['ref_p_start_date']
     if metadata.get('ref_p_end_date'):
         downstream_metadata['ref_period_end_date'] = metadata['ref_p_end_date']
 

--- a/app/templates/introduction.html
+++ b/app/templates/introduction.html
@@ -25,14 +25,14 @@
             <div class="grid__col col-7@m">
 
                 <h2 class="saturn">You are completing this for
-                    <span>{{ meta.respondent.name}}</span>
-                    {% if meta.respondent.trading_as %}
-                        <span class="trading_as">(<span class="trad_as">{{meta.respondent.trading_as }}</span>)</span>
+                    <span>{{ metadata.ru_name }}</span>
+                    {% if metadata.trad_as %}
+                        <span class="trading_as">(<span class="trad_as">{{ metadata.trad_as }}</span>)</span>
                     {% endif %}
                 </h2>
 
                 <p class="mars">If the company details or structure have changed contact us on {{ helpers.telephone_number() }}
-                    or email {{ helpers.email_address('details-changed-title', subject="Change of details reference " + meta.respondent.respondent_id) }}.
+                    or email {{ helpers.email_address('details-changed-title', subject="Change of details reference " + metadata.ru_ref) }}.
                 </p>
 
             </div>

--- a/app/templates/partials/header.html
+++ b/app/templates/partials/header.html
@@ -18,9 +18,9 @@
                     <dt class="info__dt first"><abbr title="Survey identification code">ID:</abbr></dt>
                     <dd class="info__dd">{{ survey_id or 'N/A'}}</dd>
                     <dt class="info__dt">Period:</dt>
-                    <dd class="info__dd">{{ meta.survey.period_str or 'N/A'}}</dd>
+                    <dd class="info__dd">{{ metadata.period_str or 'N/A'}}</dd>
                     <dt class="info__dt"><abbr title="Reference number">Ref:</abbr></dt>
-                    <dd class="info__dd last">{{ meta.respondent.respondent_id or 'N/A'}}</dd>
+                    <dd class="info__dd last">{{ metadata.ru_ref or 'N/A'}}</dd>
                 </dl>
             </div>
             {% endif %}

--- a/app/templates/partials/topbar.html
+++ b/app/templates/partials/topbar.html
@@ -2,8 +2,8 @@
     <div class="bar__inner container">
         <div class="bar__title venus">{{ survey_title }}
             <span class="mars">
-            {% if meta and meta.respondent.name %}
-                for&nbsp;<span>{{ meta.respondent.name }}</span>
+            {% if meta and metadata.ru_name %}
+                for&nbsp;<span>{{ metadata.ru_name }}</span>
             {% endif %}
             {% if content and content.variables and content.variables.period %}
                 <p class="u-mb-no pluto">Period:

--- a/app/templates/thank-you.html
+++ b/app/templates/thank-you.html
@@ -10,8 +10,8 @@
 
 <div class="u-mb-s">
     <div class="panel panel--simple panel--success panel--spacious">
-        <p class="mars">Your answers were submitted for <b>{{meta.respondent.ru_name}}</b> on {{meta.survey.submitted_time|format_datetime}}</p>
-        <p class="mars">Transaction ID: <b>{{meta.respondent.tx_id}}</b></p>
+        <p class="mars">Your answers were submitted for <b>{{metadata.ru_name}}</b> on {{metadata.submitted_time|format_datetime}}</p>
+        <p class="mars">Transaction ID: <b>{{metadata.tx_id}}</b></p>
     </div>
 </div>
 

--- a/app/templates/view-submission.html
+++ b/app/templates/view-submission.html
@@ -11,8 +11,8 @@
 
 <div class="u-mb-s">
     <div class="panel panel--simple panel--success panel--spacious">
-        <p class="mars">Your answers were submitted for <b>{{meta.respondent.ru_name}}</b> on {{meta.survey.submitted_time|format_datetime}}</p>
-        <p class="mars">Transaction ID: <b>{{meta.respondent.tx_id}}</b></p>
+        <p class="mars">Your answers were submitted for <b>{{metadata.ru_name}}</b> on {{metadata.submitted_time|format_datetime}}</p>
+        <p class="mars">Transaction ID: <b>{{metadata.tx_id}}</b></p>
     </div>
 </div>
 

--- a/app/templating/metadata_context.py
+++ b/app/templating/metadata_context.py
@@ -1,61 +1,38 @@
 from app.libs.utils import convert_tx_id
 from app.templating.schema_context import json_and_html_safe
+from app.templating.schema_context import build_schema_metadata
 
 
 def build_metadata_context(metadata):
     """
-    :param metadata: user metadata
+    Builds the metadata context using eq claims and schema defined metadata
+    :param metadata: token metadata
     :return: metadata context
     """
-    render_data = {
-        'survey': _build_survey_meta(metadata),
-        'respondent': _build_respondent_meta(metadata),
-    }
-    return render_data
-
-
-def _build_respondent_meta(metadata):
-    respondent_id = None
-    name = None
-    trading_as = None
-
-    if metadata:
-        respondent_id = metadata['ru_ref']
-        name = metadata['ru_name']
-        trading_as = metadata['trad_as']
-
-    respondent_meta = {
-        'tx_id': convert_tx_id(metadata['tx_id']),
-        'respondent_id': json_and_html_safe(respondent_id),
-        'name': json_and_html_safe(name),
-        'trading_as': json_and_html_safe(trading_as),
-    }
-    return respondent_meta
-
-
-def _build_survey_meta(metadata):
-    return {
-        'return_by': metadata['return_by'],
-        'start_date': metadata['ref_p_start_date'],
-        'end_date': metadata['ref_p_end_date'],
-        'employment_date': metadata['employment_date'],
-        'region_code': json_and_html_safe(metadata['region_code']) if 'region_code' in metadata else None,
-        'period_str': json_and_html_safe(metadata['period_str']),
+    eq_context = {
         'eq_id': json_and_html_safe(metadata['eq_id']),
         'collection_id': json_and_html_safe(metadata['collection_exercise_sid']),
         'form_type': json_and_html_safe(metadata['form_type']),
+        'ru_ref': json_and_html_safe(metadata['ru_ref']),
+        'tx_id': json_and_html_safe(metadata['tx_id'])
     }
+
+    eq_context.update(build_schema_metadata(metadata))
+
+    return eq_context
 
 
 def build_metadata_context_for_survey_completed(session_data):
-    return {
-        'survey': {
-            'period_str': session_data.period_str,
-            'submitted_time': session_data.submitted_time
-        },
-        'respondent': {
-            'tx_id': convert_tx_id(session_data.tx_id),
-            'ru_name': session_data.ru_name,
-            'ru_ref': session_data.ru_ref,
-        },
+
+    metadata_context = {
+        'submitted_time': session_data.submitted_time,
+        'tx_id': convert_tx_id(session_data.tx_id),
+        'ru_ref': session_data.ru_ref
     }
+
+    if session_data.period_str:
+        metadata_context['period_str'] = session_data.period_str
+    if session_data.ru_name:
+        metadata_context['ru_name'] = session_data.ru_name
+
+    return metadata_context

--- a/app/templating/schema_context.py
+++ b/app/templating/schema_context.py
@@ -13,8 +13,7 @@ def build_schema_context(metadata, answer_store, answer_ids_on_path, group_insta
     :return: questionnaire schema context
     """
     return {
-        'exercise': _build_exercise(metadata),
-        'respondent': _build_respondent(metadata),
+        'metadata': build_schema_metadata(metadata),
         'answers': _build_answers(answer_store, answer_ids_on_path),
         'group_instance': group_instance,
     }
@@ -46,27 +45,27 @@ def _build_answers(answer_store, answer_ids_on_path):
     return answers
 
 
-def _build_exercise(metadata):
-    return {
-        'start_date': metadata['ref_p_start_date'],
-        'end_date': metadata['ref_p_end_date'],
-        'period_str': json_and_html_safe(metadata['period_str']),
-        'employment_date': metadata['employment_date'],
-        'return_by': metadata['return_by'],
-        'region_code': json_and_html_safe(metadata['region_code']),
-    }
+def build_schema_metadata(metadata):
 
+    schema_metadata = g.schema.json['metadata']
+    parsed = {key: json_and_html_safe(metadata[key]) for key in schema_metadata.keys() if key in metadata}
+    trad_as = json_and_html_safe(metadata.get('trad_as'))
+    ru_name = json_and_html_safe(metadata.get('ru_name'))
 
-def _build_respondent(metadata):
-    return {
-        'ru_name': json_and_html_safe(metadata['ru_name']),
-        'trad_as': json_and_html_safe(metadata['trad_as']),
-        'trad_as_or_ru_name': json_and_html_safe(metadata['trad_as'] or metadata['ru_name']),
-    }
+    if trad_as:
+        parsed['trad_as'] = trad_as
+
+    if ru_name:
+        parsed['ru_name'] = ru_name
+
+    if 'trad_as_or_ru_name' in schema_metadata:
+        parsed['trad_as_or_ru_name'] = trad_as or ru_name
+
+    return parsed
 
 
 def json_and_html_safe(data):
-    if isinstance(data, str):
+    if data and isinstance(data, str):
         return escape(data.replace('\\', r'\\'))
     return data
 

--- a/app/themes/northernireland/templates/introduction.html
+++ b/app/themes/northernireland/templates/introduction.html
@@ -25,14 +25,14 @@
             <div class="grid__col col-7@m">
 
                 <h2 class="saturn">You are completing this for
-                    <span>{{ meta.respondent.name}}</span>
-                    {% if meta.respondent.trading_as %}
-                        <span class="trading_as">(<span class="trad_as">{{meta.respondent.trading_as }}</span>)</span>
+                    <span>{{ metadata.ru_name }}</span>
+                    {% if metadata.trad_as %}
+                        <span class="trading_as">(<span class="trad_as">{{ metadata.trad_as }}</span>)</span>
                     {% endif %}
                 </h2>
 
                 <p class="mars">If the company details or structure have changed contact us on {{ helpers.telephone_number() }}
-                    or email {{ helpers.email_address('details-changed-title', subject="Change of details reference " + meta.respondent.respondent_id) }}.
+                    or email {{ helpers.email_address('details-changed-title', subject="Change of details reference " + metadata.ru_ref) }}.
                 </p>
 
             </div>

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -225,7 +225,7 @@ def get_thank_you(eq_id, form_type):  # pylint: disable=unused-argument
 
         return render_theme_template(schema.json['theme'],
                                      template_name='thank-you.html',
-                                     meta=metadata_context,
+                                     metadata=metadata_context,
                                      analytics_ua_id=current_app.config['EQ_UA_ID'],
                                      survey_id=schema.json['survey_id'],
                                      survey_title=TemplateRenderer.safe_content(schema.json['title']),
@@ -278,7 +278,7 @@ def get_view_submission(eq_id, form_type):  # pylint: disable=unused-argument
 
             return render_theme_template(g.schema.json['theme'],
                                          template_name='view-submission.html',
-                                         meta=metadata_context,
+                                         metadata=metadata_context,
                                          analytics_ua_id=current_app.config['EQ_UA_ID'],
                                          survey_id=g.schema.json['survey_id'],
                                          survey_title=TemplateRenderer.safe_content(g.schema.json['title']),

--- a/data/en/0_rogue_one.json
+++ b/data/en/0_rogue_one.json
@@ -7,6 +7,14 @@
     "description": "Test with a confirmation page instead of a summary",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/0_star_wars.json
+++ b/data/en/0_star_wars.json
@@ -7,6 +7,23 @@
     "theme": "starwars",
     "legal_basis": "Voluntary",
     "description": "Kitchen sink test for the Star Wars questionnaire",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "employment_date": {
+            "validator": "date"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{
@@ -561,7 +578,7 @@
                                     "type": "Date"
                                 }
                             ],
-                            "description": "It could be between {{exercise.start_date|format_date}} and {{exercise.end_date|format_date}}. But that might just be a test",
+                            "description": "It could be between {{metadata['ref_p_start_date']|format_date}} and {{metadata['ref_p_end_date']|format_date}}. But that might just be a test",
                             "id": "empire-strikes-back-to-question",
                             "title": "When was The Empire Strikes Back released?",
                             "type": "DateRange"
@@ -668,7 +685,7 @@
                             "type": "General"
                         }
                     ],
-                    "title": "On {{exercise.employment_date|format_date}} how many were employed?"
+                    "title": "On {{metadata['employment_date']|format_date}} how many were employed?"
                 },
                 {
                     "type": "Question",

--- a/data/en/1_0005.json
+++ b/data/en/1_0005.json
@@ -7,6 +7,26 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "period_str": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "introduction-section",
             "title": "Introduction",
@@ -330,7 +350,7 @@
                                 ]
                             },
                             "id": "weekly-pay-paid-employees-question",
-                            "title": "What was the <em>number</em> of <em>weekly paid</em> employees paid in the last week of {{exercise.period_str}}?",
+                            "title": "What was the <em>number</em> of <em>weekly paid</em> employees paid in the last week of {{metadata['period_str']}}?",
                             "type": "General"
                         }],
                         "title": "Weekly Pay",
@@ -380,7 +400,7 @@
                                 ]
                             },
                             "id": "weekly-pay-gross-pay-question",
-                            "title": "What was the <em>total gross weekly pay</em> paid to employees in the last week of {{exercise.period_str}}?",
+                            "title": "What was the <em>total gross weekly pay</em> paid to employees in the last week of {{metadata['period_str']}}?",
                             "type": "General"
                         }],
                         "title": "Weekly Pay",
@@ -415,7 +435,7 @@
                                 "mandatory": true
                             }],
                             "id": "confirm-weekly-pay-gross-pay-question",
-                            "title": "The <em>total gross weekly pay</em> paid to employees in the last week of {{exercise.period_str}} was <em>£0</em>, is this correct?"
+                            "title": "The <em>total gross weekly pay</em> paid to employees in the last week of {{metadata['period_str']}} was <em>£0</em>, is this correct?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -477,7 +497,7 @@
                                 }
                             ],
                             "id": "weekly-pay-breakdown-question",
-                            "title": "Of the <em>{{answers['weekly-pay-gross-pay-answer']|format_currency}}</em> paid to <em>weekly</em> paid employees in the last week of {{exercise.period_str}}, what other amounts were paid? ",
+                            "title": "Of the <em>{{answers['weekly-pay-gross-pay-answer']|format_currency}}</em> paid to <em>weekly</em> paid employees in the last week of {{metadata['period_str']}}, what other amounts were paid? ",
                             "type": "Calculated",
                             "calculations": [{
                                 "calculation_type": "sum",
@@ -524,7 +544,7 @@
                                 "q_code": "90w",
                                 "type": "Radio"
                             }],
-                            "description": "<p>This is your own interpretation of whether there has been a significant change in {{respondent.trad_as_or_ru_name}}’s figures compared with the previous month.</p><p>Also consider whether there has been a significant change from the same month in the previous year. </p>",
+                            "description": "<p>This is your own interpretation of whether there has been a significant change in {{metadata['trad_as_or_ru_name']}}’s figures compared with the previous month.</p><p>Also consider whether there has been a significant change from the same month in the previous year. </p>",
                             "guidance": {
                                 "content": [{
                                     "title": "Include:",
@@ -759,7 +779,7 @@
                                 ]
                             },
                             "id": "fortnightly-pay-paid-employees-question",
-                            "title": "What was the <em>number</em> of <em>fortnightly paid</em> employees paid in the last week of {{exercise.period_str}}?",
+                            "title": "What was the <em>number</em> of <em>fortnightly paid</em> employees paid in the last week of {{metadata['period_str']}}?",
                             "type": "General"
                         }],
                         "title": "Fortnightly Pay",
@@ -809,7 +829,7 @@
                                 ]
                             },
                             "id": "fortnightly-pay-gross-pay-question",
-                            "title": "What was the <em>total gross fortnightly pay</em> paid to employees in the last week of {{exercise.period_str}}?",
+                            "title": "What was the <em>total gross fortnightly pay</em> paid to employees in the last week of {{metadata['period_str']}}?",
                             "type": "General"
                         }],
                         "title": "Fortnightly Pay",
@@ -844,7 +864,7 @@
                                 "mandatory": true
                             }],
                             "id": "confirm-fortnightly-pay-gross-pay-question",
-                            "title": "The <em>total gross fortnightly pay</em> paid to employees in the last week of {{exercise.period_str}} was <em>£0</em>, is this correct?"
+                            "title": "The <em>total gross fortnightly pay</em> paid to employees in the last week of {{metadata['period_str']}} was <em>£0</em>, is this correct?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -920,7 +940,7 @@
                                     "equals"
                                 ]
                             }],
-                            "title": "Of the <em>{{answers['fortnightly-pay-gross-pay-answer']|format_currency}}</em> paid to <em>fortnightly</em> paid employees in the last week of {{exercise.period_str}}, what other amounts were paid?",
+                            "title": "Of the <em>{{answers['fortnightly-pay-gross-pay-answer']|format_currency}}</em> paid to <em>fortnightly</em> paid employees in the last week of {{metadata['period_str']}}, what other amounts were paid?",
                             "guidance": {
                                 "content": [{
                                     "title": "Include:",
@@ -953,7 +973,7 @@
                                 "q_code": "90f",
                                 "type": "Radio"
                             }],
-                            "description": "<p>This is your own interpretation of whether there has been a significant change in  {{respondent.trad_as_or_ru_name}}’s figures compared with the previous month.</p><p>Also consider whether there has been a significant change from the same month in the previous year.</p>",
+                            "description": "<p>This is your own interpretation of whether there has been a significant change in  {{metadata['trad_as_or_ru_name']}}’s figures compared with the previous month.</p><p>Also consider whether there has been a significant change from the same month in the previous year.</p>",
                             "guidance": {
                                 "content": [{
                                     "title": "Include:",
@@ -1188,7 +1208,7 @@
                                 ]
                             },
                             "id": "calendar-monthly-pay-paid-employees-question",
-                            "title": "What was the <em>number</em> of <em>calendar monthly</em> paid employees paid in {{exercise.period_str}}?",
+                            "title": "What was the <em>number</em> of <em>calendar monthly</em> paid employees paid in {{metadata['period_str']}}?",
                             "type": "General"
                         }],
                         "title": "Calendar Monthly Pay",
@@ -1211,7 +1231,7 @@
                                 }
                             }],
                             "id": "calendar-monthly-pay-gross-pay-question",
-                            "title": "What was the <em>total gross calendar monthly pay</em> paid to employees in {{exercise.period_str}}?",
+                            "title": "What was the <em>total gross calendar monthly pay</em> paid to employees in {{metadata['period_str']}}?",
                             "type": "General",
                             "guidance": {
                                 "content": [{
@@ -1272,7 +1292,7 @@
                                 "mandatory": true
                             }],
                             "id": "confirm-calendar-monthly-pay-gross-pay-question",
-                            "title": "The <em>total gross calendar monthly pay</em> paid to employees in {{exercise.period_str}} was <em>£0</em>, is this correct?"
+                            "title": "The <em>total gross calendar monthly pay</em> paid to employees in {{metadata['period_str']}} was <em>£0</em>, is this correct?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -1334,7 +1354,7 @@
                                     "less than"
                                 ]
                             }],
-                            "title": "Of the <em>{{answers['calendar-monthly-pay-gross-pay-answer']|format_currency}}</em> paid to <em>calendar monthly</em> paid employees in {{exercise.period_str}}, what other amounts were paid?",
+                            "title": "Of the <em>{{answers['calendar-monthly-pay-gross-pay-answer']|format_currency}}</em> paid to <em>calendar monthly</em> paid employees in {{metadata['period_str']}}, what other amounts were paid?",
                             "guidance": {
                                 "content": [{
                                     "title": "Include:",
@@ -1370,7 +1390,7 @@
                             "id": "calendar-monthly-pay-significant-changes-paid-employees-question",
                             "title": "Did any significant changes occur to the <em>total pay or number</em> of <em>calendar monthly</em> paid employees?",
                             "type": "General",
-                            "description": "<p>This is your own interpretation of whether there has been a significant change in  {{respondent.trad_as_or_ru_name}}’s figures compared with the previous month.</p><p>Also consider whether there has been a significant change from the same month in the previous year.</p>",
+                            "description": "<p>This is your own interpretation of whether there has been a significant change in  {{metadata['trad_as_or_ru_name']}}’s figures compared with the previous month.</p><p>Also consider whether there has been a significant change from the same month in the previous year.</p>",
                             "guidance": {
                                 "content": [{
                                     "title": "Include:",
@@ -1602,7 +1622,7 @@
                                 ]
                             },
                             "id": "four-weekly-pay-paid-employees-question",
-                            "title": "What was the <em>number</em> of <em>four weekly</em> paid employees paid in {{exercise.period_str}}?",
+                            "title": "What was the <em>number</em> of <em>four weekly</em> paid employees paid in {{metadata['period_str']}}?",
                             "type": "General"
                         }],
                         "title": "Four Weekly Pay",
@@ -1625,7 +1645,7 @@
                                 }
                             }],
                             "id": "four-weekly-pay-gross-pay-question",
-                            "title": "What was the <em>total gross four weekly pay</em> paid to employees in {{exercise.period_str}}?",
+                            "title": "What was the <em>total gross four weekly pay</em> paid to employees in {{metadata['period_str']}}?",
                             "type": "General",
                             "guidance": {
                                 "content": [{
@@ -1686,7 +1706,7 @@
                                 "mandatory": true
                             }],
                             "id": "confirm-four-weekly-gross-pay-question",
-                            "title": "The <em>total gross four weekly pay</em> paid to employees in {{exercise.period_str}} was <em>£0</em>, is this correct?"
+                            "title": "The <em>total gross four weekly pay</em> paid to employees in {{metadata['period_str']}} was <em>£0</em>, is this correct?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -1748,7 +1768,7 @@
                                     "less than"
                                 ]
                             }],
-                            "title": "Of the <em>{{answers['four-weekly-pay-gross-pay-answer']|format_currency}}</em> paid to <em>four weekly</em> paid employees in {{exercise.period_str}}, what other amounts were paid?",
+                            "title": "Of the <em>{{answers['four-weekly-pay-gross-pay-answer']|format_currency}}</em> paid to <em>four weekly</em> paid employees in {{metadata['period_str']}}, what other amounts were paid?",
                             "guidance": {
                                 "content": [{
                                     "title": "Include:",
@@ -1784,7 +1804,7 @@
                             "id": "four-weekly-pay-significant-changes-paid-employees-question",
                             "title": "Did any significant changes occur to the <em>total pay or number</em> of <em>four weekly</em> paid employees?",
                             "type": "General",
-                            "description": "<p>This is your own interpretation of whether there has been a significant change in  {{respondent.trad_as_or_ru_name}}’s figures compared with the previous month.</p><p>Also consider whether there has been a significant change from the same month in the previous year.</p>",
+                            "description": "<p>This is your own interpretation of whether there has been a significant change in  {{metadata['trad_as_or_ru_name']}}’s figures compared with the previous month.</p><p>Also consider whether there has been a significant change from the same month in the previous year.</p>",
                             "guidance": {
                                 "content": [{
                                     "title": "Include:",
@@ -2023,7 +2043,7 @@
                                 ]
                             },
                             "id": "five-weekly-pay-paid-employees-question",
-                            "title": "What was the <em>number</em> of <em>five weekly</em> paid employees paid in {{exercise.period_str}}?",
+                            "title": "What was the <em>number</em> of <em>five weekly</em> paid employees paid in {{metadata['period_str']}}?",
                             "type": "General"
                         }],
                         "title": "Five Weekly Pay",
@@ -2073,7 +2093,7 @@
                                 ]
                             },
                             "id": "five-weekly-pay-gross-pay-question",
-                            "title": "What was the <em>total gross five weekly pay</em> paid to employees in {{exercise.period_str}}?",
+                            "title": "What was the <em>total gross five weekly pay</em> paid to employees in {{metadata['period_str']}}?",
                             "type": "General"
                         }],
                         "title": "Five Weekly Pay",
@@ -2108,7 +2128,7 @@
                                 "mandatory": true
                             }],
                             "id": "confirm-five-weekly-gross-pay-question",
-                            "title": "The <em>total gross five weekly pay</em> paid to employees {{exercise.period_str}} was <em>£0</em>, is this correct?"
+                            "title": "The <em>total gross five weekly pay</em> paid to employees {{metadata['period_str']}} was <em>£0</em>, is this correct?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -2158,7 +2178,7 @@
                                 }
                             ],
                             "id": "five-weekly-pay-breakdown-question",
-                            "title": "Of the <em>{{answers['five-weekly-pay-gross-pay-answer']|format_currency}}</em> paid to <em>five weekly paid employees</em> in {{exercise.period_str}}, what other amounts were paid?",
+                            "title": "Of the <em>{{answers['five-weekly-pay-gross-pay-answer']|format_currency}}</em> paid to <em>five weekly paid employees</em> in {{metadata['period_str']}}, what other amounts were paid?",
                             "type": "Calculated",
                             "calculations": [{
                                 "calculation_type": "sum",
@@ -2206,7 +2226,7 @@
                             "id": "five-weekly-pay-significant-changes-paid-employees-question",
                             "title": "Did any significant changes occur to the <em>total pay or number</em> of <em>five weekly</em> paid employees?",
                             "type": "General",
-                            "description": "<p>This is your own interpretation of whether there has been a significant change in  {{respondent.trad_as_or_ru_name}}’s figures compared with the previous month.</p><p>Also consider whether there has been a significant change from the same month in the previous year.</p>",
+                            "description": "<p>This is your own interpretation of whether there has been a significant change in  {{metadata['trad_as_or_ru_name']}}’s figures compared with the previous month.</p><p>Also consider whether there has been a significant change from the same month in the previous year.</p>",
                             "guidance": {
                                 "content": [{
                                     "title": "Include:",
@@ -2460,6 +2480,6 @@
     "theme": "default",
     "title": "Monthly Wages and Salaries Survey",
     "variables": {
-        "period": "{{ format_date_range(exercise.start_date, exercise.end_date) }}"
+        "period": "{{ format_date_range(metadata['ref_p_start_date'], metadata['ref_p_end_date']) }}"
     }
 }

--- a/data/en/1_0102.json
+++ b/data/en/1_0102.json
@@ -8,11 +8,28 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "variables": {
-        "period": "{{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}"
+        "period": "{{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}"
     },
     "view_submitted_response": {
         "enabled": true,
         "duration": 900
+    },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
     },
     "sections": [{
         "id": "default-section",
@@ -106,7 +123,7 @@
                             "mandatory": true
                         }],
                         "id": "reporting-period-choice-question",
-                        "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
+                        "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
                     }],
                     "type": "Question",
                     "title": "Reporting period",
@@ -185,7 +202,7 @@
                             "default": 0
                         }],
                         "id": "total-turnover-question",
-                        "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total retail turnover</em>?",
+                        "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>total retail turnover</em>?",
                         "type": "General"
                     }],
                     "title": "Retail Turnover"
@@ -219,7 +236,7 @@
                             "mandatory": true
                         }],
                         "id": "confirm-zero-turnover-question",
-                        "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, the value of the total retail turnover was <em>£0</em>, is this correct?"
+                        "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total retail turnover was <em>£0</em>, is this correct?"
                     }],
                     "routing_rules": [{
                             "goto": {
@@ -312,9 +329,9 @@
                             "q_code": "146a",
                             "type": "Radio"
                         }],
-                        "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                        "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
                         "id": "significant-change-question",
-                        "title": "Did any significant changes occur to the total retail turnover for {{respondent.trad_as_or_ru_name}}?",
+                        "title": "Did any significant changes occur to the total retail turnover for {{metadata['trad_as_or_ru_name']}}?",
                         "type": "General"
                     }],
                     "title": "Changes in total retail turnover",
@@ -366,7 +383,7 @@
                             "type": "Checkbox"
                         }],
                         "id": "reason-for-change-question",
-                        "title": "Please indicate the reasons for any changes in the total retail turnover for {{respondent.trad_as_or_ru_name}}",
+                        "title": "Please indicate the reasons for any changes in the total retail turnover for {{metadata['trad_as_or_ru_name']}}",
                         "type": "General"
                     }],
                     "title": "Changes in total retail turnover"
@@ -404,7 +421,7 @@
                         }],
                         "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
                         "id": "change-comment-question",
-                        "title": "Please describe the changes in total retail turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+                        "title": "Please describe the changes in total retail turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
                         "type": "General"
                     }],
                     "title": "Changes in total retail turnover"

--- a/data/en/1_0112.json
+++ b/data/en/1_0112.json
@@ -11,6 +11,26 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "employment_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{
@@ -148,7 +168,7 @@
                         }
                     ],
                     "questions": [{
-                        "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?",
+                        "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?",
                         "type": "General",
                         "id": "reporting-period-choice-question",
                         "answers": [{
@@ -229,7 +249,7 @@
                             "default": 0
                         }],
                         "id": "total-turnover-question",
-                        "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total retail turnover</em>?",
+                        "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>total retail turnover</em>?",
                         "type": "General"
                     }],
                     "title": "Retail Turnover"
@@ -263,7 +283,7 @@
                             "mandatory": true
                         }],
                         "id": "confirm-zero-turnover-question",
-                        "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, the value of the total retail turnover was <em>£0</em>, is this correct?"
+                        "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total retail turnover was <em>£0</em>, is this correct?"
                     }],
                     "routing_rules": [{
                             "goto": {
@@ -344,9 +364,9 @@
                             "q_code": "146a",
                             "type": "Radio"
                         }],
-                        "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                        "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
                         "id": "significant-change-question",
-                        "title": "Did any significant changes occur to the total retail turnover for {{respondent.trad_as_or_ru_name}}?",
+                        "title": "Did any significant changes occur to the total retail turnover for {{metadata['trad_as_or_ru_name']}}?",
                         "type": "General"
                     }],
                     "title": "Changes in total retail turnover"
@@ -404,7 +424,7 @@
                             "type": "Checkbox"
                         }],
                         "id": "reason-for-change-question",
-                        "title": "Please indicate the reasons for any changes in the total retail turnover for {{respondent.trad_as_or_ru_name}}",
+                        "title": "Please indicate the reasons for any changes in the total retail turnover for {{metadata['trad_as_or_ru_name']}}",
                         "type": "General"
                     }],
                     "title": "Changes in total retail turnover"
@@ -449,7 +469,7 @@
                         }],
                         "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
                         "id": "change-comment-question",
-                        "title": "Please describe the changes in total retail turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+                        "title": "Please describe the changes in total retail turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
                         "type": "General"
                     }],
                     "title": "Changes in total retail turnover"
@@ -488,7 +508,7 @@
                         }],
                         "description": "<p>An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.</p>",
                         "id": "total-number-employees-question",
-                        "title": "On {{exercise.employment_date|format_date}} what was the number of employees for {{respondent.trad_as_or_ru_name}}?",
+                        "title": "On {{metadata['employment_date']|format_date}} what was the number of employees for {{metadata['trad_as_or_ru_name']}}?",
                         "type": "General"
                     }],
                     "title": "Employees"
@@ -522,7 +542,7 @@
                             "mandatory": true
                         }],
                         "id": "confirm-zero-employees-question",
-                        "title": "On {{exercise.employment_date|format_date}}, the number of employees for {{respondent.trad_as_or_ru_name}} was <em>0</em>, is this correct?"
+                        "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{metadata['trad_as_or_ru_name']}} was <em>0</em>, is this correct?"
                     }],
                     "routing_rules": [{
                             "goto": {
@@ -634,7 +654,7 @@
                             }
                         ],
                         "id": "employee-breakdown-questions",
-                        "title": "Of the <em>{{answers['total-number-employees']|format_number}}</em> total employees employed on {{exercise.employment_date|format_date}}, please specify the number of:",
+                        "title": "Of the <em>{{answers['total-number-employees']|format_number}}</em> total employees employed on {{metadata['employment_date']|format_date}}, please specify the number of:",
                         "type": "Calculated"
                     }],
                     "title": "Employees"

--- a/data/en/1_0203.json
+++ b/data/en/1_0203.json
@@ -8,11 +8,28 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "variables": {
-        "period": "{{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}"
+        "period": "{{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}"
     },
     "view_submitted_response": {
         "enabled": true,
         "duration": 900
+    },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
     },
     "sections": [{
         "id": "default-section",
@@ -196,7 +213,7 @@
                         }
                     ],
                     "questions": [{
-                        "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?",
+                        "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?",
                         "type": "General",
                         "id": "reporting-period-choice-question",
                         "answers": [{
@@ -279,7 +296,7 @@
                         }],
                         "description": "",
                         "id": "total-turnover-question",
-                        "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total retail turnover</em>?",
+                        "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>total retail turnover</em>?",
                         "type": "General"
                     }],
                     "title": "Retail Turnover"
@@ -313,7 +330,7 @@
                             "mandatory": true
                         }],
                         "id": "confirm-zero-turnover-question",
-                        "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, the value of the total retail turnover was <em>£0</em>, is this correct?"
+                        "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total retail turnover was <em>£0</em>, is this correct?"
                     }],
                     "routing_rules": [{
                             "goto": {
@@ -624,9 +641,9 @@
                             "q_code": "146a",
                             "type": "Radio"
                         }],
-                        "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                        "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
                         "id": "significant-change-question",
-                        "title": "Did any significant changes occur to the total retail turnover for {{respondent.trad_as_or_ru_name}}?",
+                        "title": "Did any significant changes occur to the total retail turnover for {{metadata['trad_as_or_ru_name']}}?",
                         "type": "General"
                     }],
                     "title": "Changes in total retail turnover",
@@ -680,7 +697,7 @@
                             "type": "Checkbox"
                         }],
                         "id": "reason-for-change-question",
-                        "title": "Please indicate the reasons for any changes in the total retail turnover for {{respondent.trad_as_or_ru_name}}",
+                        "title": "Please indicate the reasons for any changes in the total retail turnover for {{metadata['trad_as_or_ru_name']}}",
                         "type": "General"
                     }],
                     "title": "Changes in total retail turnover"
@@ -718,7 +735,7 @@
                         }],
                         "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
                         "id": "change-comment-question",
-                        "title": "Please describe the changes in total retail turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+                        "title": "Please describe the changes in total retail turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
                         "type": "General"
                     }],
                     "title": "Changes in total retail turnover"

--- a/data/en/1_0205.json
+++ b/data/en/1_0205.json
@@ -8,11 +8,28 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "variables": {
-        "period": "{{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}"
+        "period": "{{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}"
     },
     "view_submitted_response": {
         "enabled": true,
         "duration": 900
+    },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
     },
     "sections": [{
         "id": "default-section",
@@ -212,7 +229,7 @@
                         }
                     ],
                     "questions": [{
-                        "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?",
+                        "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?",
                         "type": "General",
                         "id": "reporting-period-choice-question",
                         "answers": [{
@@ -296,7 +313,7 @@
                         }],
                         "description": "",
                         "id": "total-turnover-question",
-                        "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total retail turnover</em>?",
+                        "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>total retail turnover</em>?",
                         "type": "General"
                     }],
                     "title": "Retail Turnover"
@@ -330,7 +347,7 @@
                             "mandatory": true
                         }],
                         "id": "confirm-zero-turnover-question",
-                        "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, the value of the total retail turnover was <em>£0</em>, is this correct?"
+                        "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total retail turnover was <em>£0</em>, is this correct?"
                     }],
                     "routing_rules": [{
                             "goto": {
@@ -674,9 +691,9 @@
                             "q_code": "146a",
                             "type": "Radio"
                         }],
-                        "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                        "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
                         "id": "significant-change-question",
-                        "title": "Did any significant changes occur to the total retail turnover for {{respondent.trad_as_or_ru_name}}?",
+                        "title": "Did any significant changes occur to the total retail turnover for {{metadata['trad_as_or_ru_name']}}?",
                         "type": "General"
                     }],
                     "title": "Changes in total retail turnover",
@@ -729,7 +746,7 @@
                             "type": "Checkbox"
                         }],
                         "id": "reason-for-change-question",
-                        "title": "Please indicate the reasons for any changes in the total retail turnover for {{respondent.trad_as_or_ru_name}}",
+                        "title": "Please indicate the reasons for any changes in the total retail turnover for {{metadata['trad_as_or_ru_name']}}",
                         "type": "General"
                     }],
                     "title": "Changes in total retail turnover"
@@ -767,7 +784,7 @@
                         }],
                         "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
                         "id": "change-comment-question",
-                        "title": "Please describe the changes in total retail turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+                        "title": "Please describe the changes in total retail turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
                         "type": "General"
                     }],
                     "title": "Changes in total retail turnover"

--- a/data/en/1_0213.json
+++ b/data/en/1_0213.json
@@ -11,6 +11,26 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "employment_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{
@@ -239,7 +259,7 @@
                         }
                     ],
                     "questions": [{
-                        "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?",
+                        "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?",
                         "type": "General",
                         "id": "reporting-period-choice-question",
                         "answers": [{
@@ -321,7 +341,7 @@
                             "default": 0
                         }],
                         "id": "total-turnover-question",
-                        "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total retail turnover</em>?",
+                        "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>total retail turnover</em>?",
                         "type": "General"
                     }],
                     "title": "Retail Turnover"
@@ -355,7 +375,7 @@
                             "mandatory": true
                         }],
                         "id": "confirm-zero-turnover-question",
-                        "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, the value of the total retail turnover was <em>£0</em>, is this correct?"
+                        "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total retail turnover was <em>£0</em>, is this correct?"
                     }],
                     "routing_rules": [{
                             "goto": {
@@ -642,9 +662,9 @@
                             "q_code": "146a",
                             "type": "Radio"
                         }],
-                        "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                        "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
                         "id": "significant-change-question",
-                        "title": "Did any significant changes occur to the total retail turnover for {{respondent.trad_as_or_ru_name}}?",
+                        "title": "Did any significant changes occur to the total retail turnover for {{metadata['trad_as_or_ru_name']}}?",
                         "type": "General"
                     }],
                     "title": "Changes in total retail turnover",
@@ -704,7 +724,7 @@
                             "type": "Checkbox"
                         }],
                         "id": "reason-for-change-question",
-                        "title": "Please indicate the reasons for any changes in the total retail turnover for {{respondent.trad_as_or_ru_name}}",
+                        "title": "Please indicate the reasons for any changes in the total retail turnover for {{metadata['trad_as_or_ru_name']}}",
                         "type": "General"
                     }],
                     "title": "Changes in total retail turnover"
@@ -749,7 +769,7 @@
                         }],
                         "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
                         "id": "change-comment-question",
-                        "title": "Please describe the changes in total retail turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+                        "title": "Please describe the changes in total retail turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
                         "type": "General"
                     }],
                     "title": "Changes in total retail turnover"
@@ -788,7 +808,7 @@
                         }],
                         "description": "<p>An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.</p>",
                         "id": "total-number-employees-question",
-                        "title": "On {{exercise.employment_date|format_date}} what was the number of employees for {{respondent.trad_as_or_ru_name}}?",
+                        "title": "On {{metadata['employment_date']|format_date}} what was the number of employees for {{metadata['trad_as_or_ru_name']}}?",
                         "type": "General"
                     }],
                     "title": "Employees"
@@ -822,7 +842,7 @@
                             "mandatory": true
                         }],
                         "id": "confirm-zero-employees-question",
-                        "title": "On {{exercise.employment_date|format_date}}, the number of employees for {{respondent.trad_as_or_ru_name}} was <em>0</em>, is this correct?"
+                        "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{metadata['trad_as_or_ru_name']}} was <em>0</em>, is this correct?"
                     }],
                     "routing_rules": [{
                             "goto": {
@@ -934,7 +954,7 @@
                             }
                         ],
                         "id": "employee-breakdown-questions",
-                        "title": "Of the <em>{{answers['total-number-employees']|format_number}}</em> total employees employed on {{exercise.employment_date|format_date}}, please specify the number of:",
+                        "title": "Of the <em>{{answers['total-number-employees']|format_number}}</em> total employees employed on {{metadata['employment_date']|format_date}}, please specify the number of:",
                         "type": "Calculated"
                     }],
                     "title": "Employees"

--- a/data/en/1_0215.json
+++ b/data/en/1_0215.json
@@ -11,6 +11,26 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "employment_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{
@@ -257,7 +277,7 @@
                         }
                     ],
                     "questions": [{
-                        "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?",
+                        "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?",
                         "type": "General",
                         "id": "reporting-period-choice-question",
                         "answers": [{
@@ -340,7 +360,7 @@
                             "default": 0
                         }],
                         "id": "total-turnover-question",
-                        "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total retail turnover</em>?",
+                        "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>total retail turnover</em>?",
                         "type": "General"
                     }],
                     "title": "Retail Turnover"
@@ -374,7 +394,7 @@
                             "mandatory": true
                         }],
                         "id": "confirm-zero-turnover-question",
-                        "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, the value of the total retail turnover was <em>£0</em>, is this correct?"
+                        "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total retail turnover was <em>£0</em>, is this correct?"
                     }],
                     "routing_rules": [{
                             "goto": {
@@ -722,9 +742,9 @@
                             "q_code": "146a",
                             "type": "Radio"
                         }],
-                        "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                        "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
                         "id": "significant-change-question",
-                        "title": "Did any significant changes occur to the total retail turnover for {{respondent.trad_as_or_ru_name}}?",
+                        "title": "Did any significant changes occur to the total retail turnover for {{metadata['trad_as_or_ru_name']}}?",
                         "type": "General"
                     }],
                     "title": "Changes in total retail turnover",
@@ -777,7 +797,7 @@
                             "type": "Checkbox"
                         }],
                         "id": "reason-for-change-question",
-                        "title": "Please indicate the reasons for any changes in the total retail turnover for {{respondent.trad_as_or_ru_name}}",
+                        "title": "Please indicate the reasons for any changes in the total retail turnover for {{metadata['trad_as_or_ru_name']}}",
                         "type": "General"
                     }],
                     "title": "Changes in total retail turnover"
@@ -821,7 +841,7 @@
                         }],
                         "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
                         "id": "change-comment-question",
-                        "title": "Please describe the changes in total retail turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+                        "title": "Please describe the changes in total retail turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
                         "type": "General"
                     }],
                     "title": "Changes in total retail turnover"
@@ -860,7 +880,7 @@
                         }],
                         "description": "<p>An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.</p>",
                         "id": "total-number-employees-question",
-                        "title": "On {{exercise.employment_date|format_date}} what was the number of employees for {{respondent.trad_as_or_ru_name}}?",
+                        "title": "On {{metadata['employment_date']|format_date}} what was the number of employees for {{metadata['trad_as_or_ru_name']}}?",
                         "type": "General"
                     }],
                     "title": "Employees"
@@ -894,7 +914,7 @@
                             "mandatory": true
                         }],
                         "id": "confirm-zero-employees-question",
-                        "title": "On {{exercise.employment_date|format_date}}, the number of employees for {{respondent.trad_as_or_ru_name}} was <em>0</em>, is this correct?"
+                        "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{metadata['trad_as_or_ru_name']}} was <em>0</em>, is this correct?"
                     }],
                     "routing_rules": [{
                             "goto": {
@@ -1007,7 +1027,7 @@
                             }
                         ],
                         "id": "employee-breakdown-questions",
-                        "title": "Of the <em>{{answers['total-number-employees']|format_number}}</em> total employees employed on {{exercise.employment_date|format_date}}, please specify the number of:",
+                        "title": "Of the <em>{{answers['total-number-employees']|format_number}}</em> total employees employed on {{metadata['employment_date']|format_date}}, please specify the number of:",
                         "type": "Calculated"
                     }],
                     "title": "Employees"

--- a/data/en/2_0001.json
+++ b/data/en/2_0001.json
@@ -5,6 +5,20 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{
@@ -97,7 +111,7 @@
                             ]
                         },
                         "id": "number-of-employees-total-question",
-                        "title": "On {{exercise.start_date|format_date}}, what was the number of employees for {{respondent.trad_as_or_ru_name}}?",
+                        "title": "On {{metadata['ref_p_start_date']|format_date}}, what was the number of employees for {{metadata['trad_as_or_ru_name']}}?",
                         "type": "General"
                     }],
                     "title": "Quarterly Business Survey",
@@ -132,7 +146,7 @@
                             "mandatory": true
                         }],
                         "id": "confirm-zero-employees-question",
-                        "title": "On {{exercise.start_date|format_date}}, the number of employees for {{respondent.trad_as_or_ru_name}} was <em>0</em>, is this correct?"
+                        "title": "On {{metadata['ref_p_start_date']|format_date}}, the number of employees for {{metadata['trad_as_or_ru_name']}} was <em>0</em>, is this correct?"
                     }],
                     "routing_rules": [{
                             "goto": {
@@ -245,7 +259,7 @@
                             ]
                         },
                         "id": "number-of-employees-split-question",
-                        "title": "Of the <em>{{answers['number-of-employees-total']}}</em> total employees employed on {{exercise.start_date|format_date}}, how many male and female employees worked the following hours?",
+                        "title": "Of the <em>{{answers['number-of-employees-total']}}</em> total employees employed on {{metadata['ref_p_start_date']|format_date}}, how many male and female employees worked the following hours?",
                         "type": "Calculated"
                     }]
                 },

--- a/data/en/census_communal.json
+++ b/data/en/census_communal.json
@@ -7,6 +7,14 @@
     "description": "Census England Communal Schema",
     "theme": "census",
     "legal_basis": "Voluntary",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/census_household.json
+++ b/data/en/census_household.json
@@ -10,6 +10,20 @@
     "navigation": {
         "visible": true
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "region_code": {
+            "validator": "string"
+        },
+        "variant_flags": {
+            "validator": "object"
+        }
+    },
     "sections": [{
             "id": "address-section",
             "title": "Introduction",

--- a/data/en/census_individual.json
+++ b/data/en/census_individual.json
@@ -7,6 +7,20 @@
     "description": "Census England Individual Schema",
     "theme": "census",
     "legal_basis": "Voluntary",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "region_code": {
+            "validator": "string"
+        },
+        "variant_flags": {
+            "validator": "object"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/e_commerce.json
+++ b/data/en/e_commerce.json
@@ -7,6 +7,17 @@
     "navigation": {
         "visible": true
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "trad_as": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "use-of-computers",
             "title": "Use Of Computers",
@@ -34,7 +45,7 @@
                                     }
                                 ]
                             },
-                            "title": "Does {{respondent.trad_as}} use any of the following computers: desktops, laptops, notebooks, netbooks, tablets, and other portable devices such as smartphones?",
+                            "title": "Does {{metadata['trad_as']}} use any of the following computers: desktops, laptops, notebooks, netbooks, tablets, and other portable devices such as smartphones?",
                             "answers": [{
                                 "type": "Radio",
                                 "label": "",
@@ -104,7 +115,7 @@
                                     }
                                 ]
                             },
-                            "title": "What percentage of people in {{respondent.trad_as}} use computers, as defined in the previous question, for their work?",
+                            "title": "What percentage of people in {{metadata['trad_as']}} use computers, as defined in the previous question, for their work?",
                             "answers": [{
                                 "description": "Please provide percentages to one decimal place where possible",
                                 "type": "Percentage",
@@ -181,7 +192,7 @@
                                     }
                                 ]
                             },
-                            "title": "Does {{respondent.trad_as}} employ ICT or IT specialists?",
+                            "title": "Does {{metadata['trad_as']}} employ ICT or IT specialists?",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide ICT Definition",
@@ -217,7 +228,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "ict-specialists-and-skills-question-6",
-                            "title": "During 2017, did {{respondent.trad_as}} provide any type of training to develop the ICT or IT related skills of the following?",
+                            "title": "During 2017, did {{metadata['trad_as']}} provide any type of training to develop the ICT or IT related skills of the following?",
                             "answers": [{
                                 "type": "Checkbox",
                                 "id": "ict-specialists-and-skills-answer-6",
@@ -249,7 +260,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "ict-specialists-and-skills-question-7",
-                            "title": "During 2017, did {{respondent.trad_as}} recruit or try to recruit ICT or IT specialists?",
+                            "title": "During 2017, did {{metadata['trad_as']}} recruit or try to recruit ICT or IT specialists?",
                             "answers": [{
                                 "type": "Radio",
                                 "id": "ict-specialists-and-skills-answer-7",
@@ -292,7 +303,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "ict-specialists-and-skills-question-8",
-                            "title": "During 2017, did {{respondent.trad_as}} have vacancies for ICT or IT specialists that were difficult to fill?",
+                            "title": "During 2017, did {{metadata['trad_as']}} have vacancies for ICT or IT specialists that were difficult to fill?",
                             "answers": [{
                                 "type": "Radio",
                                 "id": "ict-specialists-and-skills-answer-8",
@@ -665,7 +676,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "access-and-use-of-the-internet-question-17",
-                            "title": "Does {{respondent.trad_as}} have internet access?",
+                            "title": "Does {{metadata['trad_as']}} have internet access?",
                             "answers": [{
                                 "type": "Radio",
                                 "id": "access-and-use-of-the-internet-answer-17",
@@ -728,7 +739,7 @@
                             },
                             "type": "General",
                             "id": "access-and-use-of-the-internet-question-18",
-                            "title": "What percentage of people in {{respondent.trad_as}} use computers with internet access for their work?",
+                            "title": "What percentage of people in {{metadata['trad_as']}} use computers with internet access for their work?",
                             "answers": [{
                                 "type": "Percentage",
                                 "label": "",
@@ -757,7 +768,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "access-and-use-of-the-internet-question-19",
-                            "title": "Does {{respondent.trad_as}} use a fixed broadband connection to the internet, for example DSL, (ADSL, SDSL, VDSL), fibre optic technology, cable technology?",
+                            "title": "Does {{metadata['trad_as']}} use a fixed broadband connection to the internet, for example DSL, (ADSL, SDSL, VDSL), fibre optic technology, cable technology?",
                             "answers": [{
                                 "type": "Radio",
                                 "label": "",
@@ -814,7 +825,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "access-and-use-of-the-internet-question-20",
-                            "title": "What is the maximum contracted download speed of the fastest fixed internet connection of {{respondent.trad_as}}?",
+                            "title": "What is the maximum contracted download speed of the fastest fixed internet connection of {{metadata['trad_as']}}?",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide Mbps and Internet Connection Speeds Definitions",
@@ -874,7 +885,7 @@
                                     "description": ""
                                 }]
                             },
-                            "title": "Does {{respondent.trad_as}} provide the people employed with portable devices that allow a mobile telephone network connection to the internet for business purposes?",
+                            "title": "Does {{metadata['trad_as']}} provide the people employed with portable devices that allow a mobile telephone network connection to the internet for business purposes?",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide Mobile Connection to the Internet Definition",
@@ -926,7 +937,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "access-and-use-of-the-internet-question-22",
-                            "title": "What percentage of people employed in {{respondent.trad_as}} use portable devices provided by this business that allow a mobile telephone connection to the internet for business purposes?",
+                            "title": "What percentage of people employed in {{metadata['trad_as']}} use portable devices provided by this business that allow a mobile telephone connection to the internet for business purposes?",
                             "answers": [{
                                 "description": "Please provide percentages to one decimal place where possible",
                                 "type": "Percentage",
@@ -948,7 +959,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "access-and-use-of-the-internet-question-23",
-                            "title": "Does {{respondent.trad_as}} provide portable devices that allow mobile connection to the internet using mobile telephone networks, for business use to <em>access the business’ e-mail system</em>?",
+                            "title": "Does {{metadata['trad_as']}} provide portable devices that allow mobile connection to the internet using mobile telephone networks, for business use to <em>access the business’ e-mail system</em>?",
                             "answers": [{
                                 "type": "Radio",
                                 "id": "access-and-use-of-the-internet-answer-23",
@@ -978,7 +989,7 @@
                                     "description": "For example spreadsheets, word documents, presentations etc."
                                 }]
                             },
-                            "title": "Does {{respondent.trad_as}} provide portable devices that allow mobile connection to the internet using mobile telephone networks, for business use to <em>access and modify the business’ documents</em>?",
+                            "title": "Does {{metadata['trad_as']}} provide portable devices that allow mobile connection to the internet using mobile telephone networks, for business use to <em>access and modify the business’ documents</em>?",
                             "answers": [{
                                 "type": "Radio",
                                 "id": "access-and-use-of-the-internet-answer-24",
@@ -1012,7 +1023,7 @@
                                     "description": "For example for orders or sales management, ERP (Enterprise Resource Planning) related applications, etc."
                                 }]
                             },
-                            "title": "Does {{respondent.trad_as}} provide portable devices that allow mobile connection to the internet using mobile telephone networks, for business use to <em>use dedicated business software applications</em>?",
+                            "title": "Does {{metadata['trad_as']}} provide portable devices that allow mobile connection to the internet using mobile telephone networks, for business use to <em>use dedicated business software applications</em>?",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide ERP Definition",
@@ -1056,7 +1067,7 @@
                                     "description": ""
                                 }]
                             },
-                            "title": "Does {{respondent.trad_as}} have a website, either its own or third party?",
+                            "title": "Does {{metadata['trad_as']}} have a website, either its own or third party?",
                             "answers": [{
                                 "type": "Radio",
                                 "id": "access-and-use-of-the-internet-answer-26",
@@ -1105,7 +1116,7 @@
                                     "description": "For example using a shopping cart."
                                 }]
                             },
-                            "title": "Does {{respondent.trad_as}}’s website have <em>online ordering or reservation/booking?</em>",
+                            "title": "Does {{metadata['trad_as']}}’s website have <em>online ordering or reservation/booking?</em>",
                             "answers": [{
                                 "type": "Radio",
                                 "id": "access-and-use-of-the-internet-answer-27",
@@ -1133,7 +1144,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "access-and-use-of-the-internet-question-28",
-                            "title": "Does {{respondent.trad_as}}’s website have <em>description of goods or services, price lists</em>?",
+                            "title": "Does {{metadata['trad_as']}}’s website have <em>description of goods or services, price lists</em>?",
                             "answers": [{
                                 "type": "Radio",
                                 "id": "access-and-use-of-the-internet-answer-28",
@@ -1160,7 +1171,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "access-and-use-of-the-internet-question-29",
-                            "title": "Does {{respondent.trad_as}}’s website have <em>order tracking</em>?",
+                            "title": "Does {{metadata['trad_as']}}’s website have <em>order tracking</em>?",
                             "answers": [{
                                 "type": "Radio",
                                 "id": "access-and-use-of-the-internet-answer-29",
@@ -1187,7 +1198,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "access-and-use-of-the-internet-question-30",
-                            "title": "Does {{respondent.trad_as}}’s website have <em>the possibility for visitors to customise or design the goods or services online</em>?",
+                            "title": "Does {{metadata['trad_as']}}’s website have <em>the possibility for visitors to customise or design the goods or services online</em>?",
                             "answers": [{
                                 "type": "Radio",
                                 "id": "access-and-use-of-the-internet-answer-30",
@@ -1214,7 +1225,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "access-and-use-of-the-internet-question-31",
-                            "title": "Does {{respondent.trad_as}}’s website have <em>personalised content for regular/repeat visitors</em>?",
+                            "title": "Does {{metadata['trad_as']}}’s website have <em>personalised content for regular/repeat visitors</em>?",
                             "answers": [{
                                 "type": "Radio",
                                 "id": "access-and-use-of-the-internet-answer-31",
@@ -1241,7 +1252,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "access-and-use-of-the-internet-question-32",
-                            "title": "Does {{respondent.trad_as}}’s website have <em>links or references to this business’ social media profiles</em>?",
+                            "title": "Does {{metadata['trad_as']}}’s website have <em>links or references to this business’ social media profiles</em>?",
                             "answers": [{
                                 "type": "Radio",
                                 "id": "access-and-use-of-the-internet-answer-32",
@@ -1268,7 +1279,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "access-and-use-of-the-internet-question-33",
-                            "title": "Does {{respondent.trad_as}} pay to advertise on the internet, for example adverts on search engines, on social media, on other websites?",
+                            "title": "Does {{metadata['trad_as']}} pay to advertise on the internet, for example adverts on search engines, on social media, on other websites?",
                             "answers": [{
                                 "type": "Radio",
                                 "id": "access-and-use-of-the-internet-answer-33",
@@ -1311,7 +1322,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "access-and-use-of-the-internet-question-34",
-                            "title": "Does {{respondent.trad_as}} pay to advertise on the internet  <em>based on webpages’ content or keywords searched by users</em>?",
+                            "title": "Does {{metadata['trad_as']}} pay to advertise on the internet  <em>based on webpages’ content or keywords searched by users</em>?",
                             "answers": [{
                                 "type": "Radio",
                                 "id": "access-and-use-of-the-internet-answer-34",
@@ -1339,7 +1350,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "access-and-use-of-the-internet-question-35",
-                            "title": "Does {{respondent.trad_as}} pay to advertise on the internet <em>based on the tracking of internet users' past activities or profile</em>?",
+                            "title": "Does {{metadata['trad_as']}} pay to advertise on the internet <em>based on the tracking of internet users' past activities or profile</em>?",
                             "answers": [{
                                 "type": "Radio",
                                 "id": "access-and-use-of-the-internet-answer-35",
@@ -1367,7 +1378,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "access-and-use-of-the-internet-question-36",
-                            "title": "Does {{respondent.trad_as}} pay to advertise on the internet <em>based on the geolocation of internet users</em>?",
+                            "title": "Does {{metadata['trad_as']}} pay to advertise on the internet <em>based on the geolocation of internet users</em>?",
                             "answers": [{
                                 "type": "Radio",
                                 "id": "access-and-use-of-the-internet-answer-36",
@@ -1395,7 +1406,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "access-and-use-of-the-internet-question-37",
-                            "title": "Does {{respondent.trad_as}} pay to advertise on the internet using <em>any other method of targeted advertising on the internet not specified previously</em>?",
+                            "title": "Does {{metadata['trad_as']}} pay to advertise on the internet using <em>any other method of targeted advertising on the internet not specified previously</em>?",
                             "answers": [{
                                 "type": "Radio",
                                 "id": "access-and-use-of-the-internet-answer-37",
@@ -1435,7 +1446,7 @@
                                     }
                                 ]
                             },
-                            "title": "During 2017, did {{respondent.trad_as}} arrange accommodation from a private individual, for example a room, apartment or house, via <em>dedicated websites or ‘apps’</em>?",
+                            "title": "During 2017, did {{metadata['trad_as']}} arrange accommodation from a private individual, for example a room, apartment or house, via <em>dedicated websites or ‘apps’</em>?",
                             "answers": [{
                                 "type": "Radio",
                                 "id": "access-and-use-of-the-internet-answer-38",
@@ -1472,7 +1483,7 @@
                                     "description": ""
                                 }]
                             },
-                            "title": "During 2017, did {{respondent.trad_as}} arrange accommodation from a private individual, for example a room, apartment or house, via any<em> other websites or ‘apps’?</em>",
+                            "title": "During 2017, did {{metadata['trad_as']}} arrange accommodation from a private individual, for example a room, apartment or house, via any<em> other websites or ‘apps’?</em>",
                             "answers": [{
                                 "type": "Radio",
                                 "id": "access-and-use-of-the-internet-answer-39",
@@ -1509,7 +1520,7 @@
                                     "description": ""
                                 }]
                             },
-                            "title": "During 2017, did {{respondent.trad_as}} arrange a transport service from a private individual, for example by car, via <em>dedicated websites or ‘apps’, for example Uber, Lyft, Liftshare, BlaBlaCar?</em>",
+                            "title": "During 2017, did {{metadata['trad_as']}} arrange a transport service from a private individual, for example by car, via <em>dedicated websites or ‘apps’, for example Uber, Lyft, Liftshare, BlaBlaCar?</em>",
                             "answers": [{
                                 "type": "Radio",
                                 "id": "access-and-use-of-the-internet-answer-40",
@@ -1554,7 +1565,7 @@
                                     }
                                 ]
                             },
-                            "title": "During 2017, did {{respondent.trad_as}} arrange a transport service from a private individual, for example by car, via any <em>other websites or ‘apps’?</em> ",
+                            "title": "During 2017, did {{metadata['trad_as']}} arrange a transport service from a private individual, for example by car, via any <em>other websites or ‘apps’?</em> ",
                             "answers": [{
                                 "type": "Radio",
                                 "id": "access-and-use-of-the-internet-answer-41",
@@ -1646,7 +1657,7 @@
                                     "description": ""
                                 }]
                             },
-                            "title": "Does {{respondent.trad_as}} buy any cloud computing services used over the internet?",
+                            "title": "Does {{metadata['trad_as']}} buy any cloud computing services used over the internet?",
                             "answers": [{
                                 "type": "Radio",
                                 "label": "",
@@ -1718,7 +1729,7 @@
                                     "description": "For example Gmail"
                                 }]
                             },
-                            "title": "Does {{respondent.trad_as}} buy <em>email</em> (as a cloud computing service)  over the internet?",
+                            "title": "Does {{metadata['trad_as']}} buy <em>email</em> (as a cloud computing service)  over the internet?",
                             "answers": [{
                                 "type": "Radio",
                                 "label": "",
@@ -1774,7 +1785,7 @@
                                     "description": "For example Google Docs, Microsoft 365 etc."
                                 }]
                             },
-                            "title": "Does {{respondent.trad_as}} buy <em>office software</em> (as a cloud computing service)  over the internet?",
+                            "title": "Does {{metadata['trad_as']}} buy <em>office software</em> (as a cloud computing service)  over the internet?",
                             "answers": [{
                                 "type": "Radio",
                                 "label": "",
@@ -1824,7 +1835,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "use-of-cloud-computing-services-question-46",
-                            "title": "Does {{respondent.trad_as}} buy <em>hosting of the business’ database</em> (as a cloud computing service) over the internet?",
+                            "title": "Does {{metadata['trad_as']}} buy <em>hosting of the business’ database</em> (as a cloud computing service) over the internet?",
                             "answers": [{
                                 "type": "Radio",
                                 "label": "",
@@ -1873,7 +1884,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "use-of-cloud-computing-services-question-47",
-                            "title": "Does {{respondent.trad_as}} buy <em>storage of files</em> (as a cloud computing service) over the internet?",
+                            "title": "Does {{metadata['trad_as']}} buy <em>storage of files</em> (as a cloud computing service) over the internet?",
                             "answers": [{
                                 "type": "Radio",
                                 "label": "",
@@ -1922,7 +1933,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "use-of-cloud-computing-services-question-48",
-                            "title": "Does {{respondent.trad_as}} buy<em> finance or accounting software applications</em> (as a cloud computing service)  over the internet?",
+                            "title": "Does {{metadata['trad_as']}} buy<em> finance or accounting software applications</em> (as a cloud computing service)  over the internet?",
                             "answers": [{
                                 "type": "Radio",
                                 "label": "",
@@ -1971,7 +1982,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "use-of-cloud-computing-services-question-49",
-                            "title": "Does {{respondent.trad_as}} buy <em>Customer Relationship Management (CRM) software application for managing information about customers</em> (as a cloud computing service) over the internet?",
+                            "title": "Does {{metadata['trad_as']}} buy <em>Customer Relationship Management (CRM) software application for managing information about customers</em> (as a cloud computing service) over the internet?",
                             "answers": [{
                                 "type": "Radio",
                                 "label": "",
@@ -2028,7 +2039,7 @@
                                     "description": "This is using cloud computing for running the business’ software applications. This may be provided either as Software as a service (SaaS) or as Infrastructure (hardware/software)  as a Service (IaaS). For the former the business uses the software application that has been developed and it is accessible and used through a browser. For the latter the business maintains control of the software environment."
                                 }]
                             },
-                            "title": "Does {{respondent.trad_as}} buy <em>computing power to run the business’ own software</em> (as a cloud computing service) over the internet?",
+                            "title": "Does {{metadata['trad_as']}} buy <em>computing power to run the business’ own software</em> (as a cloud computing service) over the internet?",
                             "answers": [{
                                 "type": "Radio",
                                 "label": "",
@@ -2078,7 +2089,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "use-of-cloud-computing-services-question-51",
-                            "title": "Does {{respondent.trad_as}} buy any cloud computing services from <em>shared servers of service providers</em>?",
+                            "title": "Does {{metadata['trad_as']}} buy any cloud computing services from <em>shared servers of service providers</em>?",
                             "answers": [{
                                 "type": "Radio",
                                 "label": "",
@@ -2127,7 +2138,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "use-of-cloud-computing-services-question-52",
-                            "title": "Does {{respondent.trad_as}} buy any cloud computing services from <em>servers of service providers exclusively reserved for this business</em>?",
+                            "title": "Does {{metadata['trad_as']}} buy any cloud computing services from <em>servers of service providers exclusively reserved for this business</em>?",
                             "answers": [{
                                 "type": "Radio",
                                 "label": "",
@@ -2226,7 +2237,7 @@
                                     "description": ""
                                 }]
                             },
-                            "title": "During 2017, did {{respondent.trad_as}} use 3D printing by using your business’ 3D printers?",
+                            "title": "During 2017, did {{metadata['trad_as']}} use 3D printing by using your business’ 3D printers?",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide 3D Printing Definition",
@@ -2286,7 +2297,7 @@
                                     "description": ""
                                 }]
                             },
-                            "title": "During 2017, did {{respondent.trad_as}} use 3D printing by using printing services provided by other businesses?",
+                            "title": "During 2017, did {{metadata['trad_as']}} use 3D printing by using printing services provided by other businesses?",
                             "answers": [{
                                 "type": "Radio",
                                 "label": "",
@@ -2339,7 +2350,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "use-of-3d-printing-question-56",
-                            "title": "During 2017, did {{respondent.trad_as}} use 3D printing for <em>the following</em>?",
+                            "title": "During 2017, did {{metadata['trad_as']}} use 3D printing for <em>the following</em>?",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide 3D Printing Definition",
@@ -2384,7 +2395,7 @@
                                     "description": "For example moulds, tools, parts of goods, semi-finished goods, etc."
                                 }]
                             },
-                            "title": "During 2017, did {{respondent.trad_as}} use 3D printing for <em>goods for sale excluding prototypes or models</em>?",
+                            "title": "During 2017, did {{metadata['trad_as']}} use 3D printing for <em>goods for sale excluding prototypes or models</em>?",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide 3D Printing Definition",
@@ -2426,7 +2437,7 @@
                                     "description": "For example moulds, tools, parts of goods, semi-finished goods, etc."
                                 }]
                             },
-                            "title": "During 2017, did {{respondent.trad_as}} use 3D printing for <em>goods to be used in {{respondent.trad_as}} production process excluding prototypes or models?</em>",
+                            "title": "During 2017, did {{metadata['trad_as']}} use 3D printing for <em>goods to be used in {{metadata['trad_as']}} production process excluding prototypes or models?</em>",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide 3D Printing Definition",
@@ -2499,7 +2510,7 @@
                                     "description": ""
                                 }]
                             },
-                            "title": "In 2017, did {{respondent.trad_as}} issue/send <em>invoices in electronic form, in a standard structure suitable for automated processing, for example EDI, UBL, XML</em>?",
+                            "title": "In 2017, did {{metadata['trad_as']}} issue/send <em>invoices in electronic form, in a standard structure suitable for automated processing, for example EDI, UBL, XML</em>?",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide Invoices, EDI, UBL and XML Definitions",
@@ -2562,7 +2573,7 @@
                                     "description": ""
                                 }]
                             },
-                            "title": "In 2017, did {{respondent.trad_as}} issue/send <em>invoices in electronic form not suitable for automated processing, for example, emails, PDF email attachments, images in TIF, JPEG or other formats</em>?",
+                            "title": "In 2017, did {{metadata['trad_as']}} issue/send <em>invoices in electronic form not suitable for automated processing, for example, emails, PDF email attachments, images in TIF, JPEG or other formats</em>?",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide Invoices Definition",
@@ -2613,7 +2624,7 @@
                                     "description": ""
                                 }]
                             },
-                            "title": "In 2017, did {{respondent.trad_as}} issue/send <em>only paper invoices</em>?",
+                            "title": "In 2017, did {{metadata['trad_as']}} issue/send <em>only paper invoices</em>?",
                             "answers": [{
                                 "type": "Radio",
                                 "id": "invoicing-answer-62",
@@ -2687,7 +2698,7 @@
                                     }
                                 ]
                             },
-                            "title": "During 2017, did {{respondent.trad_as}} receive any orders from customers for goods or services via a website or ‘app’?",
+                            "title": "During 2017, did {{metadata['trad_as']}} receive any orders from customers for goods or services via a website or ‘app’?",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide EDI and Extranet Definitions",
@@ -2818,7 +2829,7 @@
                                     "description": ""
                                 }]
                             },
-                            "title": "During 2017, did {{respondent.trad_as}} receive orders for goods or services via this business’ own website or ‘app’?",
+                            "title": "During 2017, did {{metadata['trad_as']}} receive orders for goods or services via this business’ own website or ‘app’?",
                             "answers": [{
                                 "type": "Radio",
                                 "label": "",
@@ -2877,7 +2888,7 @@
                                     "description": "For example Booking, eBay, Amazon, Amazon Business, Alibaba, Rakuten, Etsy etc."
                                 }]
                             },
-                            "title": "During 2017, did {{respondent.trad_as}} receive orders for goods or services via an e-commerce market place website or ‘app’ used by several businesses for trading products?",
+                            "title": "During 2017, did {{metadata['trad_as']}} receive orders for goods or services via an e-commerce market place website or ‘app’ used by several businesses for trading products?",
                             "answers": [{
                                 "type": "Radio",
                                 "id": "e-commerce-answer-68",
@@ -2973,7 +2984,7 @@
                                     }
                                 ]
                             },
-                            "title": "During 2017, did {{respondent.trad_as}} receive any orders from customers for goods or services via EDI type messages? ",
+                            "title": "During 2017, did {{metadata['trad_as']}} receive any orders from customers for goods or services via EDI type messages? ",
                             "answers": [{
                                 "type": "Radio",
                                 "label": "",
@@ -3087,7 +3098,7 @@
                                     }
                                 ]
                             },
-                            "title": "During 2017, did {{respondent.trad_as}} place any orders for goods or services, excluding capital goods, via websites, ‘apps’ or EDI type messages?",
+                            "title": "During 2017, did {{metadata['trad_as']}} place any orders for goods or services, excluding capital goods, via websites, ‘apps’ or EDI type messages?",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide EDI Definition",

--- a/data/en/labour_force.json
+++ b/data/en/labour_force.json
@@ -12,6 +12,20 @@
     "navigation": {
         "visible": true
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "region_code": {
+            "validator": "string"
+        },
+        "ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "household-section",
             "title": "About the household",
@@ -21,7 +35,7 @@
                     "blocks": [{
                             "type": "Interstitial",
                             "id": "about-household",
-                            "title": "About you and people who live at {{ respondent.ru_name }}",
+                            "title": "About you and people who live at {{ metadata['ru_name'] }}",
                             "description": "In this section, we’re going to ask about you, and the people that live with you.",
                             "content": [{
                                 "title": "Information you need",
@@ -35,7 +49,7 @@
                             "type": "Question",
                             "id": "address-check-block",
                             "title": "Your address:",
-                            "description": "{{respondent.ru_name}}",
+                            "description": "{{metadata['ru_name']}}",
                             "questions": [{
                                 "id": "address-check-question",
                                 "title": "Is the address above your main residence?",
@@ -87,7 +101,7 @@
                         {
                             "type": "Question",
                             "id": "address-type-check-block",
-                            "title": "You said {{ respondent.ru_name }} is not your main residence",
+                            "title": "You said {{ metadata['ru_name'] }} is not your main residence",
                             "description": "",
                             "questions": [{
                                 "id": "address-type-check-question",
@@ -144,7 +158,7 @@
                             "type": "Question",
                             "questions": [{
                                 "id": "household-composition-question",
-                                "title": "What are the names of everyone who lives in the <em>{{ respondent.ru_name }}</em> household?",
+                                "title": "What are the names of everyone who lives in the <em>{{ metadata['ru_name'] }}</em> household?",
                                 "type": "RepeatingAnswer",
                                 "answers": [{
                                         "id": "first-name",

--- a/data/en/mbs_0106.json
+++ b/data/en/mbs_0106.json
@@ -11,6 +11,23 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "section",
             "groups": [{
@@ -111,7 +128,7 @@
                             }],
                             "type": "General",
                             "id": "reporting-period-question",
-                            "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -217,7 +234,7 @@
                                 "mandatory": true
                             }],
                             "type": "General",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total turnover</em>, excluding VAT?"
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>total turnover</em>, excluding VAT?"
                         }],
                         "title": "Total turnover"
                     },
@@ -225,9 +242,9 @@
                         "id": "changes-in-total-turnover-block",
                         "type": "Question",
                         "questions": [{
-                            "title": "Did any significant changes occur to the total turnover for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "Did any significant changes occur to the total turnover for {{metadata['trad_as_or_ru_name']}}?",
                             "id": "changes-in-total-turnover-question",
-                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "answers": [{
                                 "options": [{
                                         "value": "Yes",
@@ -280,7 +297,7 @@
                         "id": "changes-in-total-turnover-block-2",
                         "type": "Question",
                         "questions": [{
-                            "title": "Please indicate the reasons for any changes in the total turnover for {{respondent.trad_as_or_ru_name}}",
+                            "title": "Please indicate the reasons for any changes in the total turnover for {{metadata['trad_as_or_ru_name']}}",
                             "answers": [{
                                 "options": [{
                                         "q_code": "146a",
@@ -334,7 +351,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "changes-in-total-turnover-question-3",
-                            "title": "Please describe the changes in total turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+                            "title": "Please describe the changes in total turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide examples of commentary on changes to turnover",

--- a/data/en/mbs_0111.json
+++ b/data/en/mbs_0111.json
@@ -13,6 +13,23 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "section",
             "groups": [{
@@ -112,7 +129,7 @@
                             }],
                             "type": "General",
                             "id": "reporting-period-question",
-                            "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -217,7 +234,7 @@
                                 "mandatory": true
                             }],
                             "type": "General",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total turnover</em>, excluding VAT?"
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>total turnover</em>, excluding VAT?"
                         }],
                         "title": "Total Turnover"
                     },
@@ -225,9 +242,9 @@
                         "id": "changes-in-turnover-block",
                         "type": "Question",
                         "questions": [{
-                            "title": "Did any significant changes occur to the total turnover for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "Did any significant changes occur to the total turnover for {{metadata['trad_as_or_ru_name']}}?",
                             "id": "changes-in-turnover-question",
-                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "answers": [{
                                 "options": [{
                                         "value": "Yes",
@@ -280,7 +297,7 @@
                         "id": "changes-in-turnover-block-2",
                         "type": "Question",
                         "questions": [{
-                            "title": "Please indicate the reasons for any changes in the total turnover for {{respondent.trad_as_or_ru_name}}",
+                            "title": "Please indicate the reasons for any changes in the total turnover for {{metadata['trad_as_or_ru_name']}}",
                             "answers": [{
                                 "options": [{
                                         "q_code": "146a",
@@ -334,7 +351,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "changes-in-turnover-question-3",
-                            "title": "Please describe the changes in total turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+                            "title": "Please describe the changes in total turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide examples of commentary on changes to total turnover",

--- a/data/en/mbs_0117.json
+++ b/data/en/mbs_0117.json
@@ -12,6 +12,23 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "section",
             "groups": [{
@@ -121,7 +138,7 @@
                             }],
                             "type": "General",
                             "id": "reporting-period-question",
-                            "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -227,7 +244,7 @@
                                 "mandatory": true
                             }],
                             "type": "General",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>turnover</em>, excluding VAT?"
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>turnover</em>, excluding VAT?"
                         }],
                         "title": "Turnover"
                     },
@@ -254,9 +271,9 @@
                         "id": "changes-in-turnover-block",
                         "type": "Question",
                         "questions": [{
-                            "title": "Did any significant changes occur to the turnover for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "Did any significant changes occur to the turnover for {{metadata['trad_as_or_ru_name']}}?",
                             "id": "changes-in-turnover-question",
-                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "answers": [{
                                 "options": [{
                                         "value": "Yes",
@@ -309,7 +326,7 @@
                         "id": "changes-in-turnover-block-2",
                         "type": "Question",
                         "questions": [{
-                            "title": "Please indicate the reasons for any changes in the turnover for {{respondent.trad_as_or_ru_name}}",
+                            "title": "Please indicate the reasons for any changes in the turnover for {{metadata['trad_as_or_ru_name']}}",
                             "answers": [{
                                 "options": [{
                                         "q_code": "146a",
@@ -363,7 +380,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "changes-in-turnover-question-3",
-                            "title": "Please describe the changes in turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+                            "title": "Please describe the changes in turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide examples of commentary on changes to turnover",

--- a/data/en/mbs_0123.json
+++ b/data/en/mbs_0123.json
@@ -13,6 +13,23 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "section",
             "groups": [{
@@ -108,7 +125,7 @@
                             }],
                             "type": "General",
                             "id": "reporting-period-question",
-                            "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -181,7 +198,7 @@
                             "description": "For example, as a travel agent, where you do not hold title to goods/services",
                             "id": "commission-and-fees-question",
                             "type": "General",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>commission and fees</em>, excluding VAT?",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>commission and fees</em>, excluding VAT?",
                             "answers": [{
                                 "id": "commission-and-fees-answer",
                                 "label": "Total commission and fees excluding VAT",
@@ -212,7 +229,7 @@
                             "id": "sales-on-own-account-question",
                             "type": "General",
                             "description": "For example, as a tour operator",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>sales on own account and turnover from other activities</em>, excluding VAT?",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>sales on own account and turnover from other activities</em>, excluding VAT?",
                             "answers": [{
                                 "id": "sales-on-own-account-answer",
                                 "label": "Total Sales on own account and turnover from other activities  excluding VAT",
@@ -228,9 +245,9 @@
                         "id": "changes-block",
                         "type": "Question",
                         "questions": [{
-                            "title": "Did any significant changes occur to the figures provided for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "Did any significant changes occur to the figures provided for {{metadata['trad_as_or_ru_name']}}?",
                             "id": "changes-question",
-                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "answers": [{
                                 "options": [{
                                         "value": "Yes",
@@ -283,7 +300,7 @@
                         "id": "changes-block-2",
                         "type": "Question",
                         "questions": [{
-                            "title": "Please indicate the reasons for any changes in the turnover for {{respondent.trad_as_or_ru_name}}",
+                            "title": "Please indicate the reasons for any changes in the turnover for {{metadata['trad_as_or_ru_name']}}",
                             "type": "General",
                             "id": "changes-question-2",
                             "answers": [{
@@ -337,7 +354,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "changes-question-3",
-                            "title": "Please describe the changes in turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+                            "title": "Please describe the changes in turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide examples of commentary on changes to turnover",

--- a/data/en/mbs_0158.json
+++ b/data/en/mbs_0158.json
@@ -13,6 +13,26 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "employment_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "section",
             "groups": [{
@@ -150,7 +170,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "reporting-period-question",
-                            "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?",
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?",
                             "answers": [{
                                 "id": "reporting-period-answer",
                                 "type": "Radio",
@@ -235,7 +255,7 @@
                         "title": "Total turnover",
                         "questions": [{
                             "type": "General",
-                            "title": "For the period {{format_conditional_date (answers['period-from'], exercise.start_date)}} to {{format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total turnover</em>, excluding VAT?",
+                            "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>total turnover</em>, excluding VAT?",
                             "guidance": {
                                 "content": [{
                                         "title": "Include:",
@@ -279,7 +299,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "number-of-employees-total-question",
-                            "title": "On {{exercise.employment_date|format_date}}, what was the number of employees for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "On {{metadata['employment_date']|format_date}}, what was the number of employees for {{metadata['trad_as_or_ru_name']}}?",
                             "type": "General",
                             "description": "An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.",
                             "answers": [{
@@ -326,7 +346,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "confirm-zero-employees-question",
-                            "title": "On {{exercise.employment_date|format_date}}, the number of employees for {{respondent.trad_as_or_ru_name}} was <em>0</em>, is this correct?",
+                            "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{metadata['trad_as_or_ru_name']}} was <em>0</em>, is this correct?",
                             "answers": [{
                                 "type": "Radio",
                                 "id": "confirm-zero-employees-answer",
@@ -366,7 +386,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "number-of-employees-split-question",
-                            "title": "Of the <em>{{answers['number-of-employees-total']}}</em> total employees employed on {{exercise.employment_date|format_date}}, how many male and female employees worked the following hours?",
+                            "title": "Of the <em>{{answers['number-of-employees-total']}}</em> total employees employed on {{metadata['employment_date']|format_date}}, how many male and female employees worked the following hours?",
                             "type": "Calculated",
                             "calculations": [{
                                     "calculation_type": "sum",
@@ -464,9 +484,9 @@
                         "title": "Changes in total turnover",
                         "questions": [{
                             "type": "General",
-                            "title": "Did any significant changes occur to the total turnover for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "Did any significant changes occur to the total turnover for {{metadata['trad_as_or_ru_name']}}?",
                             "id": "changes-in-turnover-question",
-                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
+                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
                             "answers": [{
                                 "id": "changes-in-turnover-answer",
                                 "type": "Radio",
@@ -520,7 +540,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "changes-in-turnover-question-2",
-                            "title": "Please indicate the reasons for any changes in the total turnover for {{respondent.trad_as_or_ru_name}}",
+                            "title": "Please indicate the reasons for any changes in the total turnover for {{metadata['trad_as_or_ru_name']}}",
                             "answers": [{
                                 "id": "changes-in-turnover-answer-2",
                                 "type": "Checkbox",
@@ -571,7 +591,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "changes-in-turnover-question-3",
-                            "title": "Please describe the changes in total turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+                            "title": "Please describe the changes in total turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
                             "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.</p>",
                             "answers": [{
                                 "type": "TextArea",

--- a/data/en/mbs_0161.json
+++ b/data/en/mbs_0161.json
@@ -13,6 +13,26 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "employment_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "section",
             "groups": [{
@@ -166,7 +186,7 @@
                             }],
                             "type": "General",
                             "id": "reporting-period-question",
-                            "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -271,7 +291,7 @@
                                 "mandatory": true
                             }],
                             "type": "General",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total turnover</em>, excluding VAT?"
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>total turnover</em>, excluding VAT?"
                         }],
                         "title": "Total Turnover"
                     },
@@ -308,7 +328,7 @@
                                 ]
                             },
                             "id": "number-of-employees-total-question",
-                            "title": "On {{exercise.employment_date|format_date}}, what was the number of employees for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "On {{metadata['employment_date']|format_date}}, what was the number of employees for {{metadata['trad_as_or_ru_name']}}?",
                             "type": "General"
                         }],
                         "title": "Employees",
@@ -343,7 +363,7 @@
                                 "mandatory": true
                             }],
                             "id": "confirm-zero-employees-question",
-                            "title": "On {{exercise.employment_date|format_date}}, the number of employees for {{respondent.trad_as_or_ru_name}} was <em>0</em>, is this correct?"
+                            "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{metadata['trad_as_or_ru_name']}} was <em>0</em>, is this correct?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -456,7 +476,7 @@
                                 ]
                             },
                             "id": "number-of-employees-split-question",
-                            "title": "Of the <em>{{answers['number-of-employees-total']}}</em> total employees employed on {{exercise.employment_date|format_date}}, how many male and female employees worked the following hours?",
+                            "title": "Of the <em>{{answers['number-of-employees-total']}}</em> total employees employed on {{metadata['employment_date']|format_date}}, how many male and female employees worked the following hours?",
                             "type": "Calculated"
                         }]
                     },
@@ -464,9 +484,9 @@
                         "id": "changes-in-turnover-block",
                         "type": "Question",
                         "questions": [{
-                            "title": "Did any significant changes occur to the total turnover for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "Did any significant changes occur to the total turnover for {{metadata['trad_as_or_ru_name']}}?",
                             "id": "changes-in-turnover-question",
-                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "answers": [{
                                 "options": [{
                                         "value": "Yes",
@@ -519,7 +539,7 @@
                         "id": "changes-in-turnover-block-2",
                         "type": "Question",
                         "questions": [{
-                            "title": "Please indicate the reasons for any changes in the total turnover for {{respondent.trad_as_or_ru_name}}",
+                            "title": "Please indicate the reasons for any changes in the total turnover for {{metadata['trad_as_or_ru_name']}}",
                             "answers": [{
                                 "options": [{
                                         "q_code": "146a",
@@ -573,7 +593,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "changes-in-turnover-question-3",
-                            "title": "Please describe the changes in total turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+                            "title": "Please describe the changes in total turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide examples of commentary on changes to total turnover",

--- a/data/en/mbs_0167.json
+++ b/data/en/mbs_0167.json
@@ -12,6 +12,26 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "employment_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "section",
             "groups": [{
@@ -175,7 +195,7 @@
                             }],
                             "type": "General",
                             "id": "reporting-period-question",
-                            "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -281,7 +301,7 @@
                                 "mandatory": true
                             }],
                             "type": "General",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>turnover</em>, excluding VAT?"
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>turnover</em>, excluding VAT?"
                         }],
                         "title": "Turnover"
                     },
@@ -337,7 +357,7 @@
                                 ]
                             },
                             "id": "number-of-employees-total-question",
-                            "title": "On {{exercise.employment_date|format_date}}, what was the number of employees for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "On {{metadata['employment_date']|format_date}}, what was the number of employees for {{metadata['trad_as_or_ru_name']}}?",
                             "type": "General"
                         }],
                         "routing_rules": [{
@@ -388,7 +408,7 @@
                                 "mandatory": true
                             }],
                             "id": "confirm-zero-employees-question",
-                            "title": "On {{exercise.employment_date|format_date}}, the number of employees for {{respondent.trad_as_or_ru_name}} was <em>0</em>, is this correct?"
+                            "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{metadata['trad_as_or_ru_name']}} was <em>0</em>, is this correct?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -501,7 +521,7 @@
                                 ]
                             },
                             "id": "number-of-employees-split-question",
-                            "title": "Of the <em>{{answers['number-of-employees-total']}}</em> total employees employed on {{exercise.employment_date|format_date}}, how many male and female employees worked the following hours?",
+                            "title": "Of the <em>{{answers['number-of-employees-total']}}</em> total employees employed on {{metadata['employment_date']|format_date}}, how many male and female employees worked the following hours?",
                             "type": "Calculated"
                         }]
                     },
@@ -509,9 +529,9 @@
                         "id": "changes-in-turnover-block",
                         "type": "Question",
                         "questions": [{
-                            "title": "Did any significant changes occur to the turnover for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "Did any significant changes occur to the turnover for {{metadata['trad_as_or_ru_name']}}?",
                             "id": "changes-in-turnover-question",
-                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "answers": [{
                                 "options": [{
                                         "value": "Yes",
@@ -564,7 +584,7 @@
                         "id": "changes-in-turnover-block-2",
                         "type": "Question",
                         "questions": [{
-                            "title": "Please indicate the reasons for any changes in the turnover for {{respondent.trad_as_or_ru_name}}",
+                            "title": "Please indicate the reasons for any changes in the turnover for {{metadata['trad_as_or_ru_name']}}",
                             "answers": [{
                                 "options": [{
                                         "q_code": "146a",
@@ -618,7 +638,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "changes-in-turnover-question-3",
-                            "title": "Please describe the changes in turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+                            "title": "Please describe the changes in turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide examples of commentary on changes to turnover",

--- a/data/en/mbs_0173.json
+++ b/data/en/mbs_0173.json
@@ -13,6 +13,26 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "employment_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "section",
             "groups": [{
@@ -157,7 +177,7 @@
                             }],
                             "type": "General",
                             "id": "reporting-period-question",
-                            "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -229,7 +249,7 @@
                         "questions": [{
                             "id": "commission-and-fees-question",
                             "type": "General",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>commission and fees</em>, excluding VAT?",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>commission and fees</em>, excluding VAT?",
                             "description": "For example, as a travel agent, where you do not hold title to goods/services",
                             "answers": [{
                                 "id": "commission-and-fees-answer",
@@ -261,7 +281,7 @@
                             },
                             "id": "sales-on-own-account-question",
                             "type": "General",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>sales on own account and turnover from other activities</em>, excluding VAT?",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>sales on own account and turnover from other activities</em>, excluding VAT?",
                             "answers": [{
                                 "id": "sales-on-own-account-answer",
                                 "label": "Total Sales on own account and turnover from other activities  excluding VAT",
@@ -301,7 +321,7 @@
                             },
                             "id": "employees-question",
                             "type": "General",
-                            "title": "On {{exercise.employment_date|format_date}}, what was the number of employees for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "On {{metadata['employment_date']|format_date}}, what was the number of employees for {{metadata['trad_as_or_ru_name']}}?",
                             "description": "An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.",
                             "answers": [{
                                 "id": "number-of-employees-total",
@@ -342,7 +362,7 @@
                                 "mandatory": true
                             }],
                             "id": "confirm-zero-employees-question",
-                            "title": "On {{exercise.employment_date|format_date}}, the number of employees for {{respondent.trad_as_or_ru_name}} was <em>0</em>, is this correct?"
+                            "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{metadata['trad_as_or_ru_name']}} was <em>0</em>, is this correct?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -455,7 +475,7 @@
                                 ]
                             },
                             "id": "number-of-employees-split-question",
-                            "title": "Of the <em>{{answers['number-of-employees-total']}}</em> total employees employed on {{exercise.employment_date|format_date}}, how many male and female employees worked the following hours?",
+                            "title": "Of the <em>{{answers['number-of-employees-total']}}</em> total employees employed on {{metadata['employment_date']|format_date}}, how many male and female employees worked the following hours?",
                             "type": "Calculated"
                         }]
                     },
@@ -463,9 +483,9 @@
                         "id": "changes-block",
                         "type": "Question",
                         "questions": [{
-                            "title": "Did any significant changes occur to the figures provided for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "Did any significant changes occur to the figures provided for {{metadata['trad_as_or_ru_name']}}?",
                             "id": "changes-question",
-                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "answers": [{
                                 "options": [{
                                         "value": "Yes",
@@ -518,7 +538,7 @@
                         "id": "changes-block-2",
                         "type": "Question",
                         "questions": [{
-                            "title": "Please indicate the reasons for any changes in the turnover for {{respondent.trad_as_or_ru_name}}",
+                            "title": "Please indicate the reasons for any changes in the turnover for {{metadata['trad_as_or_ru_name']}}",
                             "type": "General",
                             "id": "changes-question-2",
                             "answers": [{
@@ -572,7 +592,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "changes-question-3",
-                            "title": "Please describe the changes in turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+                            "title": "Please describe the changes in turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide examples of commentary on changes to turnover",

--- a/data/en/mbs_0201.json
+++ b/data/en/mbs_0201.json
@@ -12,6 +12,23 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "section",
             "groups": [{
@@ -119,7 +136,7 @@
                             }],
                             "type": "General",
                             "id": "reporting-period-question",
-                            "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -225,7 +242,7 @@
                                 "default": 0
                             }],
                             "type": "General",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total turnover</em>, excluding VAT?"
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>total turnover</em>, excluding VAT?"
                         }]
                     },
                     {
@@ -257,7 +274,7 @@
                                 "mandatory": true
                             }],
                             "id": "confirm-zero-turnover-question",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, the value of the total turnover was <em>£0</em>, is this correct?"
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>£0</em>, is this correct?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -310,9 +327,9 @@
                         "id": "changes-in-turnover-block",
                         "type": "Question",
                         "questions": [{
-                            "title": "Did any significant changes occur to the total turnover for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "Did any significant changes occur to the total turnover for {{metadata['trad_as_or_ru_name']}}?",
                             "id": "changes-in-turnover-question",
-                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "answers": [{
                                 "options": [{
                                         "value": "Yes",
@@ -365,7 +382,7 @@
                         "id": "changes-in-turnover-block-2",
                         "type": "Question",
                         "questions": [{
-                            "title": "Please indicate the reasons for any changes in the total turnover for {{respondent.trad_as_or_ru_name}}",
+                            "title": "Please indicate the reasons for any changes in the total turnover for {{metadata['trad_as_or_ru_name']}}",
                             "answers": [{
                                 "options": [{
                                         "q_code": "146a",
@@ -419,7 +436,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "changes-in-turnover-question-3",
-                            "title": "Please describe the changes in total turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+                            "title": "Please describe the changes in total turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide examples of commentary on changes to total turnover",

--- a/data/en/mbs_0202.json
+++ b/data/en/mbs_0202.json
@@ -12,6 +12,23 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "section",
             "groups": [{
@@ -119,7 +136,7 @@
                             }],
                             "type": "General",
                             "id": "reporting-period-question",
-                            "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -225,7 +242,7 @@
                                 "default": 0
                             }],
                             "type": "General",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total turnover</em>, excluding VAT?"
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>total turnover</em>, excluding VAT?"
                         }]
                     },
                     {
@@ -257,7 +274,7 @@
                                 "mandatory": true
                             }],
                             "id": "confirm-zero-turnover-question",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, the value of the total turnover was <em>£0</em>, is this correct?"
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>£0</em>, is this correct?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -310,9 +327,9 @@
                         "id": "changes-in-turnover-block",
                         "type": "Question",
                         "questions": [{
-                            "title": "Did any significant changes occur to the total turnover for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "Did any significant changes occur to the total turnover for {{metadata['trad_as_or_ru_name']}}?",
                             "id": "changes-in-turnover-question",
-                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "answers": [{
                                 "options": [{
                                         "value": "Yes",
@@ -365,7 +382,7 @@
                         "id": "changes-in-turnover-block-2",
                         "type": "Question",
                         "questions": [{
-                            "title": "Please indicate the reasons for any changes in the total turnover for {{respondent.trad_as_or_ru_name}}",
+                            "title": "Please indicate the reasons for any changes in the total turnover for {{metadata['trad_as_or_ru_name']}}",
                             "answers": [{
                                 "options": [{
                                         "q_code": "146a",
@@ -419,7 +436,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "changes-in-turnover-question-3",
-                            "title": "Please describe the changes in total turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+                            "title": "Please describe the changes in total turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide examples of commentary on changes to total turnover",

--- a/data/en/mbs_0203.json
+++ b/data/en/mbs_0203.json
@@ -11,6 +11,23 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "section",
             "groups": [{
@@ -73,7 +90,7 @@
                             }],
                             "type": "General",
                             "id": "reporting-period-question",
-                            "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -145,7 +162,7 @@
                         "questions": [{
                             "id": "water-volume-question",
                             "type": "General",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the total volume of {{respondent.trad_as_or_ru_name}}’s <em>potable water that was supplied to customers</em>, in megalitres?",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the total volume of {{metadata['trad_as_or_ru_name']}}’s <em>potable water that was supplied to customers</em>, in megalitres?",
                             "answers": [{
                                 "id": "water-volume",
                                 "mandatory": true,
@@ -163,8 +180,8 @@
                         "questions": [{
                             "type": "General",
                             "id": "significant-change-question",
-                            "title": "Did any significant changes occur to the figures provided for {{respondent.trad_as_or_ru_name}}?",
-                            "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                            "title": "Did any significant changes occur to the figures provided for {{metadata['trad_as_or_ru_name']}}?",
+                            "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
                             "answers": [{
                                 "id": "significant-change-established-answer",
                                 "label": "",
@@ -212,7 +229,7 @@
                             }],
                             "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
                             "id": "change-comment-question",
-                            "title": "Please describe the changes for {{respondent.trad_as_or_ru_name}} in more detail",
+                            "title": "Please describe the changes for {{metadata['trad_as_or_ru_name']}} in more detail",
                             "type": "General"
                         }],
                         "title": "Significant changes"

--- a/data/en/mbs_0204.json
+++ b/data/en/mbs_0204.json
@@ -11,6 +11,23 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "section",
             "groups": [{
@@ -73,7 +90,7 @@
                             }],
                             "type": "General",
                             "id": "reporting-period-question",
-                            "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -145,7 +162,7 @@
                         "questions": [{
                             "id": "water-volume-question",
                             "type": "General",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the total volume of {{respondent.trad_as_or_ru_name}}’s <em>potable water that was supplied to customers</em>, in megalitres?",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the total volume of {{metadata['trad_as_or_ru_name']}}’s <em>potable water that was supplied to customers</em>, in megalitres?",
                             "answers": [{
                                 "id": "water-volume",
                                 "mandatory": true,
@@ -163,8 +180,8 @@
                         "questions": [{
                             "type": "General",
                             "id": "significant-change-question",
-                            "title": "Did any significant changes occur to the figures provided for {{respondent.trad_as_or_ru_name}}?",
-                            "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                            "title": "Did any significant changes occur to the figures provided for {{metadata['trad_as_or_ru_name']}}?",
+                            "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
                             "answers": [{
                                 "id": "significant-change-established-answer",
                                 "label": "",
@@ -212,7 +229,7 @@
                             }],
                             "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
                             "id": "change-comment-question",
-                            "title": "Please describe the changes for {{respondent.trad_as_or_ru_name}} in more detail",
+                            "title": "Please describe the changes for {{metadata['trad_as_or_ru_name']}} in more detail",
                             "type": "General"
                         }],
                         "title": "Significant changes"

--- a/data/en/mbs_0205.json
+++ b/data/en/mbs_0205.json
@@ -11,6 +11,23 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "section",
             "groups": [{
@@ -120,7 +137,7 @@
                             }],
                             "type": "General",
                             "id": "reporting-period-question",
-                            "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -223,7 +240,7 @@
                                 "mandatory": true
                             }],
                             "type": "General",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>turnover</em>, excluding VAT?"
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>turnover</em>, excluding VAT?"
                         }],
                         "title": "Turnover"
                     },
@@ -277,9 +294,9 @@
                         "id": "changes-in-turnover-block",
                         "type": "Question",
                         "questions": [{
-                            "title": "Did any significant changes occur to the turnover for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "Did any significant changes occur to the turnover for {{metadata['trad_as_or_ru_name']}}?",
                             "id": "changes-in-turnover-question",
-                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "answers": [{
                                 "options": [{
                                         "value": "Yes",
@@ -332,7 +349,7 @@
                         "id": "changes-in-turnover-block-2",
                         "type": "Question",
                         "questions": [{
-                            "title": "Please indicate the reasons for any changes in the turnover for {{respondent.trad_as_or_ru_name}}",
+                            "title": "Please indicate the reasons for any changes in the turnover for {{metadata['trad_as_or_ru_name']}}",
                             "answers": [{
                                 "options": [{
                                         "q_code": "146a",
@@ -386,7 +403,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "changes-in-turnover-question-3",
-                            "title": "Please describe the changes in turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+                            "title": "Please describe the changes in turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide examples of commentary on changes to turnover",

--- a/data/en/mbs_0216.json
+++ b/data/en/mbs_0216.json
@@ -11,6 +11,23 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "section",
             "groups": [{
@@ -120,7 +137,7 @@
                             }],
                             "type": "General",
                             "id": "reporting-period-question",
-                            "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -223,7 +240,7 @@
                                 "mandatory": true
                             }],
                             "type": "General",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>turnover</em>, excluding VAT?"
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>turnover</em>, excluding VAT?"
                         }],
                         "title": "Turnover"
                     },
@@ -277,9 +294,9 @@
                         "id": "changes-in-turnover-block",
                         "type": "Question",
                         "questions": [{
-                            "title": "Did any significant changes occur to the turnover for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "Did any significant changes occur to the turnover for {{metadata['trad_as_or_ru_name']}}?",
                             "id": "changes-in-turnover-question",
-                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "answers": [{
                                 "options": [{
                                         "value": "Yes",
@@ -332,7 +349,7 @@
                         "id": "changes-in-turnover-block-2",
                         "type": "Question",
                         "questions": [{
-                            "title": "Please indicate the reasons for any changes in the turnover for {{respondent.trad_as_or_ru_name}}",
+                            "title": "Please indicate the reasons for any changes in the turnover for {{metadata['trad_as_or_ru_name']}}",
                             "answers": [{
                                 "options": [{
                                         "q_code": "146a",
@@ -386,7 +403,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "changes-in-turnover-question-3",
-                            "title": "Please describe the changes in turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+                            "title": "Please describe the changes in turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide examples of commentary on changes to turnover",

--- a/data/en/mbs_0251.json
+++ b/data/en/mbs_0251.json
@@ -12,6 +12,26 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "employment_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "section",
             "groups": [{
@@ -173,7 +193,7 @@
                             }],
                             "type": "General",
                             "id": "reporting-period-question",
-                            "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -279,7 +299,7 @@
                                 "default": 0
                             }],
                             "type": "General",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total turnover</em>, excluding VAT?"
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>total turnover</em>, excluding VAT?"
                         }]
                     },
                     {
@@ -311,7 +331,7 @@
                                 "mandatory": true
                             }],
                             "id": "confirm-zero-turnover-question",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, the value of the total turnover was <em>£0</em>, is this correct?"
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>£0</em>, is this correct?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -393,7 +413,7 @@
                                 ]
                             },
                             "id": "number-of-employees-total-question",
-                            "title": "On {{exercise.employment_date|format_date}}, what was the number of employees for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "On {{metadata['employment_date']|format_date}}, what was the number of employees for {{metadata['trad_as_or_ru_name']}}?",
                             "type": "General"
                         }],
                         "title": "Employees",
@@ -428,7 +448,7 @@
                                 "mandatory": true
                             }],
                             "id": "confirm-zero-employees-question",
-                            "title": "On {{exercise.employment_date|format_date}}, the number of employees for {{respondent.trad_as_or_ru_name}} was <em>0</em>, is this correct?"
+                            "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{metadata['trad_as_or_ru_name']}} was <em>0</em>, is this correct?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -541,7 +561,7 @@
                                 ]
                             },
                             "id": "number-of-employees-split-question",
-                            "title": "Of the <em>{{answers['number-of-employees-total']}}</em> total employees employed on {{exercise.employment_date|format_date}}, how many male and female employees worked the following hours?",
+                            "title": "Of the <em>{{answers['number-of-employees-total']}}</em> total employees employed on {{metadata['employment_date']|format_date}}, how many male and female employees worked the following hours?",
                             "type": "Calculated"
                         }]
                     },
@@ -549,9 +569,9 @@
                         "id": "changes-in-turnover-block",
                         "type": "Question",
                         "questions": [{
-                            "title": "Did any significant changes occur to the total turnover for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "Did any significant changes occur to the total turnover for {{ metadata['trad_as_or_ru_name'] }}?",
                             "id": "changes-in-turnover-question",
-                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ metadata['trad_as_or_ru_name'] }}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "answers": [{
                                 "options": [{
                                         "value": "Yes",
@@ -604,7 +624,7 @@
                         "id": "changes-in-turnover-block-2",
                         "type": "Question",
                         "questions": [{
-                            "title": "Please indicate the reasons for any changes in the total turnover for {{respondent.trad_as_or_ru_name}}",
+                            "title": "Please indicate the reasons for any changes in the total turnover for {{ metadata['trad_as_or_ru_name'] }}",
                             "answers": [{
                                 "options": [{
                                         "q_code": "146a",
@@ -658,7 +678,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "changes-in-turnover-question-3",
-                            "title": "Please describe the changes in total turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+                            "title": "Please describe the changes in total turnover for {{ metadata['trad_as_or_ru_name'] }} in more detail",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide examples of commentary on changes to total turnover",

--- a/data/en/mbs_0253.json
+++ b/data/en/mbs_0253.json
@@ -11,6 +11,26 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "employment_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "section",
             "groups": [{
@@ -130,7 +150,7 @@
                             }],
                             "type": "General",
                             "id": "reporting-period-question",
-                            "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -202,7 +222,7 @@
                         "questions": [{
                             "id": "water-volume-question",
                             "type": "General",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the total volume of {{respondent.trad_as_or_ru_name}}’s <em>potable water that was supplied to customers</em>, in megalitres?",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the total volume of {{metadata['trad_as_or_ru_name']}}’s <em>potable water that was supplied to customers</em>, in megalitres?",
                             "answers": [{
                                 "id": "water-volume",
                                 "mandatory": true,
@@ -226,7 +246,7 @@
                                 "default": 0
                             }],
                             "id": "total-number-employees-question",
-                            "title": "On {{exercise.employment_date|format_date}} what was the number of employees for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "On {{metadata['employment_date']|format_date}} what was the number of employees for {{metadata['trad_as_or_ru_name']}}?",
                             "description": "An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.",
                             "guidance": {
                                 "content": [{
@@ -281,7 +301,7 @@
                                 "mandatory": true
                             }],
                             "id": "confirm-zero-employees-question",
-                            "title": "On {{exercise.employment_date|format_date}}, the number of employees for {{respondent.trad_as_or_ru_name}} was <em>0</em>, is this correct?"
+                            "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{metadata['trad_as_or_ru_name']}} was <em>0</em>, is this correct?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -393,7 +413,7 @@
                                 }
                             ],
                             "id": "employee-breakdown-questions",
-                            "title": "Of the <em>{{answers['total-number-employees']|format_number}}</em> total employees employed on {{exercise.employment_date|format_date}}, how many male and female employees worked the following hours?",
+                            "title": "Of the <em>{{answers['total-number-employees']|format_number}}</em> total employees employed on {{metadata['employment_date']|format_date}}, how many male and female employees worked the following hours?",
                             "type": "Calculated"
                         }],
                         "title": "Employees"
@@ -405,8 +425,8 @@
                         "questions": [{
                             "type": "General",
                             "id": "significant-change-question",
-                            "title": "Did any significant changes occur to the figures provided for {{respondent.trad_as_or_ru_name}}?",
-                            "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                            "title": "Did any significant changes occur to the figures provided for {{metadata['trad_as_or_ru_name']}}?",
+                            "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
                             "answers": [{
                                 "id": "significant-change-established-answer",
                                 "label": "",
@@ -454,7 +474,7 @@
                             }],
                             "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
                             "id": "change-comment-question",
-                            "title": "Please describe the changes for {{respondent.trad_as_or_ru_name}} in more detail",
+                            "title": "Please describe the changes for {{metadata['trad_as_or_ru_name']}} in more detail",
                             "type": "General"
                         }],
                         "title": "Significant changes"

--- a/data/en/mbs_0255.json
+++ b/data/en/mbs_0255.json
@@ -13,6 +13,26 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "employment_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "section",
             "groups": [{
@@ -176,7 +196,7 @@
                             }],
                             "type": "General",
                             "id": "reporting-period-question",
-                            "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -279,7 +299,7 @@
                                 "mandatory": true
                             }],
                             "type": "General",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>turnover</em>, excluding VAT?"
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>turnover</em>, excluding VAT?"
                         }],
                         "title": "Turnover"
                     },
@@ -362,7 +382,7 @@
                                 ]
                             },
                             "id": "number-of-employees-total-question",
-                            "title": "On {{exercise.employment_date|format_date}}, what was the number of employees for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "On {{metadata['employment_date']|format_date}}, what was the number of employees for {{metadata['trad_as_or_ru_name']}}?",
                             "type": "General"
                         }],
                         "title": "Employees",
@@ -397,7 +417,7 @@
                                 "mandatory": true
                             }],
                             "id": "confirm-zero-employees-question",
-                            "title": "On {{exercise.employment_date|format_date}}, the number of employees for {{respondent.trad_as_or_ru_name}} was <em>0</em>, is this correct?"
+                            "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{metadata['trad_as_or_ru_name']}} was <em>0</em>, is this correct?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -510,7 +530,7 @@
                                 ]
                             },
                             "id": "number-of-employees-split-question",
-                            "title": "Of the <em>{{answers['number-of-employees-total']}}</em> total employees employed on {{exercise.employment_date|format_date}}, how many male and female employees worked the following hours?",
+                            "title": "Of the <em>{{answers['number-of-employees-total']}}</em> total employees employed on {{metadata['employment_date']|format_date}}, how many male and female employees worked the following hours?",
                             "type": "Calculated"
                         }]
                     },
@@ -518,9 +538,9 @@
                         "id": "changes-in-turnover-block",
                         "type": "Question",
                         "questions": [{
-                            "title": "Did any significant changes occur to the turnover for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "Did any significant changes occur to the turnover for {{metadata['trad_as_or_ru_name']}}?",
                             "id": "changes-in-turnover-question",
-                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "answers": [{
                                 "options": [{
                                         "value": "Yes",
@@ -573,7 +593,7 @@
                         "id": "changes-in-turnover-block-2",
                         "type": "Question",
                         "questions": [{
-                            "title": "Please indicate the reasons for any changes in the turnover for {{respondent.trad_as_or_ru_name}}",
+                            "title": "Please indicate the reasons for any changes in the turnover for {{metadata['trad_as_or_ru_name']}}",
                             "answers": [{
                                 "options": [{
                                         "q_code": "146a",
@@ -627,7 +647,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "changes-in-turnover-question-3",
-                            "title": "Please describe the changes in turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+                            "title": "Please describe the changes in turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide examples of commentary on changes to turnover",

--- a/data/en/mbs_0817.json
+++ b/data/en/mbs_0817.json
@@ -11,6 +11,23 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "section",
             "groups": [{
@@ -109,7 +126,7 @@
                             }],
                             "type": "General",
                             "id": "reporting-period-question",
-                            "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -213,7 +230,7 @@
                                 "mandatory": true
                             }],
                             "type": "General",
-                            "title": "For the period {{format_conditional_date (answers['period-from'], exercise.start_date)}} to {{format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total turnover</em>, excluding VAT?"
+                            "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>total turnover</em>, excluding VAT?"
                         }],
                         "title": "Total turnover"
                     },
@@ -221,9 +238,9 @@
                         "id": "changes-in-turnover-block",
                         "type": "Question",
                         "questions": [{
-                            "title": "Did any significant changes occur to the turnover for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "Did any significant changes occur to the turnover for {{metadata['trad_as_or_ru_name']}}?",
                             "id": "changes-in-turnover-question",
-                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "answers": [{
                                 "options": [{
                                         "value": "Yes",
@@ -276,7 +293,7 @@
                         "id": "changes-in-turnover-block-2",
                         "type": "Question",
                         "questions": [{
-                            "title": "Please indicate the reasons for any changes in the turnover for {{respondent.trad_as_or_ru_name}}",
+                            "title": "Please indicate the reasons for any changes in the turnover for {{metadata['trad_as_or_ru_name']}}",
                             "answers": [{
                                 "options": [{
                                         "q_code": "146a",
@@ -330,7 +347,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "changes-in-turnover-question-3",
-                            "title": "Please describe the changes in turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+                            "title": "Please describe the changes in turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide examples of commentary on changes to turnover",

--- a/data/en/mbs_0823.json
+++ b/data/en/mbs_0823.json
@@ -11,6 +11,23 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "section",
             "groups": [{
@@ -109,7 +126,7 @@
                             }],
                             "type": "General",
                             "id": "reporting-period-question",
-                            "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -213,7 +230,7 @@
                                 "mandatory": true
                             }],
                             "type": "General",
-                            "title": "For the period {{format_conditional_date (answers['period-from'], exercise.start_date)}} to {{format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total turnover</em>, excluding VAT?"
+                            "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>total turnover</em>, excluding VAT?"
                         }],
                         "title": "Total Turnover"
                     },
@@ -221,9 +238,9 @@
                         "id": "changes-in-turnover-block",
                         "type": "Question",
                         "questions": [{
-                            "title": "Did any significant changes occur to the total turnover for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "Did any significant changes occur to the total turnover for {{metadata['trad_as_or_ru_name']}}?",
                             "id": "changes-in-turnover-question",
-                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "answers": [{
                                 "options": [{
                                         "value": "Yes",
@@ -276,7 +293,7 @@
                         "id": "changes-in-turnover-block-2",
                         "type": "Question",
                         "questions": [{
-                            "title": "Please indicate the reasons for any changes in the total turnover for {{respondent.trad_as_or_ru_name}}",
+                            "title": "Please indicate the reasons for any changes in the total turnover for {{metadata['trad_as_or_ru_name']}}",
                             "answers": [{
                                 "options": [{
                                         "q_code": "146a",
@@ -330,7 +347,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "changes-in-turnover-question-3",
-                            "title": "Please describe the changes in total turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+                            "title": "Please describe the changes in total turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide examples of commentary on changes to total turnover",

--- a/data/en/mbs_0867.json
+++ b/data/en/mbs_0867.json
@@ -11,6 +11,26 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "employment_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "section",
             "groups": [{
@@ -163,7 +183,7 @@
                             }],
                             "type": "General",
                             "id": "reporting-period-question",
-                            "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -267,7 +287,7 @@
                                 "mandatory": true
                             }],
                             "type": "General",
-                            "title": "For the period {{format_conditional_date (answers['period-from'], exercise.start_date)}} to {{format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total turnover</em>, excluding VAT?"
+                            "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>total turnover</em>, excluding VAT?"
                         }],
                         "title": "Total turnover"
                     },
@@ -304,7 +324,7 @@
                                 ]
                             },
                             "id": "number-of-employees-total-question",
-                            "title": "On {{exercise.employment_date|format_date}}, what was the number of employees for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "On {{metadata['employment_date']|format_date}}, what was the number of employees for {{metadata['trad_as_or_ru_name']}}?",
                             "type": "General"
                         }],
                         "title": "Employees",
@@ -339,7 +359,7 @@
                                 "mandatory": true
                             }],
                             "id": "confirm-zero-employees-question",
-                            "title": "On {{exercise.employment_date|format_date}}, the number of employees for {{respondent.trad_as_or_ru_name}} was <em>0</em>, is this correct?"
+                            "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{metadata['trad_as_or_ru_name']}} was <em>0</em>, is this correct?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -452,7 +472,7 @@
                                 ]
                             },
                             "id": "number-of-employees-split-question",
-                            "title": "Of the <em>{{answers['number-of-employees-total']}}</em> total employees employed on {{exercise.employment_date|format_date}}, how many male and female employees worked the following hours?",
+                            "title": "Of the <em>{{answers['number-of-employees-total']}}</em> total employees employed on {{metadata['employment_date']|format_date}}, how many male and female employees worked the following hours?",
                             "type": "Calculated"
                         }]
                     },
@@ -460,9 +480,9 @@
                         "id": "changes-in-turnover-block",
                         "type": "Question",
                         "questions": [{
-                            "title": "Did any significant changes occur to the turnover for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "Did any significant changes occur to the turnover for {{metadata['trad_as_or_ru_name']}}?",
                             "id": "changes-in-turnover-question",
-                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "answers": [{
                                 "options": [{
                                         "value": "Yes",
@@ -515,7 +535,7 @@
                         "id": "changes-in-turnover-block-2",
                         "type": "Question",
                         "questions": [{
-                            "title": "Please indicate the reasons for any changes in the turnover for {{respondent.trad_as_or_ru_name}}",
+                            "title": "Please indicate the reasons for any changes in the turnover for {{metadata['trad_as_or_ru_name']}}",
                             "answers": [{
                                 "options": [{
                                         "q_code": "146a",
@@ -569,7 +589,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "changes-in-turnover-question-3",
-                            "title": "Please describe the changes in turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+                            "title": "Please describe the changes in turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide examples of commentary on changes to turnover",

--- a/data/en/mbs_0873.json
+++ b/data/en/mbs_0873.json
@@ -11,6 +11,26 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "employment_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "section",
             "groups": [{
@@ -163,7 +183,7 @@
                             }],
                             "type": "General",
                             "id": "reporting-period-question",
-                            "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -267,7 +287,7 @@
                                 "mandatory": true
                             }],
                             "type": "General",
-                            "title": "For the period {{format_conditional_date (answers['period-from'], exercise.start_date)}} to {{format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total turnover</em>, excluding VAT?"
+                            "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>total turnover</em>, excluding VAT?"
                         }],
                         "title": "Total Turnover"
                     },
@@ -304,7 +324,7 @@
                                 ]
                             },
                             "id": "number-of-employees-total-question",
-                            "title": "On {{exercise.employment_date|format_date}}, what was the number of employees for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "On {{metadata['employment_date']|format_date}}, what was the number of employees for {{metadata['trad_as_or_ru_name']}}?",
                             "type": "General"
                         }],
                         "title": "Employees",
@@ -339,7 +359,7 @@
                                 "mandatory": true
                             }],
                             "id": "confirm-zero-employees-question",
-                            "title": "On {{exercise.employment_date|format_date}}, the number of employees for {{respondent.trad_as_or_ru_name}} was <em>0</em>, is this correct?"
+                            "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{metadata['trad_as_or_ru_name']}} was <em>0</em>, is this correct?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -452,7 +472,7 @@
                                 ]
                             },
                             "id": "number-of-employees-split-question",
-                            "title": "Of the <em>{{answers['number-of-employees-total']}}</em> total employees employed on {{exercise.employment_date|format_date}}, how many male and female employees worked the following hours?",
+                            "title": "Of the <em>{{answers['number-of-employees-total']}}</em> total employees employed on {{metadata['employment_date']|format_date}}, how many male and female employees worked the following hours?",
                             "type": "Calculated"
                         }]
                     },
@@ -460,9 +480,9 @@
                         "id": "changes-in-turnover-block",
                         "type": "Question",
                         "questions": [{
-                            "title": "Did any significant changes occur to the total turnover for {{respondent.trad_as_or_ru_name}}?",
+                            "title": "Did any significant changes occur to the total turnover for {{metadata['trad_as_or_ru_name']}}?",
                             "id": "changes-in-turnover-question",
-                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "answers": [{
                                 "options": [{
                                         "value": "Yes",
@@ -515,7 +535,7 @@
                         "id": "changes-in-turnover-block-2",
                         "type": "Question",
                         "questions": [{
-                            "title": "Please indicate the reasons for any changes in the total turnover for {{respondent.trad_as_or_ru_name}}",
+                            "title": "Please indicate the reasons for any changes in the total turnover for {{metadata['trad_as_or_ru_name']}}",
                             "answers": [{
                                 "options": [{
                                         "q_code": "146a",
@@ -569,7 +589,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "changes-in-turnover-question-3",
-                            "title": "Please describe the changes in total turnover for {{respondent.trad_as_or_ru_name}} in more detail",
+                            "title": "Please describe the changes in total turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide examples of commentary on changes to total turnover",

--- a/data/en/multiple_answers.json
+++ b/data/en/multiple_answers.json
@@ -7,6 +7,14 @@
     "description": "A survey containing questions which have more than one answer",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/rsi_transformation.json
+++ b/data/en/rsi_transformation.json
@@ -13,6 +13,23 @@
         "enabled": true,
         "duration": 900
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{
@@ -140,7 +157,7 @@
                             "mandatory": true
                         }],
                         "id": "reporting-period-choice-question",
-                        "title": "Are you able to report for the period from {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}?"
+                        "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
                     }],
                     "type": "Question",
                     "title": "Reporting period",
@@ -240,7 +257,7 @@
                             "default": 0
                         }],
                         "id": "total-turnover-question",
-                        "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, how much was {{respondent.trad_as_or_ru_name}}’s <em>total turnover excluding VAT</em>?",
+                        "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, how much was {{metadata['trad_as_or_ru_name']}}’s <em>total turnover excluding VAT</em>?",
                         "type": "General"
                     }],
                     "title": "Total turnover excluding VAT"
@@ -274,7 +291,7 @@
                             "mandatory": true
                         }],
                         "id": "confirm-zero-turnover-question",
-                        "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, the value of the total turnover was <em>£0</em>, is this correct?"
+                        "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>£0</em>, is this correct?"
                     }],
                     "routing_rules": [{
                             "goto": {
@@ -363,7 +380,7 @@
                             "mandatory": true
                         }],
                         "id": "confirm-zero-retail-sales-question",
-                        "title": "For the period {{ format_conditional_date (answers['period-from'], exercise.start_date)}} to {{ format_conditional_date (answers['period-to'], exercise.end_date)}}, the value of retail sales was <em>£0</em>, is this correct?"
+                        "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of retail sales was <em>£0</em>, is this correct?"
                     }],
                     "routing_rules": [{
                             "goto": {
@@ -451,9 +468,9 @@
                             "q_code": "146a",
                             "type": "Radio"
                         }],
-                        "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{respondent.trad_as_or_ru_name}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                        "description": "Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
                         "id": "significant-change-question",
-                        "title": "Did any significant changes occur to the retail sales for {{respondent.trad_as_or_ru_name}}?",
+                        "title": "Did any significant changes occur to the retail sales for {{metadata['trad_as_or_ru_name']}}?",
                         "type": "General"
                     }],
                     "title": "Changes in retail sales",
@@ -521,7 +538,7 @@
                             "type": "Checkbox"
                         }],
                         "id": "reason-for-change-question",
-                        "title": "Please indicate the reasons for any changes in the retail sales for {{respondent.trad_as_or_ru_name}}",
+                        "title": "Please indicate the reasons for any changes in the retail sales for {{metadata['trad_as_or_ru_name']}}",
                         "type": "General"
                     }],
                     "title": "Changes in retail sales"
@@ -559,7 +576,7 @@
                         }],
                         "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
                         "id": "change-comment-question",
-                        "title": "Please describe the changes in retail sales for {{respondent.trad_as_or_ru_name}} in more detail",
+                        "title": "Please describe the changes in retail sales for {{metadata['trad_as_or_ru_name']}} in more detail",
                         "type": "General"
                     }],
                     "title": "Changes in retail sales"

--- a/data/en/test_0102.json
+++ b/data/en/test_0102.json
@@ -7,6 +7,20 @@
     "description": "RSI Description",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{
@@ -50,7 +64,7 @@
                                 "type": "Date"
                             }
                         ],
-                        "description": "If possible, this should be for the period {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}.",
+                        "description": "If possible, this should be for the period {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}.",
                         "id": "reporting-period-question",
                         "title": "What are the dates of the period that you will be reporting for?",
                         "type": "DateRange"

--- a/data/en/test_0112.json
+++ b/data/en/test_0112.json
@@ -7,6 +7,24 @@
     "description": "RSI Description",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "employment_date": {
+            "validator": "date"
+        }
+
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{
@@ -51,7 +69,7 @@
                                 "type": "Date"
                             }
                         ],
-                        "description": "If possible, this should be for the period {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}.",
+                        "description": "If possible, this should be for the period {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}.",
                         "id": "reporting-period-question",
                         "title": "What are the dates of the period that you will be reporting for?",
                         "type": "DateRange"
@@ -223,7 +241,7 @@
                             }
                         ],
                         "id": "number-of-employees-question",
-                        "title": "On {{exercise.employment_date|format_date}} what was the number of employees?",
+                        "title": "On {{metadata['employment_date']|format_date}} what was the number of employees?",
                         "description": "<p>An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.</p>",
                         "guidance": {
                             "content": [{

--- a/data/en/test_0203.json
+++ b/data/en/test_0203.json
@@ -7,6 +7,20 @@
     "description": "MCI Description",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{
@@ -55,7 +69,7 @@
                                     "type": "Date"
                                 }
                             ],
-                            "description": "If possible, this should be for the period {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}.",
+                            "description": "If possible, this should be for the period {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}.",
                             "id": "reporting-period-question",
                             "title": "What are the dates of the sales period you are reporting for?",
                             "type": "DateRange"

--- a/data/en/test_0205.json
+++ b/data/en/test_0205.json
@@ -7,6 +7,20 @@
     "description": "MCI Description",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{
@@ -45,7 +59,7 @@
                     "questions": [{
                             "id": "reporting-period-question",
                             "title": "What are the dates of the sales period you are reporting for?",
-                            "description": "If possible, this should be for the period {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}.",
+                            "description": "If possible, this should be for the period {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}.",
                             "type": "DateRange",
                             "answers": [{
                                     "id": "period-from",

--- a/data/en/test_0213.json
+++ b/data/en/test_0213.json
@@ -7,6 +7,23 @@
     "description": "MCI Description",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "employment_date": {
+            "validator": "date"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{
@@ -54,7 +71,7 @@
                                     "type": "Date"
                                 }
                             ],
-                            "description": "If possible, this should be for the period {{exercise.start_date|format_date}} to {{exercise.end_date|format_date}}.",
+                            "description": "If possible, this should be for the period {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}.",
                             "id": "reporting-period-question",
                             "title": "What are the dates of the sales period you are reporting for?",
                             "type": "DateRange"
@@ -406,7 +423,7 @@
                             "type": "General"
                         }
                     ],
-                    "title": "On {{exercise.employment_date|format_date}} what was the number of employees for the business?"
+                    "title": "On {{metadata['employment_date']|format_date}} what was the number of employees for the business?"
                 },
                 {
                     "type": "Summary",

--- a/data/en/test_big_list_naughty_strings.json
+++ b/data/en/test_big_list_naughty_strings.json
@@ -1,5 +1,13 @@
 {
     "mime_type": "application/json/ons/eq",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_checkbox.json
+++ b/data/en/test_checkbox.json
@@ -12,6 +12,14 @@
         "NUMBER_TOO_SMALL": "Number cannot be less than zero",
         "INVALID_NUMBER": "Please enter an integer"
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_conditional_dates.json
+++ b/data/en/test_conditional_dates.json
@@ -7,6 +7,20 @@
     "description": "A test schema for different date formats",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{
@@ -50,7 +64,7 @@
                             "type": "Number"
                         }],
                         "id": "total-retail-turnover-question",
-                        "title": "For the period {{ format_conditional_date (answers['date-start-from'], exercise.start_date)}} to {{ format_conditional_date (answers['date-end-to'], exercise.end_date)}}, what was the value of the business’s total retail turnover?",
+                        "title": "For the period {{ format_conditional_date (answers['date-start-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['date-end-to'], metadata['ref_p_end_date'])}}, what was the value of the business’s total retail turnover?",
                         "type": "General"
                     }],
                     "title": "Conditional Date Validation"

--- a/data/en/test_conditional_routing.json
+++ b/data/en/test_conditional_routing.json
@@ -7,6 +7,14 @@
     "description": "",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_confirmation_question.json
+++ b/data/en/test_confirmation_question.json
@@ -14,6 +14,17 @@
     "navigation": {
         "visible": true
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "default-section",
             "title": "Questions",
@@ -32,7 +43,7 @@
                                 "default": 0
                             }],
                             "id": "number-of-employees-total-question",
-                            "title": "How many employees work at {{respondent.trad_as_or_ru_name}}?",
+                            "title": "How many employees work at {{metadata['trad_as_or_ru_name']}}?",
                             "type": "General"
                         }],
                         "type": "Question"
@@ -66,7 +77,7 @@
                                 "q_code": "d50"
                             }],
                             "id": "confirm-zero-employees-question",
-                            "title": "The current number of employees for {{respondent.trad_as_or_ru_name}} is <em>0</em>, is this correct?"
+                            "title": "The current number of employees for {{metadata['trad_as_or_ru_name']}} is <em>0</em>, is this correct?"
                         }],
                         "routing_rules": [{
                                 "goto": {

--- a/data/en/test_currency.json
+++ b/data/en/test_currency.json
@@ -12,6 +12,14 @@
         "NUMBER_TOO_SMALL": "Number cannot be less than zero",
         "INVALID_DECIMAL": "Please enter a number to %(max)d decimal places"
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_date_validation_combined.json
+++ b/data/en/test_date_validation_combined.json
@@ -7,8 +7,19 @@
     "description": "A test schema for different date formats",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
-    "variables": {
-        "period": "{{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}"
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        }
     },
     "sections": [{
         "id": "default-section",
@@ -27,8 +38,8 @@
                             "content": [{
                                 "list": [
                                     "Dates between 10 and 50 days apart",
-                                    "Period from date greater than 19 days before {{exercise.start_date|format_date}}",
-                                    "Period to date no greater than 20 days after {{exercise.end_date|format_date}}"
+                                    "Period from date greater than 19 days before {{ metadata['ref_p_start_date']|format_date }}",
+                                    "Period to date no greater than 20 days after {{ metadata['ref_p_end_date']|format_date }}"
                                 ]
                             }]
                         },

--- a/data/en/test_date_validation_mm_yyyy_combined.json
+++ b/data/en/test_date_validation_mm_yyyy_combined.json
@@ -8,7 +8,21 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "variables": {
-        "period": "{{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}"
+        "period": "{{ format_conditional_date (answers.period_from, metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers.period_to, metadata['ref_p_end_date'])}}"
+    },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        }
     },
     "sections": [{
         "id": "default-section",
@@ -27,8 +41,8 @@
                             "content": [{
                                 "list": [
                                     "Dates between 2 and 3 months apart",
-                                    "Period from date greater than 1 month before {{exercise.start_date|format_date}}",
-                                    "Period to date no greater than 3 months after {{exercise.end_date|format_date}}"
+                                    "Period from date greater than 1 month before {{metadata['ref_p_start_date']|format_date}}",
+                                    "Period to date no greater than 3 months after {{metadata['ref_p_end_date']|format_date}}"
                                 ]
                             }]
                         },

--- a/data/en/test_date_validation_range.json
+++ b/data/en/test_date_validation_range.json
@@ -7,8 +7,13 @@
     "description": "A test schema for different date formats",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
-    "variables": {
-        "period": "{{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}"
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
     },
     "sections": [{
         "id": "default-section",

--- a/data/en/test_date_validation_single.json
+++ b/data/en/test_date_validation_single.json
@@ -7,8 +7,16 @@
     "description": "A test schema for single date period validation",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
-    "variables": {
-        "period": "{{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}"
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        }
     },
     "sections": [{
         "id": "default-section",
@@ -43,7 +51,7 @@
                         "guidance": {
                             "content": [{
                                 "list": [
-                                    "Period 'from' date should be greater than 19 days before {{exercise.start_date|format_date}}",
+                                    "Period 'from' date should be greater than 19 days before {{metadata['ref_p_start_date']|format_date}}",
                                     "Period 'from' should also be no greater than 20 days after 11 June 2017",
                                     "Period 'to' date should be greater than 1 month 10 days after {{answers['date']|format_date}}"
                                 ]

--- a/data/en/test_dates.json
+++ b/data/en/test_dates.json
@@ -7,6 +7,14 @@
     "description": "A test schema for different date formats",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_default.json
+++ b/data/en/test_default.json
@@ -7,6 +7,14 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A test survey for routing based on an number equals",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_dependencies.json
+++ b/data/en/test_dependencies.json
@@ -10,6 +10,14 @@
     "navigation": {
         "visible": true
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "default-section",
             "title": "Validate Sum Section",

--- a/data/en/test_dependencies_calculation.json
+++ b/data/en/test_dependencies_calculation.json
@@ -10,6 +10,14 @@
     "navigation": {
         "visible": true
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "default-section",
             "title": "Validate Sum Section",

--- a/data/en/test_dependencies_max_value.json
+++ b/data/en/test_dependencies_max_value.json
@@ -10,6 +10,14 @@
     "navigation": {
         "visible": true
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "default-section",
             "title": "Max Dependency",

--- a/data/en/test_dependencies_min_value.json
+++ b/data/en/test_dependencies_min_value.json
@@ -10,6 +10,14 @@
     "navigation": {
         "visible": true
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "default-section",
             "title": "Min Dependency",

--- a/data/en/test_difference_in_years.json
+++ b/data/en/test_difference_in_years.json
@@ -7,6 +7,14 @@
     "description": "A test schema for calculate age from date",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_difference_in_years_month_year.json
+++ b/data/en/test_difference_in_years_month_year.json
@@ -7,6 +7,14 @@
     "description": "A test schema for calculate age from date",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_difference_in_years_month_year_range.json
+++ b/data/en/test_difference_in_years_month_year_range.json
@@ -7,6 +7,14 @@
     "description": "A test schema for calculate age from date",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_difference_in_years_range.json
+++ b/data/en/test_difference_in_years_range.json
@@ -7,6 +7,14 @@
     "description": "A test schema for calculate age from date",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_dropdown_mandatory.json
+++ b/data/en/test_dropdown_mandatory.json
@@ -6,6 +6,14 @@
     "title": "Dropdown Mandatory",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_dropdown_mandatory_with_overridden_error.json
+++ b/data/en/test_dropdown_mandatory_with_overridden_error.json
@@ -6,6 +6,14 @@
     "title": "Dropdown Mandatory With Overridden Error",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_dropdown_optional.json
+++ b/data/en/test_dropdown_optional.json
@@ -6,6 +6,14 @@
     "title": "Dropdown Mandatory",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_error_messages.json
+++ b/data/en/test_error_messages.json
@@ -7,6 +7,14 @@
     "description": "Test Description",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_final_confirmation.json
+++ b/data/en/test_final_confirmation.json
@@ -15,6 +15,14 @@
         "NUMBER_TOO_SMALL": "Number cannot be less than zero",
         "INVALID_NUMBER": "Please enter an integer"
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "first-group",
             "title": "First group",

--- a/data/en/test_household_question.json
+++ b/data/en/test_household_question.json
@@ -7,6 +7,14 @@
     "description": "",
     "theme": "census",
     "legal_basis": "Voluntary",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_interstitial_page.json
+++ b/data/en/test_interstitial_page.json
@@ -12,6 +12,14 @@
         "NUMBER_TOO_SMALL": "Number cannot be less than zero",
         "INVALID_NUMBER": "Please enter an integer"
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_introduction.json
+++ b/data/en/test_introduction.json
@@ -1,6 +1,17 @@
 {
     "data_version": "0.0.1",
     "description": "UK Innovation Survey",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ru_name": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{
@@ -158,9 +169,9 @@
                             "content": [{
                                 "title": "Definition of innovation",
                                 "list": [
-                                    "Innovation, for the purpose of this survey, is defined as <strong>new</strong> or <strong>significantly improved goods or services</strong> as well as <strong>processes</strong> used to produce or supply all goods or services that {{ respondent.ru_name }} has introduced, regardless of their origin.",
-                                    "These innovations may be new to {{ respondent.ru_name }} or new to the market",
-                                    "Investments for future innovation and changes that {{ respondent.ru_name }} has introduced at a <strong>strategic</strong> level (in organisation and practices) are also covered"
+                                    "Innovation, for the purpose of this survey, is defined as <strong>new</strong> or <strong>significantly improved goods or services</strong> as well as <strong>processes</strong> used to produce or supply all goods or services that {{ metadata['ru_name'] }} has introduced, regardless of their origin.",
+                                    "These innovations may be new to {{ metadata['ru_name'] }} or new to the market",
+                                    "Investments for future innovation and changes that {{ metadata['ru_name'] }} has introduced at a <strong>strategic</strong> level (in organisation and practices) are also covered"
                                 ]
                             }]
                         }, {

--- a/data/en/test_language.json
+++ b/data/en/test_language.json
@@ -7,6 +7,14 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to demonstrate english language",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_language_cy.json
+++ b/data/en/test_language_cy.json
@@ -7,6 +7,14 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to demonstrate welsh language",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_markup.json
+++ b/data/en/test_markup.json
@@ -7,6 +7,14 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test rendering of markup in questionnaires",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_metadata_routing.json
+++ b/data/en/test_metadata_routing.json
@@ -7,6 +7,17 @@
     "description": "Census England Household Schema",
     "theme": "census",
     "legal_basis": "Voluntary",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "variant_flags": {
+            "validator": "object"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_multiple_piping.json
+++ b/data/en/test_multiple_piping.json
@@ -7,6 +7,14 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test multiple piping into a question and answer",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_navigation.json
+++ b/data/en/test_navigation.json
@@ -10,6 +10,14 @@
     "navigation": {
         "visible": true
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "property-details-section",
             "title": "Property Details",

--- a/data/en/test_navigation_completeness.json
+++ b/data/en/test_navigation_completeness.json
@@ -10,6 +10,14 @@
     "navigation": {
         "visible": true
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "coffee-section",
             "title": "Coffee",

--- a/data/en/test_navigation_confirmation.json
+++ b/data/en/test_navigation_confirmation.json
@@ -10,6 +10,14 @@
     "navigation": {
         "visible": true
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "property-details-section",
             "title": "Property Details",

--- a/data/en/test_navigation_routing.json
+++ b/data/en/test_navigation_routing.json
@@ -9,6 +9,14 @@
     "navigation": {
         "visible": true
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "group-1-section",
             "title": "Group 1",

--- a/data/en/test_numbers.json
+++ b/data/en/test_numbers.json
@@ -7,6 +7,14 @@
     "description": "Test Description",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_percentage.json
+++ b/data/en/test_percentage.json
@@ -10,6 +10,14 @@
     "navigation": {
         "visible": true
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "percent-input-section",
             "title": "Percent Input",

--- a/data/en/test_question_guidance.json
+++ b/data/en/test_question_guidance.json
@@ -7,6 +7,14 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test question guidance content",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_radio_checkbox_descriptions.json
+++ b/data/en/test_radio_checkbox_descriptions.json
@@ -7,6 +7,14 @@
     "description": "",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_radio_mandatory.json
+++ b/data/en/test_radio_mandatory.json
@@ -6,6 +6,14 @@
     "title": "Radio Mandatory",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_radio_mandatory_with_mandatory_other.json
+++ b/data/en/test_radio_mandatory_with_mandatory_other.json
@@ -6,6 +6,14 @@
     "title": "Radio Mandatory with Mandatory Other",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_radio_mandatory_with_mandatory_other_overridden_error.json
+++ b/data/en/test_radio_mandatory_with_mandatory_other_overridden_error.json
@@ -6,6 +6,14 @@
     "title": "Radio Mandatory with Mandatory Other Overridden Error",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_radio_mandatory_with_optional_other.json
+++ b/data/en/test_radio_mandatory_with_optional_other.json
@@ -6,6 +6,14 @@
     "title": "Radio Mandatory with Optional Other",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_radio_mandatory_with_overridden_error.json
+++ b/data/en/test_radio_mandatory_with_overridden_error.json
@@ -6,6 +6,14 @@
     "title": "Radio Mandatory with Overridden Error",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_radio_optional.json
+++ b/data/en/test_radio_optional.json
@@ -6,6 +6,14 @@
     "title": "Radio Optional",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "section-1",
         "groups": [{

--- a/data/en/test_radio_optional_with_mandatory_other.json
+++ b/data/en/test_radio_optional_with_mandatory_other.json
@@ -6,6 +6,14 @@
     "title": "Radio Optional with Mandatory Other",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_radio_optional_with_mandatory_other_overridden_error.json
+++ b/data/en/test_radio_optional_with_mandatory_other_overridden_error.json
@@ -6,6 +6,14 @@
     "title": "Radio Optional with Mandatory Other Overridden Error",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_radio_optional_with_optional_other.json
+++ b/data/en/test_radio_optional_with_optional_other.json
@@ -6,6 +6,14 @@
     "title": "Radio Optional with Optional Other",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_relationship_household.json
+++ b/data/en/test_relationship_household.json
@@ -7,6 +7,14 @@
     "description": "",
     "theme": "census",
     "legal_basis": "Voluntary",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_repeating_and_conditional_routing.json
+++ b/data/en/test_repeating_and_conditional_routing.json
@@ -7,6 +7,14 @@
     "description": "",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_repeating_household.json
+++ b/data/en/test_repeating_household.json
@@ -10,6 +10,14 @@
     "navigation": {
         "visible": true
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "group-1-section",
             "title": "Group 1",

--- a/data/en/test_routing_date_equals.json
+++ b/data/en/test_routing_date_equals.json
@@ -7,6 +7,14 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A test survey for routing based on equal dates",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_routing_date_greater_than.json
+++ b/data/en/test_routing_date_greater_than.json
@@ -7,6 +7,17 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A test survey for routing based on a date greater than",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "return_by": {
+            "validator": "date"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{
@@ -23,7 +34,7 @@
                         }],
                         "description": "",
                         "id": "date-questions",
-                        "title": "Enter a date greater than Return date: {{ exercise.return_by|format_date }}",
+                        "title": "Enter a date greater than Return date: {{ metadata['return_by']|format_date }}",
                         "type": "General"
                     }],
                     "title": "",
@@ -50,7 +61,7 @@
                     "type": "Interstitial",
                     "id": "incorrect-answer",
                     "title": "Incorrect Date",
-                    "description": "You entered a return date earlier than {{ exercise.return_by|format_date }}.",
+                    "description": "You entered a return date earlier than {{ metadata['return_by']|format_date }}.",
                     "routing_rules": [{
                         "goto": {
                             "block": "summary"
@@ -61,7 +72,7 @@
                     "type": "Interstitial",
                     "id": "correct-answer",
                     "title": "Correct Date",
-                    "description": "You entered a return date later than {{ exercise.return_by|format_date }}."
+                    "description": "You entered a return date later than {{ metadata['return_by']|format_date }}."
                 },
                 {
                     "type": "Summary",

--- a/data/en/test_routing_date_less_than.json
+++ b/data/en/test_routing_date_less_than.json
@@ -7,6 +7,14 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A test survey for routing based on a Date less than",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_routing_date_not_equals.json
+++ b/data/en/test_routing_date_not_equals.json
@@ -7,6 +7,14 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A test survey for routing based on a date not equals",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_routing_group.json
+++ b/data/en/test_routing_group.json
@@ -6,6 +6,14 @@
     "title": "Routing Group",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_routing_number_equals.json
+++ b/data/en/test_routing_number_equals.json
@@ -7,6 +7,14 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A test survey for routing based on an number equals",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_routing_number_greater_than.json
+++ b/data/en/test_routing_number_greater_than.json
@@ -7,6 +7,14 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A test survey for routing based on a number greater than",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_routing_number_greater_than_or_equal.json
+++ b/data/en/test_routing_number_greater_than_or_equal.json
@@ -7,6 +7,14 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A test survey for routing based on a number greater than or equal",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_routing_number_less_than.json
+++ b/data/en/test_routing_number_less_than.json
@@ -7,6 +7,14 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A test survey for routing based on a number less than",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_routing_number_less_than_or_equal.json
+++ b/data/en/test_routing_number_less_than_or_equal.json
@@ -7,6 +7,14 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A test survey for routing based on a number less than or equal",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_routing_number_not_equals.json
+++ b/data/en/test_routing_number_not_equals.json
@@ -7,6 +7,14 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A test survey for routing based on a number not equals",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_routing_on_multiple_select.json
+++ b/data/en/test_routing_on_multiple_select.json
@@ -7,6 +7,14 @@
     "description": "Test schema for routing on multiple selected answers",
     "theme": "census",
     "legal_basis": "Voluntary",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_schema_context.json
+++ b/data/en/test_schema_context.json
@@ -1,0 +1,110 @@
+{
+    "data_version": "0.0.1",
+    "description": "Test Schema Context",
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "survey_id": "144",
+    "theme": "default",
+    "legal_basis": "Voluntary",
+    "title": "Test Schema Context",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "period_str": {
+            "validator": "string"
+        },
+        "ru_name": {
+            "validator": "string"
+        },
+        "trad_as": {
+            "validator": "string"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "employment_date": {
+            "validator": "date"
+        },
+        "return_by": {
+            "validator": "date"
+        },
+        "region_code": {
+            "validator": "string"
+        },
+        "variant_flags": {
+            "validator": "object"
+        }
+    },
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+                "blocks": [{
+                    "id": "introduction",
+                    "type": "Introduction",
+                    "primary_content": [{
+                        "type": "Preview",
+                        "id": "preview",
+                        "title": "",
+                        "content": [{
+                            "title": "period_str: {{ metadata['period_str'] }}"
+                        }, {
+                            "title": "ru_name: {{ metadata['ru_name'] }}"
+                        }, {
+                            "title": "trad_as: {{ metadata['trad_as'] }}"
+                        }, {
+                            "title": "trad_as_or_ru_name: {{ metadata['trad_as_or_ru_name'] }}"
+                        }, {
+                            "title": "ref_p_start_date: {{ metadata['ref_p_start_date'] }}"
+                        }, {
+                            "title": "ref_p_end_date: {{ metadata['ref_p_end_date'] }}"
+                        }, {
+                            "title": "employment_date: {{ metadata['employment_date'] }}"
+                        }, {
+                            "title": "return_by: {{ metadata['return_by'] }}"
+                        }, {
+                            "title": "region_code: {{ metadata['region_code'] }}"
+                        }, {
+                            "title": "variant_flags: {{ metadata['variant_flags'] }}"
+                        }]
+                    }]
+                }],
+                "id": "general-business-information",
+                "title": "General Business Information"
+            },
+            {
+                "blocks": [{
+                    "id": "confirmation",
+                    "description": "",
+                    "questions": [{
+                        "answers": [],
+                        "id": "ready-to-submit-completed-question",
+                        "title": "Submission",
+                        "type": "General",
+                        "guidance": {
+                            "content": [{
+                                "list": [
+                                    "You will not be able to access or change your answers on submitting the questionnaire",
+                                    "If you wish to review your answers please select the relevant completed sections"
+                                ]
+                            }]
+                        }
+                    }],
+                    "title": "You are now ready to submit this survey",
+                    "type": "Confirmation"
+                }],
+                "id": "ready-to-submit",
+                "title": "Submit answers"
+            }
+        ]
+    }]
+}

--- a/data/en/test_section_summary.json
+++ b/data/en/test_section_summary.json
@@ -14,6 +14,14 @@
     "navigation": {
         "visible": true
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
             "id": "property-details-section",
             "title": "Property Details Section",

--- a/data/en/test_skip_condition.json
+++ b/data/en/test_skip_condition.json
@@ -8,6 +8,14 @@
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test skip condition.",
     "messages": {},
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_skip_condition_block.json
+++ b/data/en/test_skip_condition_block.json
@@ -6,6 +6,14 @@
     "title": "Skip group",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_skip_condition_group.json
+++ b/data/en/test_skip_condition_group.json
@@ -6,6 +6,14 @@
     "title": "Skip group",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_skip_condition_question.json
+++ b/data/en/test_skip_condition_question.json
@@ -6,6 +6,14 @@
     "title": "Skip group",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_sum_equal_or_less_validation_against_total.json
+++ b/data/en/test_sum_equal_or_less_validation_against_total.json
@@ -7,6 +7,14 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A survey that tests grouped and calculated answers against a total",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_sum_equal_validation_against_total.json
+++ b/data/en/test_sum_equal_validation_against_total.json
@@ -7,6 +7,14 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A survey that tests grouped and calculated answers against a total",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_sum_less_validation_against_total.json
+++ b/data/en/test_sum_less_validation_against_total.json
@@ -7,6 +7,14 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A survey that tests grouped and calculated answers against a total",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_sum_multi_validation_against_total.json
+++ b/data/en/test_sum_multi_validation_against_total.json
@@ -7,6 +7,14 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A survey that tests grouped and calculated answers against a total",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_summary.json
+++ b/data/en/test_summary.json
@@ -7,6 +7,14 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to demo radio field Other input.",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_textarea.json
+++ b/data/en/test_textarea.json
@@ -12,6 +12,14 @@
         "NUMBER_TOO_SMALL": "Number cannot be less than zero",
         "INVALID_NUMBER": "Please enter an integer"
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_textfield.json
+++ b/data/en/test_textfield.json
@@ -12,6 +12,14 @@
         "NUMBER_TOO_SMALL": "Number cannot be less than zero",
         "INVALID_NUMBER": "Please enter an integer"
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_timeout.json
+++ b/data/en/test_timeout.json
@@ -9,6 +9,14 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test the time out functionality",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_total_breakdown.json
+++ b/data/en/test_total_breakdown.json
@@ -7,6 +7,14 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A survey that tests the totalling of percentage input fields",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_unit_patterns.json
+++ b/data/en/test_unit_patterns.json
@@ -7,6 +7,14 @@
     "description": "Tests for localised (UK rendering) measurements.",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/data/en/test_view_submitted_response.json
+++ b/data/en/test_view_submitted_response.json
@@ -11,6 +11,14 @@
         "enabled": true,
         "duration": 5
     },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/tests/app/forms/test_fields.py
+++ b/tests/app/forms/test_fields.py
@@ -4,7 +4,6 @@ from wtforms import validators, StringField, FormField, SelectField, SelectMulti
 
 from app.forms.custom_fields import MaxTextAreaField
 from app.forms.fields import CustomIntegerField, CustomDecimalField, get_field, get_mandatory_validator, get_length_validator, _coerce_str_unless_none
-from app.storage.metadata_parser import parse_metadata
 from app.validation.error_messages import error_messages
 from app.validation.validators import ResponseRequired
 from app.data_model.answer_store import AnswerStore
@@ -15,7 +14,7 @@ class TestFields(unittest.TestCase):
 
     def setUp(self):
         self.answer_store = AnswerStore()
-        self.metadata = parse_metadata({
+        self.metadata = {
             'user_id': '789473423',
             'form_type': '0205',
             'collection_exercise_sid': 'test-sid',
@@ -29,7 +28,7 @@ class TestFields(unittest.TestCase):
             'return_by': '2016-07-07',
             'case_id': '1234567890',
             'case_ref': '1000000000000001'
-        })
+        }
 
     def tearDown(self):
         self.answer_store.clear()

--- a/tests/app/parser/test_metadata_parser.py
+++ b/tests/app/parser/test_metadata_parser.py
@@ -2,7 +2,7 @@ import unittest
 import uuid
 
 from sdc.crypto.exceptions import InvalidTokenException
-from app.storage.metadata_parser import parse_metadata, is_valid_metadata
+from app.storage.metadata_parser import validate_metadata, parse_runner_claims, clean_leading_trailing_spaces
 from tests.app.framework.survey_runner_test_case import SurveyRunnerTestCase
 
 
@@ -10,7 +10,7 @@ class TestMetadataParser(SurveyRunnerTestCase):  # pylint: disable=too-many-publ
 
     def setUp(self):
         super().setUp()
-        self.jwt = {
+        self.metadata = {
             'jti': str(uuid.uuid4()),
             'user_id': '1',
             'form_type': 'a',
@@ -28,117 +28,73 @@ class TestMetadataParser(SurveyRunnerTestCase):  # pylint: disable=too-many-publ
             'case_ref': '1000000000000001',
             'account_service_url': 'https://ras.ons.gov.uk'
         }
+
+        self.schema_metadata = {
+            'user_id': {
+                'validator': 'string'
+            },
+            'period_id': {
+                'validator': 'string'
+            }
+        }
+
         with self.application.test_request_context():
-            self.metadata = parse_metadata(self.jwt)
+            validate_metadata(self.metadata, self.schema_metadata)
 
     def test_transaction_id(self):
         with self.application.test_request_context():
-            self.assertEqual(self.jwt.get('tx_id'), self.metadata['tx_id'])
+            self.assertEqual(self.metadata.get('tx_id'), self.metadata['tx_id'])
 
     def test_form_type(self):
         with self.application.test_request_context():
-            self.assertEqual(self.jwt.get('form_type'), self.metadata['form_type'])
+            self.assertEqual(self.metadata.get('form_type'), self.metadata['form_type'])
 
     def test_collection_id(self):
         with self.application.test_request_context():
-            self.assertEqual(self.jwt.get('collection_exercise_sid'), self.metadata['collection_exercise_sid'])
+            self.assertEqual(self.metadata.get('collection_exercise_sid'), self.metadata['collection_exercise_sid'])
 
     def test_get_eq_id(self):
         with self.application.test_request_context():
-            self.assertEqual(self.jwt.get('eq_id'), self.metadata['eq_id'])
+            self.assertEqual(self.metadata.get('eq_id'), self.metadata['eq_id'])
 
     def test_get_period_id(self):
         with self.application.test_request_context():
-            self.assertEqual(self.jwt.get('period_id'), self.metadata['period_id'])
+            self.assertEqual(self.metadata.get('period_id'), self.metadata['period_id'])
 
     def test_get_period_str(self):
         with self.application.test_request_context():
-            self.assertEqual(self.jwt.get('period_str'), self.metadata['period_str'])
+            self.assertEqual(self.metadata.get('period_str'), self.metadata['period_str'])
 
     def test_ref_p_start_date(self):
         with self.application.test_request_context():
-            self.assertEqual(self.jwt.get('ref_p_start_date'), self.metadata['ref_p_start_date'])
+            self.assertEqual(self.metadata.get('ref_p_start_date'), self.metadata['ref_p_start_date'])
 
     def test_ref_p_end_date(self):
         with self.application.test_request_context():
-            self.assertEqual(self.jwt.get('ref_p_end_date'), self.metadata['ref_p_end_date'])
+            self.assertEqual(self.metadata.get('ref_p_end_date'), self.metadata['ref_p_end_date'])
 
     def test_ru_ref(self):
         with self.application.test_request_context():
-            self.assertEqual(self.jwt.get('ref_p_end_date'), self.metadata['ref_p_end_date'])
+            self.assertEqual(self.metadata.get('ref_p_end_date'), self.metadata['ref_p_end_date'])
 
     def test_case_id(self):
         with self.application.test_request_context():
-            self.assertEqual(self.jwt.get('case_id'), self.metadata['case_id'])
+            self.assertEqual(self.metadata.get('case_id'), self.metadata['case_id'])
 
     def test_case_ref(self):
         with self.application.test_request_context():
-            self.assertEqual(self.jwt.get('case_ref'), self.metadata['case_ref'])
+            self.assertEqual(self.metadata.get('case_ref'), self.metadata['case_ref'])
 
     def test_account_service_url(self):
         with self.application.test_request_context():
-            self.assertEqual(self.jwt.get('account_service_url'), self.metadata['account_service_url'])
+            self.assertEqual(self.metadata.get('account_service_url'), self.metadata['account_service_url'])
 
     def test_is_valid(self):
         with self.application.test_request_context():
-            self.assertTrue(is_valid_metadata(self.jwt))
+            validate_metadata(self.metadata, self.schema_metadata)
 
-    def test_is_valid_fails_missing_user_id(self):
-        jwt = {
-            'jti': str(uuid.uuid4()),
-            'form_type': 'a',
-            'collection_exercise_sid': 'test-sid',
-            'eq_id': '2',
-            'period_id': '3',
-            'period_str': '2016-01-01',
-            'ref_p_start_date': '2016-02-02',
-            'ref_p_end_date': '2016-03-03',
-            'ru_ref': '2016-04-04',
-            'ru_name': 'Apple',
-            'return_by': '2016-07-07'
-        }
-        valid, field = is_valid_metadata(jwt)
-        self.assertFalse(valid)
-        self.assertEqual('user_id', field)
-
-    def test_is_valid_fails_missing_form_type(self):
-        jwt = {
-            'jti': str(uuid.uuid4()),
-            'user_id': '1',
-            'collection_exercise_sid': 'test-sid',
-            'eq_id': '2',
-            'period_id': '3',
-            'period_str': '2016-01-01',
-            'ref_p_start_date': '2016-02-02',
-            'ref_p_end_date': '2016-03-03',
-            'ru_ref': '2016-04-04',
-            'ru_name': 'Apple',
-            'return_by': '2016-07-07'
-        }
-        valid, field = is_valid_metadata(jwt)
-        self.assertFalse(valid)
-        self.assertEqual('form_type', field)
-
-    def test_is_valid_fails_missing_collection_exercise_sid(self):
-        jwt = {
-            'jti': str(uuid.uuid4()),
-            'user_id': '1',
-            'form_type': 'a',
-            'eq_id': '2',
-            'period_id': '3',
-            'period_str': '2016-01-01',
-            'ref_p_start_date': '2016-02-02',
-            'ref_p_end_date': '2016-03-03',
-            'ru_ref': '2016-04-04',
-            'ru_name': 'Apple',
-            'return_by': '2016-07-07'
-        }
-        valid, field = is_valid_metadata(jwt)
-        self.assertFalse(valid)
-        self.assertEqual('collection_exercise_sid', field)
-
-    def test_is_valid_fails_missing_eq_id(self):
-        jwt = {
+    def test_missing_required_eq_id_in_token(self):
+        metadata = {
             'jti': str(uuid.uuid4()),
             'user_id': '1',
             'form_type': 'a',
@@ -151,262 +107,179 @@ class TestMetadataParser(SurveyRunnerTestCase):  # pylint: disable=too-many-publ
             'ru_name': 'Apple',
             'return_by': '2016-07-07'
         }
-        valid, field = is_valid_metadata(jwt)
-        self.assertFalse(valid)
-        self.assertEqual('eq_id', field)
 
-    def test_is_valid_fails_missing_period_id(self):
-        jwt = {
+        with self.assertRaises(InvalidTokenException) as ite:
+            parse_runner_claims(metadata)
+
+        self.assertEqual('Missing key/value for eq_id', str(ite.exception))
+
+    def test_missing_required_metadata_user_id_in_token(self):
+        metadata = {
             'jti': str(uuid.uuid4()),
-            'user_id': '1',
             'form_type': 'a',
             'collection_exercise_sid': 'test-sid',
             'eq_id': '2',
-            'period_str': '2016-01-01',
-            'ref_p_start_date': '2016-02-02',
-            'ref_p_end_date': '2016-03-03',
+            'period_id': '3',
             'ru_ref': '2016-04-04',
-            'ru_name': 'Apple',
-            'return_by': '2016-07-07'
         }
-        valid, field = is_valid_metadata(jwt)
-        self.assertFalse(valid)
-        self.assertEqual('period_id', field)
 
-    def test_is_valid_fails_missing_period_str(self):
-        jwt = {
+        with self.assertRaises(InvalidTokenException) as ite:
+            validate_metadata(metadata, self.schema_metadata)
+
+        self.assertEqual('Missing key/value for user_id', str(ite.exception))
+
+    def test_missing_required_metadata_period_id_in_token(self):
+        metadata = {
+            'jti': str(uuid.uuid4()),
+            'user_id': '1',
+            'form_type': 'a',
+            'eq_id': '2',
+            'period_str': '2016-01-01',
+            'ru_ref': '2016-04-04',
+        }
+
+        with self.assertRaises(InvalidTokenException) as ite:
+            validate_metadata(metadata, self.schema_metadata)
+
+        self.assertEqual('Missing key/value for period_id', str(ite.exception))
+
+    def test_missing_required_metadata_return_by_in_token(self):
+        metadata = {
             'jti': str(uuid.uuid4()),
             'user_id': '1',
             'form_type': 'a',
             'collection_exercise_sid': 'test-sid',
             'eq_id': '2',
             'period_id': '3',
-            'ref_p_start_date': '2016-02-02',
-            'ref_p_end_date': '2016-03-03',
             'ru_ref': '2016-04-04',
-            'ru_name': 'Apple',
-            'return_by': '2016-07-07'
         }
-        valid, field = is_valid_metadata(jwt)
-        self.assertFalse(valid)
-        self.assertEqual('period_str', field)
 
-    def test_is_valid_fails_missing_ref_p_start_date(self):
-        jwt = {
+        self.schema_metadata['return_by'] = {'validator': 'date'}
+
+        with self.assertRaises(InvalidTokenException) as ite:
+            validate_metadata(metadata, self.schema_metadata)
+
+        self.assertEqual('Missing key/value for return_by', str(ite.exception))
+
+    def test_required_metadata_trad_as_or_ru_name_in_token(self):
+        metadata = {
             'jti': str(uuid.uuid4()),
             'user_id': '1',
             'form_type': 'a',
             'collection_exercise_sid': 'test-sid',
             'eq_id': '2',
             'period_id': '3',
-            'period_str': '2016-01-01',
-            'ref_p_end_date': '2016-03-03',
             'ru_ref': '2016-04-04',
-            'ru_name': 'Apple',
-            'return_by': '2016-07-07'
+            'ru_name': 'ESSENTIAL ENTERPRISE LIMITED'
         }
-        valid, field = is_valid_metadata(jwt)
-        self.assertFalse(valid)
-        self.assertEqual('ref_p_start_date', field)
 
-    def test_is_valid_fails_invalid_ref_p_start_date(self):
-        jwt = {
+        self.schema_metadata['trad_as_or_ru_name'] = {'validator': 'string'}
+
+        try:
+            validate_metadata(metadata, self.schema_metadata)
+        except InvalidTokenException:
+            self.fail('Unexpected exception raised.')
+
+    def test_invalid_required_ref_p_start_date(self):
+        metadata = {
             'jti': str(uuid.uuid4()),
             'user_id': '1',
             'form_type': 'a',
             'collection_exercise_sid': 'test-sid',
             'eq_id': '2',
             'period_id': '3',
-            'period_str': '2016-01-01',
             'ref_p_start_date': '2016-13-31',
-            'ref_p_end_date': '2016-03-03',
             'ru_ref': '2016-04-04',
-            'ru_name': 'Apple',
-            'return_by': '2016-07-07'
         }
-        valid, _ = is_valid_metadata(jwt)
-        self.assertTrue(valid)
+
+        self.schema_metadata['ref_p_start_date'] = {'validator': 'date'}
+
         with self.assertRaises(InvalidTokenException) as ite:
-            parse_metadata(jwt)
-        self.assertIn('incorrect data in token', ite.exception.value)
+            validate_metadata(metadata, self.schema_metadata)
 
-    def test_is_valid_fails_invalid_ref_p_end_date(self):
-        jwt = {
-            'jti': str(uuid.uuid4()),
-            'user_id': '1',
-            'form_type': 'a',
-            'collection_exercise_sid': 'test-sid',
-            'eq_id': '2',
-            'period_id': '3',
-            'period_str': '2016-01-01',
-            'ref_p_start_date': '2016-12-31',
-            'ref_p_end_date': '2016-04-31',
-            'ru_ref': '2016-04-04',
-            'ru_name': 'Apple',
-            'return_by': '2016-07-07'
-        }
-        valid, _ = is_valid_metadata(jwt)
-        self.assertTrue(valid)
-        with self.assertRaises(InvalidTokenException) as ite:
-            parse_metadata(jwt)
-        self.assertIn('incorrect data in token', ite.exception.value)
-
-    def test_is_valid_fails_invalid_return_by(self):
-        jwt = {
-            'jti': str(uuid.uuid4()),
-            'user_id': '1',
-            'form_type': 'a',
-            'collection_exercise_sid': 'test-sid',
-            'eq_id': '2',
-            'period_id': '3',
-            'period_str': '2016-01-01',
-            'ref_p_start_date': '2016-12-31',
-            'ref_p_end_date': '2016-03-31',
-            'ru_ref': '2016-04-04',
-            'ru_name': 'Apple',
-            'return_by': '2016-09-31'
-        }
-        valid, _ = is_valid_metadata(jwt)
-        self.assertTrue(valid)
-        with self.assertRaises(InvalidTokenException) as ite:
-            parse_metadata(jwt)
-        self.assertIn('incorrect data in token', ite.exception.value)
-
-    def test_is_valid_succeeds_missing_ref_p_end_date(self):
-        jwt = {
-            'jti': str(uuid.uuid4()),
-            'user_id': '1',
-            'form_type': 'a',
-            'collection_exercise_sid': 'test-sid',
-            'eq_id': '2',
-            'period_id': '3',
-            'period_str': '2016-01-01',
-            'ref_p_start_date': '2016-02-02',
-            'ru_ref': '2016-04-04',
-            'ru_name': 'Apple',
-            'return_by': '2016-07-07'
-        }
-        valid, _ = is_valid_metadata(jwt)
-        self.assertTrue(valid)
-
-    def test_is_valid_fails_missing_ru_ref(self):
-        jwt = {
-            'jti': str(uuid.uuid4()),
-            'user_id': '1',
-            'form_type': 'a',
-            'collection_exercise_sid': 'test-sid',
-            'eq_id': '2',
-            'period_id': '3',
-            'period_str': '2016-01-01',
-            'ref_p_start_date': '2016-02-02',
-            'ref_p_end_date': '2016-03-03',
-            'ru_name': 'Apple',
-            'return_by': '2016-07-07'
-        }
-        valid, field = is_valid_metadata(jwt)
-        self.assertFalse(valid)
-        self.assertEqual('ru_ref', field)
-
-    def test_is_valid_fails_missing_ru_name(self):
-        jwt = {
-            'jti': str(uuid.uuid4()),
-            'user_id': '1',
-            'form_type': 'a',
-            'collection_exercise_sid': 'test-sid',
-            'eq_id': '2',
-            'period_id': '3',
-            'period_str': '2016-01-01',
-            'ref_p_start_date': '2016-02-02',
-            'ref_p_end_date': '2016-03-03',
-            'ru_ref': '2016-04-04',
-            'return_by': '2016-07-07'
-        }
-        valid, field = is_valid_metadata(jwt)
-        self.assertFalse(valid)
-        self.assertEqual('ru_name', field)
-
-    def test_is_valid_fails_missing_return_by(self):
-        jwt = {
-            'jti': str(uuid.uuid4()),
-            'user_id': '1',
-            'form_type': 'a',
-            'collection_exercise_sid': 'test-sid',
-            'eq_id': '2',
-            'period_id': '3',
-            'period_str': '2016-01-01',
-            'ref_p_start_date': '2016-02-02',
-            'ref_p_end_date': '2016-03-03',
-            'ru_ref': '2016-04-04',
-            'ru_name': 'Apple'
-        }
-        valid, field = is_valid_metadata(jwt)
-        self.assertFalse(valid)
-        self.assertEqual('return_by', field)
-
-    def test_is_valid_does_not_fail_missing_optional_value_in_token(self):
-        # tx_id, trad_as and employment_date are optional and might not be in the token
-        jwt = {
-            'jti': str(uuid.uuid4()),
-            'user_id': '1',
-            'form_type': 'a',
-            'collection_exercise_sid': 'test-sid',
-            'eq_id': '2',
-            'period_id': '3',
-            'period_str': '2016-01-01',
-            'ref_p_start_date': '2016-02-02',
-            'ref_p_end_date': '2016-03-03',
-            'ru_ref': '2016-04-04',
-            'ru_name': 'Apple',
-            'return_by': '2016-07-07'
-        }
-        valid, _ = is_valid_metadata(jwt)
-        self.assertTrue(valid)
+        self.assertEqual('incorrect data in token', str(ite.exception))
 
     def test_invalid_tx_id(self):
-        jwt = {
+        metadata = {
             'jti': str(uuid.uuid4()),
             'user_id': '1',
             'form_type': 'a',
             'collection_exercise_sid': 'test-sid',
             'eq_id': '2',
             'period_id': '3',
-            'period_str': '2016-01-01',
-            'ref_p_start_date': '2016-02-02',
-            'ref_p_end_date': '2016-03-03',
             'ru_ref': '2016-04-04',
-            'ru_name': 'Apple',
-            'return_by': '2016-07-07',
             # invalid
             'tx_id': '12121'
         }
-        valid, _ = is_valid_metadata(jwt)
-        self.assertTrue(valid)
+
         with self.assertRaises(InvalidTokenException) as ite:
-            parse_metadata(jwt)
-        self.assertIn('incorrect data in token', ite.exception.value)
+            parse_runner_claims(metadata)
+
+        self.assertEqual('incorrect data in token', str(ite.exception))
 
     def test_malformed_tx_id(self):
-        jwt = {
+        metadata = {
             'jti': str(uuid.uuid4()),
             'user_id': '1',
             'form_type': 'a',
             'collection_exercise_sid': 'test-sid',
             'eq_id': '2',
             'period_id': '3',
-            'period_str': '2016-01-01',
-            'ref_p_start_date': '2016-02-02',
-            'ref_p_end_date': '2016-03-03',
             'ru_ref': '2016-04-04',
-            'ru_name': 'Apple',
-            'return_by': '2016-07-07',
             # one character short
             'tx_id': '83a3db82-bea7-403c-a411-6357ff70f2f'
         }
-        valid, _ = is_valid_metadata(jwt)
-        self.assertTrue(valid)
+
         with self.assertRaises(InvalidTokenException) as ite:
-            parse_metadata(jwt)
-        self.assertIn('incorrect data in token', ite.exception.value)
+            parse_runner_claims(metadata)
+
+        self.assertEqual('incorrect data in token', str(ite.exception))
+
+    def test_generated_tx_id_format(self):
+
+        metadata = {
+            'jti': str(uuid.uuid4()),
+            'user_id': '1',
+            'form_type': 'a',
+            'collection_exercise_sid': 'test-sid',
+            'eq_id': '2',
+            'period_id': '3',
+            'ru_ref': '2016-04-04',
+        }
+
+        parsed = parse_runner_claims(metadata)
+        tx_id = parsed['tx_id']
+
+        self.assertEqual(tx_id, str(uuid.UUID(tx_id)))
+
+    def test_invalid_schema_metadata(self):
+        metadata = {
+            'jti': str(uuid.uuid4()),
+            'user_id': '1',
+            'form_type': 'a',
+            'collection_exercise_sid': 'test-sid',
+            'eq_id': '2',
+            'period_id': '3',
+            'ru_ref': '2016-04-04',
+            'period_str': 'May 2016'
+        }
+
+        self.schema_metadata['period_id'] = {'validator': 'invalidValidator'}
+
+        with self.assertRaises(KeyError) as ite:
+            validate_metadata(metadata, self.schema_metadata)
+
+        self.assertEqual('Invalid validator for schema metadata - invalidValidator', ite.exception.args[0])
+
+    def test_clean_leading_trailing_spaces(self):
+        metadata = self.metadata.copy()
+        metadata['trad_as'] = ' '
+        metadata['ru_name'] = '   Apple   '
+
+        metadata = clean_leading_trailing_spaces(metadata)
+
+        self.assertEqual(metadata['trad_as'], '')
+        self.assertEqual(metadata['ru_name'], 'Apple')
 
 
 if __name__ == '__main__':

--- a/tests/app/submitter/test_converter.py
+++ b/tests/app/submitter/test_converter.py
@@ -5,7 +5,7 @@ import dateutil.parser
 from app.data_model.answer_store import AnswerStore
 from app.questionnaire.questionnaire_schema import QuestionnaireSchema
 from app.questionnaire.location import Location
-from app.storage.metadata_parser import parse_metadata
+from app.storage.metadata_parser import validate_metadata, parse_runner_claims
 from app.submitter.converter import convert_answers, DataVersionError
 from tests.app.app_context_test_case import AppContextTestCase
 
@@ -13,6 +13,20 @@ from tests.app.app_context_test_case import AppContextTestCase
 class TestConverter(AppContextTestCase):  # pylint: disable=too-many-public-methods
     def setUp(self):
         super().setUp()
+
+        def parse_metadata(claims, schema_metadata):
+            validated_claims = parse_runner_claims(claims)
+            validate_metadata(validated_claims, schema_metadata)
+            return validated_claims
+
+        self.schema_metadata = {
+            'user_id': {
+                'validator': 'string'
+            },
+            'period_id': {
+                'validator': 'string'
+            }
+        }
         self.metadata = parse_metadata({
             'user_id': '789473423',
             'form_type': '0205',
@@ -27,7 +41,7 @@ class TestConverter(AppContextTestCase):  # pylint: disable=too-many-public-meth
             'return_by': '2016-07-07',
             'case_id': '1234567890',
             'case_ref': '1000000000000001'
-        })
+        }, self.schema_metadata)
 
     def test_convert_answers_flushed_flag_default_is_false(self):
         with self._app.test_request_context():

--- a/tests/app/templating/test_metadata_context.py
+++ b/tests/app/templating/test_metadata_context.py
@@ -1,22 +1,24 @@
-from app.storage.metadata_parser import parse_metadata
+from flask import g
+
 from app.templating.metadata_context import build_metadata_context
-from tests.app.framework.survey_runner_test_case import SurveyRunnerTestCase
+from app.utilities.schema import load_schema_from_params
+from tests.app.app_context_test_case import AppContextTestCase
 
-STRING_PROPERTIES = 'user_id', 'form_type', 'collection_exercise_sid',\
-                    'eq_id', 'period_id', 'ru_ref', 'ru_name', 'trad_as',\
-                    'transaction_id', 'region_code', 'period_str'
-
-DATE_PROPERTIES = 'ref_p_start_date', 'ref_p_end_date', 'return_by'
+PROPERTIES = 'user_id', 'collection_exercise_sid',\
+             'period_id', 'ru_ref', 'ru_name', 'trad_as',\
+             'region_code', 'period_str'
 
 
-class TestMetadataContext(SurveyRunnerTestCase):
+class TestMetadataContext(AppContextTestCase):
+
     def setUp(self):
         super().setUp()
+
         self.jwt = {
             'user_id': '1',
-            'form_type': 'a',
+            'form_type': 'schema_context',
             'collection_exercise_sid': 'test-sid',
-            'eq_id': '2',
+            'eq_id': 'test',
             'period_id': '3',
             'period_str': '2016-01-14',
             'ref_p_start_date': '2016-02-22',
@@ -25,65 +27,40 @@ class TestMetadataContext(SurveyRunnerTestCase):
             'ru_name': 'Apple',
             'trad_as': 'Apple',
             'return_by': '2016-07-17',
-            'transaction_id': '4ec3aa9e-e8ac-4c8d-9793-6ed88b957c2f'
+            'tx_id': '4ec3aa9e-e8ac-4c8d-9793-6ed88b957c2f',
         }
 
+        g.schema = load_schema_from_params(self.jwt['eq_id'], self.jwt['form_type'])
+
     def test_build_metadata_context(self):
-        with self.application.test_request_context():
-            metadata = parse_metadata(self.jwt)
+        metadata_context = build_metadata_context(self.jwt)
 
-        render_data = build_metadata_context(metadata)
-
-        self.assertIsNotNone(render_data)
-
-        survey_data = render_data['survey']
-        self.assertIsNotNone(survey_data)
-
-        self.assertEqual('2016-07-17', survey_data['return_by'])
-        self.assertEqual('2016-02-22', survey_data['start_date'])
-        self.assertEqual('2016-03-30', survey_data['end_date'])
-        self.assertIsNone(survey_data['employment_date'])
-        self.assertIsNone(survey_data['region_code'])
-        self.assertEqual(self.jwt['period_str'], survey_data['period_str'])
-
-        respondent = render_data['respondent']
-        self.assertIsNotNone(respondent)
-
-        self.assertEqual(self.jwt['ru_ref'], respondent['respondent_id'])
-        self.assertEqual(self.jwt['ru_name'], respondent['name'])
-        self.assertEqual(self.jwt['trad_as'], respondent['trading_as'])
+        self.assertIsNotNone(metadata_context)
+        self.assertEqual('2016-07-17', metadata_context['return_by'])
+        self.assertEqual('2016-02-22', metadata_context['ref_p_start_date'])
+        self.assertEqual('2016-03-30', metadata_context['ref_p_end_date'])
+        self.assertIsNone(metadata_context.get('employment_date'))
+        self.assertIsNone(metadata_context.get('region_code'))
+        self.assertEqual(self.jwt['period_str'], metadata_context['period_str'])
+        self.assertEqual(self.jwt['ru_ref'], metadata_context['ru_ref'])
+        self.assertEqual(self.jwt['ru_name'], metadata_context['ru_name'])
+        self.assertEqual(self.jwt['trad_as'], metadata_context['trad_as'])
 
     def test_defend_against_XSS_attack(self):
         jwt = self.jwt.copy()
         escaped_bad_characters = r'&lt;&#34;&gt;\\'
 
-        for key in STRING_PROPERTIES:
+        for key in PROPERTIES:
             jwt[key] = '<">\\'
 
-        with self.application.test_request_context():
-            metadata = parse_metadata(jwt)
+        metadata_context = build_metadata_context(jwt)
 
-        render_data = build_metadata_context(metadata)
-
-        respondent = render_data['respondent']
-        self.assertEqual(escaped_bad_characters, respondent['respondent_id'])
-        self.assertEqual(escaped_bad_characters, respondent['name'])
-        self.assertEqual(escaped_bad_characters, respondent['trading_as'])
-
-        survey = render_data['survey']
-        self.assertEqual(escaped_bad_characters, survey['region_code'])
-        self.assertEqual(escaped_bad_characters, survey['period_str'])
-        self.assertEqual(escaped_bad_characters, survey['eq_id'])
-        self.assertEqual(escaped_bad_characters, survey['collection_id'])
-        self.assertEqual(escaped_bad_characters, survey['form_type'])
-
-    def test_clean_leading_trailing_spaces(self):
-        jwt = self.jwt.copy()
-        jwt['trad_as'] = ' '
-        jwt['ru_name'] = '   Apple   '
-
-        with self.application.test_request_context():
-            metadata = parse_metadata(jwt)
-
-        self.assertEqual(metadata['trad_as'], '')
-        self.assertEqual(metadata['ru_name'], 'Apple')
+        self.assertEqual(escaped_bad_characters, metadata_context['user_id'])
+        self.assertEqual(escaped_bad_characters, metadata_context['period_id'])
+        self.assertEqual(escaped_bad_characters, metadata_context['period_str'])
+        self.assertEqual(escaped_bad_characters, metadata_context['ru_ref'])
+        self.assertEqual(escaped_bad_characters, metadata_context['ru_name'])
+        self.assertEqual(escaped_bad_characters, metadata_context['trad_as'])
+        self.assertEqual(escaped_bad_characters, metadata_context['trad_as_or_ru_name'])
+        self.assertEqual(escaped_bad_characters, metadata_context['region_code'])
+        self.assertEqual(escaped_bad_characters, metadata_context['collection_id'])

--- a/tests/app/templating/test_template_renderer.py
+++ b/tests/app/templating/test_template_renderer.py
@@ -150,14 +150,14 @@ class TestTemplateRenderer(unittest.TestCase):
         self.assertEqual(safe_content, 'How is … related to the people below?')
 
     def test_should_replace_jinja_template_variable_containing_function(self):
-        content = 'Is {{ format_date_range(meta.survey.start_date, meta.survey.end_date)}} correct?'
+        content = 'Is {{ format_date_range(metadata.ref_p_start_date, metadata.ref_p_end_date)}} correct?'
 
         safe_content = TemplateRenderer.safe_content(content)
 
         self.assertEqual(safe_content, 'Is … correct?')
 
     def test_should_replace_jinja_template_condtional_dates(self):
-        content = 'Is {{ format_condtional_date(meta.survey.start_date, meta.survey.end_date)}} correct?'
+        content = 'Is {{ format_condtional_date(metadata.ref_p_start_date, metadata.ref_p_end_date)}} correct?'
 
         safe_content = TemplateRenderer.safe_content(content)
 
@@ -185,7 +185,7 @@ class TestTemplateRenderer(unittest.TestCase):
         self.assertEqual(safe_content, ' This string contains some HTML tags?')
 
     def test_should_replace_html_tags_and_jinja_templates_together(self):
-        content = 'Is {{ format_something(meta.survey.start_date|length)}} really <strong>correct</strong>?'
+        content = 'Is {{ format_something(metadata.ref_p_start_date|length)}} really <strong>correct</strong>?'
 
         safe_content = TemplateRenderer.safe_content(content)
 

--- a/tests/functional/helpers.js
+++ b/tests/functional/helpers.js
@@ -8,7 +8,7 @@ const getUri = uri => browser.options.baseUrl + uri;
 const getRandomString = length => _.sampleSize('ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789', length).join('');
 
 const openCensusQuestionnaire = (schema, sexualIdentity = false, region = 'GB-ENG', language = 'en') => {
-  return generateToken(schema, getRandomString(10), getRandomString(10), null, null, region, language, sexualIdentity)
+  return generateToken(schema, getRandomString(10), getRandomString(10), '2011', null, region, language, sexualIdentity)
     .then(function(token) {
       return browser.url('/session?token=' + token);
     });

--- a/tests/integration/session/test_login.py
+++ b/tests/integration/session/test_login.py
@@ -67,7 +67,7 @@ class TestLogin(IntegrationTestCase):
         self.get('/session?token=' + token)
 
         # Then
-        self.assertStatusNotFound()
+        self.assertStatusForbidden()
 
     def test_http_head_request_to_login_returns_successfully_and_get_still_works(self):
         # Given
@@ -126,7 +126,7 @@ class TestLogin(IntegrationTestCase):
     @staticmethod
     @urlmatch(netloc=r'eq-survey-register', path=r'\/my-test-schema')
     def survey_url_mock(_url, _request):
-        schema_path = get_schema_file_path('1_0205.json')
+        schema_path = get_schema_file_path('test_textarea.json')
 
         with open(schema_path, encoding='utf8') as json_data:
             return json_data.read()


### PR DESCRIPTION
### What is the context of this PR?
Refactor how runner makes use of metadata. Check trello [card](https://trello.com/c/LIK77JbM/1909-specify-metadata-in-the-survey-json-l) for specs.
These changes ensure that runner has the required metadata to successfully launch and submit a survey. The idea is that we should fail earlier if we do not have all the required details.

Each schema must now define the metadata it requires in the `metadata` field.
By default all schemas must contain the following metadata:
1. `user_id`
2. `period_id`

The validator [PR](https://github.com/ONSdigital/eq-schema-validator/pull/50) will enforce the above.

The `exercise` and `respondent` metadata are now under one single context var (`metadata`).

This change affects the downstream data as well, therefore, need to ensure that everything is still functioning as expected.

All metadata used within the current schemas has been documented in the `metadata` field.
As we are using bracket notation for piping answers in the schemas, I have also changed the dot notation for metadata piping ie `metadata.ru_name` -> `metadata['ru_name']`, both ways are valid.

### How to review 
1. Ensure all tests pass.
2. Check downstream metadata still works correctly.
3. Check all previous references to `exercise.` and `respondent.` is correctly configured to `metadata.`
4. Check that piping is still working as expected.
5. Ensure all piped metadata in schemas are documented in `metadata` field.
