### PR TITLE
Added various schema and content changes to mbs schemas

### DIFF
--- a/data/en/mbs_0123.json
+++ b/data/en/mbs_0123.json
@@ -53,6 +53,9 @@
                                             "grants"
                                         ]
                                     }]
+                                },
+                                {
+                                    "question": "Significant changes"
                                 }
                             ]
                         },
@@ -241,7 +244,7 @@
                             },
                             "type": "General"
                         }],
-                        "title": "Changes",
+                        "title": "Significant changes",
                         "routing_rules": [{
                                 "goto": {
                                     "when": [{
@@ -308,7 +311,7 @@
                                 "mandatory": true
                             }]
                         }],
-                        "title": "Changes"
+                        "title": "Significant changes"
                     },
                     {
                         "type": "Question",

--- a/data/en/mbs_0203.json
+++ b/data/en/mbs_0203.json
@@ -35,7 +35,10 @@
                             "title": "Information you need",
                             "content": [{
                                 "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate.",
-                                "list": ["Volume of potable water that was supplied to customers"]
+                                "list": [
+                                  "Volume of potable water that was supplied to customers",
+                                  "Significant changes"
+                                ]
                             }]
                         },
                         "secondary_content": [{
@@ -155,7 +158,7 @@
                     },
                     {
                         "id": "significant-change",
-                        "title": "Changes",
+                        "title": "Significant changes",
                         "type": "Question",
                         "questions": [{
                             "type": "General",
@@ -212,7 +215,7 @@
                             "title": "Please describe the changes for {{respondent.trad_as_or_ru_name}} in more detail",
                             "type": "General"
                         }],
-                        "title": "Changes"
+                        "title": "Significant changes"
                     }
                 ]
             }]

--- a/data/en/mbs_0204.json
+++ b/data/en/mbs_0204.json
@@ -35,7 +35,10 @@
                             "title": "Information you need",
                             "content": [{
                                 "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate.",
-                                "list": ["Volume of potable water that was supplied to customers"]
+                                "list": [
+                                  "Volume of potable water that was supplied to customers",
+                                  "Significant changes"
+                                ]
                             }]
                         },
                         "secondary_content": [{
@@ -155,7 +158,7 @@
                     },
                     {
                         "id": "significant-change",
-                        "title": "Changes",
+                        "title": "Significant changes",
                         "type": "Question",
                         "questions": [{
                             "type": "General",
@@ -212,7 +215,7 @@
                             "title": "Please describe the changes for {{respondent.trad_as_or_ru_name}} in more detail",
                             "type": "General"
                         }],
-                        "title": "Changes"
+                        "title": "Significant changes"
                     }
                 ]
             }]

--- a/data/en/mbs_0205.json
+++ b/data/en/mbs_0205.json
@@ -61,6 +61,18 @@
                                     ]
                                 },
                                 {
+                                    "question": "Value of exports",
+                                    "content": [{
+                                        "description": "Include:",
+                                        "list": [
+                                            "all countries outside of England, Scotland, Wales and Northern Ireland"
+                                        ]
+                                    }]
+                                },
+                                {
+                                    "question": "Value of excise duty"
+                                },
+                                {
                                     "question": "Changes in turnover",
                                     "content": [{
                                         "description": "Include:",
@@ -73,18 +85,6 @@
                                             "currency effects (increase/decrease in the currency value)"
                                         ]
                                     }]
-                                },
-                                {
-                                    "question": "Value of exports",
-                                    "content": [{
-                                        "description": "Include:",
-                                        "list": [
-                                            "all countries outside of England, Scotland, Wales and Northern Ireland"
-                                        ]
-                                    }]
-                                },
-                                {
-                                    "question": "Value of excise duty"
                                 }
                             ]
                         },
@@ -372,7 +372,7 @@
                                 ],
                                 "id": "changes-in-turnover-answer-2",
                                 "type": "Checkbox",
-                                "mandatory": false
+                                "mandatory": true
                             }],
                             "type": "General",
                             "id": "changes-in-turnover-question-2"

--- a/data/en/mbs_0216.json
+++ b/data/en/mbs_0216.json
@@ -61,6 +61,18 @@
                                     ]
                                 },
                                 {
+                                    "question": "Value of exports",
+                                    "content": [{
+                                        "description": "Include:",
+                                        "list": [
+                                            "all countries outside of England, Scotland, Wales and Northern Ireland"
+                                        ]
+                                    }]
+                                },
+                                {
+                                    "question": "Value of excise duty"
+                                },
+                                {
                                     "question": "Changes in turnover",
                                     "content": [{
                                         "description": "Include:",
@@ -73,18 +85,6 @@
                                             "currency effects (increase/decrease in the currency value)"
                                         ]
                                     }]
-                                },
-                                {
-                                    "question": "Value of exports",
-                                    "content": [{
-                                        "description": "Include:",
-                                        "list": [
-                                            "all countries outside of England, Scotland, Wales and Northern Ireland"
-                                        ]
-                                    }]
-                                },
-                                {
-                                    "question": "Value of excise duty"
                                 }
                             ]
                         },
@@ -372,7 +372,7 @@
                                 ],
                                 "id": "changes-in-turnover-answer-2",
                                 "type": "Checkbox",
-                                "mandatory": false
+                                "mandatory": true
                             }],
                             "type": "General",
                             "id": "changes-in-turnover-question-2"

--- a/data/en/mbs_0253.json
+++ b/data/en/mbs_0253.json
@@ -92,6 +92,9 @@
                                             ]
                                         }
                                     ]
+                                },
+                                {
+                                  "question": "Significant changes"
                                 }
                             ]
                         },
