### PR TITLE
Consider group instance when removing answers

### DIFF
--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -549,7 +549,10 @@ def update_questionnaire_store_with_form_data(questionnaire_store, location, ans
                 if latest_answer_store_hash != questionnaire_store.answer_store.get_hash():
                     _remove_dependent_answers_from_completed_blocks(answer_id, questionnaire_store)
             else:
-                _remove_answer_from_questionnaire_store(answer_id, questionnaire_store)
+                _remove_answer_from_questionnaire_store(
+                    answer_id,
+                    questionnaire_store,
+                    group_instance=location.group_instance)
 
     if location not in questionnaire_store.completed_blocks:
         questionnaire_store.completed_blocks.append(location)
@@ -586,8 +589,11 @@ def _remove_dependent_answers_from_completed_blocks(answer_id, questionnaire_sto
             questionnaire_store.completed_blocks.remove(location)
 
 
-def _remove_answer_from_questionnaire_store(answer_id, questionnaire_store):
-    questionnaire_store.answer_store.remove(answer_ids=[answer_id], answer_instance=0)
+def _remove_answer_from_questionnaire_store(answer_id, questionnaire_store,
+                                            group_instance=0):
+    questionnaire_store.answer_store.remove(answer_ids=[answer_id],
+                                            group_instance=group_instance,
+                                            answer_instance=0)
 
 
 def answer_value_empty(answer_value_dict):

--- a/data/en/test_repeating_household_routing.json
+++ b/data/en/test_repeating_household_routing.json
@@ -1,0 +1,253 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "0",
+    "title": "Test repeating household routing",
+    "description": "Tests a repeating group with alternate paths based on an optional answer",
+    "theme": "census",
+    "legal_basis": "Voluntary",
+    "eq_id": "1",
+    "form_type": "1",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
+    "navigation": {
+        "visible": true
+    },
+    "sections": [{
+            "id": "household-section",
+            "title": "About the household",
+            "groups": [{
+                "id": "about-household-group",
+                "title": "About the household",
+                "blocks": [{
+                        "id": "household-composition",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "household-composition-question",
+                            "title": "What are the names of everyone who lives in your household?",
+                            "type": "RepeatingAnswer",
+                            "answers": [{
+                                    "id": "first-name",
+                                    "label": "First name",
+                                    "mandatory": true,
+                                    "type": "TextField",
+                                    "validation": {
+                                        "messages": {
+                                            "MANDATORY_TEXTFIELD": "Please enter a name or remove the person to continue"
+                                        }
+                                    }
+                                },
+                                {
+                                    "id": "middle-names",
+                                    "label": "Middle names",
+                                    "mandatory": false,
+                                    "type": "TextField"
+                                },
+                                {
+                                    "id": "last-name",
+                                    "label": "Last name",
+                                    "mandatory": true,
+                                    "type": "TextField",
+                                    "validation": {
+                                        "messages": {
+                                            "MANDATORY_TEXTFIELD": "Please enter a name or remove the person to continue"
+                                        }
+                                    }
+                                }
+                            ]
+                        }]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "everyone-at-address-confirmation",
+                        "description": "<h2 class='neptune'>You have added...</h2> {{ [answers['first-name'], answers['middle-names'], answers['last-name']]|format_household_summary }}",
+                        "questions": [{
+                            "id": "everyone-at-address-confirmation-question",
+                            "title": "Is that everyone?",
+                            "description": "",
+                            "type": "General",
+                            "answers": [{
+                                "id": "everyone-at-address-confirmation-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes",
+                                        "description": "That is everyone who classes this address as their main residence"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No",
+                                        "description": "I need to add someone else"
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "household-composition",
+                                    "when": [{
+                                        "id": "everyone-at-address-confirmation-answer",
+                                        "condition": "equals",
+                                        "value": "No"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "household-member-group"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }]
+        },
+        {
+            "id": "household-members-section",
+            "title_from_answers": [
+                "first-name",
+                "last-name"
+            ],
+            "groups": [{
+                "id": "household-member-group",
+                "title": "Household Member Details",
+                "routing_rules": [{
+                    "repeat": {
+                        "type": "answer_count",
+                        "answer_id": "first-name"
+                    }
+                }],
+                "blocks": [{
+                        "type": "Question",
+                        "id": "date-of-birth",
+                        "questions": [{
+                            "id": "date-of-birth-question",
+                            "title": "What is {{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive }} date of birth?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "date-of-birth-answer",
+                                "mandatory": false,
+                                "type": "Date",
+                                "maximum": {
+                                    "value": "now"
+                                }
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "date-of-birth-check",
+                                    "when": [{
+                                        "id": "date-of-birth-answer",
+                                        "condition": "not set"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "sex"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "ConfirmationQuestion",
+                        "id": "date-of-birth-check",
+                        "questions": [{
+                            "id": "dob-check-question",
+                            "title": "Is {{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name }} aged 16 or over?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "dob-check-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "household-member-completed",
+                                    "when": [{
+                                        "id": "dob-check-answer",
+                                        "condition": "equals",
+                                        "value": "No"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "household-member-completed",
+                                    "when": [{
+                                        "id": "dob-check-answer",
+                                        "condition": "not set"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "sex"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "sex",
+                        "questions": [{
+                            "id": "sex-question",
+                            "title": "What is {{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive }} sex?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "sex-answer",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Male",
+                                        "value": "Male"
+                                    },
+                                    {
+                                        "label": "Female",
+                                        "value": "Female"
+                                    }
+                                ]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "household-member-completed",
+                        "title": "There are no more questions for {{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}",
+                        "description": "",
+                        "type": "Interstitial"
+                    }
+                ]
+            }]
+        },
+        {
+            "id": "summary-section",
+            "title": "Summary",
+            "groups": [{
+                "blocks": [{
+                    "type": "Summary",
+                    "id": "summary"
+                }],
+                "id": "summary-group",
+                "title": "Summary"
+            }]
+        }
+    ]
+}

--- a/tests/integration/household_composition/test_repeating_household_routing.py
+++ b/tests/integration/household_composition/test_repeating_household_routing.py
@@ -1,0 +1,135 @@
+from werkzeug.datastructures import MultiDict
+
+from tests.integration.integration_test_case import IntegrationTestCase
+
+
+class TestRepeatingHouseholdRouting(IntegrationTestCase):
+    """Test repeating household with routing.
+
+    Tests repeating groups with routing to and around questions within the
+    repeating group.
+    """
+    def setUp(self):
+        super().setUp()
+        self.launchSurvey('test', 'repeating_household_routing',
+                          roles=['dumper'])
+        self.post(action='start_questionnaire')
+        self.household_composition_url = self.last_url
+
+    def test_repeating_group_no_skip(self):
+        # Given I add some people
+        form_data = MultiDict()
+        form_data.add('household-0-first-name', 'Joe')
+        form_data.add('household-0-middle-names', '')
+        form_data.add('household-0-last-name', 'Bloggs')
+        form_data.add('household-1-first-name', 'Jane')
+        form_data.add('household-1-middle-names', '')
+        form_data.add('household-1-last-name', 'Doe')
+        self.post(form_data)
+        self.assertInPage('Is that everyone?')
+        self.post({'everyone-at-address-confirmation-answer': 'Yes'})
+
+        # Then provide details for each member
+        joe_dob = {
+            'date-of-birth-answer-day': '12',
+            'date-of-birth-answer-month': '3',
+            'date-of-birth-answer-year': '1990'
+        }
+        self.post(joe_dob)
+        self.post({'sex-answer': 'Male'})
+        self.post(action='save_continue')
+        jane_dob = {
+            'date-of-birth-answer-day': '27',
+            'date-of-birth-answer-month': '11',
+            'date-of-birth-answer-year': '1995'
+        }
+        self.post(jane_dob)
+        self.post({'sex-answer': 'Female'})
+        self.post(action='save_continue')
+
+        # The survey answers should still contain the first occupant's DoB
+        result = self.dumpAnswers()
+        dobs = [a for a in result['answers']
+                if a['block_id'] == 'date-of-birth']
+        self.assertEqual(len(dobs), 2, 'There should be two date-of-birth '
+                                       'answers')
+        self.assertEqual(dobs[0]['value'], '1990-03-12')
+        self.assertEqual(dobs[1]['value'], '1995-11-27')
+
+    def test_repeating_group_skip_first(self):
+        # Given I add some people
+        form_data = MultiDict()
+        form_data.add('household-0-first-name', 'Joe')
+        form_data.add('household-0-middle-names', '')
+        form_data.add('household-0-last-name', 'Bloggs')
+        form_data.add('household-1-first-name', 'Jane')
+        form_data.add('household-1-middle-names', '')
+        form_data.add('household-1-last-name', 'Doe')
+        self.post(form_data)
+        self.assertInPage('Is that everyone?')
+        self.post({'everyone-at-address-confirmation-answer': 'Yes'})
+
+        # Then provide details for each member while skipping DoB
+        # question for the first member
+        self.post(action='save_continue')
+        self.assertInPage('Is Joe Bloggs aged 16 or over?')
+        self.post({'dob-check-answer': 'Yes'})
+        self.post({'sex-answer': 'Male'})
+        self.post(action='save_continue')
+        jane_dob = {
+            'date-of-birth-answer-day': '27',
+            'date-of-birth-answer-month': '11',
+            'date-of-birth-answer-year': '1995'
+        }
+        self.post(jane_dob)
+        self.post({'sex-answer': 'Female'})
+        self.post(action='save_continue')
+
+        # The survey answers should still contain the first occupant's DoB
+        result = self.dumpAnswers()
+        janes_dob = [a for a in result['answers']
+                     if a['block_id'] == 'date-of-birth' and
+                     a['group_instance'] == 1]
+        self.assertEqual(len(janes_dob), 1, 'There should be a date-of-birth '
+                                            'answer in group instance 1')
+        self.assertEqual(janes_dob[0]['value'], '1995-11-27')
+
+    def test_repeating_group_skip_second(self):
+        # Given I add some people
+        form_data = MultiDict()
+        form_data.add('household-0-first-name', 'Joe')
+        form_data.add('household-0-middle-names', '')
+        form_data.add('household-0-last-name', 'Bloggs')
+        form_data.add('household-1-first-name', 'Jane')
+        form_data.add('household-1-middle-names', '')
+        form_data.add('household-1-last-name', 'Doe')
+        self.post(form_data)
+        self.assertInPage('Is that everyone?')
+        self.post({'everyone-at-address-confirmation-answer': 'Yes'})
+
+        # Then provide details for the first member
+        joe_dob = {
+            'date-of-birth-answer-day': '12',
+            'date-of-birth-answer-month': '3',
+            'date-of-birth-answer-year': '1990'
+        }
+        self.post(joe_dob)
+        self.post({'sex-answer': 'Male'})
+        self.post(action='save_continue')
+
+        # When I skip DoB for second member and answer remaining questions
+        self.post(action='save_continue')
+        self.assertInPage('Is Jane Doe aged 16 or over?')
+        self.post({'dob-check-answer': 'Yes'})
+        self.assertInPage('What is Jane Doe’s sex?')
+        self.post({'sex-answer': 'Female'})
+
+        # The survey answers should still contain the first occupant's DoB
+        self.post(action='save_continue')
+        result = self.dumpAnswers()
+        joes_dob = [a for a in result['answers']
+                    if a['block_id'] == 'date-of-birth' and
+                    a['group_instance'] == 0]
+        self.assertEqual(len(joes_dob), 1, 'There should be a date-of-birth '
+                                           'answer in group instance 0')
+        self.assertEqual(joes_dob[0]['value'], '1990-03-12')

--- a/tests/integration/views/test_questionnaire.py
+++ b/tests/integration/views/test_questionnaire.py
@@ -535,3 +535,43 @@ class TestQuestionnaire(IntegrationTestCase):
             update_questionnaire_store_with_form_data(self.question_store, calculation_answer_location, calculation_answer_data)
 
         self.assertNotIn(dependent_location, self.question_store.completed_blocks)
+
+    def test_updating_questionnaire_store_specific_group(self):
+        g.schema = load_schema_from_params('test',
+                                           'repeating_household_routing')
+        answers = [
+            Answer(
+                group_instance=0,
+                answer_id='first-name',
+                answer_instance=0,
+                value='Joe'
+            ), Answer(
+                group_instance=0,
+                answer_id='last-name',
+                answer_instance=0,
+                value='Bloggs'
+            ), Answer(
+                group_instance=0,
+                answer_id='date-of-birth-answer',
+                answer_instance=0,
+                value='2016-03-12'
+            ), Answer(
+                group_instance=1,
+                answer_id='date-of-birth-answer',
+                answer_instance=0,
+                value='2018-01-01'
+            )
+        ]
+
+        for answer in answers:
+            self.question_store.answer_store.add_or_update(answer)
+
+        answer_form_data = {'date-of-birth-answer': {}}
+        location = Location('household-member-group', 1, 'date-of-birth')
+        with self._application.test_request_context():
+            update_questionnaire_store_with_form_data(
+                self.question_store, location, answer_form_data)
+
+        self.assertIsNone(self.question_store.answer_store.find(answers[3]))
+        for answer in answers[:2]:
+            self.assertIsNotNone(self.question_store.answer_store.find(answer))


### PR DESCRIPTION
### What is the context of this PR?
While testing LFS we were getting strange routing behaviour and answer store being updated incorrectly.  This update resolves that `app/views/questionnaire.py:_remove_answer_from_questionnaire_store` didn't consider group instance ID when updating an answer, meaning an answer in a repeating group always updated the first group instance's answer.

### How to review 
- Run the tests
- Run LFS
-  Add min 2 household occupants.
- Answer "Yes" to "Is that everyone"
- Continue
- Answer all questions for first occupant
- Begin answers for second occupant but when asked DoB skip (i.e. click Save and Continue)
- Observe that navigation still shows Occupant-1 as completed.