### PR TITLE
2063 add date validation to all mbs schemas

### DIFF
--- a/data/en/mbs_0106.json
+++ b/data/en/mbs_0106.json
@@ -139,19 +139,39 @@
                             "type": "DateRange",
                             "id": "reporting-period-question-2",
                             "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
                             "answers": [{
                                     "type": "Date",
                                     "id": "period-from",
                                     "label": "From",
                                     "mandatory": true,
-                                    "q_code": "11"
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
                                 },
                                 {
                                     "type": "Date",
                                     "id": "period-to",
                                     "label": "To",
                                     "mandatory": true,
-                                    "q_code": "12"
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
                                 }
                             ]
                         }]

--- a/data/en/mbs_0111.json
+++ b/data/en/mbs_0111.json
@@ -140,19 +140,39 @@
                             "type": "DateRange",
                             "id": "reporting-period-question-2",
                             "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
                             "answers": [{
                                     "type": "Date",
                                     "id": "period-from",
                                     "label": "From",
                                     "mandatory": true,
-                                    "q_code": "11"
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
                                 },
                                 {
                                     "type": "Date",
                                     "id": "period-to",
                                     "label": "To",
                                     "mandatory": true,
-                                    "q_code": "12"
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
                                 }
                             ]
                         }]

--- a/data/en/mbs_0117.json
+++ b/data/en/mbs_0117.json
@@ -149,19 +149,39 @@
                             "type": "DateRange",
                             "id": "reporting-period-question-2",
                             "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
                             "answers": [{
                                     "type": "Date",
                                     "id": "period-from",
                                     "label": "From",
                                     "mandatory": true,
-                                    "q_code": "11"
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
                                 },
                                 {
                                     "type": "Date",
                                     "id": "period-to",
                                     "label": "To",
                                     "mandatory": true,
-                                    "q_code": "12"
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
                                 }
                             ]
                         }]

--- a/data/en/mbs_0123.json
+++ b/data/en/mbs_0123.json
@@ -116,19 +116,39 @@
                             "type": "DateRange",
                             "id": "reporting-period-question-2",
                             "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
                             "answers": [{
                                     "type": "Date",
                                     "id": "period-from",
                                     "label": "From",
                                     "mandatory": true,
-                                    "q_code": "11"
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
                                 },
                                 {
                                     "type": "Date",
                                     "id": "period-to",
                                     "label": "To",
                                     "mandatory": true,
-                                    "q_code": "12"
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
                                 }
                             ]
                         }]

--- a/data/en/mbs_0158.json
+++ b/data/en/mbs_0158.json
@@ -192,19 +192,39 @@
                             "type": "DateRange",
                             "id": "reporting-period-question-2",
                             "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
                             "answers": [{
                                     "type": "Date",
                                     "id": "period-from",
                                     "label": "From",
                                     "mandatory": true,
-                                    "q_code": "11"
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
                                 },
                                 {
                                     "type": "Date",
                                     "id": "period-to",
                                     "label": "To",
                                     "mandatory": true,
-                                    "q_code": "12"
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
                                 }
                             ]
                         }]

--- a/data/en/mbs_0161.json
+++ b/data/en/mbs_0161.json
@@ -195,19 +195,39 @@
                             "type": "DateRange",
                             "id": "reporting-period-question-2",
                             "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
                             "answers": [{
                                     "type": "Date",
                                     "id": "period-from",
                                     "label": "From",
                                     "mandatory": true,
-                                    "q_code": "11"
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
                                 },
                                 {
                                     "type": "Date",
                                     "id": "period-to",
                                     "label": "To",
                                     "mandatory": true,
-                                    "q_code": "12"
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
                                 }
                             ]
                         }]

