### PR TITLE
Remove empty spaces from Metadata

### DIFF
--- a/app/storage/metadata_parser.py
+++ b/app/storage/metadata_parser.py
@@ -83,7 +83,8 @@ def parse_metadata(metadata_to_check):
     except (RuntimeError, ValueError, TypeError) as e:
         logger.error('unable to parse metadata', exc_info=e)
         raise InvalidTokenException('incorrect data in token')
-    return parsed
+
+    return clean_leading_trailing_spaces(parsed)
 
 
 def is_valid_metadata(metadata):
@@ -91,3 +92,14 @@ def is_valid_metadata(metadata):
         if field.mandatory and key not in metadata:
             return False, key
     return True, ''
+
+
+def clean_leading_trailing_spaces(metadata):
+    clean_metadata = {}
+    for key, value in metadata.items():
+        if isinstance(value, str):
+            value = value.strip()
+
+        clean_metadata[key] = value
+
+    return clean_metadata

--- a/tests/app/templating/test_metadata_context.py
+++ b/tests/app/templating/test_metadata_context.py
@@ -76,3 +76,14 @@ class TestMetadataContext(SurveyRunnerTestCase):
         self.assertEqual(escaped_bad_characters, survey['eq_id'])
         self.assertEqual(escaped_bad_characters, survey['collection_id'])
         self.assertEqual(escaped_bad_characters, survey['form_type'])
+
+    def test_clean_leading_trailing_spaces(self):
+        jwt = self.jwt.copy()
+        jwt['trad_as'] = ' '
+        jwt['ru_name'] = '   Apple   '
+
+        with self.application.test_request_context():
+            metadata = parse_metadata(jwt)
+
+        self.assertEqual(metadata['trad_as'], '')
+        self.assertEqual(metadata['ru_name'], 'Apple')


### PR DESCRIPTION
### What is the context of this PR?
At the moment if **Trading As** is passed as a single space " " then it will display that instead of the **Runame**. By removing leading and trailing spaces from the metadata only actual strings are evaluated.

### How to review 
Currently:
Launch a survey with a trading as value of " " (one empty space)
Front page shows "You are completing this for ESSENTIAL ENTERPRISE LTD. (trading as )"
