### PR TITLE
Add min and max jinja filters

### DIFF
--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -8,6 +8,8 @@ from dateutil import relativedelta, tz
 import flask
 
 from jinja2 import Markup, escape, evalcontextfilter, evalcontextfunction
+from jinja2.exceptions import UndefinedError
+
 from babel import units, numbers
 
 
@@ -199,6 +201,26 @@ def format_number_to_alphabetic_letter(number):
     if 0 <= int(number) < 26:
         return string.ascii_lowercase[int(number)]
     return ''
+
+
+@blueprint.app_template_filter()
+def min_value(a, b):
+    try:
+        return min(i for i in [a, b] if i is not None)
+    except (TypeError, UndefinedError):
+        msg = ('Cannot determine minimum of incompatible types '
+               'min({}, {})'.format(a.__class__, b.__class__))
+        raise Exception(msg)
+
+
+@blueprint.app_template_filter()
+def max_value(a, b):
+    try:
+        return max(i for i in [a, b] if i is not None)
+    except (TypeError, UndefinedError):
+        msg = ('Cannot determine maximum of incompatible types '
+               'max({}, {})'.format(a.__class__, b.__class__))
+        raise Exception(msg)
 
 
 @blueprint.app_context_processor

--- a/app/templating/template_renderer.py
+++ b/app/templating/template_renderer.py
@@ -24,6 +24,8 @@ class TemplateRenderer:
         env.filters['concatenated_list'] = filters.concatenated_list
         env.globals['calculate_years_difference'] = filters.calculate_years_difference
         env.globals['get_current_date'] = filters.get_current_date
+        env.globals['min_value'] = filters.min_value
+        env.globals['max_value'] = filters.max_value
         self.environment = env
 
     def render(self, renderable, **context):

--- a/data/en/test_dates.json
+++ b/data/en/test_dates.json
@@ -78,6 +78,22 @@
                     "title": "Date Examples"
                 },
                 {
+                    "type": "Interstitial",
+                    "id": "min-max-block",
+                    "title": "Application of min and max filters to dates",
+                    "description": "",
+                    "content": [{
+                        "title": "",
+                        "list": [
+                            "The most recent Date Range value entered was <em>{{ max_value(answers['date-range-from'], answers['date-range-to'])|format_date }}</em>",
+                            "The least recent Date Range value entered was <em>{{ min_value(answers['date-range-from'], answers['date-range-to'])|format_date }}</em>",
+                            "The most recent of the dates <em>Date with month and year</em> and <em>Period From</em> is <em>{{ max_value(answers['date-range-from'], answers['month-year-answer'])|format_date }}</em>",
+                            "The most recent of the dates <em>Single date</em> and <em>Non-mandatory date</em>: <em>{{ max_value(answers['single-date-answer'], answers['non-mandatory-date-answer']) }}</em>",
+                            "The least recent of the dates <em>Single date</em> and <em>Non-mandatory date</em> (if non-mandatory date is unset this will be blank): <em>{{ min_value(answers['single-date-answer'], answers['non-mandatory-date-answer']) }}</em>"
+                        ]
+                    }]
+                },
+                {
                     "type": "Summary",
                     "id": "summary"
                 }

--- a/data/en/test_numbers.json
+++ b/data/en/test_numbers.json
@@ -154,7 +154,7 @@
                                     }
                                 }
                             ],
-                            "description": "",
+                            "description": "You entered a minimum value of <em>{{ min_value(answers['set-minimum'], answers['set-maximum']) }}</em> and a maximum value of <em>{{ max_value(answers['set-minimum'], answers['set-maximum']) }}</em>",
                             "id": "test-min-max-range-question",
                             "title": "Please enter test values (none mandatory)",
                             "type": "General"

--- a/data/en/test_textfield.json
+++ b/data/en/test_textfield.json
@@ -32,8 +32,20 @@
                         "title": "",
                         "type": "General"
                     }],
-                    "title": "Date Test",
+                    "title": "Text Field Test",
                     "routing_rules": []