--- a/data/en/mbs_0167.json
+++ b/data/en/mbs_0167.json
@@ -203,19 +203,39 @@
                             "type": "DateRange",
                             "id": "reporting-period-question-2",
                             "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
                             "answers": [{
                                     "type": "Date",
                                     "id": "period-from",
                                     "label": "From",
                                     "mandatory": true,
-                                    "q_code": "11"
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
                                 },
                                 {
                                     "type": "Date",
                                     "id": "period-to",
                                     "label": "To",
                                     "mandatory": true,
-                                    "q_code": "12"
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
                                 }
                             ]
                         }]

--- a/data/en/mbs_0173.json
+++ b/data/en/mbs_0173.json
@@ -179,19 +179,39 @@
                             "type": "DateRange",
                             "id": "reporting-period-question-2",
                             "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
                             "answers": [{
                                     "type": "Date",
                                     "id": "period-from",
                                     "label": "From",
                                     "mandatory": true,
-                                    "q_code": "11"
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
                                 },
                                 {
                                     "type": "Date",
                                     "id": "period-to",
                                     "label": "To",
                                     "mandatory": true,
-                                    "q_code": "12"
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
                                 }
                             ]
                         }]

--- a/data/en/mbs_0201.json
+++ b/data/en/mbs_0201.json
@@ -147,19 +147,39 @@
                             "type": "DateRange",
                             "id": "reporting-period-question-2",
                             "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
                             "answers": [{
                                     "type": "Date",
                                     "id": "period-from",
                                     "label": "From",
                                     "mandatory": true,
-                                    "q_code": "11"
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
                                 },
                                 {
                                     "type": "Date",
                                     "id": "period-to",
                                     "label": "To",
                                     "mandatory": true,
-                                    "q_code": "12"
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
                                 }
                             ]
                         }]

--- a/data/en/mbs_0202.json
+++ b/data/en/mbs_0202.json
@@ -147,19 +147,39 @@
                             "type": "DateRange",
                             "id": "reporting-period-question-2",
                             "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
                             "answers": [{
                                     "type": "Date",
                                     "id": "period-from",
                                     "label": "From",
                                     "mandatory": true,
-                                    "q_code": "11"
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
                                 },
                                 {
                                     "type": "Date",
                                     "id": "period-to",
                                     "label": "To",
                                     "mandatory": true,
-                                    "q_code": "12"
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
                                 }
                             ]
                         }]

--- a/data/en/mbs_0203.json
+++ b/data/en/mbs_0203.json
@@ -98,19 +98,39 @@
                             "type": "DateRange",
                             "id": "reporting-period-question-2",
                             "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
                             "answers": [{
                                     "type": "Date",
                                     "id": "period-from",
                                     "label": "From",
                                     "mandatory": true,
-                                    "q_code": "11"
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
                                 },
                                 {
                                     "type": "Date",
                                     "id": "period-to",
                                     "label": "To",
                                     "mandatory": true,
-                                    "q_code": "12"
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
                                 }
                             ]
                         }]

--- a/data/en/mbs_0204.json
+++ b/data/en/mbs_0204.json
@@ -98,19 +98,39 @@
                             "type": "DateRange",
                             "id": "reporting-period-question-2",
                             "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
                             "answers": [{
                                     "type": "Date",
                                     "id": "period-from",
                                     "label": "From",
                                     "mandatory": true,
-                                    "q_code": "11"
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
                                 },
                                 {
                                     "type": "Date",
                                     "id": "period-to",
                                     "label": "To",
                                     "mandatory": true,
-                                    "q_code": "12"
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
                                 }
                             ]
                         }]

--- a/data/en/mbs_0205.json
+++ b/data/en/mbs_0205.json
@@ -148,19 +148,39 @@
                             "type": "DateRange",
                             "id": "reporting-period-question-2",
                             "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
                             "answers": [{
                                     "type": "Date",
                                     "id": "period-from",
                                     "label": "From",
                                     "mandatory": true,
-                                    "q_code": "11"
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
                                 },
                                 {
                                     "type": "Date",
                                     "id": "period-to",
                                     "label": "To",
                                     "mandatory": true,
-                                    "q_code": "12"
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
                                 }
                             ]
                         }]

