### PR TITLE
Add month year formatter to template renderer

### DIFF
--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -81,18 +81,20 @@ def get_current_date(context):
 @evalcontextfilter
 @blueprint.app_template_filter()
 def format_date(context, value):
+    """Format a datetime string.
+
+    :param (jinja2.nodes.EvalContext) context: Evaluation context.
+    :param (any) value: Value representing a datetime.
+    :returns (str): Formatted datetime.
+    """
+    value = value[0] if isinstance(value, list) else value
+    if not isinstance(value, str):
+        return value
     date_format = '%B %Y'
     if value and re.match(r'\d{4}-\d{2}-\d{2}', value):
         date_format = DATE_FORMAT
-
-    result = "<span class='date'>{date}</span>".format(date=convert_to_datetime(value).strftime(date_format))
-    return mark_safe(context, result)
-
-
-@evalcontextfilter
-@blueprint.app_template_filter()
-def format_month_year_date(context, value, date_format='%B %Y'):
-    result = "<span class='date'>{date}</span>".format(date=datetime.strptime(value, '%Y-%m').strftime(date_format))
+    result = "<span class='date'>{date}</span>".format(
+        date=convert_to_datetime(value).strftime(date_format))
     return mark_safe(context, result)
 
 

--- a/app/templates/partials/summary/monthyeardate.html
+++ b/app/templates/partials/summary/monthyeardate.html
@@ -1,5 +1,5 @@
 {% if question.type == 'DateRange' %}
     {{format_date_range(answer.value.from, answer.value.to)}}
 {% else %}
-    {{answer.value|format_month_year_date}}
+    {{answer.value|format_date}}
 {% endif %}

--- a/app/templating/template_renderer.py
+++ b/app/templating/template_renderer.py
@@ -5,52 +5,58 @@ import json
 import re
 from jinja2 import Environment
 
-from app.jinja_filters import format_date, format_household_member_name, format_currency, format_number,\
-    get_currency_symbol, format_household_summary, format_conditional_date, format_unordered_list, \
-    format_date_range, format_household_member_name_possessive, concatenated_list, calculate_years_difference, \
-    get_current_date
+import app.jinja_filters as filters
 
 
 class TemplateRenderer:
     def __init__(self):
-        self.environment = Environment(autoescape=True)
-
-        self.environment.filters['format_date'] = format_date
-        self.environment.filters['format_household_name'] = format_household_member_name
-        self.environment.filters['format_household_name_possessive'] = format_household_member_name_possessive
-        self.environment.filters['format_household_summary'] = format_household_summary
-        self.environment.filters['format_unordered_list'] = format_unordered_list
-        self.environment.globals['format_conditional_date'] = format_conditional_date
-        self.environment.filters['format_currency'] = format_currency
-        self.environment.filters['format_number'] = format_number
-        self.environment.filters['get_currency_symbol'] = get_currency_symbol
-        self.environment.globals['format_date_range'] = format_date_range
-        self.environment.filters['concatenated_list'] = concatenated_list
-        self.environment.globals['calculate_years_difference'] = calculate_years_difference
-        self.environment.globals['get_current_date'] = get_current_date
+        env = Environment(autoescape=True)
+        env.filters['format_date'] = filters.format_date
+        env.filters['format_household_name'] = filters.format_household_member_name
+        env.filters['format_household_name_possessive'] = filters.format_household_member_name_possessive
+        env.filters['format_household_summary'] = filters.format_household_summary
+        env.filters['format_unordered_list'] = filters.format_unordered_list
+        env.globals['format_conditional_date'] = filters.format_conditional_date
+        env.filters['format_currency'] = filters.format_currency
+        env.filters['format_number'] = filters.format_number
+        env.filters['get_currency_symbol'] = filters.get_currency_symbol
+        env.globals['format_date_range'] = filters.format_date_range
+        env.filters['concatenated_list'] = filters.concatenated_list
+        env.globals['calculate_years_difference'] = filters.calculate_years_difference
+        env.globals['get_current_date'] = filters.get_current_date
+        self.environment = env
 
     def render(self, renderable, **context):
+        """Render.
+
+        Substitute variables into renderable with the variables in context.
+
+        :param (dict) renderable: Map of variables to be substituted.
+        :param (dict) context: Map of variables to substitute.
+        :returns (dict): The rendered version of the original renderable dict.
         """