+                },
+                {
+                    "type": "Interstitial",
+                    "id": "min-max-block",
+                    "title": "Application of min and max filters to strings",
+                    "description": "",
+                    "content": [{
+                        "title": "",
+                        "list": [
+                            "Of the strings <em>{{ answers['answer'] }}</em> (entered by you) and <em>abcd123</em>, the string <em>{{ max_value(answers['answer'], 'abcd123') }}</em> is maximum."
+                        ]
+                    }]
                 },
                 {
                     "type": "Summary",

--- a/tests/app/templating/test_template_renderer.py
+++ b/tests/app/templating/test_template_renderer.py
@@ -1,5 +1,8 @@
 # coding: utf-8
 
+# pylint: disable=too-many-public-methods
+
+import datetime
 import unittest
 
 from app.templating.template_renderer import TemplateRenderer
@@ -187,3 +190,61 @@ class TestTemplateRenderer(unittest.TestCase):
         safe_content = TemplateRenderer.safe_content(content)
 
         self.assertEqual(safe_content, 'Is … really correct?')
+
+    def test_render_max(self):
+        content = 'The largest number is {{ max_value(first, second) }}'
+        context = {
+            'first': 1,
+            'second': 2
+        }
+        rendered = TemplateRenderer().render(content, **context)
+        self.assertEqual(rendered, 'The largest number is 2')
+
+    def test_render_max_str(self):
+        content = 'The largest string is {{ max_value(first, second) }}'
+        context = {
+            'first': 'zzz',
+            'second': 'zzz1'
+        }
+        rendered = TemplateRenderer().render(content, **context)
+        self.assertEqual(rendered, 'The largest string is zzz1')
+
+    def test_render_max_date(self):
+        content = 'The most recent date is {{ max_value(first, second) }}'
+        now = datetime.datetime.utcnow()
+        then = now - datetime.timedelta(seconds=60)
+        context = {
+            'first': now,
+            'second': then
+        }
+        rendered = TemplateRenderer().render(content, **context)
+        self.assertEqual(rendered, 'The most recent date is {}'.format(now))
+
+    def test_render_min(self):
+        content = 'The smallest number is {{ min_value(first, second) }}'
+        context = {
+            'first': 1,
+            'second': 2
+        }
+        rendered = TemplateRenderer().render(content, **context)
+        self.assertEqual(rendered, 'The smallest number is 1')
+
+    def test_render_min_str(self):
+        content = 'The smallest string is {{ min_value(first, second) }}'
+        context = {
+            'first': 'zzz',
+            'second': 'zzz1'
+        }
+        rendered = TemplateRenderer().render(content, **context)
+        self.assertEqual(rendered, 'The smallest string is zzz')
+
+    def test_render_min_date(self):
+        content = 'The least recent date is {{ min_value(first, second) }}'
+        now = datetime.datetime.utcnow()
+        then = now - datetime.timedelta(seconds=60)
+        context = {
+            'first': now,
+            'second': then
+        }
+        rendered = TemplateRenderer().render(content, **context)
+        self.assertEqual(rendered, 'The least recent date is {}'.format(then))

--- a/tests/app/test_jinja_filters.py
+++ b/tests/app/test_jinja_filters.py
@@ -2,7 +2,7 @@
 
 from unittest import TestCase
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from dateutil.relativedelta import relativedelta
 from jinja2 import Undefined, Markup
@@ -15,7 +15,8 @@ from app.jinja_filters import (
     format_number_to_alphabetic_letter, format_unit, format_currency_for_input,
     format_number, format_unordered_list,
     format_household_member_name_possessive, concatenated_list,
-    calculate_years_difference, get_current_date, as_london_tz
+    calculate_years_difference, get_current_date, as_london_tz, max_value,
+    min_value
 )
 
 
@@ -466,3 +467,159 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         formatted_value = format_unordered_list(self.no_autoescape_context, list_items)
 
         self.assertEqual('', formatted_value)
+
+    def test_max_value(self):
+        # Given
+        two_ints = (1, 2)
+
+        # When
+        max_of_two = max_value(*two_ints)
+
+        # Then
+        self.assertEqual(max_of_two, 2)
+
+    def test_max_value_none(self):
+        # Given
+        one_int = (1, None)
+
+        # When
+        max_of_two = max_value(*one_int)
+
+        # Then
+        self.assertEqual(max_of_two, 1)
+
+    def test_max_value_undefined(self):
+        # Given
+        args = ('foo', Undefined())
+
+        # When
+        with self.assertRaises(Exception) as exception:
+            max_value(*args)
+
+        # Then
+        self.assertIn(
+            "Cannot determine maximum of incompatible types max(<class 'str'>,"
+            " <class 'jinja2.runtime.Undefined'>)", str(exception.exception))
+
+    def test_max_values_incompatible(self):
+        # Given
+        args = (1, 'abc')
+
+        # When
+        with self.assertRaises(Exception) as exception:
+            max_value(*args)
+
+        # Then
+        self.assertIn(
+            "Cannot determine maximum of incompatible types max(<class 'int'>,"
+            " <class 'str'>)", str(exception.exception))
+
+    def test_max_values_compatible(self):
+        # Given
+        args = (-1, True)
+
+        # When
+        max_of_two = max_value(*args)
+
+        # Then
+        self.assertEqual(max_of_two, True)
+
+    def test_max_value_str(self):
+        # Given
+        two_str = ('a', 'abc')
+
+        # When
+        max_of_two = max_value(*two_str)
+
+        # Then
+        self.assertEqual(max_of_two, 'abc')
+
+    def test_max_value_date(self):
+        # Given
+        now = datetime.utcnow()
+        then = now - timedelta(seconds=60)
+        two_dates = (then, now)
+
+        # When
+        max_of_two = max_value(*two_dates)
+
+        # Then
+        self.assertEqual(max_of_two, now)
+
+    def test_min_value(self):
+        # Given
+        two_ints = (1, 2)
+
+        # When
+        min_of_two = min_value(*two_ints)
+
+        # Then
+        self.assertEqual(min_of_two, 1)
+
+    def test_min_value_none(self):
+        # Given
+        one_int = (1, None)
+
+        # When
+        min_of_two = min_value(*one_int)
+
+        # Then
+        self.assertEqual(min_of_two, 1)
+
+    def test_min_value_undefined(self):
+        # Given
+        args = ('foo', Undefined())
+
+        # When
+        with self.assertRaises(Exception) as exception:
+            min_value(*args)
+
+        # Then
+        self.assertIn(
+            "Cannot determine minimum of incompatible types min(<class 'str'>,"
+            " <class 'jinja2.runtime.Undefined'>)", str(exception.exception))
+
+    def test_min_values_incompatible(self):
+        # Given
+        args = (1, 'abc')
+
+        # When
+        with self.assertRaises(Exception) as exception:
+            min_value(*args)
+
+        # Then
+        self.assertIn(
+            "Cannot determine minimum of incompatible types min(<class 'int'>,"
+            " <class 'str'>)", str(exception.exception))
+
+    def test_min_values_compatible(self):
+        # Given
+        args = (-1, True)
+
+        # When
+        min_of_two = min_value(*args)
+
+        # Then
+        self.assertEqual(min_of_two, -1)
+
+    def test_min_value_str(self):
+        # Given
+        two_str = ('a', 'abc')
+
+        # When
+        min_of_two = min_value(*two_str)
+
+        # Then
+        self.assertEqual(min_of_two, 'a')
+
+    def test_min_value_date(self):
+        # Given
+        now = datetime.utcnow()
+        then = now - timedelta(seconds=60)
+        two_dates = (then, now)
+
+        # When
+        min_of_two = min_value(*two_dates)
+
+        # Then
+        self.assertEqual(min_of_two, then)

--- a/tests/functional/pages/surveys/dates/min-max-block.page.js
+++ b/tests/functional/pages/surveys/dates/min-max-block.page.js
@@ -1,0 +1,11 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class MinMaxBlockPage extends QuestionPage {
+
+  constructor() {
+    super('min-max-block');
+  }
+
+}
+module.exports = new MinMaxBlockPage();

--- a/tests/functional/pages/surveys/textfield/min-max-block.page.js
+++ b/tests/functional/pages/surveys/textfield/min-max-block.page.js
@@ -1,0 +1,11 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class MinMaxBlockPage extends QuestionPage {
+
+  constructor() {
+    super('min-max-block');
+  }
+
+}
+module.exports = new MinMaxBlockPage();

--- a/tests/functional/spec/dates.spec.js
+++ b/tests/functional/spec/dates.spec.js
@@ -1,5 +1,6 @@
 const helpers = require('../helpers');
 const DatesPage = require('../pages/surveys/dates/date-block.page');
+const MinMaxBlockPage = require('../pages/surveys/dates/min-max-block.page');
 const SummaryPage = require('../pages/surveys/dates/summary.page');
 
 describe('Date checks', function() {
@@ -28,6 +29,9 @@ describe('Date checks', function() {
         .setValue(DatesPage.singleDateyear(), 1999)
 
         .click(DatesPage.submit())
+        // Interstitial displaying min-max formats
+        .click(MinMaxBlockPage.submit())
+        .getUrl().should.eventually.contain(SummaryPage.pageName)
 
         // Then the summary screen shows the dates entered formatted
         .getText(SummaryPage.dateRangeFromAnswer()).should.eventually.contain('1 March 2016 to 3 May 2017')
@@ -163,6 +167,9 @@ describe('Date checks', function() {
         // Then when it is corrected, it goes to the summary page and the information is correct
         .setValue(DatesPage.monthYearanswerYear(), 2018)
         .click(DatesPage.submit())
+        // Interstitial displaying min-max formats
+        .click(MinMaxBlockPage.submit())
+        .getUrl().should.eventually.contain(SummaryPage.pageName)
 
         // Then the summary screen shows the dates entered formatted
         .getText(SummaryPage.dateRangeFromAnswer()).should.eventually.contain('1 March 2016 to 3 May 2017')

--- a/tests/functional/spec/textfield.spec.js
+++ b/tests/functional/spec/textfield.spec.js
@@ -1,5 +1,6 @@
 const helpers = require('../helpers');
 const TextFieldPage = require('../pages/surveys/textfield/block.page.js');
+const MinMaxBlockPage = require('../pages/surveys/textfield/min-max-block.page');
 const SummaryPage = require('../pages/surveys/textfield/summary.page.js');
 
 describe('Textfield', function() {
@@ -17,6 +18,9 @@ describe('Textfield', function() {
       return browser
         .setValue(TextFieldPage.answer(), "'Twenty><&Five'")
         .click(TextFieldPage.submit())
+        // Interstitial displaying min-max formats
+        .click(MinMaxBlockPage.submit())
+        .getUrl().should.eventually.contain(SummaryPage.pageName)
         .getText(SummaryPage.answer()).should.eventually.contain("Twenty><&Five'")
         .click(SummaryPage.answerEdit())
         .getValue(TextFieldPage.answer()).should.eventually.contain("'Twenty><&Five'");

--- a/tests/integration/questionnaire/test_questionnaire_change_answer.py
+++ b/tests/integration/questionnaire/test_questionnaire_change_answer.py
@@ -28,6 +28,8 @@ class TestQuestionnaireChangeAnswer(IntegrationTestCase):
         }
 
         self.post(post_data)
+        self.assertInPage('Application of min and max filters to dates')
+        self.post(action='save_continue')
         self.assertInPage('22 February 2099')
         self.assertNotInPage('No answer provided')
 


### PR DESCRIPTION
### What is the context of this PR?
Social Demographic require a page in LFS to render the most recent of two date responses.  This PR implements two general purpose filters `max_value` and `min_value` that fulfil the SD requirement as well as providing a useful feature for other use cases.  Currently blocking #1581.

### How to review 
- Review code in `app/jinja_filters.py` and `app/templating/template_renderer.py`.
- Review and run related tests in `tests/app/templating/test_template_renderer.py` and `tests/app/test_jinja_filters.py`.
- Apply the following patch to `labour_force.json` in `master` and run the survey (rename to `.diff`):
    [lfs.diff](https://github.com/ONSdigital/eq-survey-runner/files/2014939/lfs.diff.txt)