--- a/data/en/mbs_0216.json
+++ b/data/en/mbs_0216.json
@@ -148,19 +148,39 @@
                             "type": "DateRange",
                             "id": "reporting-period-question-2",
                             "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
                             "answers": [{
                                     "type": "Date",
                                     "id": "period-from",
                                     "label": "From",
                                     "mandatory": true,
-                                    "q_code": "11"
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
                                 },
                                 {
                                     "type": "Date",
                                     "id": "period-to",
                                     "label": "To",
                                     "mandatory": true,
-                                    "q_code": "12"
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
                                 }
                             ]
                         }]

--- a/data/en/mbs_0251.json
+++ b/data/en/mbs_0251.json
@@ -201,19 +201,39 @@
                             "type": "DateRange",
                             "id": "reporting-period-question-2",
                             "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
                             "answers": [{
                                     "type": "Date",
                                     "id": "period-from",
                                     "label": "From",
                                     "mandatory": true,
-                                    "q_code": "11"
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
                                 },
                                 {
                                     "type": "Date",
                                     "id": "period-to",
                                     "label": "To",
                                     "mandatory": true,
-                                    "q_code": "12"
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
                                 }
                             ]
                         }]

--- a/data/en/mbs_0253.json
+++ b/data/en/mbs_0253.json
@@ -155,19 +155,39 @@
                             "type": "DateRange",
                             "id": "reporting-period-question-2",
                             "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
                             "answers": [{
                                     "type": "Date",
                                     "id": "period-from",
                                     "label": "From",
                                     "mandatory": true,
-                                    "q_code": "11"
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
                                 },
                                 {
                                     "type": "Date",
                                     "id": "period-to",
                                     "label": "To",
                                     "mandatory": true,
-                                    "q_code": "12"
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
                                 }
                             ]
                         }]

--- a/data/en/mbs_0255.json
+++ b/data/en/mbs_0255.json
@@ -204,19 +204,39 @@
                             "type": "DateRange",
                             "id": "reporting-period-question-2",
                             "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
                             "answers": [{
                                     "type": "Date",
                                     "id": "period-from",
                                     "label": "From",
                                     "mandatory": true,
-                                    "q_code": "11"
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
                                 },
                                 {
                                     "type": "Date",
                                     "id": "period-to",
                                     "label": "To",
                                     "mandatory": true,
-                                    "q_code": "12"
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
                                 }
                             ]
                         }]

--- a/data/en/mbs_0817.json
+++ b/data/en/mbs_0817.json
@@ -137,19 +137,39 @@
                             "type": "DateRange",
                             "id": "reporting-period-question-2",
                             "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
                             "answers": [{
                                     "type": "Date",
-                                    "id": "reporting-period-answer-from",
+                                    "id": "period-from",
                                     "label": "From",
                                     "mandatory": true,
-                                    "q_code": "11"
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
                                 },
                                 {
                                     "type": "Date",
-                                    "id": "reporting-period-answer-to",
+                                    "id": "period-to",
                                     "label": "To",
                                     "mandatory": true,
-                                    "q_code": "12"
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
                                 }
                             ]
                         }]
@@ -193,7 +213,7 @@
                                 "mandatory": true
                             }],
                             "type": "General",
-                            "title": "For the period {{format_conditional_date (answers['reporting-period-answer-from'], exercise.start_date)}} to {{format_conditional_date (answers['reporting-period-answer-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total turnover</em>, excluding VAT?"
+                            "title": "For the period {{format_conditional_date (answers['period-from'], exercise.start_date)}} to {{format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total turnover</em>, excluding VAT?"
                         }],
                         "title": "Turnover"
                     },

