### PR TITLE
Removed Northern Ireland from introductions of mbs 817 and 867

### DIFF
--- a/data/en/mbs_0817.json
+++ b/data/en/mbs_0817.json
@@ -24,7 +24,7 @@
                             "id": "use-of-information",
                             "content": [{
                                 "list": [
-                                    "Data should relate to all sites in England, Scotland, Wales and Northern Ireland.",
+                                    "Data should relate to all sites in England, Scotland and Wales.",
                                     "You can provide informed estimates if actual figures aren’t available.",
                                     "We will treat your data securely and confidentially."
                                 ]

--- a/data/en/mbs_0867.json
+++ b/data/en/mbs_0867.json
@@ -24,7 +24,7 @@
                             "id": "use-of-information",
                             "content": [{
                                 "list": [
-                                    "Data should relate to all sites in England, Scotland, Wales and Northern Ireland.",
+                                    "Data should relate to all sites in England, Scotland and Wales.",
                                     "You can provide informed estimates if actual figures aren’t available.",
                                     "We will treat your data securely and confidentially."
                                 ]


### PR DESCRIPTION
### What is the context of this PR?
Remove the reference to Northern Ireland in use of information section of the Introduction for several surveys as mentioned on the trello card

### How to review 
View each survey. 

https://trello.com/c/WWan8FIg