### PR TITLE
2112 address codacy warning about using jinja2 rendering without autoescape

### DIFF
--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -145,9 +145,12 @@ def calculate_years_difference(from_str, to_str):
 @evalcontextfunction
 def format_date_range(context, start_date, end_date=None):
     if end_date:
-        return '{from_date} to {to_date}'.format(from_date=format_date(context, start_date),
-                                                 to_date=format_date(context, end_date))
-    return format_date(context, start_date)
+        result = '{from_date} to {to_date}'.format(from_date=format_date(context, start_date),
+                                                   to_date=format_date(context, end_date))
+    else:
+        result = format_date(context, start_date)
+
+    return mark_safe(context, result)
 
 
 @blueprint.app_template_filter()

--- a/tests/app/test_jinja_filters.py
+++ b/tests/app/test_jinja_filters.py
@@ -23,7 +23,6 @@ from app.jinja_filters import (
 class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
     def setUp(self):
         self.autoescape_context = Mock(autoescape=True)
-        self.no_autoescape_context = Mock(autoescape=False)
         super(TestJinjaFilters, self).setUp()
 
     def test_format_currency_for_input(self):
@@ -73,7 +72,7 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         new_line = 'this is on a new\rline'
 
         # When
-        format_value = format_multilined_string(self.no_autoescape_context, new_line)
+        format_value = format_multilined_string(self.autoescape_context, new_line)
 
         self.assertEqual(format_value, '<p>this is on a new<br>line</p>')
 
@@ -82,7 +81,7 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         new_line = 'this is on a new\nline'
 
         # When
-        format_value = format_multilined_string(self.no_autoescape_context,
+        format_value = format_multilined_string(self.autoescape_context,
                                                 new_line)
 
         self.assertEqual(format_value, '<p>this is on a new<br>line</p>')
@@ -92,7 +91,7 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         new_line = 'this is on a new\r\nline'
 
         # When
-        format_value = format_multilined_string(self.no_autoescape_context, new_line)
+        format_value = format_multilined_string(self.autoescape_context, new_line)
 
         self.assertEqual(format_value, '<p>this is on a new<br>line</p>')
 
@@ -101,7 +100,7 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         new_line = 'this is\ron a\nnew\r\nline'
 
         # When
-        format_value = format_multilined_string(self.no_autoescape_context,
+        format_value = format_multilined_string(self.autoescape_context,
                                                 new_line)
 
         self.assertEqual(format_value, '<p>this is<br>on a<br>new<br>line</p>')
@@ -120,7 +119,7 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         date_format = '%-d %B %Y'
 
         # When
-        format_value = get_current_date(self.no_autoescape_context)
+        format_value = get_current_date(self.autoescape_context)
         current_date = as_london_tz(datetime.utcnow()).strftime(date_format)
 
         # Then
@@ -131,7 +130,7 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         date = '2017-01-01'
 
         # When
-        format_value = format_date(self.no_autoescape_context, date)
+        format_value = format_date(self.autoescape_context, date)
 
         # Then
         self.assertEqual(format_value, "<span class='date'>1 January 2017</span>")
@@ -141,7 +140,7 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         date = '2017-01'
 
         # When
-        format_value = format_date(self.no_autoescape_context, date)
+        format_value = format_date(self.autoescape_context, date)
 
         # Then
         self.assertEqual(format_value, "<span class='date'>January 2017</span>")
@@ -151,7 +150,7 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         date = [Markup('2017-01')]
 
         # When
-        format_value = format_date(self.no_autoescape_context, date)
+        format_value = format_date(self.autoescape_context, date)
 
         # Then
         self.assertEqual(format_value, "<span class='date'>January 2017</span>")
@@ -161,7 +160,7 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         date = 123
 
         # When
-        format_value = format_date(self.no_autoescape_context, date)
+        format_value = format_date(self.autoescape_context, date)
 
         # Then
         self.assertEqual(format_value, 123)
@@ -171,7 +170,7 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         date = None
 
         # When
-        format_value = format_date(self.no_autoescape_context, date)
+        format_value = format_date(self.autoescape_context, date)
 
         # Then
         self.assertIsNone(format_value)
@@ -182,7 +181,7 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         date_format = '%-d %B %Y at %H:%M'
 
         # When
-        format_value = format_datetime(self.no_autoescape_context, date_time, date_format)
+        format_value = format_datetime(self.autoescape_context, date_time, date_format)
 
         # Then
         self.assertEqual(format_value, "<span class='date'>29 March 2018 at 12:59</span>")
@@ -193,7 +192,7 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         date_format = '%-d %B %Y at %H:%M'
 
         # When
-        format_value = format_datetime(self.no_autoescape_context, date_time, date_format)
+        format_value = format_datetime(self.autoescape_context, date_time, date_format)
 
         # Then
         self.assertEqual(format_value, "<span class='date'>28 October 2018 at 11:59</span>")
@@ -209,7 +208,7 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
             date1 = nonsense[0]
             date2 = nonsense[1]
             with self.assertRaises(Exception) as exception:
-                format_conditional_date(self.no_autoescape_context, date1, date2)
+                format_conditional_date(self.autoescape_context, date1, date2)
         # Then
             self.assertIn("does not match format '%Y-%m'", str(exception.exception))
 
@@ -218,7 +217,7 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
 
         # When
         with self.assertRaises(Exception) as exception:
-            format_conditional_date(self.no_autoescape_context, None, None)
+            format_conditional_date(self.autoescape_context, None, None)
 
         # Then
         self.assertIn('No valid dates passed to format_conditional_dates filter', str(exception.exception))
@@ -235,7 +234,7 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
             date1 = triple[0]
             date2 = triple[1]
 
-            format_value = format_conditional_date(self.no_autoescape_context, date1, date2)
+            format_value = format_conditional_date(self.autoescape_context, date1, date2)
 
             # Then
             self.assertEqual(format_value, "<span class='date'>{date}</span>".format(date=triple[2]))
@@ -276,7 +275,7 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         end_date = '2017-01-31'
 
         # When
-        format_value = format_date_range(self.no_autoescape_context, start_date, end_date)
+        format_value = format_date_range(self.autoescape_context, start_date, end_date)
 
         # Then
         self.assertEqual(format_value, "<span class='date'>1 January 2017</span> to <span class='date'>31 January 2017</span>")
@@ -286,7 +285,7 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         start_date = '2017-01-01'
 
         # When
-        format_value = format_date_range(self.no_autoescape_context, start_date)
+        format_value = format_date_range(self.autoescape_context, start_date)
 
         # Then
         self.assertEqual(format_value, "<span class='date'>1 January 2017</span>")
@@ -448,7 +447,7 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
     def test_format_unordered_list(self):
         list_items = [['item 1', 'item 2']]
 
-        formatted_value = format_unordered_list(self.no_autoescape_context, list_items)
+        formatted_value = format_unordered_list(self.autoescape_context, list_items)
 
         expected_value = '<ul><li>item 1</li><li>item 2</li></ul>'
 
@@ -457,14 +456,14 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
     def test_format_unordered_list_with_no_input(self):
         list_items = []
 
-        formatted_value = format_unordered_list(self.no_autoescape_context, list_items)
+        formatted_value = format_unordered_list(self.autoescape_context, list_items)
 
         self.assertEqual('', formatted_value)
 
     def test_format_unordered_list_with_empty_list(self):
         list_items = [[]]
 
-        formatted_value = format_unordered_list(self.no_autoescape_context, list_items)
+        formatted_value = format_unordered_list(self.autoescape_context, list_items)
 
         self.assertEqual('', formatted_value)
 


### PR DESCRIPTION
### What is the context of this PR?
Defect fix stemming from #1594

Fixes another Jinja filter that wasn't returning a string marked as safe

### How to review 
Test MWSS (1_0005.json) and assert that the period as shown in the header is not escaped.
Test one of the RSI schemas (E.g. 1_0205.json) and assert the same. These schemas make use of `format_conditional_date` which should benefit from the same fix.