### PR TITLE
Added date validation to all RSI/MCI schemas

### DIFF
--- a/data/en/1_0102.json
+++ b/data/en/1_0102.json
@@ -147,28 +147,48 @@
                 },
                 {
                     "type": "Question",
+                    "id": "reporting-period",
+                    "title": "Reporting period",
                     "questions": [{
+                        "id": "reporting-period-question",
+                        "title": "What are the dates of the period that you will be reporting for?",
                         "type": "DateRange",
+                        "period_limits": {
+                            "minimum": {
+                                "days": 23
+                            },
+                            "maximum": {
+                                "days": 50
+                            }
+                        },
                         "answers": [{
                                 "label": "From",
                                 "type": "Date",
                                 "id": "period-from",
                                 "q_code": "11",
-                                "mandatory": true
+                                "mandatory": true,
+                                "minimum": {
+                                    "meta": "ref_p_start_date",
+                                    "offset_by": {
+                                        "days": -19
+                                    }
+                                }
                             },
                             {
                                 "label": "To",
                                 "type": "Date",
                                 "id": "period-to",
                                 "q_code": "12",
-                                "mandatory": true
+                                "mandatory": true,
+                                "maximum": {
+                                    "meta": "ref_p_end_date",
+                                    "offset_by": {
+                                        "days": 20
+                                    }
+                                }
                             }
-                        ],
-                        "id": "reporting-period-question",
-                        "title": "What are the dates of the period that you will be reporting for?"
-                    }],
-                    "id": "reporting-period",
-                    "title": "Reporting period"
+                        ]
+                    }]
                 },
                 {
                     "type": "Question",

--- a/data/en/1_0112.json
+++ b/data/en/1_0112.json
@@ -191,28 +191,48 @@
                 },
                 {
                     "title": "Reporting period",
+                    "id": "reporting-period",
+                    "type": "Question",
                     "questions": [{
                         "title": "What are the dates of the period that you will be reporting for?",
                         "type": "DateRange",
                         "id": "reporting-period-question",
+                        "period_limits": {
+                            "minimum": {
+                                "days": 23
+                            },
+                            "maximum": {
+                                "days": 50
+                            }
+                        },
                         "answers": [{
                                 "mandatory": true,
                                 "label": "From",
                                 "id": "period-from",
                                 "q_code": "11",
-                                "type": "Date"
+                                "type": "Date",
+                                "minimum": {
+                                    "meta": "ref_p_start_date",
+                                    "offset_by": {
+                                        "days": -19
+                                    }
+                                }
                             },
                             {
                                 "mandatory": true,
                                 "label": "To",
                                 "id": "period-to",
                                 "q_code": "12",
-                                "type": "Date"
+                                "type": "Date",
+                                "maximum": {
+                                    "meta": "ref_p_end_date",
+                                    "offset_by": {
+                                        "days": 20
+                                    }
+                                }
                             }
                         ]
-                    }],
-                    "id": "reporting-period",
-                    "type": "Question"
+                    }]
                 },
                 {
                     "type": "Question",

--- a/data/en/1_0203.json
+++ b/data/en/1_0203.json
@@ -236,28 +236,48 @@
                 },
                 {
                     "title": "Reporting period",
+                    "id": "reporting-period",
+                    "type": "Question",
                     "questions": [{
                         "title": "What are the dates of the period that you will be reporting for?",
                         "type": "DateRange",
                         "id": "reporting-period-question",
+                        "period_limits": {
+                            "minimum": {
+                                "days": 23
+                            },
+                            "maximum": {
+                                "days": 50
+                            }
+                        },
                         "answers": [{
                                 "mandatory": true,
                                 "label": "From",
                                 "id": "period-from",
                                 "q_code": "11",
-                                "type": "Date"
+                                "type": "Date",
+                                "minimum": {
+                                    "meta": "ref_p_start_date",
+                                    "offset_by": {
+                                        "days": -19
+                                    }
+                                }
                             },
                             {
                                 "mandatory": true,
                                 "label": "To",
                                 "id": "period-to",
                                 "q_code": "12",
-                                "type": "Date"
+                                "type": "Date",
+                                "maximum": {
+                                    "meta": "ref_p_end_date",
+                                    "offset_by": {
+                                        "days": 20
+                                    }
+                                }
                             }
                         ]
-                    }],
-                    "id": "reporting-period",
-                    "type": "Question"
+                    }]
                 },
                 {
                     "type": "Question",

--- a/data/en/1_0205.json
+++ b/data/en/1_0205.json
@@ -252,28 +252,48 @@
                 },
                 {
                     "title": "Reporting period",
+                    "id": "reporting-period",
+                    "type": "Question",
                     "questions": [{
                         "title": "What are the dates of the period that you will be reporting for?",
                         "type": "DateRange",
                         "id": "reporting-period-question",
+                        "period_limits": {
+                            "minimum": {
+                                "days": 23
+                            },
+                            "maximum": {
+                                "days": 50
+                            }
+                        },
                         "answers": [{
                                 "mandatory": true,
                                 "label": "From",
                                 "id": "period-from",
                                 "q_code": "11",
-                                "type": "Date"
+                                "type": "Date",
+                                "minimum": {
+                                    "meta": "ref_p_start_date",
+                                    "offset_by": {
+                                        "days": -19
+                                    }
+                                }
                             },
                             {
                                 "mandatory": true,
                                 "label": "To",
                                 "id": "period-to",
                                 "q_code": "12",
-                                "type": "Date"
+                                "type": "Date",
+                                "maximum": {
+                                    "meta": "ref_p_end_date",
+                                    "offset_by": {
+                                        "days": 20
+                                    }
+                                }
                             }
                         ]
-                    }],
-                    "id": "reporting-period",
-                    "type": "Question"
+                    }]
                 },
                 {
                     "type": "Question",

--- a/data/en/1_0213.json
+++ b/data/en/1_0213.json
@@ -282,28 +282,48 @@
                 },
                 {
                     "title": "Reporting period",
+                    "id": "reporting-period",
+                    "type": "Question",
                     "questions": [{
                         "title": "What are the dates of the period that you will be reporting for?",
                         "type": "DateRange",
                         "id": "reporting-period-question",
+                        "period_limits": {
+                            "minimum": {
+                                "days": 23
+                            },
+                            "maximum": {
+                                "days": 50
+                            }
+                        },
                         "answers": [{
                                 "mandatory": true,
                                 "label": "From",
                                 "id": "period-from",
                                 "q_code": "11",
-                                "type": "Date"
+                                "type": "Date",
+                                "minimum": {
+                                    "meta": "ref_p_start_date",
+                                    "offset_by": {
+                                        "days": -19
+                                    }
+                                }
                             },
                             {
                                 "mandatory": true,
                                 "label": "To",
                                 "id": "period-to",
                                 "q_code": "12",
-                                "type": "Date"
+                                "type": "Date",
+                                "maximum": {
+                                    "meta": "ref_p_end_date",
+                                    "offset_by": {
+                                        "days": 20
+                                    }
+                                }
                             }
                         ]
-                    }],
-                    "id": "reporting-period",
-                    "type": "Question"
+                    }]
                 },
                 {
                     "type": "Question",

--- a/data/en/1_0215.json
+++ b/data/en/1_0215.json
@@ -300,28 +300,48 @@
                 },
                 {
                     "title": "Reporting period",
+                    "id": "reporting-period",
+                    "type": "Question",
                     "questions": [{
                         "title": "What are the dates of the period that you will be reporting for?",
                         "type": "DateRange",
                         "id": "reporting-period-question",
+                        "period_limits": {
+                            "minimum": {
+                                "days": 23
+                            },
+                            "maximum": {
+                                "days": 50
+                            }
+                        },
                         "answers": [{
                                 "mandatory": true,
                                 "label": "From",
                                 "id": "period-from",
                                 "q_code": "11",
-                                "type": "Date"
+                                "type": "Date",
+                                "minimum": {
+                                    "meta": "ref_p_start_date",
+                                    "offset_by": {
+                                        "days": -19
+                                    }
+                                }
                             },
                             {
                                 "mandatory": true,
                                 "label": "To",
                                 "id": "period-to",
                                 "q_code": "12",
-                                "type": "Date"
+                                "type": "Date",
+                                "maximum": {
+                                    "meta": "ref_p_end_date",
+                                    "offset_by": {
+                                        "days": 20
+                                    }
+                                }
                             }
                         ]
-                    }],
-                    "id": "reporting-period",
-                    "type": "Question"
+                    }]
                 },
                 {
                     "type": "Question",


### PR DESCRIPTION
### What is the context of this PR?
Date validations added to all rsi/mci surveys as follows to `DateRange` question, with q_codes (11 and 12):
- Minimum period - `23 days`
- Maximum period - `50 days`
- Date From - **POST** `19 days prior` to exercise **start** date
- Date To - **PRE** `20 days after` exercise **end** date

RSI/MCI Schemas:
- `1_0102.json`
- `1_0112.json`
- `1_0203.json`
- `1_0205.json`
- `1_0213.json`
- `1_0215.json`

### How to review 
Launch Schemas and check validation added