@@ -397,7 +400,7 @@
                     },
                     {
                         "id": "significant-change",
-                        "title": "Changes",
+                        "title": "Significant changes",
                         "type": "Question",
                         "questions": [{
                             "type": "General",
@@ -454,7 +457,7 @@
                             "title": "Please describe the changes for {{respondent.trad_as_or_ru_name}} in more detail",
                             "type": "General"
                         }],
-                        "title": "Changes"
+                        "title": "Significant changes"
                     }
                 ]
             }]

--- a/data/en/mbs_0255.json
+++ b/data/en/mbs_0255.json
@@ -63,20 +63,6 @@
                                     ]
                                 },
                                 {
-                                    "question": "Changes in turnover",
-                                    "content": [{
-                                        "description": "Include:",
-                                        "list": [
-                                            "change in level of business activity",
-                                            "maintenance/shutdowns",
-                                            "special/calendar events",
-                                            "weather",
-                                            "price effects",
-                                            "currency effects (increase/decrease in the currency value)"
-                                        ]
-                                    }]
-                                },
-                                {
                                     "question": "Value of exports",
                                     "content": [{
                                         "description": "Include:",
@@ -141,6 +127,20 @@
                                             ]
                                         }
                                     ]
+                                },
+                                {
+                                    "question": "Changes in turnover",
+                                    "content": [{
+                                        "description": "Include:",
+                                        "list": [
+                                            "change in level of business activity",
+                                            "maintenance/shutdowns",
+                                            "special/calendar events",
+                                            "weather",
+                                            "price effects",
+                                            "currency effects (increase/decrease in the currency value)"
+                                        ]
+                                    }]
                                 }
                             ]
                         },
@@ -613,7 +613,7 @@
                                 ],
                                 "id": "changes-in-turnover-answer-2",
                                 "type": "Checkbox",
-                                "mandatory": false
+                                "mandatory": true
                             }],
                             "type": "General",
                             "id": "changes-in-turnover-question-2"

--- a/data/en/mbs_0817.json
+++ b/data/en/mbs_0817.json
@@ -215,7 +215,7 @@
                             "type": "General",
                             "title": "For the period {{format_conditional_date (answers['period-from'], exercise.start_date)}} to {{format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total turnover</em>, excluding VAT?"
                         }],
-                        "title": "Turnover"
+                        "title": "Total turnover"
                     },
                     {
                         "id": "changes-in-turnover-block",
@@ -316,7 +316,7 @@
                                 ],
                                 "id": "changes-in-turnover-answer-2",
                                 "type": "Checkbox",
-                                "mandatory": false
+                                "mandatory": true
                             }],
                             "type": "General",
                             "id": "changes-in-turnover-question-2"

--- a/data/en/mbs_0867.json
+++ b/data/en/mbs_0867.json
@@ -62,20 +62,6 @@
                                     ]
                                 },
                                 {
-                                    "question": "Changes in turnover",
-                                    "content": [{
-                                        "description": "Include:",
-                                        "list": [
-                                            "change in level of business activity",
-                                            "maintenance/shutdowns",
-                                            "special/calendar events",
-                                            "weather",
-                                            "price effects",
-                                            "currency effects (increase/decrease in the currency value)"
-                                        ]
-                                    }]
-                                },
-                                {
                                     "question": "Number of employees",
                                     "content": [{
                                             "description": "An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme."
@@ -128,6 +114,20 @@
                                             ]
                                         }
                                     ]
+                                },
+                                {
+                                    "question": "Changes in turnover",
+                                    "content": [{
+                                        "description": "Include:",
+                                        "list": [
+                                            "change in level of business activity",
+                                            "maintenance/shutdowns",
+                                            "special/calendar events",
+                                            "weather",
+                                            "price effects",
+                                            "currency effects (increase/decrease in the currency value)"
+                                        ]
+                                    }]
                                 }
                             ]
                         },
@@ -269,7 +269,7 @@
                             "type": "General",
                             "title": "For the period {{format_conditional_date (answers['period-from'], exercise.start_date)}} to {{format_conditional_date (answers['period-to'], exercise.end_date)}}, what was the value of {{respondent.trad_as_or_ru_name}}’s <em>total turnover</em>, excluding VAT?"
                         }],
-                        "title": "Turnover"
+                        "title": "Total turnover"
                     },
                     {
                         "id": "number-of-employees-total-block",
@@ -555,7 +555,7 @@
                                 ],
                                 "id": "changes-in-turnover-answer-2",
                                 "type": "Checkbox",
-                                "mandatory": false
+                                "mandatory": true
                             }],
                             "type": "General",
                             "id": "changes-in-turnover-question-2"


### PR DESCRIPTION
form types

- 0123

- 0203

- 0204

- 0205

- 0216

- 0253

- 0255

- 0817

- 0867

### What is the context of this PR?
0123 - Preview content on introduction page missing significant changes
0867 - Significant changes moved to last preview topic on introduction page
0203 - Preview content on introduction page missing significant changes
0204 - Preview content on introduction page missing significant changes
0205 - Significant changes moved to last preview topic on introduction page
0205 - Checkboxes in significant changes group made mandatory
0216 - Significant changes moved to last preview topic on introduction page
0216 - Checkboxes in significant changes group made mandatory
0253 - Preview content on introduction page missing significant changes
0255 - Significant changes moved to last preview topic on introduction page
0255 - Checkboxes in significant changes group made mandatory
0817 - Turnover block title changed to Total turnover
0817 - Checkboxes in significant changes group made mandatory
0867 - Turnover block title changed to Total turnover
0867 - Checkboxes in significant changes group made mandatory


### How to review 
Are changes correct?