### PR TITLE
Allow for different versions of a question title depending on a conditional question

### DIFF
--- a/app/forms/household_composition_form.py
+++ b/app/forms/household_composition_form.py
@@ -3,20 +3,22 @@ from flask_wtf import FlaskForm
 from wtforms import FieldList, Form, FormField
 from werkzeug.datastructures import MultiDict
 
+from app.data_model import answer_store
 from app.data_model.answer_store import Answer
 from app.forms.fields import get_string_field
+from app.templating.utils import get_question_title
 
 logger = get_logger()
 
 
-def get_name_form(schema, block_json):
+def get_name_form(schema, block_json, metadata, group_instance):
     class NameForm(Form):
         pass
 
     for question in schema.get_questions_for_block(block_json):
         for answer in question['answers']:
             guidance = answer.get('guidance', '')
-            label = answer.get('label') or question.get('title')
+            label = answer.get('label') or get_question_title(question, answer_store, metadata, group_instance)
 
             field = get_string_field(answer, label, guidance, schema.error_messages)
 
@@ -60,10 +62,10 @@ def map_field_errors(errors, index):
     return ordered_errors
 
 
-def generate_household_composition_form(schema, block_json, data):
+def generate_household_composition_form(schema, block_json, data, metadata, group_instance):
     class HouseHoldCompositionForm(FlaskForm):
         question_errors = {}
-        household = FieldList(FormField(get_name_form(schema, block_json)), min_entries=1)
+        household = FieldList(FormField(get_name_form(schema, block_json, metadata, group_instance)), min_entries=1)
 
         def map_errors(self):
             ordered_errors = []

