### PR TITLE
Pay pattern confirmation in MWSS missing default routing rule

### DIFF
--- a/data/en/1_0005.json
+++ b/data/en/1_0005.json
@@ -275,6 +275,11 @@
                                         "value": "Five weekly"
                                     }]
                                 }
+                            },
+                            {
+                                "goto": {
+                                    "group": "weekly-pay"
+                                }
                             }
                         ]
                     }


### PR DESCRIPTION
### What is the context of this PR?
Schema validator wasn't working for routing rules properly, so a fix revealed invalid schema in `1_0005.json`. All that was missing was a default routing rule which has been added. 

### How to review 
MWSS should still work functionally as it was
