### PR TITLE
Added alt tag for the OGL image in the footer

### DIFF
--- a/app/templates/partials/footer2.html
+++ b/app/templates/partials/footer2.html
@@ -56,7 +56,7 @@
                     </ul>
                     <br />
                 </div>
-                <div class="dl__data mars"><img src="{{ olg_cdn }}" class="ogl__img"/>
+                <div class="dl__data mars"><img src="{{ olg_cdn }}" class="ogl__img" alt="Open Government License logo"/>
                     All content is available under
                     the <a class="footer2__link"
                            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"

--- a/app/themes/northernireland/templates/partials/footer2.html
+++ b/app/themes/northernireland/templates/partials/footer2.html
@@ -59,7 +59,7 @@
                 </ul>
                 <br />
             </div>
-            <div class="dl__data mars"><img src="{{ olg_cdn }}" class="ogl__img"/>
+            <div class="dl__data mars"><img src="{{ olg_cdn }}" class="ogl__img" alt="Open Government License logo"/>
                 All content is available under
                 the <a class="footer2__link"
                        href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"


### PR DESCRIPTION
### What is the context of this PR?
The footer failed accessibility due to the OGL logo image not having the "alt" attribute.

### How to review 
Check that the two instances of the footer (standard and N.I) contain the alt tag on the OGL image.