--- a/app/helpers/form_helper.py
+++ b/app/helpers/form_helper.py
@@ -32,7 +32,7 @@ def get_form_for_location(schema, block_json, location, answer_store, metadata, 
 
         data = deserialise_composition_answers(answers)
 
-        return generate_household_composition_form(schema, block_json, data)
+        return generate_household_composition_form(schema, block_json, data, metadata, location.group_instance)
 
     elif location.block_id in ['relationships', 'household-relationships']:
         answer_ids = schema.get_answer_ids_for_block(location.block_id)
@@ -63,7 +63,7 @@ def get_form_for_location(schema, block_json, location, answer_store, metadata, 
 
     mapped_answers = deserialise_dates(schema, location.block_id, mapped_answers)
 
-    return generate_form(schema, block_json, mapped_answers, answer_store, metadata)
+    return generate_form(schema, block_json, mapped_answers, answer_store, metadata, location.group_instance)
 
 
 def post_form_for_location(schema, block_json, location, answer_store, metadata, request_form, disable_mandatory=False):
@@ -82,7 +82,7 @@ def post_form_for_location(schema, block_json, location, answer_store, metadata,
         block_json = disable_mandatory_answers(block_json)
 
     if location.block_id == 'household-composition':
-        return generate_household_composition_form(schema, block_json, request_form)
+        return generate_household_composition_form(schema, block_json, request_form, metadata, location.group_instance)
 
     elif location.block_id in ['relationships', 'household-relationships']:
         relationship_choices = build_relationship_choices(answer_store, location.group_instance)
@@ -91,7 +91,7 @@ def post_form_for_location(schema, block_json, location, answer_store, metadata,
         return form
 
     data = clear_other_text_field(request_form, schema.get_questions_for_block(block_json))
-    return generate_form(schema, block_json, data, answer_store, metadata)
+    return generate_form(schema, block_json, data, answer_store, metadata, location.group_instance)
 
 
 def disable_mandatory_answers(block_json):

--- a/app/questionnaire/answer_dependencies.py
+++ b/app/questionnaire/answer_dependencies.py
@@ -1,0 +1,94 @@
+from collections import defaultdict
+
+
+class AnswerDependencies:
+    """represents the dependencies for a group of answers
+    held internally as a dict(string,set) where set contains dependent ids
+    set used to prevent duplicates
+
+    To add a dependency either call add with a single dependency
+    or update with another dependency object
+
+    To access dependencies for a question id simply index
+    i.e  a['question_id']
+    indexing is read only
+    """
+    def __init__(self):
+        self._answer_dependencies = defaultdict(set)
+
+    def __len__(self):
+        """returns length of answer dependencies, needed for index access"""
+        return len(self._answer_dependencies)
+
+    def __getitem__(self, answer_id):
+        """allows the support of indexing e.g a[answer_id]"""
+        return self._answer_dependencies[answer_id]
+
+    @property
+    def answer_dependencies(self):
+        return self._answer_dependencies
+
+    def add(self, answer_id, dependency):
+        """ Adds a dependency to a specific answer_id """
+        self._answer_dependencies[answer_id].add(dependency)
+
+    def update(self, other):
+        for key, dependencies in other.answer_dependencies.items():
+            self.answer_dependencies[key] |= dependencies
+
+
+def get_dependencies(schema):
+    """gets the all the answer dependencies for a schema by walking questions and answers
+    """
+    dependencies = _get_answer_level_dependencies(schema)
+    dependencies.update(_get_question_level_dependencies(schema))
+    return dependencies
+
+
+def _get_answer_level_dependencies(schema):
+    # Answer level dependencies
+    dependencies = AnswerDependencies()
+    for answer in schema.answers:
+        dependency_id = answer['id']
+        if 'min_value' in answer and 'answer_id' in answer['min_value']:
+            answer_id = answer['min_value']['answer_id']
+            dependencies.add(answer_id, dependency_id)
+        if 'max_value' in answer and 'answer_id' in answer['max_value']:
+            answer_id = answer['max_value']['answer_id']
+            dependencies.add(answer_id, dependency_id)
+    return dependencies
+
+
+def _get_question_level_dependencies(schema):
+    # Question level dependencies
+    dependencies = AnswerDependencies()
+    for question in schema.questions:
+        dependencies.update(_get_titles_dependencies_for_question(schema, question))
+        for calculation in question.get('calculations', []):
+            answer_id = calculation.get('answer_id')
+            if answer_id:
+                for dependency_id in calculation['answers_to_calculate']:
+                    dependencies[answer_id].add(dependency_id)
+    return dependencies
+
+
+def _get_titles_dependencies_for_question(schema, question):
+    """
+    gets the unique ids of any answers on a question as dependents
+    of any when id associated with a questions titles
+
+    :param schema: the json schema to use
+    :param question: the id of a question
+    """
+    dependencies = AnswerDependencies()
+
+    answer_ids = schema.get_answer_ids_for_question(question['id'])
+
+    when_clauses = [title.get('when')[0] for title in question.get('titles', []) if title.get('when')]
+
+    for when_clause in when_clauses:
+        when_id = when_clause.get('id')
+        for answer_id in answer_ids:
+            dependencies.add(when_id, answer_id)
+
+    return dependencies

--- a/app/questionnaire/rules.py
+++ b/app/questionnaire/rules.py
@@ -174,7 +174,10 @@ def evaluate_when_rules(when_rules, metadata, answer_store, group_instance):
     """
     for when_rule in when_rules:
         if 'id' in when_rule:
-            value = get_answer_store_value(when_rule['id'], answer_store, group_instance)
+            when_specified_group_instance = when_rule.get('group_instance')
+            instance = when_specified_group_instance or group_instance
+
+            value = get_answer_store_value(when_rule['id'], answer_store, instance)
         elif 'meta' in when_rule:
             value = get_metadata_value(metadata, when_rule['meta'])
         else:

--- a/app/templates/partials/question.html
+++ b/app/templates/partials/question.html
@@ -4,7 +4,7 @@
 {% set invalid = form.question_errors[question.id] | length > 0 if form else False %}
 
 {% set question_number = question.number %}
-{% set question_title = question.title %}
+{% set question_title = get_question_title(question.id) %}
 {% set question_subtitle = question.subtitle %}
 {% set question_guidance = "" %}
 

--- a/app/templates/partials/summary/summary.html
+++ b/app/templates/partials/summary/summary.html
@@ -15,7 +15,7 @@
 
             {% for question in block.questions %}
 
-              <div class="summary__question" id="{{question.id}}">
+              <div class="summary__question" id="{{question.id}}" data-qa="summary-question-title">
                 {{question.number or ''}} {{question.title|striptags}}
               </div>
 

--- a/app/templates/partials/widgets/multiple_choice_widget.html
+++ b/app/templates/partials/widgets/multiple_choice_widget.html
@@ -1,5 +1,5 @@
 <fieldset>
-  {% set answer_label = answer.label or question.title %}
+    {% set answer_label = get_answer_label(answer.id, question.id) %}
   <legend class="field__legend mars {{'u-vh' if answer.label|length == 0}}">
     {{answer_label}}
     {%- if answer_label and answer.description -%}

--- a/app/templating/summary/block.py
+++ b/app/templating/summary/block.py
@@ -29,7 +29,7 @@ class Block:
         for question_schema in block_schema.get('questions', []):
             is_skipped = evaluate_skip_conditions(question_schema.get('skip_conditions'), metadata, answer_store)
             if not is_skipped:
-                question = Question(question_schema, answer_store).serialize()
+                question = Question(question_schema, answer_store, metadata).serialize()
                 questions.append(question)
         return questions
 

--- a/app/templating/summary/question.py
+++ b/app/templating/summary/question.py
@@ -1,16 +1,19 @@
 import collections
 
 from app.templating.summary.answer import Answer
+from app.templating.utils import get_question_title
 
 
 class Question:
 
-    def __init__(self, question_schema, answer_store):
+    def __init__(self, question_schema, answer_store, metadata):
         self.id = question_schema['id']
         self.type = question_schema['type']
 
         answer_schemas = iter(question_schema['answers'])
-        self.title = question_schema['title'] or question_schema['answers'][0]['label']
+
+        # Using group instance as 0 for now as summary rendering context only has knowledge of current locations group instance (i.e. 0)
+        self.title = get_question_title(question_schema, answer_store, metadata, group_instance=0) or question_schema['answers'][0]['label']
         self.number = question_schema.get('number', None)
         self.answers = self._build_answers(answer_store, question_schema, answer_schemas)
 
@@ -31,7 +34,8 @@ class Question:
                 continue
             if question_schema['type'] == 'RepeatingAnswer':
                 for answer_value in self._get_answers(answer_store, answer_schema['id']):
-                    answer = self._build_answer(answer_store, question_schema, answer_schema, answer_schemas, answer_value)
+                    answer = self._build_answer(answer_store, question_schema, answer_schema, answer_schemas,
+                                                answer_value)
                     summary_answers.append(Answer(answer_schema, answer))
             else:
                 answer_value = self._get_answer(answer_store, answer_schema['id'])

--- a/app/templating/utils.py
+++ b/app/templating/utils.py
@@ -1,0 +1,22 @@
+from app.questionnaire.rules import evaluate_when_rules
+
+
+def get_question_title(question_schema, answer_store, metadata, group_instance):
+    """Return the value that should be used as the title to a question
+    May be from question.title or question.titles"""
+
+    if question_schema.get('title') is not None:
+        return question_schema['title']
+
+    titles = question_schema.get('titles')
+
+    return get_title_from_titles(metadata, answer_store, titles, group_instance)
+
+
+def get_title_from_titles(metadata, answer_store, titles, group_instance):
+    """returns a title from titles available by evaluating the when rules , if all fail returns default"""
+
+    for when, value in ((title['when'], title['value']) for title in titles if 'when' in title):
+        if evaluate_when_rules(when, metadata, answer_store, group_instance):
+            return value
+    return titles[-1]['value']

--- a/data/en/test_titles.json
+++ b/data/en/test_titles.json
@@ -1,0 +1,215 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "0",
+    "title": "Multiple Question Title Test",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "description": "A questionnaire to test multiple question title versions",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ru_name": {
+            "validator": "string"
+        }
+    },
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "id": "group",
+            "title": "",
+            "blocks": [{
+                    "type": "Question",
+                    "id": "single-title-block",
+                    "title": "Single question title",
+                    "questions": [{
+                        "id": "single-title-question",
+                        "titles": [{
+                            "value": "How are you feeling??"
+                        }],
+                        "type": "General",
+                        "answers": [{
+                            "type": "Radio",
+                            "id": "feeling-answer",
+                            "mandatory": true,
+                            "options": [{
+                                    "label": "Good",
+                                    "value": "good"
+                                },
+                                {
+                                    "label": "Bad",
+                                    "value": "bad"
+                                }
+                            ]
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "who-is-answering-block",
+                    "questions": [{
+                        "id": "behalf-of-question",
+                        "title": "Who are you answering on behalf of?",
+                        "guidance": {
+                            "content": [{
+                                "description": "The answer you choose will have an effect on question titles in next question"
+                            }]
+                        },
+                        "type": "General",
+                        "answers": [{
+                            "type": "Radio",
+                            "id": "behalf-of-answer",
+                            "mandatory": true,
+                            "options": [{
+                                    "label": "Myself",
+                                    "value": "myself"
+                                },
+                                {
+                                    "label": "Chad",
+                                    "value": "chad"
+                                },
+                                {
+                                    "label": "Kelly",
+                                    "value": "kelly"
+                                },
+                                {
+                                    "label": "Someone else",
+                                    "value": "else"
+                                }
+                            ]
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "multiple-question-versions-block",
+                    "title": "Multiple question versions",
+                    "questions": [{
+                            "id": "what-gender-question",
+                            "titles": [{
+                                    "value": "What is <em>{{[answers['behalf-of-answer']]|format_household_name_possessive}}</em> gender?",
+                                    "when": [{
+                                        "id": "behalf-of-answer",
+                                        "condition": "equals",
+                                        "value": "chad"
+                                    }]
+                                },
+                                {
+                                    "value": "What is <em>{{[answers['behalf-of-answer']]|format_household_name_possessive}}</em> gender?",
+                                    "when": [{
+                                        "id": "behalf-of-answer",
+                                        "condition": "equals",
+                                        "value": "kelly"
+                                    }]
+                                },
+                                {
+                                    "value": "What is their gender?",
+                                    "when": [{
+                                        "id": "behalf-of-answer",
+                                        "condition": "equals",
+                                        "value": "else"
+                                    }]
+                                },
+                                {
+                                    "value": "What is your gender?"
+                                }
+                            ],
+                            "guidance": {
+                                "content": [{
+                                    "description": "Your question should be phrased correctly depending on the answer selected in the previous question"
+                                }]
+                            },
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "gender-answer",
+                                "mandatory": true,
+                                "options": [{
+                                        "label": "Male",
+                                        "value": "male"
+                                    },
+                                    {
+                                        "label": "Female",
+                                        "value": "female"
+                                    }
+                                ]
+                            }]
+                        },
+                        {
+                            "id": "what-age-question",
+                            "titles": [{
+                                    "value": "What is <em>{{[answers['behalf-of-answer']]|format_household_name_possessive}}</em> age?",
+                                    "when": [{
+                                        "id": "behalf-of-answer",
+                                        "condition": "equals",
+                                        "value": "chad"
+                                    }]
+                                },
+                                {
+                                    "value": "What is <em>{{[answers['behalf-of-answer']]|format_household_name_possessive}}</em> age?",
+                                    "when": [{
+                                        "id": "behalf-of-answer",
+                                        "condition": "equals",
+                                        "value": "kelly"
+                                    }]
+                                },
+                                {
+                                    "value": "What is their age?",
+                                    "when": [{
+                                        "id": "behalf-of-answer",
+                                        "condition": "equals",
+                                        "value": "else"
+                                    }]
+                                },
+                                {
+                                    "value": "What is your age?"
+                                }
+                            ],
+                            "guidance": {
+                                "content": [{
+                                    "description": "Your question should be phrased correctly depending on the answer selected in the previous question"
+                                }]
+                            },
+                            "type": "General",
+                            "answers": [{
+                                "type": "Number",
+                                "id": "age-answer",
+                                "mandatory": true
+                            }]
+                        },
+                        {
+                            "id": "sure-question",
+                            "titles": [{
+                                "value": "Are you sure??"
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "sure-answer",
+                                "mandatory": true,
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "no"
+                                    }
+                                ]
+                            }]
+                        }
+                    ]
+                },
+                {
+                    "type": "Summary",
+                    "id": "summary"
+                }
+            ]
+        }]
+    }]
+}

--- a/data/en/test_titles_radio_and_checkbox.json
+++ b/data/en/test_titles_radio_and_checkbox.json
@@ -1,0 +1,163 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "0",
+    "title": "Test Survey - Checkbox and Radio titles",
+    "description": "",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ru_name": {
+            "validator": "string"
+        }
+    },
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "id": "radio-checkbox-group",
+            "title": "",
+            "blocks": [{
+                    "id": "preamble-block",
+                    "type": "Question",
+                    "questions": [{
+                        "id": "name-question",
+                        "title": "what is your name",
+                        "type": "General",
+                        "guidance": {
+                            "content": [{
+                                "description": "The answer you write will have an effect on question titles in next question",
+                                "list": [
+                                    "If you type 'Peter', the question will be aimed for Peter",
+                                    "If you type 'Mary', the question will be aimed for Mary",
+                                    "If you type anything else the question will be the default question"
+                                ]
+                            }]
+                        },
+                        "answers": [{
+                            "id": "name-answer",
+                            "type": "TextField",
+                            "mandatory": true
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "checkbox-block",
+                    "title": "Checkbox Answer",
+                    "questions": [{
+                        "id": "checkbox-question",
+                        "type": "General",
+                        "titles": [{
+                                "value": "Did <em>Peter</em> make changes to this business?",
+                                "when": [{
+                                    "id": "name-answer",
+                                    "condition": "equals",
+                                    "value": "Peter"
+                                }]
+                            },
+                            {
+                                "value": "Did <em>Mary</em> make changes to this business?",
+                                "when": [{
+                                    "id": "name-answer",
+                                    "condition": "equals",
+                                    "value": "Mary"
+                                }]
+                            },
+                            {
+                                "value": "Did this business make major changes in the following areas?"
+                            }
+                        ],
+                        "answers": [{
+                            "id": "checkbox-answer",
+                            "type": "Checkbox",
+                            "mandatory": true,
+                            "options": [{
+                                    "label": "New business practices for organising procedures",
+                                    "value": "New business practices for organising procedures"
+                                },
+                                {
+                                    "label": "New methods of organising work responsibilities and decision making",
+                                    "value": "New methods of organising work responsibilities and decision making"
+                                },
+                                {
+                                    "label": "New methods of organising external relationships with other firms or public institutions",
+                                    "value": "New methods of organising external relationships with other firms or public institutions"
+                                },
+                                {
+                                    "label": "Implementation of changes to marketing concepts or strategies",
+                                    "value": "Implementation of changes to marketing concepts or strategies"
+                                }
+                            ]
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "radio-block",
+                    "title": "Radio Block",
+                    "questions": [{
+                        "id": "radio-question",
+                        "type": "General",
+                        "titles": [{
+                                "value": "Is <em>Peter</em> the boss?",
+                                "when": [{
+                                    "id": "name-answer",
+                                    "condition": "equals",
+                                    "value": "Peter"
+                                }]
+                            },
+                            {
+                                "value": "Is <em>Mary</em> the boss?",
+                                "when": [{
+                                    "id": "name-answer",
+                                    "condition": "equals",
+                                    "value": "Mary"
+                                }]
+                            },
+                            {
+                                "value": "Is <em>{{[answers['name-answer']]|format_household_name}}</em> the boss?"
+                            }
+                        ],
+                        "answers": [{
+                            "id": "radio-answer",
+                            "mandatory": true,
+                            "type": "Radio",
+                            "options": [{
+                                    "label": "Yes",
+                                    "value": "yes"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "no"
+                                },
+                                {
+                                    "label": "Maybe",
+                                    "value": "maybe"
+                                },
+                                {
+                                    "label": "I don't know",
+                                    "value": "know"
+                                },
+                                {
+                                    "label": "Can you repeat the question",
+                                    "value": "repeat"
+                                }
+                            ]
+                        }]
+                    }]
+                },
+                {
+                    "type": "Summary",
+                    "id": "summary"
+                }
+            ]
+        }]
+    }]
+}

--- a/data/en/test_titles_within_repeating_blocks.json
+++ b/data/en/test_titles_within_repeating_blocks.json
@@ -1,0 +1,169 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "0",
+    "title": "Multiple Question Title Test",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "description": "A questionnaire to test multiple question title versions",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ru_name": {
+            "validator": "string"
+        }
+    },
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+                "id": "group",
+                "title": "",
+                "blocks": [{
+                    "type": "Question",
+                    "id": "household-composition",
+                    "title": "Household",
+                    "questions": [{
+                        "id": "household-composition-question",
+                        "title": "Who lives here",
+                        "description": "Add more than one person",
+                        "type": "RepeatingAnswer",
+                        "answers": [{
+                            "id": "first-name",
+                            "label": "First Name",
+                            "mandatory": true,
+                            "type": "TextField"
+                        }]
+                    }]
+                }]
+            },
+            {
+                "id": "repeating-group",
+                "title": "Group 2",
+                "routing_rules": [{
+                    "repeat": {
+                        "type": "answer_count",
+                        "answer_id": "first-name"
+                    }
+                }],
+                "blocks": [{
+                        "type": "Question",
+                        "id": "who-is-answering-block",
+                        "questions": [{
+                            "id": "behalf-of-question",
+                            "title": "Who is <em>{{[answers['first-name'][group_instance]]|format_household_name}}</em> answering on behalf of?",
+                            "guidance": {
+                                "content": [{
+                                    "description": "The answer you choose will have an affect on question titles in next question"
+                                }]
+                            },
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "behalf-of-answer",
+                                "mandatory": true,
+                                "options": [{
+                                        "label": "Myself",
+                                        "value": "myself"
+                                    },
+                                    {
+                                        "label": "Chad",
+                                        "value": "chad"
+                                    },
+                                    {
+                                        "label": "Kelly",
+                                        "value": "kelly"
+                                    },
+                                    {
+                                        "label": "Someone else",
+                                        "value": "else"
+                                    }
+                                ]
+                            }]
+                        }]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "repeating-block-1",
+                        "title": "{{[answers['first-name'][group_instance]]|format_household_name}}",
+                        "description": "This question is for {{[answers['first-name'][group_instance]]|format_household_name}}",
+                        "questions": [{
+                            "id": "repeating-question-1",
+                            "title": "",
+                            "type": "General",
+                            "answers": [{
+                                "id": "age-difference",
+                                "label": "What is their age difference to {{answers['behalf-of-answer'][group_instance]}}?",
+                                "mandatory": true,
+                                "type": "Number"
+                            }]
+                        }]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "repeating-block-3",
+                        "questions": [{
+                            "id": "repeating-question-3",
+                            "titles": [{
+                                    "value": "Please confirm your age difference to {{[answers['behalf-of-answer'][group_instance]]|format_household_name}} is {{answers['age-difference'][group_instance]}}",
+                                    "when": [{
+                                        "id": "behalf-of-answer",
+                                        "condition": "equals",
+                                        "value": "myself"
+                                    }]
+                                },
+                                {
+                                    "value": "Please confirm {{[answers['first-name'][group_instance]]|format_household_name_possessive}} age difference to Chad is {{answers['age-difference'][group_instance]}}",
+                                    "when": [{
+                                        "id": "behalf-of-answer",
+                                        "condition": "equals",
+                                        "value": "chad"
+                                    }]
+                                },
+                                {
+                                    "value": "Please confirm {{[answers['first-name'][group_instance]]|format_household_name_possessive}} age difference to Kelly is {{answers['age-difference'][group_instance]}}",
+                                    "when": [{
+                                        "id": "behalf-of-answer",
+                                        "condition": "equals",
+                                        "value": "kelly"
+                                    }]
+                                },
+                                {
+                                    "value": "Please confirm {{[answers['first-name'][group_instance]]|format_household_name_possessive}} age difference to DEFAULT is {{answers['age-difference'][group_instance]}}"
+                                }
+
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "confirm-answer",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    }
+                                ]
+                            }]
+                        }]
+                    }
+                ]
+            },
+            {
+                "id": "summary-group",
+                "title": "Summary",
+                "blocks": [{
+                    "type": "Summary",
+                    "id": "summary"
+                }]
+            }
+        ]
+    }]
+}

--- a/tests/app/forms/test_questionnaire_form.py
+++ b/tests/app/forms/test_questionnaire_form.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 from decimal import Decimal
 from mock import patch
 
@@ -21,7 +22,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
 
             block_json = schema.get_block('reporting-period')
 
-            form = generate_form(schema, block_json, {}, AnswerStore(), metadata=None)
+            form = generate_form(schema, block_json, {}, AnswerStore(), metadata=None, group_instance=0)
 
             for answer in schema.get_answers_for_block('reporting-period'):
                 self.assertTrue(hasattr(form, answer['id']))
@@ -46,7 +47,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'period-from': {'day': '01', 'month': '3', 'year': '2016'},
                 'period-to': {'day': '31', 'month': '3', 'year': '2016'}
             }
-            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None)
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None, group_instance=0)
 
             self.assertEqual(form.data, expected_form_data)
 
@@ -70,7 +71,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'period-from': {'day': '25', 'month': '12', 'year': '2016'},
                 'period-to': {'day': '25', 'month': '12', 'year': '2016'}
             }
-            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None)
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None, group_instance=0)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -97,7 +98,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'period-from': {'day': '25', 'month': '12', 'year': '2016'},
                 'period-to': {'day': '24', 'month': '12', 'year': '2016'}
             }
-            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None)
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None, group_instance=0)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -124,7 +125,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-from': {'day': '25', 'month': '12', 'year': '2016'},
                 'date-range-to': {'day': '24', 'month': '12', 'year': '2017'}
             }
-            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None)
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None, group_instance=0)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -151,7 +152,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-from': {'day': '25', 'month': '12', 'year': '2016'},
                 'date-range-to': {'day': '26', 'month': '12', 'year': '2016'}
             }
-            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None)
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None, group_instance=0)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -178,7 +179,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-from': {'day': '25', 'month': '12', 'year': '2016'},
                 'date-range-to': {'day': '26', 'month': '01', 'year': '2017'}
             }
-            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None)
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None, group_instance=0)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -208,7 +209,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-from': {'day': '01', 'month': '1', 'year': '2017'},
                 'date-range-to': {'day': '14', 'month': '3', 'year': '2017'}
             }
-            form = generate_form(schema, block_json, data, AnswerStore(), metadata)
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata, group_instance=0)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -243,7 +244,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-from': {'day': '01', 'month': '1', 'year': '2017'},
                 'date-range-to': {'day': '10', 'month': '1', 'year': '2017'}
             }
-            form = generate_form(schema, block_json, data, AnswerStore(), metadata)
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata, group_instance=0)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -275,13 +276,12 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-from': {'day': '01', 'month': '1', 'year': '2017'},
                 'date-range-to': {'day': '21', 'month': '2', 'year': '2017'}
             }
-            form = generate_form(schema, block_json, data, AnswerStore(), metadata)
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata, group_instance=0)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
             self.assertEqual(form.question_errors['date-range-question'],
                              schema.error_messages['DATE_PERIOD_TOO_LARGE'] % dict(max='50 days'))
-
 
     def test_date_mm_yyyy_combined_single_validation(self):
         with self.test_request_context():
@@ -306,7 +306,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-from': {'month': '11', 'year': '2016'},
                 'date-range-to': {'month': '6', 'year': '2017'}
             }
-            form = generate_form(schema, block_json, data, AnswerStore(), metadata)
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata, group_instance=0)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -339,7 +339,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-from': {'month': '1', 'year': '2017'},
                 'date-range-to': {'month': '2', 'year': '2017'}
             }
-            form = generate_form(schema, block_json, data, AnswerStore(), metadata)
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata, group_instance=0)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -369,7 +369,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-from': {'month': '1', 'year': '2017'},
                 'date-range-to': {'month': '5', 'year': '2017'}
             }
-            form = generate_form(schema, block_json, data, AnswerStore(), metadata)
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata, group_instance=0)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -391,7 +391,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-from': {'year': 2015},
                 'date-range-to': {'year': 2021}
             }
-            form = generate_form(schema, block_json, data, AnswerStore(), metadata)
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata, group_instance=0)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -416,7 +416,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-from': {'year': 2016},
                 'date-range-to': {'year': 2017}
             }
-            form = generate_form(schema, block_json, data, AnswerStore(), metadata)
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata, group_instance=0)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -438,7 +438,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-from': {'year': 2016},
                 'date-range-to': {'year': 2020}
             }
-            form = generate_form(schema, block_json, data, AnswerStore(), metadata)
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata, group_instance=0)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -486,7 +486,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-to-year': '2018'
             }
 
-            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None)
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None, group_instance=0)
 
             with patch('app.questionnaire.questionnaire_schema.QuestionnaireSchema.get_questions_for_block',
                        return_value=[question_json]):
@@ -541,7 +541,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-to-year': '2018'
             }
 
-            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None)
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None, group_instance=0)
 
             with self.assertRaises(Exception) as ite:
                 with patch('app.questionnaire.questionnaire_schema.QuestionnaireSchema.get_questions_for_block',
@@ -597,7 +597,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-to-year': '2018'
             }
 
-            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None)
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata=None, group_instance=0)
 
             with self.assertRaises(Exception) as ite:
                 with patch('app.questionnaire.questionnaire_schema.QuestionnaireSchema.get_questions_for_block',
@@ -657,7 +657,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-to-year': '2018'
             }
 
-            form = generate_form(schema, block_json, data, store, metadata=None)
+            form = generate_form(schema, block_json, data, store, metadata=None, group_instance=0)
 
             with self.assertRaises(Exception) as ite:
                 with patch('app.questionnaire.questionnaire_schema.QuestionnaireSchema.get_questions_for_block',
@@ -712,7 +712,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'breakdown-2': '5',
             }
 
-            form = generate_form(schema, block_json, data, store, metadata=None)
+            form = generate_form(schema, block_json, data, store, metadata=None, group_instance=0)
 
             with self.assertRaises(Exception) as ite:
                 with patch('app.questionnaire.questionnaire_schema.QuestionnaireSchema.get_questions_for_block',
@@ -772,7 +772,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'breakdown-2': '5',
             }
 
-            form = generate_form(schema, block_json, data, store, metadata=None)
+            form = generate_form(schema, block_json, data, store, metadata=None, group_instance=0)
 
             with patch('app.questionnaire.questionnaire_schema.QuestionnaireSchema.get_questions_for_block',
                        return_value=[question_json]):
@@ -810,7 +810,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'breakdown-3': Decimal('4'),
                 'breakdown-4': None
             }
-            form = generate_form(schema, block_json, data, store, metadata=None)
+            form = generate_form(schema, block_json, data, store, metadata=None, group_instance=0)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -848,7 +848,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'breakdown-3': Decimal('4'),
                 'breakdown-4': Decimal('1')
             }
-            form = generate_form(schema, block_json, data, store, metadata=None)
+            form = generate_form(schema, block_json, data, store, metadata=None, group_instance=0)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -884,7 +884,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'breakdown-3': None,
                 'breakdown-4': None
             }
-            form = generate_form(schema, block_json, data, store, metadata=None)
+            form = generate_form(schema, block_json, data, store, metadata=None, group_instance=0)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -916,7 +916,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             }
 
             # With no answers question validation should pass
-            form = generate_form(schema, block_json, data, store, metadata=None)
+            form = generate_form(schema, block_json, data, store, metadata=None, group_instance=0)
             form.validate()
 
             self.assertEqual(len(form.question_errors), 0)
@@ -924,7 +924,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             # With the data equaling the total question validation should pass
             data['breakdown-1'] = '10'
 
-            form = generate_form(schema, block_json, data, store, metadata=None)
+            form = generate_form(schema, block_json, data, store, metadata=None, group_instance=0)
             form.validate()
 
             self.assertEqual(len(form.question_errors), 0)
@@ -932,11 +932,48 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             # With the data not equaling zero or the total, question validation should fail
             data['breakdown-1'] = '1'
 
-            form = generate_form(schema, block_json, data, store, metadata=None)
+            form = generate_form(schema, block_json, data, store, metadata=None, group_instance=0)
             form.validate()
 
             self.assertEqual(form.question_errors['breakdown-question'],
                              schema.error_messages['TOTAL_SUM_NOT_EQUALS'] % dict(total='10'))
+
+    def test_generate_form_with_titles_and_no_answer_label(self):
+        """
+        Checks that the form is still generated when there is no answer label and a question titles object
+        """
+        store = AnswerStore()
+
+        conditional_answer = Answer(
+            answer_id='behalf-of-answer',
+            answer_instance=0,
+            group_instance=0,
+            value='chad',
+        )
+
+        store.add(conditional_answer)
+
+        with self.test_request_context():
+            schema = load_schema_from_params('test', 'titles')
+
+            block_json = schema.get_block('multiple-question-versions-block')
+
+            data = {
+                'gender-answer': 'male',
+                'age-answer': '25',
+                'sure-answer': 'yes'
+            }
+
+            expected_form_data = {
+                'csrf_token': '',
+                'gender-answer': 'male',
+                'age-answer': int('25'),
+                'sure-answer': 'yes'
+            }
+            form = generate_form(schema, block_json, data, store, metadata={}, group_instance=0)
+
+            form.validate()
+            self.assertEqual(form.data, expected_form_data)
 
     def test_form_errors_are_correctly_mapped(self):
         with self.test_request_context():
@@ -944,7 +981,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
 
             block_json = schema.get_block('total-retail-turnover')
 
-            form = generate_form(schema, block_json, {}, AnswerStore(), metadata=None)
+            form = generate_form(schema, block_json, {}, AnswerStore(), metadata=None, group_instance=0)
 
             form.validate()
             mapped_errors = form.map_errors()
@@ -958,7 +995,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
 
             block_json = schema.get_block('reporting-period')
 
-            form = generate_form(schema, block_json, {}, AnswerStore(), metadata=None)
+            form = generate_form(schema, block_json, {}, AnswerStore(), metadata=None, group_instance=0)
 
             form.validate()
             mapped_errors = form.map_errors()
@@ -974,7 +1011,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
 
             form = generate_form(schema, block_json, {
                 'radio-mandatory-answer': 'Other'
-            }, AnswerStore(), metadata=None)
+            }, AnswerStore(), metadata=None, group_instance=0)
 
             child_field = getattr(form, 'other-answer-mandatory')
 
@@ -988,7 +1025,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
 
             form = generate_form(schema, block_json, {
                 'radio-mandatory-answer': 'Other'
-            }, AnswerStore(), metadata=None)
+            }, AnswerStore(), metadata=None, group_instance=0)
 
             form.validate()
             mapped_errors = form.map_errors()
@@ -1006,7 +1043,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
 
             form = generate_form(schema, block_json, {
                 'total-number-employees': '-1'
-            }, AnswerStore(), metadata=None)
+            }, AnswerStore(), metadata=None, group_instance=0)
 
             form.validate()
             answer_errors = form.answer_errors('total-number-employees')
@@ -1018,7 +1055,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             schema = load_schema_from_params('test', 'checkbox')
             block_json = schema.get_block('mandatory-checkbox')
 
-            form = generate_form(schema, block_json, {}, AnswerStore(), metadata=None)
+            form = generate_form(schema, block_json, {}, AnswerStore(), metadata=None, group_instance=0)
 
             self.assertFalse(form.option_has_other('mandatory-checkbox-answer', 1))
             self.assertTrue(form.option_has_other('mandatory-checkbox-answer', 6))
@@ -1027,7 +1064,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             schema = load_schema_from_params('test', 'checkbox_mutually_exclusive')
             block_json = schema.get_block('mandatory-checkbox')
 
-            form = generate_form(schema, block_json, {}, AnswerStore(), metadata=None)
+            form = generate_form(schema, block_json, {}, AnswerStore(), metadata=None, group_instance=0)
 
             self.assertFalse(form.option_has_other('mandatory-checkbox-answer', 1))
             self.assertTrue(form.option_has_other('mandatory-checkbox-answer', 5))
@@ -1040,7 +1077,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
 
             form = generate_form(schema, block_json, {
                 'other-answer-mandatory': 'Some data'
-            }, AnswerStore(), metadata=None)
+            }, AnswerStore(), metadata=None, group_instance=0)
 
             field = form.get_other_answer('mandatory-checkbox-answer', 6)
 
@@ -1052,7 +1089,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
 
             form = generate_form(schema, block_json, {
                 'other-answer-mandatory': 'Some data'
-            }, AnswerStore(), metadata=None)
+            }, AnswerStore(), metadata=None, group_instance=0)
 
             field = form.get_other_answer('mandatory-checkbox-answer', 5)
 
@@ -1066,7 +1103,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
 
             form = generate_form(schema, block_json, {
                 'other-answer-mandatory': 'Some data'
-            }, AnswerStore(), metadata=None)
+            }, AnswerStore(), metadata=None, group_instance=0)
 
             field = form.get_other_answer('mandatory-checkbox-answer', 4)
 
@@ -1078,7 +1115,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
 
             form = generate_form(schema, block_json, {
                 'other-answer-mandatory': 'Some data'
-            }, AnswerStore(), metadata=None)
+            }, AnswerStore(), metadata=None, group_instance=0)
 
             field = form.get_other_answer('mandatory-checkbox-answer', 4)
 

--- a/tests/app/questionnaire/test_answer_dependencies.py
+++ b/tests/app/questionnaire/test_answer_dependencies.py
@@ -1,0 +1,315 @@
+import unittest
+from app.questionnaire.answer_dependencies import AnswerDependencies
+from app.questionnaire.answer_dependencies import get_dependencies
+from app.questionnaire.questionnaire_schema import QuestionnaireSchema
+
+
+class TestDependencies(unittest.TestCase):
+    def test_length_returns_number_answer_ids_added(self):
+        sut = AnswerDependencies()
+
+        sut.add('answer1', 'dependency_id')
+        sut.add('answer2', 'dependency_id')
+        sut.add('answer3', 'dependency_id')
+
+        self.assertEqual(len(sut), 3)
+        self.assertEqual(sut['answer1'], {'dependency_id'})
+
+    def test_duplicate_dependencies_do_not_duplicate(self):
+        sut = AnswerDependencies()
+
+        sut.add('answer1', 'dependency_id')
+        sut.add('answer1', 'dependency_id')
+
+        self.assertEqual(sut['answer1'], {'dependency_id'})
+
+    def test_multiple_adds_are_added_to_correct_answer(self):
+        sut = AnswerDependencies()
+
+        sut.add('answer1', 'dependency_id1')
+        sut.add('answer2', 'dependency_id2')
+        sut.add('answer2', 'dependency_id4')
+        sut.add('answer3', 'dependency_id3')
+        sut.add('answer3', 'dependency_id5')
+        sut.add('answer3', 'dependency_id6')
+
+        self.assertEqual(sut['answer1'], {'dependency_id1'})
+        self.assertEqual(sut['answer2'], {'dependency_id2', 'dependency_id4'})
+        self.assertEqual(sut['answer3'], {'dependency_id3', 'dependency_id5', 'dependency_id6'})
+
+    def test_dependencies_can_be_added_with_update(self):
+
+        sut_a = AnswerDependencies()
+        sut_a.add('answer1', 'dependency_id1')
+
+        sut_b = AnswerDependencies()
+        sut_b.add('answer2', 'dependency_id2')
+        sut_b.add('answer2', 'dependency_id4')
+        sut_b.add('answer3', 'dependency_id3')
+        sut_b.add('answer3', 'dependency_id5')
+        sut_b.add('answer3', 'dependency_id6')
+
+        sut_a.update(sut_b)
+
+        self.assertEqual(sut_a['answer1'], {'dependency_id1'})
+        self.assertEqual(sut_a['answer2'], {'dependency_id2', 'dependency_id4'})
+        self.assertEqual(sut_a['answer3'], {'dependency_id3', 'dependency_id5', 'dependency_id6'})
+
+
+class TestGetDependencies(unittest.TestCase):
+
+    def test_min_values_from_answer_ids_are_added_to_dependencies(self):
+        survey_json = {
+            'sections': [{
+                'id': 'section1',
+                'groups': [{
+                    'id': 'question-group',
+                    'blocks': [
+                        {
+                            'id': 'repeating-question-block',
+                            'type': 'Question',
+                            'questions': [{
+                                'id': 'set-min-question',
+                                'title': 'Please set the minimum and maximum used for future questions',
+                                'type': 'General',
+                                'answers': [
+                                    {
+                                        'id': 'set-minimum',
+                                        'label': 'Minimum Value',
+                                        'mandatory': True,
+                                        'type': 'Number',
+                                        'decimal_places': 2,
+                                        'min_value': {
+                                            'answer_id': 'dependency1'
+                                        },
+                                        'max_value': {
+                                            'value': 1000
+                                        }
+                                    },
+                                    {
+                                        'id': 'set-maximum',
+                                        'label': 'Maximum Value',
+                                        'mandatory': True,
+                                        'type': 'Number',
+                                        'decimal_places': 2,
+                                        'min_value': {
+                                            'answer_id': 'dependency2'
+                                        },
+                                        'max_value': {
+                                            'value': 10000
+                                        }
+                                    }
+                                ]
+                            }],
+                        }
+                    ]
+                }]
+            }]
+        }
+
+        schema = QuestionnaireSchema(survey_json)   # schema uses a dependencies builder, using an external one to make tests obvious
+
+        dependencies = get_dependencies(schema)
+
+        self.assertEqual(len(dependencies), 2)
+        self.assertEqual(dependencies['dependency1'], {'set-minimum'})
+        self.assertEqual(dependencies['dependency2'], {'set-maximum'})
+
+    def test_max_values_from_answer_ids_are_added_to_dependencies(self):
+
+        survey_json = {
+            'sections': [{
+                'id': 'section1',
+                'groups': [{
+                    'id': 'question-group',
+                    'blocks': [
+                        {
+                            'id': 'repeating-question-block',
+                            'type': 'Question',
+                            'questions': [{
+                                'id': 'set-min-question',
+                                'title': 'Please set the minimum and maximum used for future questions',
+                                'type': 'General',
+                                'answers': [
+                                    {
+                                        'id': 'set-minimum',
+                                        'label': 'Minimum Value',
+                                        'mandatory': True,
+                                        'type': 'Number',
+                                        'decimal_places': 2,
+                                        'max_value': {
+                                            'answer_id': 'dependency1'
+                                        },
+                                        'min_value': {
+                                            'value': 1000
+                                        }
+                                    },
+                                    {
+                                        'id': 'set-maximum',
+                                        'label': 'Maximum Value',
+                                        'mandatory': True,
+                                        'type': 'Number',
+                                        'decimal_places': 2,
+                                        'max_value': {
+                                            'answer_id': 'dependency2'
+                                        },
+                                        'min_value': {
+                                            'value': 10000
+                                        }
+                                    }
+                                ]
+                            }],
+                        }
+                    ]
+                }]
+            }]
+        }
+
+        schema = QuestionnaireSchema(survey_json)
+
+        dependencies = get_dependencies(schema)
+
+        self.assertEqual(len(dependencies), 2)
+        self.assertEqual(dependencies['dependency1'], {'set-minimum'})
+        self.assertEqual(dependencies['dependency2'], {'set-maximum'})
+
+    def test_calculation_ids_are_added_to_dependencies(self):
+        survey_json = {
+            'sections': [{
+                'id': 'section1',
+                'groups': [{
+                    'id': 'question-group',
+                    'blocks': [
+                        {
+                            'id': 'repeating-question-block',
+                            'type': 'Question',
+                            'questions': [{
+                                'id': 'breakdown-question',
+                                'title': 'Breakdown',
+                                'type': 'Calculated',
+                                'calculations': [{
+                                    'calculation_type': 'sum',
+                                    'answer_id': 'total-answer',
+                                    'answers_to_calculate': [
+                                        'breakdown-1',
+                                        'breakdown-2',
+                                        'breakdown-3',
+                                        'breakdown-4'
+                                    ],
+                                    'conditions': [
+                                        'less than',
+                                        'equals'
+                                    ]
+                                }],
+                                'answers': [
+                                    {
+                                        'id': 'breakdown-1',
+                                        'label': 'Breakdown 1',
+                                        'mandatory': False,
+                                        'decimal_places': 2,
+                                        'type': 'Number'
+                                    },
+                                    {
+                                        'id': 'breakdown-2',
+                                        'label': 'Breakdown 2',
+                                        'mandatory': False,
+                                        'decimal_places': 2,
+                                        'type': 'Number'
+                                    },
+                                    {
+                                        'id': 'breakdown-3',
+                                        'label': 'Breakdown 3',
+                                        'mandatory': False,
+                                        'decimal_places': 2,
+                                        'type': 'Number'
+                                    },
+                                    {
+                                        'id': 'breakdown-4',
+                                        'label': 'Breakdown 4',
+                                        'mandatory': False,
+                                        'decimal_places': 2,
+                                        'type': 'Number'
+                                    }
+                                ]
+                            }]
+                        }
+                    ]
+                }]
+            }]
+        }
+        schema = QuestionnaireSchema(survey_json)
+
+        dependencies = get_dependencies(schema)
+
+        self.assertEqual(len(dependencies), 1)
+        self.assertEqual(dependencies['total-answer'], {'breakdown-1', 'breakdown-2', 'breakdown-3', 'breakdown-4'})
+
+    def test_question_titles_when_dependencies_are_added_to_dependencies(self):
+        survey_json = {
+            'sections': [{
+                'id': 'section1',
+                'groups': [{
+                    'id': 'question-group',
+                    'blocks': [
+                        {
+                            'id': 'repeating-question-block',
+                            'type': 'Question',
+                            'questions': [{
+                                'id': 'what-gender-question',
+                                'titles': [
+                                    {
+                                        'value': 'Some Title',
+                                        'when': [{
+                                            'id': 'behalf-of-answer1',
+                                            'condition': 'equals',
+                                            'value': 'chad'
+                                        }]
+                                    },
+                                    {
+                                        'value': 'Another Title',
+                                        'when': [{
+                                            'id': 'behalf-of-answer2',
+                                            'condition': 'equals',
+                                            'value': 'kelly'
+                                        }]
+                                    },
+                                    {
+                                        'value': 'What is their gender?',
+                                        'when': [{
+                                            'id': 'behalf-of-answer3',
+                                            'condition': 'equals',
+                                            'value': 'else'
+                                        }]
+                                    }
+                                ],
+                                'type': 'General',
+                                'answers': [{
+                                    'type': 'Radio',
+                                    'id': 'gender-answer',
+                                    'mandatory': True,
+                                    'options': [
+                                        {
+                                            'label': 'Male',
+                                            'value': 'male'
+                                        },
+                                        {
+                                            'label': 'Female',
+                                            'value': 'female'
+                                        }
+                                    ]
+                                }]
+                            }],
+                        }
+                    ]
+                }]
+            }]
+        }
+
+        schema = QuestionnaireSchema(survey_json)
+
+        dependencies = get_dependencies(schema)
+
+        self.assertEqual(len(dependencies), 3)
+        self.assertEqual(dependencies['behalf-of-answer1'], {'gender-answer'})
+        self.assertEqual(dependencies['behalf-of-answer2'], {'gender-answer'})
+        self.assertEqual(dependencies['behalf-of-answer3'], {'gender-answer'})

--- a/tests/app/questionnaire/test_completeness.py
+++ b/tests/app/questionnaire/test_completeness.py
@@ -274,7 +274,10 @@ class TestCompleteness(AppContextTestCase): # pylint: disable=too-many-public-me
                             'id': 'question-block',
                             'type': 'Question',
                             'questions': [{
-                                'id': 'question'
+                                'id': 'question',
+                                'title': 'foo',
+                                'type': 'general',
+                                'answers': []
                             }]
                         },
                         {
@@ -282,6 +285,9 @@ class TestCompleteness(AppContextTestCase): # pylint: disable=too-many-public-me
                             'type': 'Interstitial',
                             'questions': [{
                                 'id': 'interstitial-question',
+                                'title': 'bar',
+                                'type': 'general',
+                                'answers': []
                             }]
                         }
                     ]
@@ -316,14 +322,20 @@ class TestCompleteness(AppContextTestCase): # pylint: disable=too-many-public-me
                             'id': 'question-block',
                             'type': 'Question',
                             'questions': [{
-                                'id': 'question'
+                                'id': 'question',
+                                'title': 'foo',
+                                'type': 'general',
+                                'answers': []
                             }]
                         },
                         {
                             'id': 'confirm-question-block',
                             'type': 'ConfirmationQuestion',
                             'questions': [{
-                                'id': 'confirm-question'
+                                'id': 'confirm-question',
+                                'title': 'bar',
+                                'type': 'general',
+                                'answers': []
                             }]
                         }
                     ]

--- a/tests/app/questionnaire/test_questionnaire_schema.py
+++ b/tests/app/questionnaire/test_questionnaire_schema.py
@@ -251,7 +251,6 @@ class TestQuestionnaireSchema(AppContextTestCase):
             }]
         }
 
-
         schema = QuestionnaireSchema(survey_json)
         self.assertTrue(schema.is_confirmation_section(schema.get_section('section-1')))
         self.assertTrue(schema.is_confirmation_group(schema.get_group('group-1')))
@@ -328,3 +327,11 @@ class TestQuestionnaireSchema(AppContextTestCase):
 
         self.assertFalse(schema.answer_is_in_repeating_group('first-name'))
         self.assertTrue(schema.answer_is_in_repeating_group('confirm-answer'))
+
+    def test_title_when_dependencies_are_added_to_dependencies(self):
+        schema = load_schema_from_params('test', 'titles')
+        dependencies = schema.dependencies['behalf-of-answer']
+
+        self.assertIn('gender-answer', dependencies)
+        self.assertIn('age-answer', dependencies)
+        self.assertEqual(len(dependencies), 2)

--- a/tests/app/templating/summary/test_question.py
+++ b/tests/app/templating/summary/test_question.py
@@ -15,7 +15,7 @@ class TestQuestion(TestCase):
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store)
+        question = Question(question_schema, answer_store, {})
 
         # Then
         self.assertEqual(question.id, 'question_id')
@@ -29,11 +29,61 @@ class TestQuestion(TestCase):
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store)
+        question = Question(question_schema, answer_store, {})
 
         # Then
         self.assertEqual(question.id, 'question_id')
         self.assertEqual(question.title, 'question_title')
+        self.assertEqual(len(question.answers), 1)
+
+    def test_create_question_with_default_title(self):
+        # Given
+        answer_schema = mock.MagicMock()
+        answer_store = AnswerStore()
+        question_schema = {'id': 'question_id', 'titles': [{'value': 'question_title'}], 'type': 'GENERAL', 'answers': [answer_schema]}
+
+        # When
+        question = Question(question_schema, answer_store, {})
+
+        # Then
+        self.assertEqual(question.id, 'question_id')
+        self.assertEqual(question.title, 'question_title')
+        self.assertEqual(len(question.answers), 1)
+
+    def test_create_question_with_conditional_title(self):
+        # Given
+        answer_store = AnswerStore([{
+            'answer_id': 'answer_1',
+            'block_id': '',
+            'value': 'Han',
+            'answer_instance': 0,
+            'group_instance': 0
+        }])
+        answer_schema = mock.MagicMock()
+        question_schema = {'id': 'question_id', 'titles': [{'value': 'conditional_title', 'when': [{'id': 'answer_1',
+                                                                                                    'condition': 'equals',
+                                                                                                    'value': 'Han'}]},
+                                                           {'value': 'question_title'}], 'type': 'GENERAL', 'answers': [answer_schema]}
+
+        # When
+        question = Question(question_schema, answer_store, {})
+
+        # Then
+        self.assertEqual(question.id, 'question_id')
+        self.assertEqual(question.title, 'conditional_title')
+        self.assertEqual(len(question.answers), 1)
+
+    def test_create_question_with_answer_label_when_empty_title(self):
+        # Given
+        answer_schema = {'type': 'Number', 'id': 'age-answer', 'mandatory': True, 'label': 'Age'}
+        answer_store = AnswerStore()
+        question_schema = {'id': 'question_id', 'title': '', 'type': 'GENERAL', 'answers': [answer_schema]}
+
+        # When
+        question = Question(question_schema, answer_store, {})
+
+        # Then
+        self.assertEqual(question.title, 'Age')
         self.assertEqual(len(question.answers), 1)
 
     def test_create_question_with_multiple_answers(self):
@@ -55,7 +105,7 @@ class TestQuestion(TestCase):
                            'answers': [first_answer_schema, second_answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store)
+        question = Question(question_schema, answer_store, {})
 
         # Then
         self.assertEqual(len(question.answers), 2)
@@ -81,7 +131,7 @@ class TestQuestion(TestCase):
                            'answers': [first_date_answer_schema, second_date_answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store)
+        question = Question(question_schema, answer_store, {})
 
         # Then
         self.assertEqual(len(question.answers), 1)
@@ -119,7 +169,7 @@ class TestQuestion(TestCase):
                            [first_date_answer_schema, second_date_answer_schema, third_date_answer_schema, fourth_date_answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store)
+        question = Question(question_schema, answer_store, {})
 
         # Then
         self.assertEqual(len(question.answers), 2)
@@ -148,7 +198,7 @@ class TestQuestion(TestCase):
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store)
+        question = Question(question_schema, answer_store, {})
 
         # Then
         self.assertEqual(len(question.answers[0]['value']), 2)
@@ -177,7 +227,7 @@ class TestQuestion(TestCase):
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store)
+        question = Question(question_schema, answer_store, {})
 
         # Then
         self.assertEqual(len(question.answers[0]['value']), 1)
@@ -219,7 +269,7 @@ class TestQuestion(TestCase):
                            'answers': answer_schema}
 
         # When
-        question = Question(question_schema, answer_store)
+        question = Question(question_schema, answer_store, {})
 
         # Then
         self.assertEqual(len(question.answers[0]['value']), 2)
@@ -250,7 +300,7 @@ class TestQuestion(TestCase):
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store)
+        question = Question(question_schema, answer_store, {})
 
         # Then
         self.assertEqual(len(question.answers[0]['value']), 2)
@@ -273,7 +323,7 @@ class TestQuestion(TestCase):
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store)
+        question = Question(question_schema, answer_store, {})
 
         # Then
         self.assertEqual(question.answers[0]['value'], None)
@@ -300,7 +350,7 @@ class TestQuestion(TestCase):
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store)
+        question = Question(question_schema, answer_store, {})
 
         # Then
         self.assertEqual(question.answers[0]['value'], 'Other option label')
@@ -327,7 +377,7 @@ class TestQuestion(TestCase):
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store)
+        question = Question(question_schema, answer_store, {})
 
         # Then
         self.assertEqual(question.answers[0]['value'], 'I want to be on the dark side')
@@ -348,7 +398,7 @@ class TestQuestion(TestCase):
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store)
+        question = Question(question_schema, answer_store, {})
 
         # Then
         self.assertEqual(question.answers[0]['value'], None)
@@ -385,7 +435,7 @@ class TestQuestion(TestCase):
                            'answers': answer_schema}
 
         # When
-        question = Question(question_schema, answer_store)
+        question = Question(question_schema, answer_store, {})
 
         # Then
         self.assertEqual(question.answers[0]['child_answer_value'], 'Test')
@@ -413,7 +463,7 @@ class TestQuestion(TestCase):
                            'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store)
+        question = Question(question_schema, answer_store, {})
 
         # Then
         self.assertEqual(len(question.answers), 3)

--- a/tests/app/templating/test_templating_utils.py
+++ b/tests/app/templating/test_templating_utils.py
@@ -1,0 +1,55 @@
+import unittest
+from mock import patch
+from app.templating.utils import get_question_title
+
+
+class TestTemplatingUtils(unittest.TestCase):
+
+    def test_get_question_title_returns_empty_title(self):
+        expected_value = ''
+        test_schema = {'title': expected_value}
+
+        actual_value = get_question_title(test_schema, None, None, None)
+
+        self.assertEqual(expected_value, actual_value)
+
+    def test_get_question_title_no_title_results_in_titles_resolution(self):
+        expected_value = 'TitlesElement'
+        test_schema = {}
+
+        with patch('app.templating.utils.get_title_from_titles', return_value='TitlesElement'):
+            actual_value = get_question_title(test_schema, None, None, None)
+            self.assertEqual(expected_value, actual_value)
+
+    def test_get_question_title_title_returned_if_present(self):
+        expected_value = 'MyTitle'
+        test_schema = {'title': expected_value}
+
+        actual_value = get_question_title(test_schema, None, None, None)
+
+        self.assertEqual(expected_value, actual_value)
+
+    def test_default_titles_if_no_when_clauses(self):
+        expected_value = 'MyTitle'
+        test_schema = {'titles': [{'value': expected_value}]}
+
+        actual_value = get_question_title(test_schema, None, None, None)
+        self.assertEqual(expected_value, actual_value)
+
+    def test_evaluates_when_rule_if_present(self):
+        expected_value = 'MyTitle'
+        test_schema = {
+            'titles':
+                [{
+                    'value': expected_value,
+                    'when': [{
+                        'id': 'behalf-of-answer',
+                        'condition': 'equals',
+                        'value': 'chad'
+                    }]
+                }]
+            }
+
+        with patch('app.templating.utils.evaluate_when_rules', return_value=True):
+            actual_value = get_question_title(test_schema, None, None, None)
+            self.assertEqual(expected_value, actual_value)

--- a/tests/app/test_jinja_filters.py
+++ b/tests/app/test_jinja_filters.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-
+from types import SimpleNamespace
 from unittest import TestCase
 
 from datetime import datetime, timedelta
@@ -16,7 +16,7 @@ from app.jinja_filters import (
     format_number, format_unordered_list,
     format_household_member_name_possessive, concatenated_list,
     calculate_years_difference, get_current_date, as_london_tz, max_value,
-    min_value
+    min_value, get_question_title, get_answer_label
 )
 
 
@@ -622,3 +622,113 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
 
         # Then
         self.assertEqual(min_of_two, then)
+
+    def test_get_question_title_with_title_value(self):
+        # Given
+        question_id = 'question'
+        context = SimpleNamespace(
+            parent={
+                'question': {
+                    'id': 'question',
+                    'title': 'question_title'
+                }
+            }
+        )
+
+        # When
+        title = get_question_title(context, question_id)
+
+        # Then
+        self.assertEqual(title, 'question_title')
+
+    def test_get_question_title_with_question_titles(self):
+        # Given
+        question_id = 'question'
+        context = SimpleNamespace(
+            parent={
+                'question': {
+                    'id': 'question'
+                },
+                'content': {
+                    'question_titles': {
+                        'question': 'default_question_title'
+                    }
+                }
+            }
+        )
+
+        # When
+        title = get_question_title(context, question_id)
+
+        # Then
+        self.assertEqual(title, 'default_question_title')
+
+    def test_get_answer_label_with_answer_label(self):
+        # Given
+        answer_id = 'answer'
+        question_id = 'question'
+        context = SimpleNamespace(
+            parent={
+                'question': {
+                    'id': 'question',
+                    'answers': [{
+                        'id': 'answer',
+                        'label': 'answer_label'
+                    }]
+                }
+            }
+        )
+
+        # When
+        answer_label = get_answer_label(context, answer_id, question_id)
+
+        # Then
+        self.assertEqual(answer_label, 'answer_label')
+
+    def test_get_answer_label_with_no_answer_label_and_title(self):
+        # Given
+        answer_id = 'answer'
+        question_id = 'question'
+        context = SimpleNamespace(
+            parent={
+                'question': {
+                    'id': 'question',
+                    'title': 'question_title',
+                    'answers': [{
+                        'id': 'answer'
+                    }]
+                }
+            }
+        )
+
+        # When
+        answer_label = get_answer_label(context, answer_id, question_id)
+
+        # Then
+        self.assertEqual(answer_label, 'question_title')
+
+    def test_get_answer_label_with_no_answer_label_and_question_titles(self):
+        # Given
+        answer_id = 'answer'
+        question_id = 'question'
+        context = SimpleNamespace(
+            parent={
+                'question': {
+                    'id': 'question',
+                    'answers': [{
+                        'id': 'answer'
+                    }]
+                },
+                'content': {
+                    'question_titles': {
+                        'question': 'default_question_title'
+                    }
+                }
+            }
+        )
+
+        # When
+        answer_label = get_answer_label(context, answer_id, question_id)
+
+        # Then
+        self.assertEqual(answer_label, 'default_question_title')

--- a/tests/functional/generate_pages.py
+++ b/tests/functional/generate_pages.py
@@ -195,7 +195,7 @@ def process_answer(question_type, answer, page_spec, long_names, page_name):
 
 
 def process_question(question, page_spec, num_questions, page_name):
-    logger.debug('\t\tprocessing question: %s', question['title'])
+    logger.debug('\t\tprocessing question: ', title=question.get('title', 'titles'), question_id=question['id'])
 
     question_type = question['type']
     if question_type == 'RepeatingAnswer':

--- a/tests/functional/pages/features/conditional_checkbox_titles/checkbox-block.page.js
+++ b/tests/functional/pages/features/conditional_checkbox_titles/checkbox-block.page.js
@@ -1,0 +1,35 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class CheckboxBlockPage extends QuestionPage {
+
+  constructor() {
+    super('checkbox-block');
+  }
+
+  newBusinessPracticesForOrganisingProcedures() {
+    return '#checkbox-answer-0';
+  }
+
+  newBusinessPracticesForOrganisingProceduresLabel() { return '#label-checkbox-answer-0'; }
+
+  newMethodsOfOrganisingWorkResponsibilitiesAndDecisionMaking() {
+    return '#checkbox-answer-1';
+  }
+
+  newMethodsOfOrganisingWorkResponsibilitiesAndDecisionMakingLabel() { return '#label-checkbox-answer-1'; }
+
+  newMethodsOfOrganisingExternalRelationshipsWithOtherFirmsOrPublicInstitutions() {
+    return '#checkbox-answer-2';
+  }
+
+  newMethodsOfOrganisingExternalRelationshipsWithOtherFirmsOrPublicInstitutionsLabel() { return '#label-checkbox-answer-2'; }
+
+  implementationOfChangesToMarketingConceptsOrStrategies() {
+    return '#checkbox-answer-3';
+  }
+
+  implementationOfChangesToMarketingConceptsOrStrategiesLabel() { return '#label-checkbox-answer-3'; }
+
+}
+module.exports = new CheckboxBlockPage();

--- a/tests/functional/pages/features/conditional_checkbox_titles/preamble-block.page.js
+++ b/tests/functional/pages/features/conditional_checkbox_titles/preamble-block.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class PreambleBlockPage extends QuestionPage {
+
+  constructor() {
+    super('preamble-block');
+  }
+
+  answer() {
+    return '#name-answer';
+  }
+
+  answerLabel() { return '#label-name-answer'; }
+
+}
+module.exports = new PreambleBlockPage();

--- a/tests/functional/pages/features/conditional_checkbox_titles/radio-block.page.js
+++ b/tests/functional/pages/features/conditional_checkbox_titles/radio-block.page.js
@@ -1,0 +1,35 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class RadioBlockPage extends QuestionPage {
+
+  constructor() {
+    super('radio-block');
+  }
+
+  newBusinessPracticesForOrganisingProcedures() {
+    return '#radio-answer-0';
+  }
+
+  newBusinessPracticesForOrganisingProceduresLabel() { return '#label-radio-answer-0'; }
+
+  newMethodsOfOrganisingWorkResponsibilitiesAndDecisionMaking() {
+    return '#radio-answer-1';
+  }
+
+  newMethodsOfOrganisingWorkResponsibilitiesAndDecisionMakingLabel() { return '#label-radio-answer-1'; }
+
+  newMethodsOfOrganisingExternalRelationshipsWithOtherFirmsOrPublicInstitutions() {
+    return '#radio-answer-2';
+  }
+
+  newMethodsOfOrganisingExternalRelationshipsWithOtherFirmsOrPublicInstitutionsLabel() { return '#label-radio-answer-2'; }
+
+  implementationOfChangesToMarketingConceptsOrStrategies() {
+    return '#radio-answer-3';
+  }
+
+  implementationOfChangesToMarketingConceptsOrStrategiesLabel() { return '#label-radio-answer-3'; }
+
+}
+module.exports = new RadioBlockPage();

--- a/tests/functional/pages/features/conditional_checkbox_titles/summary.page.js
+++ b/tests/functional/pages/features/conditional_checkbox_titles/summary.page.js
@@ -1,0 +1,25 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  nameAnswer() { return '#name-answer-answer'; }
+
+  nameAnswerEdit() { return '[data-qa="name-answer-edit"]'; }
+
+  checkboxAnswer() { return '#checkbox-answer-answer'; }
+
+  checkboxAnswerEdit() { return '[data-qa="checkbox-answer-edit"]'; }
+
+  radioAnswer() { return '#radio-answer-answer'; }
+
+  radioAnswerEdit() { return '[data-qa="radio-answer-edit"]'; }
+
+  radioCheckboxDescriptioTitle() { return '#radio-checkbox-descriptio'; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/pages/features/conditional_question_title/multiple-question-versions-block.page.js
+++ b/tests/functional/pages/features/conditional_question_title/multiple-question-versions-block.page.js
@@ -1,0 +1,41 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class MultipleQuestionVersionsBlockPage extends QuestionPage {
+
+  constructor() {
+    super('multiple-question-versions-block');
+  }
+
+  genderMale() {
+    return '#gender-answer-0';
+  }
+
+  genderMaleLabel() { return '#label-gender-answer-0'; }
+
+  genderFemale() {
+    return '#gender-answer-1';
+  }
+
+  genderFemaleLabel() { return '#label-gender-answer-1'; }
+
+  age() {
+    return '#age-answer';
+  }
+
+  ageLabel() { return '#label-age-answer'; }
+
+  sureYes() {
+    return '#sure-answer-0';
+  }
+
+  sureYesLabel() { return '#label-sure-answer-0'; }
+
+  sureNo() {
+    return '#sure-answer-1';
+  }
+
+  sureNoLabel() { return '#label-sure-answer-1'; }
+
+}
+module.exports = new MultipleQuestionVersionsBlockPage();

--- a/tests/functional/pages/features/conditional_question_title/repeating_blocks/household-composition.page.js
+++ b/tests/functional/pages/features/conditional_question_title/repeating_blocks/household-composition.page.js
@@ -1,0 +1,27 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class HouseholdCompositionPage extends QuestionPage {
+
+  constructor() {
+    super('household-composition');
+  }
+
+  addPerson() {
+    return 'button[name="action[add_answer]"]';
+  }
+
+  removePerson(index = 0) {
+    return 'div.question__answer:nth-child('+ (index+1) + ') > h3 > small > span > button';
+    // Have to check whether it's visible in test code
+  }
+
+  personLegend(index = 1) {
+    return 'div.question__answer:nth-child(' + index + ') > fieldset > legend';
+  }
+  answer(index = '') {
+    return '#household-0-first-name' + index;
+  }
+
+}
+module.exports = new HouseholdCompositionPage();

--- a/tests/functional/pages/features/conditional_question_title/repeating_blocks/repeating-block-1.page.js
+++ b/tests/functional/pages/features/conditional_question_title/repeating_blocks/repeating-block-1.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class RepeatingBlock1Page extends QuestionPage {
+
+  constructor() {
+    super('repeating-block-1');
+  }
+
+  answer() {
+    return '#age-difference';
+  }
+
+  answerLabel() { return '#label-age-difference'; }
+
+}
+module.exports = new RepeatingBlock1Page();

--- a/tests/functional/pages/features/conditional_question_title/repeating_blocks/repeating-block-3.page.js
+++ b/tests/functional/pages/features/conditional_question_title/repeating_blocks/repeating-block-3.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class RepeatingBlock3Page extends QuestionPage {
+
+  constructor() {
+    super('repeating-block-3');
+  }
+
+  yes() {
+    return '#confirm-answer-0';
+  }
+
+  yesLabel() { return '#label-confirm-answer-0'; }
+
+  no() {
+    return '#confirm-answer-1';
+  }
+
+  noLabel() { return '#label-confirm-answer-1'; }
+
+}
+module.exports = new RepeatingBlock3Page();

--- a/tests/functional/pages/features/conditional_question_title/repeating_blocks/summary.page.js
+++ b/tests/functional/pages/features/conditional_question_title/repeating_blocks/summary.page.js
@@ -1,0 +1,33 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  behalfOfAnswer() { return '#behalf-of-answer-answer'; }
+
+  behalfOfAnswerEdit() { return '[data-qa="behalf-of-answer-edit"]'; }
+
+  firstName() { return '#first-name-answer'; }
+
+  firstNameEdit() { return '[data-qa="first-name-edit"]'; }
+
+  groupTitle() { return '#group'; }
+
+  ageDifference() { return '#age-difference-answer'; }
+
+  ageDifferenceEdit() { return '[data-qa="age-difference-edit"]'; }
+
+  confirmAnswer() { return '#confirm-answer-answer'; }
+
+  confirmAnswerEdit() { return '[data-qa="confirm-answer-edit"]'; }
+
+  repeatingGroupTitle() { return '#repeating-group'; }
+
+  summaryGroupTitle() { return '#summary-group'; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/pages/features/conditional_question_title/repeating_blocks/who-is-answering-block.page.js
+++ b/tests/functional/pages/features/conditional_question_title/repeating_blocks/who-is-answering-block.page.js
@@ -1,0 +1,35 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class WhoIsAnsweringBlockPage extends QuestionPage {
+
+  constructor() {
+    super('who-is-answering-block');
+  }
+
+  myself() {
+    return '#behalf-of-answer-0';
+  }
+
+  myselfLabel() { return '#label-behalf-of-answer-0'; }
+
+  chad() {
+    return '#behalf-of-answer-1';
+  }
+
+  chadLabel() { return '#label-behalf-of-answer-1'; }
+
+  kelly() {
+    return '#behalf-of-answer-2';
+  }
+
+  kellyLabel() { return '#label-behalf-of-answer-2'; }
+
+  else() {
+    return '#behalf-of-answer-3';
+  }
+
+  elseLabel() { return '#label-behalf-of-answer-3'; }
+
+}
+module.exports = new WhoIsAnsweringBlockPage();

--- a/tests/functional/pages/features/conditional_question_title/single-title-block.page.js
+++ b/tests/functional/pages/features/conditional_question_title/single-title-block.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class SingleTitleBlockPage extends QuestionPage {
+
+  constructor() {
+    super('single-title-block');
+  }
+
+  good() {
+    return '#feeling-answer-0';
+  }
+
+  goodLabel() { return '#label-feeling-answer-0'; }
+
+  bad() {
+    return '#feeling-answer-1';
+  }
+
+  badLabel() { return '#label-feeling-answer-1'; }
+
+}
+module.exports = new SingleTitleBlockPage();

--- a/tests/functional/pages/features/conditional_question_title/summary.page.js
+++ b/tests/functional/pages/features/conditional_question_title/summary.page.js
@@ -1,0 +1,33 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  feelingAnswer() { return '#feeling-answer-answer'; }
+
+  feelingAnswerEdit() { return '[data-qa="feeling-answer-edit"]'; }
+
+  behalfOfAnswer() { return '#behalf-of-answer-answer'; }
+
+  behalfOfAnswerEdit() { return '[data-qa="behalf-of-answer-edit"]'; }
+
+  genderAnswer() { return '#gender-answer-answer'; }
+
+  genderAnswerEdit() { return '[data-qa="gender-answer-edit"]'; }
+
+  ageAnswer() { return '#age-answer-answer'; }
+
+  ageAnswerEdit() { return '[data-qa="age-answer-edit"]'; }
+
+  sureAnswer() { return '#sure-answer-answer'; }
+
+  sureAnswerEdit() { return '[data-qa="sure-answer-edit"]'; }
+
+  groupTitle() { return '#group'; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/pages/features/conditional_question_title/who-is-answering-block.page.js
+++ b/tests/functional/pages/features/conditional_question_title/who-is-answering-block.page.js
@@ -1,0 +1,35 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class WhoIsAnsweringBlockPage extends QuestionPage {
+
+  constructor() {
+    super('who-is-answering-block');
+  }
+
+  myself() {
+    return '#behalf-of-answer-0';
+  }
+
+  myselfLabel() { return '#label-behalf-of-answer-0'; }
+
+  chad() {
+    return '#behalf-of-answer-1';
+  }
+
+  chadLabel() { return '#label-behalf-of-answer-1'; }
+
+  kelly() {
+    return '#behalf-of-answer-2';
+  }
+
+  kellyLabel() { return '#label-behalf-of-answer-2'; }
+
+  else() {
+    return '#behalf-of-answer-3';
+  }
+
+  elseLabel() { return '#label-behalf-of-answer-3'; }
+
+}
+module.exports = new WhoIsAnsweringBlockPage();

--- a/tests/functional/pages/surveys/question.page.js
+++ b/tests/functional/pages/surveys/question.page.js
@@ -6,6 +6,8 @@ class QuestionPage extends BasePage {
     super(pageName);
     this.questions = [];
   }
+  summaryQuestionText() { return '[data-qa="summary-question-title"]'; }
+
   questionText() { return '[data-qa="question-title"]'; }
 
   alert() { return '[data-qa="error-body"]';  }

--- a/tests/functional/spec/features/conditional_question_title/conditional_checkbox_title.spec.js
+++ b/tests/functional/spec/features/conditional_question_title/conditional_checkbox_title.spec.js
@@ -1,0 +1,52 @@
+const helpers = require('../../../helpers');
+
+
+describe('Feature: Conditional checkbox and radio question titles', function() {
+  var CheckBoxPage = require('../../../pages/features/conditional_checkbox_titles/checkbox-block.page');
+  var NameEntryPage = require('../../../pages/features/conditional_checkbox_titles/preamble-block.page');
+  var RadioButtonsPage = require('../../../pages/features/conditional_checkbox_titles/radio-block.page');
+  var SummaryPage = require('../../../pages/features/conditional_checkbox_titles/summary.page');
+
+  beforeEach(function() {
+      return helpers.openQuestionnaire('test_titles_radio_and_checkbox.json');
+  });
+
+  describe('Given I start the test_titles_radio_and_checkbox survey', function() {
+    it('When I enter an expected name and submit', function() {
+      return browser
+        .setValue(NameEntryPage.answer(),'Peter')
+        .click(NameEntryPage.submit())
+        .getText(CheckBoxPage.questionText()).should.eventually.contain('Did Peter make changes to this business?');
+    });
+
+    it('When I enter an unknown name and go to the checkbox page', function() {
+      return browser
+        .setValue(NameEntryPage.answer(),'Fred')
+        .click(NameEntryPage.submit())
+        .getText(CheckBoxPage.questionText()).should.eventually.contain('Did this business make major changes in the following areas')
+        .click(CheckBoxPage.implementationOfChangesToMarketingConceptsOrStrategies())
+        .getText(RadioButtonsPage.questionText()).should.eventually.contain('Did this business make major changes in the following areas');
+    });
+
+    it('When I enter another known name page title should include selected title', function() {
+      return browser
+        .setValue(NameEntryPage.answer(),'Mary')
+        .click(NameEntryPage.submit())
+        .getTitle().should.eventually.contain('Did Mary make changes to this business? - Test Survey - Checkbox and Radio titles');
+    });
+
+    it('When I enter another known name and go to the summary', function() {
+      return browser
+        .setValue(NameEntryPage.answer(),'Mary')
+        .click(NameEntryPage.submit())
+        .getText(CheckBoxPage.questionText()).should.eventually.contain('Did Mary make changes to this business')
+        .click(CheckBoxPage.implementationOfChangesToMarketingConceptsOrStrategies())
+        .click(CheckBoxPage.submit())
+        .getText(RadioButtonsPage.questionText()).should.eventually.contain('Is Mary the boss?')
+        .click(RadioButtonsPage.newMethodsOfOrganisingExternalRelationshipsWithOtherFirmsOrPublicInstitutions())
+        .click(RadioButtonsPage.submit())
+        .getText(SummaryPage.nameAnswer()).should.eventually.contain('Mary')
+        .getText(SummaryPage.summaryQuestionText()).should.eventually.contain('Did Mary make changes to this business?');
+    });
+  });
+});

--- a/tests/functional/spec/features/conditional_question_title/conditional_question_title.spec.js
+++ b/tests/functional/spec/features/conditional_question_title/conditional_question_title.spec.js
@@ -1,0 +1,105 @@
+const helpers = require('../../../helpers');
+
+
+describe('Feature: Conditional question title', function() {
+  var DefaultTitlePage = require('../../../pages/features/conditional_question_title/single-title-block.page');
+  var SingleTitlePage = require('../../../pages/features/conditional_question_title/who-is-answering-block.page');
+  var ConditionalTitlePage = require('../../../pages/features/conditional_question_title/multiple-question-versions-block.page');
+  var SummaryPage = require('../../../pages/features/conditional_question_title/summary.page');
+
+  beforeEach(function() {
+      return helpers.openQuestionnaire('test_titles.json');
+  });
+  describe('Given I start the different version of question titles survey', function() {
+    it('When I am on the first page, Then I should see the default value for a question title', function() {
+      return browser
+       .getText(DefaultTitlePage.questionText()).should.eventually.contain('How are you feeling??');
+    });
+   });
+
+  describe('Given I start the different version of question titles survey', function() {
+    it('When I navigate to the second page, Then I should see a single title value', function() {
+      return browser
+        .click(DefaultTitlePage.good())
+        .click(DefaultTitlePage.submit())
+        .getText(SingleTitlePage.questionText()).should.eventually.contain('Who are you answering on behalf of?');
+    });
+  });
+
+  describe('Given I start the different version of question titles survey', function() {
+    it('When I navigate through the survey, Then I should see the correct page titles', function() {
+      return browser
+        .getTitle().should.eventually.contain('How are you feeling?? - Multiple Question Title Test')
+        .click(DefaultTitlePage.good())
+        .click(DefaultTitlePage.submit())
+        .getTitle().should.eventually.contain('Who are you answering on behalf of? - Multiple Question Title Test')
+        .click(SingleTitlePage.chad())
+        .click(SingleTitlePage.submit())
+        .getTitle().should.eventually.contain('What is chad’s gender? - Multiple Question Title Test')
+        .click(ConditionalTitlePage.genderMale())
+        .setValue(ConditionalTitlePage.age(), '25')
+        .click(ConditionalTitlePage.sureYes())
+        .click(SingleTitlePage.submit())
+        .getTitle().should.eventually.contain('Summary - Multiple Question Title Test');
+    });
+  });
+
+
+
+  describe('Given I start the different version of question titles survey', function() {
+    beforeEach(function() {
+      return browser
+        .click(DefaultTitlePage.good())
+        .click(DefaultTitlePage.submit());
+  });
+    it('When I navigate to the proxy question and select Chad, Then I should see versions of questions aimed at Chad on the next page', function() {
+      return browser
+        .click(SingleTitlePage.chad())
+        .click(SingleTitlePage.submit())
+        .getText(ConditionalTitlePage.questionText()).should.eventually.contain('What is chad’s gender?')
+        .getText(ConditionalTitlePage.questionText()).should.eventually.contain('What is chad’s age?');
+    });
+
+    it('When I navigate to the proxy question and select Kelly, Then I should see versions of questions aimed at Kelly on the next page', function() {
+      return browser
+        .click(SingleTitlePage.kelly())
+        .click(SingleTitlePage.submit())
+        .getText(ConditionalTitlePage.questionText()).should.eventually.contain('What is kelly’s gender?')
+        .getText(ConditionalTitlePage.questionText()).should.eventually.contain('What is kelly’s age?');
+    });
+
+    it('When I navigate to the proxy question and select Someone else, Then I should see versions of questions aimed at a 3rd person on the next page', function() {
+      return browser
+        .click(SingleTitlePage.else())
+        .click(SingleTitlePage.submit())
+        .getText(ConditionalTitlePage.questionText()).should.eventually.contain('What is their gender?')
+        .getText(ConditionalTitlePage.questionText()).should.eventually.contain('What is their age?');
+    });
+
+    it('When I navigate to the proxy question and select myself, Then I should see versions of questions aimed at myself on the next page', function() {
+      return browser
+        .click(SingleTitlePage.myself())
+        .click(SingleTitlePage.submit())
+        .getText(ConditionalTitlePage.questionText()).should.eventually.contain('What is your gender?')
+        .getText(ConditionalTitlePage.questionText()).should.eventually.contain('What is your age?');
+    });
+  });
+
+  describe('Given I start the different version of question titles survey', function() {
+    it('When I navigate to the summary having selected a default title, and single title and a condition title, Then I should see correct question titles rendered on the summary page', function() {
+      return browser
+        .click(DefaultTitlePage.good())
+        .click(DefaultTitlePage.submit())
+        .click(SingleTitlePage.chad())
+        .click(SingleTitlePage.submit())
+        .click(ConditionalTitlePage.genderMale())
+        .setValue(ConditionalTitlePage.age(), '25')
+        .click(ConditionalTitlePage.sureYes())
+        .click(SingleTitlePage.submit())
+        .getText(SummaryPage.summaryQuestionText()).should.eventually.contain('How are you feeling??')
+        .getText(SummaryPage.summaryQuestionText()).should.eventually.contain('Who are you answering on behalf of?')
+        .getText(SummaryPage.summaryQuestionText()).should.eventually.contain('What is chad’s gender?')
+        .getText(SummaryPage.summaryQuestionText()).should.eventually.contain('What is chad’s age?');
+    });
+  });
+});

--- a/tests/functional/spec/features/conditional_question_title/conditional_titles_in_repeating_groups.spec.js
+++ b/tests/functional/spec/features/conditional_question_title/conditional_titles_in_repeating_groups.spec.js
@@ -1,0 +1,40 @@
+const helpers = require('../../../helpers');
+
+describe('Feature: Use of Titles in Repeating blocks', function() {
+  var HouseholdCompositionPage = require('../../../pages/features/conditional_question_title/repeating_blocks/household-composition.page');
+  var WhoIsAnsweringPage = require('../../../pages/features/conditional_question_title/repeating_blocks/who-is-answering-block.page');
+  var Page1 = require('../../../pages/features/conditional_question_title/repeating_blocks/repeating-block-1.page');
+  var Page3 = require('../../../pages/features/conditional_question_title/repeating_blocks/repeating-block-3.page');
+
+  beforeEach(function() {
+      return helpers.openQuestionnaire('test_titles_within_repeating_blocks.json');
+  });
+
+  describe('Given I start the survey with a repeating block', function() {
+    it('When I enter an  names I should see those names in the title of a subsequent questions', function() {
+      return browser
+        .setValue(HouseholdCompositionPage.answer(),'FirstPerson')
+        .click(HouseholdCompositionPage.addPerson())
+        .setValue(HouseholdCompositionPage.answer('_1'),'SecondPerson')
+        .click(HouseholdCompositionPage.submit())
+        .getText(WhoIsAnsweringPage.questionText()).should.eventually.contain('Who is FirstPerson answering on behalf of?')
+        .click(WhoIsAnsweringPage.chad())
+        .click(WhoIsAnsweringPage.submit())
+        .getText(Page1.answerLabel()).should.eventually.contain('What is their age difference to chad?')
+        .setValue(Page1.answer(),'1')
+        .click(Page1.submit())
+        .getText(Page3.questionText()).should.eventually.contain('Please confirm FirstPerson’s age difference to Chad is 1')
+        .click(Page3.yes())
+        .click(Page3.submit())
+        .getText(WhoIsAnsweringPage.questionText()).should.eventually.contain('Who is SecondPerson answering on behalf of?')
+        .click(WhoIsAnsweringPage.kelly())
+        .click(WhoIsAnsweringPage.submit())
+        .getText(Page1.answerLabel()).should.eventually.contain('What is their age difference to kelly?')
+        .setValue(Page1.answer(),'5')
+        .click(Page1.submit())
+        .getText(Page3.questionText()).should.eventually.contain('Please confirm SecondPerson’s age difference to Kelly is 5')
+        .click(Page3.yes())
+        .click(Page3.submit());
+    });
+  });
+});


### PR DESCRIPTION
### What is the context of this PR?
We have a use case in SR where the user answers a proxy question, e.g. "Who are you answering on behalf of?". This means that we want subsequent questions to be asked differently depending on the users answers. Previously this meant using routing rules and having a lot of excess schema.
This PR introduces a `titles` object to question, this can be used instead of a single `title` value. The titles object consists of a `default value` with is a single title, with optional extra `titles` that are accompanied with a `when` rule (`when` functionality already exists in routing rules, so we have re-used that code). When the question title is rendered each `when clause` is evaluated and if true returns its given `title`. If no `when clauses` evaluate true then the `default title` is returned and rendered.

**UPDATE**
We have added changes that now mean all getting of question titles are handled by our templating utils and template logic on selecting the question title is handled in our jinja filters.


***NOTE***
Currently we have a bug with repeating groups that are as follows: 
- The summary only renders the latest group instance of a repeating group. (existing bug)

- When evaluating a `when` clause in a repeating group greater than `group_instance` **0** it defaults to 0 `group_instance` for summary rendering, as summary has no knowledge of which group instance the question/answer has come from.

### How to review 
Run our test_schemas created and see if the changes are correct. 
Also does the code changes make sense as to where they are. 
