### PR TITLE
Ability to validate schemas against local schema-validator

### DIFF
--- a/scripts/test_schemas.sh
+++ b/scripts/test_schemas.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 
-docker pull onsdigital/eq-schema-validator
-validator="$(docker run -d -p 5001:5000 onsdigital/eq-schema-validator)"
+run_docker=true
+if [ "$1" == "--local" ] || [ "$2" == "--local" ]; then
+    run_docker=false
+fi
 
-sleep 3
+if [ "$run_docker" == true ]; then
+    docker pull onsdigital/eq-schema-validator
+    validator="$(docker run -d -p 5001:5000 onsdigital/eq-schema-validator)"
+    sleep 3
+fi
 
 green="$(tput setaf 2)"
 red="$(tput setaf 1)"
@@ -32,7 +38,7 @@ done
 
 exit=0
 
-if [ $# -eq 0 ]; then
+if [ $# -eq 0 ] || [ "$1" == "--local" ]; then
     file_path="./data/en"
 else
     file_path="$1"
@@ -63,5 +69,8 @@ done
 
 echo -e "\\n${green}$passed Passed${default} - ${red}$failed Failed${default}"
 
-docker rm -f "$validator"
+if [ "$run_docker" == true ]; then
+    docker rm -f "$validator"
+fi
+
 exit "$exit"


### PR DESCRIPTION
## What is the context of this PR?
Just a quick PR to add the ability to validate schemas against `eq_schema_validator` locally instead of using docker.

You can now pass `--local` as the 1st or 2nd argument to run it locally.
- `/scripts/test_schemas.sh --local` to run all schemas locally.
- `./scripts/test_schemas.sh data/en/0_star_wars.json --local` to run a specific schema

Note: It will run against what ever is running on port 5001 so, if your docker `eq-schema_validator` is running, it will run against that.

### How to review 
1. `run_app` on `eq-schema_validator`
2. Run `test_schemas` script with and without `--local` flag.

Schemas should be validated as expected.