-        Substitute variables into renderable with the variables in context
-        :param renderable: dict with variables to be substituted
-        :param context: the variables to substitute
-        :return: the rendered version of the original renderable dict
-        """
-        json_string = json.dumps(renderable) if isinstance(renderable, dict) else renderable
+        json_string = json.dumps(renderable) if isinstance(
+            renderable, dict) else renderable
         template = self.environment.from_string(json_string)
         rendered = template.render(**context)
-        result = rendered if isinstance(renderable, dict) else json.dumps(rendered)
-
+        result = rendered if isinstance(
+            renderable, dict) else json.dumps(rendered)
         return json.loads(result)
 
     @staticmethod
     def safe_content(content):
+        """Make content safe.
+
+        Replaces variable with ellipsis and strips any HTML tags.
+
+        :param (str) content: Input string.
+        :returns (str): Modified string.
+        """
         if content is not None:
             # Replace piping with ellipsis
-            content = re.sub(r'\{\{[^}]+\}\}', '…', content)
+            content = re.sub(r'{{[^}]+}}', '…', content)
             # Strip HTML Tags
             content = re.sub(r'</?[^>]+>', '', content)
-
         return content
 
 

--- a/tests/app/templating/test_template_renderer.py
+++ b/tests/app/templating/test_template_renderer.py
@@ -22,6 +22,14 @@ class TestTemplateRenderer(unittest.TestCase):
 
         self.assertEqual(rendered, "<span class='date'>1 January 2017</span>")
 
+    def test_render_date_month_year(self):
+        date = '{{date|format_date}}'
+        context = {'date': '2017-01'}
+
+        rendered = TemplateRenderer().render(date, **context)
+
+        self.assertEqual(rendered, "<span class='date'>January 2017</span>")
+
     def test_strings_containing_backslashes_are_escaped(self):
         title = '{{ [answers.person_name] | format_household_name }}'
         context = {

--- a/tests/app/test_jinja_filters.py
+++ b/tests/app/test_jinja_filters.py
@@ -5,15 +5,18 @@ from unittest import TestCase
 from datetime import datetime
 
 from dateutil.relativedelta import relativedelta
-from jinja2 import Undefined
+from jinja2 import Undefined, Markup
 from mock import Mock
 
-from app.jinja_filters import format_date, format_conditional_date, format_currency, get_currency_symbol, \
-    format_multilined_string, format_percentage, format_date_range, format_household_member_name, \
-    format_month_year_date, format_datetime, format_number_to_alphabetic_letter, \
-    format_unit, format_currency_for_input, format_number, format_unordered_list, \
-    format_household_member_name_possessive, concatenated_list, calculate_years_difference, \
-    get_current_date, as_london_tz
+from app.jinja_filters import (
+    format_date, format_conditional_date, format_currency, get_currency_symbol,
+    format_multilined_string, format_percentage, format_date_range,
+    format_household_member_name, format_datetime,
+    format_number_to_alphabetic_letter, format_unit, format_currency_for_input,
+    format_number, format_unordered_list,
+    format_household_member_name_possessive, concatenated_list,
+    calculate_years_difference, get_current_date, as_london_tz
+)
 
 
 class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
@@ -142,6 +145,36 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         # Then
         self.assertEqual(format_value, "<span class='date'>January 2017</span>")
 
+    def test_format_date_markup(self):
+        # Given
+        date = [Markup('2017-01')]
+
+        # When
+        format_value = format_date(self.no_autoescape_context, date)
+
+        # Then
+        self.assertEqual(format_value, "<span class='date'>January 2017</span>")
+
+    def test_format_date_non_string(self):
+        # Given
+        date = 123
+
+        # When
+        format_value = format_date(self.no_autoescape_context, date)
+
+        # Then
+        self.assertEqual(format_value, 123)
+
+    def test_format_date_none(self):
+        # Given
+        date = None
+
+        # When
+        format_value = format_date(self.no_autoescape_context, date)
+
+        # Then
+        self.assertIsNone(format_value)
+
     def test_format_date_time_in_bst(self):
         # Given
         date_time = '2018-03-29T11:59:13.528680'
@@ -256,15 +289,6 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
 
         # Then
         self.assertEqual(format_value, "<span class='date'>1 January 2017</span>")
-
-    def test_format_month_year_date(self):
-        # Given
-        month_year_date = '2018-03'
-
-        # When
-        format_value = format_month_year_date(self.no_autoescape_context, month_year_date)
-
-        self.assertEqual(format_value, "<span class='date'>March 2018</span>")
 
     def test_format_household_member_name(self):
         # Given


### PR DESCRIPTION
### What is the context of this PR?
LFS requires that month-year date answers are rendered for display.  This change updates and existing the existing (unused) `format_month_year_date` to work correctly, adds it to the template renderer and adds/updates tests.  This change takes into consideration the following:
- There is an existing `format_month_year_date` filter defined but it is not initialised in the template renderer class.
- There is an existing `format_date` filter that could render month-year dates but currently is only used to format metadata (e.g. exercise start date) and fails to parse answers (e.g. in the form `[Markup('2000-02')]').  This could have been modified but ideally `format_date` filter should be singular in purpose and not a catch-all date formatter.
- Additionally the existing `format_date` filter does not have an overridable format parameter.
- This update takes the opportunity to improve the layout of affected code without refactoring the source too extensively.

### How to review
- Examine the code and tests, run the tests.
- Try the formatter in a schema (e.g. `labour_force.json`, `continuous-in-uk-question` and format the `arrive-in-uk-answer` month-year answer.