### PR TITLE
Added survey_ids for new schema validator rule

### DIFF
--- a/data/en/e_commerce.json
+++ b/data/en/e_commerce.json
@@ -1,7 +1,7 @@
 {
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
-    "survey_id": "e_commerce",
+    "survey_id": "ecommerce",
     "theme": "default",
     "data_version": "0.0.2",
     "navigation": {

--- a/data/en/test_metadata_routing.json
+++ b/data/en/test_metadata_routing.json
@@ -2,7 +2,7 @@
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
-    "survey_id": "",
+    "survey_id": "0",
     "title": "Census England Household Schema",
     "description": "Census England Household Schema",
     "theme": "census",

--- a/data/en/test_routing_on_multiple_select.json
+++ b/data/en/test_routing_on_multiple_select.json
@@ -2,7 +2,7 @@
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
-    "survey_id": "",
+    "survey_id": "0",
     "title": "Test schema for routing on multiple selected answers",
     "description": "Test schema for routing on multiple selected answers",
     "theme": "census",


### PR DESCRIPTION
### What is the context of this PR?
This change https://github.com/ONSdigital/eq-schema-validator/pull/56 means we had 3 surveys that didn't have valid `survey_ids`

### How to review 
Describe the steps required to test the changes (include screenshots if appropriate).