--- a/data/en/mbs_0823.json
+++ b/data/en/mbs_0823.json
@@ -137,19 +137,39 @@
                             "type": "DateRange",
                             "id": "reporting-period-question-2",
                             "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
                             "answers": [{
                                     "type": "Date",
-                                    "id": "reporting-period-answer-from",
+                                    "id": "period-from",
                                     "label": "From",
                                     "mandatory": true,
-                                    "q_code": "11"
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
                                 },
                                 {
                                     "type": "Date",
-                                    "id": "reporting-period-answer-to",
+                                    "id": "period-to",
                                     "label": "To",
                                     "mandatory": true,
-                                    "q_code": "12"
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
                                 }
                             ]
                         }]
@@ -193,7 +213,7 @@
                                 "mandatory": true
                             }],
                             "type": "General",
-                            "title": "For the period {{format_conditional_date (answers['reporting-period-answer-from'], exercise.start_date)}} to {{format_conditional_date (answers['reporting-period-answer-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total turnover</em>, excluding VAT?"
+                            "title": "For the period {{format_conditional_date (answers['period-from'], exercise.start_date)}} to {{format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total turnover</em>, excluding VAT?"
                         }],
                         "title": "Total Turnover"
                     },

--- a/data/en/mbs_0867.json
+++ b/data/en/mbs_0867.json
@@ -191,19 +191,39 @@
                             "type": "DateRange",
                             "id": "reporting-period-question-2",
                             "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
                             "answers": [{
                                     "type": "Date",
-                                    "id": "reporting-period-answer-from",
+                                    "id": "period-from",
                                     "label": "From",
                                     "mandatory": true,
-                                    "q_code": "11"
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
                                 },
                                 {
                                     "type": "Date",
-                                    "id": "reporting-period-answer-to",
+                                    "id": "period-to",
                                     "label": "To",
                                     "mandatory": true,
-                                    "q_code": "12"
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
                                 }
                             ]
                         }]
@@ -247,7 +267,7 @@
                                 "mandatory": true
                             }],
                             "type": "General",
-                            "title": "For the period {{format_conditional_date (answers['reporting-period-answer-from'], exercise.start_date)}} to {{format_conditional_date (answers['reporting-period-answer-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total turnover</em>, excluding VAT?"
+                            "title": "For the period {{format_conditional_date (answers['period-from'], exercise.start_date)}} to {{format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total turnover</em>, excluding VAT?"
                         }],
                         "title": "Turnover"
                     },

--- a/data/en/mbs_0873.json
+++ b/data/en/mbs_0873.json
@@ -191,19 +191,39 @@
                             "type": "DateRange",
                             "id": "reporting-period-question-2",
                             "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
                             "answers": [{
                                     "type": "Date",
-                                    "id": "reporting-period-answer-from",
+                                    "id": "period-from",
                                     "label": "From",
                                     "mandatory": true,
-                                    "q_code": "11"
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
                                 },
                                 {
                                     "type": "Date",
-                                    "id": "reporting-period-answer-to",
+                                    "id": "period-to",
                                     "label": "To",
                                     "mandatory": true,
-                                    "q_code": "12"
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
                                 }
                             ]
                         }]
@@ -247,7 +267,7 @@
                                 "mandatory": true
                             }],
                             "type": "General",
-                            "title": "For the period {{format_conditional_date (answers['reporting-period-answer-from'], exercise.start_date)}} to {{format_conditional_date (answers['reporting-period-answer-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total turnover</em>, excluding VAT?"
+                            "title": "For the period {{format_conditional_date (answers['period-from'], exercise.start_date)}} to {{format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total turnover</em>, excluding VAT?"
                         }],
                         "title": "Total Turnover"
                     },


### PR DESCRIPTION
### What is the context of this PR?
Added date validation (both period and individual date) to all mbs schemas for `reporting-period-block-2`.

**PERIOD**
- minimum of 10 days
- maximum of 50 days

**FROM DATE**
- should be after `ref_start_date` - 19 days

**TO DATE**
- should be before `ref_end_date` + 20 days

### How to review 
Do validations checkout?