### PR TITLE
Year Entry Field

### DIFF
--- a/app/forms/fields.py
+++ b/app/forms/fields.py
@@ -5,7 +5,7 @@ from wtforms import validators
 from structlog import get_logger
 
 from app.forms.custom_fields import MaxTextAreaField, CustomIntegerField, CustomDecimalField
-from app.forms.date_form import get_date_form, get_month_year_form
+from app.forms.date_form import get_date_form, get_month_year_form, get_year_form
 from app.validation.validators import NumberCheck, NumberRange, ResponseRequired, DecimalPlaces, MutuallyExclusive
 
 MAX_LENGTH = 2000
@@ -24,6 +24,8 @@ def get_field(answer, label, error_messages, answer_store, metadata):
         field = get_date_field(answer, label, guidance, error_messages, answer_store, metadata)
     elif answer['type'] == 'MonthYearDate':
         field = get_month_year_field(answer, label, guidance, error_messages, answer_store, metadata)
+    elif answer['type'] == 'YearDate':
+        field = get_year_field(answer, label, guidance, error_messages, answer_store, metadata)
     elif answer['type'] in ['Checkbox', 'MutuallyExclusiveCheckbox']:
         field = get_select_multiple_field(answer, label, guidance, error_messages)
     else:
@@ -118,6 +120,14 @@ def get_date_field(answer, label, guidance, error_messages, answer_store, metada
 def get_month_year_field(answer, label, guidance, error_messages, answer_store, metadata):
     return FormField(
         get_month_year_form(answer, answer_store, metadata, error_messages),
+        label=label,
+        description=guidance,
+    )
+
+
+def get_year_field(answer, label, guidance, error_messages, answer_store, metadata):
+    return FormField(
+        get_year_form(answer, answer_store, metadata, error_messages, label, guidance),
         label=label,
         description=guidance,
     )

--- a/app/helpers/form_helper.py
+++ b/app/helpers/form_helper.py
@@ -106,7 +106,7 @@ def deserialise_dates(schema, block_id, mapped_answers):
     answer_json_list = schema.get_answers_for_block(block_id)
 
     # Deserialise all dates from the store
-    date_answer_ids = [a['id'] for a in answer_json_list if a['type'] == 'Date' or a['type'] == 'MonthYearDate']
+    date_answer_ids = [a['id'] for a in answer_json_list if a['type'] in ['Date', 'MonthYearDate', 'YearDate']]
 
     for date_answer_id in date_answer_ids:
         if date_answer_id in mapped_answers:
@@ -123,6 +123,10 @@ def deserialise_dates(schema, block_id, mapped_answers):
                 mapped_answers.update({
                     '{answer_id}-year'.format(answer_id=date_answer_id): substrings[0],
                     '{answer_id}-month'.format(answer_id=date_answer_id): substrings[1].lstrip('0'),
+                })
+            if len(substrings) == 1:
+                mapped_answers.update({
+                    '{answer_id}-year'.format(answer_id=date_answer_id): substrings[0],
                 })
 
     return mapped_answers

--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -23,7 +23,7 @@ DATE_FORMAT = '%-d %B %Y'
 @blueprint.app_template_filter()
 def format_number(value):
     if value or value is 0:
-        return numbers.format_number(value, locale=DEFAULT_LOCALE)
+        return numbers.format_decimal(value, locale=DEFAULT_LOCALE)
     return ''
 
 
@@ -92,9 +92,11 @@ def format_date(context, value):
     value = value[0] if isinstance(value, list) else value
     if not isinstance(value, str):
         return value
-    date_format = '%B %Y'
-    if value and re.match(r'\d{4}-\d{2}-\d{2}', value):
-        date_format = DATE_FORMAT
+    date_format = DATE_FORMAT
+    if value and re.match(r'\d{4}-\d{2}$', value):
+        date_format = '%B %Y'
+    if value and re.match(r'\d{4}$', value):
+        date_format = '%Y'
     result = "<span class='date'>{date}</span>".format(
         date=convert_to_datetime(value).strftime(date_format))
     return mark_safe(context, result)

--- a/app/questionnaire/rules.py
+++ b/app/questionnaire/rules.py
@@ -83,6 +83,8 @@ def convert_to_datetime(value):
     date_format = '%Y-%m'
     if value and re.match(r'\d{4}-\d{2}-\d{2}', value):
         date_format = '%Y-%m-%d'
+    if value and re.match(r'\d{4}$', value):
+        date_format = '%Y'
 
     return datetime.strptime(value, date_format) if value else None
 

--- a/app/templates/partials/answers/yeardate.html
+++ b/app/templates/partials/answers/yeardate.html
@@ -1,0 +1,1 @@
+{% include 'partials/answers/date.html' %}

--- a/app/templates/partials/summary/yeardate.html
+++ b/app/templates/partials/summary/yeardate.html
@@ -1,0 +1,6 @@
+{% if question.type == 'DateRange' %}
+    {{format_date_range(answer.value.from, answer.value.to)}}
+{% else %}
+    {{answer.value|format_date}}
+{% endif %}
+

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -612,6 +612,7 @@ def _format_answer_value(answer_value):
     formatted_answer_value = None
     is_day_month_year = 'day' in answer_value and 'month' in answer_value and 'year' in answer_value
     is_month_year = 'day' not in answer_value and 'year' in answer_value and 'month' in answer_value
+    is_year = 'day' not in answer_value and 'month' not in answer_value and 'year' in answer_value
 
     if is_day_month_year:
         formatted_answer_value = '{:04d}-{:02d}-{:02d}'.format(
@@ -623,6 +624,10 @@ def _format_answer_value(answer_value):
         formatted_answer_value = '{:04d}-{:02d}'.format(
             int(answer_value['year']),
             int(answer_value['month'])
+        )
+    elif is_year:
+        formatted_answer_value = '{:04d}'.format(
+            int(answer_value['year'])
         )
     return formatted_answer_value
 

--- a/data/en/test_date_validation_yyyy_combined.json
+++ b/data/en/test_date_validation_yyyy_combined.json
@@ -1,0 +1,94 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "023",
+    "title": "Date formats",
+    "description": "A test schema for different date formats",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "variables": {
+        "period": "{{ format_conditional_date (answers.period_from, metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers.period_to, metadata['ref_p_end_date'])}}"
+    },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ru_name": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        }
+    },
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "id": "dates",
+            "title": "Date Range Validation",
+            "blocks": [{
+                    "type": "Question",
+                    "id": "date-range-block",
+                    "title": "Date Range",
+                    "questions": [{
+                        "id": "date-range-question",
+                        "title": "Enter Date Range",
+                        "type": "DateRange",
+                        "guidance": {
+                            "content": [{
+                                "list": [
+                                    "Dates between 2 and 3 years apart",
+                                    "Period from date greater than 1 year before {{metadata['ref_p_start_date']|format_date}}",
+                                    "Period to date no greater than 3 years after {{metadata['ref_p_end_date']|format_date}}"
+                                ]
+                            }]
+                        },
+                        "period_limits": {
+                            "minimum": {
+                                "years": 2
+                            },
+                            "maximum": {
+                                "years": 3
+                            }
+                        },
+                        "answers": [{
+                                "id": "date-range-from",
+                                "label": "Period from",
+                                "mandatory": true,
+                                "type": "YearDate",
+                                "minimum": {
+                                    "meta": "ref_p_start_date",
+                                    "offset_by": {
+                                        "years": -1
+                                    }
+                                }
+                            },
+                            {
+                                "id": "date-range-to",
+                                "label": "Period to",
+                                "mandatory": true,
+                                "type": "YearDate",
+                                "maximum": {
+                                    "meta": "ref_p_end_date",
+                                    "offset_by": {
+                                        "years": 3
+                                    }
+                                }
+                            }
+                        ]
+                    }]
+                },
+                {
+                    "type": "Summary",
+                    "id": "summary"
+                }
+            ]
+        }]
+    }]
+}

--- a/data/en/test_dates.json
+++ b/data/en/test_dates.json
@@ -84,6 +84,19 @@
                             "id": "non-mandatory-date-question",
                             "title": "Non Mandatory",
                             "type": "General"
+                        },
+                        {
+                            "answers": [{
+                                "id": "year-date-answer",
+                                "label": "Date",
+                                "mandatory": false,
+                                "q_code": "18",
+                                "type": "YearDate"
+                            }],
+                            "description": "",
+                            "id": "year-date-question",
+                            "title": "Year (YYYY)",
+                            "type": "General"
                         }
                     ],
                     "title": "Date Examples"

--- a/tests/app/forms/test_date_form.py
+++ b/tests/app/forms/test_date_form.py
@@ -4,8 +4,9 @@ from dateutil.relativedelta import relativedelta
 from mock import patch
 
 from app.data_model.answer_store import AnswerStore, Answer
-from app.forms.date_form import get_date_form, get_month_year_form, get_referenced_offset_value, \
-    get_dates_for_single_date_period_validation, validate_mandatory_date
+from app.forms.date_form import get_date_form, get_month_year_form, get_year_form, \
+    get_referenced_offset_value, get_dates_for_single_date_period_validation, \
+    validate_mandatory_date
 from app.questionnaire.rules import convert_to_datetime
 from app.utilities.schema import load_schema_from_params
 from tests.app.app_context_test_case import AppContextTestCase
@@ -36,6 +37,19 @@ class TestDateForm(AppContextTestCase):
         self.assertFalse(hasattr(form, 'day'))
         self.assertTrue(hasattr(form, 'month'))
         self.assertTrue(hasattr(form, 'year'))
+
+    def test_generate_year_date_form_creates_empty_form(self):
+        schema = load_schema_from_params('test', 'dates')
+        error_messages = schema.error_messages
+
+        answers = schema.get_answers_by_id_for_block('date-block')
+
+        form = get_year_form(answers['year-date-answer'], {}, {}, error_messages=error_messages, label=None, guidance=None)
+
+        self.assertFalse(hasattr(form, 'day'))
+        self.assertFalse(hasattr(form, 'month'))
+        self.assertTrue(hasattr(form, 'year'))
+
 
     def test_generate_date_form_validates_single_date_period(self):
         schema = load_schema_from_params('test', 'date_validation_single')

--- a/tests/app/forms/test_fields.py
+++ b/tests/app/forms/test_fields.py
@@ -180,6 +180,31 @@ class TestFields(unittest.TestCase):
         self.assertEqual(unbound_field.kwargs['label'], date_json['label'])
         self.assertEqual(unbound_field.kwargs['description'], date_json['guidance'])
 
+    def test_year_date_field(self):
+        date_json = {
+            'guidance': '',
+            'id': 'month-year-answer',
+            'label': 'Date',
+            'mandatory': True,
+            'options': [],
+            'q_code': '11',
+            'type': 'YearDate',
+            'validation': {
+                'messages': {
+                    'INVALID_DATE': 'The date entered is not valid.  Please correct your answer.',
+                    'MANDATORY': 'Please provide an answer to continue.'
+                }
+            }
+        }
+
+        unbound_field = get_field(date_json, date_json['label'], error_messages, self.answer_store,
+                                  self.metadata)
+
+        self.assertEqual(unbound_field.field_class, FormField)
+        self.assertEqual(unbound_field.kwargs['label'], date_json['label'])
+        self.assertEqual(unbound_field.kwargs['description'], date_json['guidance'])
+
+
     def test_radio_field(self):
         radio_json = {
             'guidance': '',

--- a/tests/app/forms/test_questionnaire_form.py
+++ b/tests/app/forms/test_questionnaire_form.py
@@ -376,6 +376,75 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             self.assertEqual(form.question_errors['date-range-question'],
                              schema.error_messages['DATE_PERIOD_TOO_LARGE'] % dict(max='3 months'))
 
+    def test_date_yyyy_combined_single_validation(self):
+        with self.test_request_context():
+            schema = load_schema_from_params('test', 'date_validation_yyyy_combined')
+
+            block_json = schema.get_block('date-range-block')
+
+            data = {'date-range-from-year': '2015', 'date-range-to-year': '2021'}
+
+            metadata = {'ref_p_start_date': '2017-01-01', 'ref_p_end_date': '2017-02-12'}
+
+            expected_form_data = {
+                'csrf_token': '',
+                'date-range-from': {'year': 2015},
+                'date-range-to': {'year': 2021}
+            }
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata)
+
+            form.validate()
+            self.assertEqual(form.data, expected_form_data)
+            self.assertEqual(form.errors['date-range-from']['year'][0],
+                             schema.error_messages['SINGLE_DATE_PERIOD_TOO_EARLY'] % dict(min='2015'))
+
+            self.assertEqual(form.errors['date-range-to']['year'][0],
+                             schema.error_messages['SINGLE_DATE_PERIOD_TOO_LATE'] % dict(max='2021'))
+
+    def test_date_yyyy_combined_range_too_small_validation(self):
+        with self.test_request_context():
+            schema = load_schema_from_params('test', 'date_validation_yyyy_combined')
+
+            block_json = schema.get_block('date-range-block')
+
+            data = {'date-range-from-year': '2016', 'date-range-to-year': '2017'}
+
+            metadata = {'ref_p_start_date': '2017-01-01', 'ref_p_end_date': '2017-02-12'}
+
+            expected_form_data = {
+                'csrf_token': '',
+                'date-range-from': {'year': 2016},
+                'date-range-to': {'year': 2017}
+            }
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata)
+
+            form.validate()
+            self.assertEqual(form.data, expected_form_data)
+            self.assertEqual(form.question_errors['date-range-question'],
+                             schema.error_messages['DATE_PERIOD_TOO_SMALL'] % dict(min='2 years'))
+
+    def test_date_yyyy_combined_range_too_large_validation(self):
+        with self.test_request_context():
+            schema = load_schema_from_params('test', 'date_validation_yyyy_combined')
+
+            block_json = schema.get_block('date-range-block')
+
+            data = {'date-range-from-year': '2016', 'date-range-to-year': '2020'}
+
+            metadata = {'ref_p_start_date': '2017-01-01', 'ref_p_end_date': '2017-02-12'}
+
+            expected_form_data = {
+                'csrf_token': '',
+                'date-range-from': {'year': 2016},
+                'date-range-to': {'year': 2020}
+            }
+            form = generate_form(schema, block_json, data, AnswerStore(), metadata)
+
+            form.validate()
+            self.assertEqual(form.data, expected_form_data)
+            self.assertEqual(form.question_errors['date-range-question'],
+                             schema.error_messages['DATE_PERIOD_TOO_LARGE'] % dict(max='3 years'))
+
     def test_bespoke_message_for_date_validation_range(self):
         with self.test_request_context():
             schema = load_schema_from_params('test', 'date_validation_range')

--- a/tests/app/validation/test_date_required.py
+++ b/tests/app/validation/test_date_required.py
@@ -39,6 +39,21 @@ class TestDateRequiredValidator(unittest.TestCase):
 
         self.assertEqual(error_messages['MANDATORY_DATE'], str(ite.exception))
 
+    def test_date_year_required_empty(self):
+        validator = DateRequired()
+
+        class TestYearSpec(object):
+            year = None
+
+        mock_form = Mock(spec=TestYearSpec)
+        mock_form.year.data = ''
+        mock_field = Mock()
+
+        with self.assertRaises(StopValidation) as ite:
+            validator(mock_form, mock_field)
+
+        self.assertEqual(error_messages['MANDATORY_DATE'], str(ite.exception))
+
     def test_valid_date(self):
 
         validator = DateRequired()
@@ -61,6 +76,20 @@ class TestDateRequiredValidator(unittest.TestCase):
 
         mock_form = Mock()
         mock_form.month.data = '01'
+        mock_form.year.data = '2017'
+
+        mock_field = Mock()
+
+        try:
+            validator(mock_form, mock_field)
+        except StopValidation:
+            self.fail('Valid date raised StopValidation')
+
+    def test_valid__year(self):
+
+        validator = DateRequired()
+
+        mock_form = Mock()
         mock_form.year.data = '2017'
 
         mock_field = Mock()

--- a/tests/app/validation/test_year_validator.py
+++ b/tests/app/validation/test_year_validator.py
@@ -1,0 +1,74 @@
+import unittest
+from unittest.mock import Mock
+from wtforms.validators import ValidationError
+
+from app.validation.error_messages import error_messages
+from app.validation.validators import YearCheck
+
+
+class TestYearValidator(unittest.TestCase):
+    def test_year_date_validator_none(self):
+        validator = YearCheck()
+
+        mock_form = Mock()
+        mock_form.year.data = None
+
+        mock_field = Mock()
+
+        with self.assertRaises(ValidationError) as ite:
+            validator(mock_form, mock_field)
+
+        self.assertEqual(error_messages['INVALID_DATE'], str(ite.exception))
+
+    def test_year_date_validator_empty_string(self):
+
+        validator = YearCheck()
+
+        mock_form = Mock()
+        mock_form.year.data = ''
+
+        mock_field = Mock()
+
+        with self.assertRaises(ValidationError) as ite:
+            validator(mock_form, mock_field)
+
+        self.assertEqual(error_messages['INVALID_DATE'], str(ite.exception))
+
+    def test_year_date_validator_invalid(self):
+        validator = YearCheck()
+
+        mock_form = Mock()
+        mock_form.year.data = 'abcd'
+
+        mock_field = Mock()
+
+        with self.assertRaises(ValidationError) as ite:
+            validator(mock_form, mock_field)
+
+        self.assertEqual(error_messages['INVALID_DATE'], str(ite.exception))
+
+    def test_year_date_validator_invalid_year(self):
+        validator = YearCheck()
+
+        mock_form = Mock()
+        mock_form.year.data = '17'
+
+        mock_field = Mock()
+
+        with self.assertRaises(ValidationError) as ite:
+            validator(mock_form, mock_field)
+
+        self.assertEqual(error_messages['INVALID_DATE'], str(ite.exception))
+
+    def test_year_date_validator_valid(self):
+        validator = YearCheck()
+
+        mock_form = Mock()
+        mock_form.year.data = '2017'
+
+        mock_field = Mock()
+
+        try:
+            validator(mock_form, mock_field)
+        except ValidationError:
+            self.fail('Valid date raised ValidationError')

--- a/tests/functional/pages/features/validation/date-validation/date-combined-yyyy/date-range-block.page.js
+++ b/tests/functional/pages/features/validation/date-validation/date-combined-yyyy/date-range-block.page.js
@@ -1,0 +1,19 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../../surveys/question.page');
+
+class DateRangeBlockPage extends QuestionPage {
+
+  constructor() {
+    super('date-range-block');
+  }
+
+  dateRangeFromyear() {
+    return '#date-range-from-year';
+  }
+
+  dateRangeToyear() {
+    return '#date-range-to-year';
+  }
+
+}
+module.exports = new DateRangeBlockPage();

--- a/tests/functional/pages/features/validation/date-validation/date-combined-yyyy/summary.page.js
+++ b/tests/functional/pages/features/validation/date-validation/date-combined-yyyy/summary.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../../surveys/question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  dateRange() { return '#date-range-from-answer'; }
+
+  dateRangeEdit() { return '[data-qa="date-range-from-edit"]'; }
+
+  datesTitle() { return '#dates'; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/spec/features/validation/date_validation/date-combined-yyyy.spec.js
+++ b/tests/functional/spec/features/validation/date_validation/date-combined-yyyy.spec.js
@@ -1,0 +1,57 @@
+const helpers = require('../../../../helpers');
+const DateRangePage = require('../../../../pages/features/validation/date-validation/date-combined-yyyy/date-range-block.page');
+var SummaryPage = require('../../../../pages/features/validation/date-validation/date-combined-yyyy/summary.page');
+
+describe('Feature: Combined question level and single validation for MM-YYYY dates', function() {
+
+  before(function() {
+    return helpers.openQuestionnaire('test_date_validation_yyyy_combined.json');
+  });
+
+  describe('Period Validation', function () {
+    describe('Given I enter dates', function() {
+
+      it('When I enter a single dates that are too early/late, Then I should see a single validation errors', function() {
+        return browser
+         .setValue(DateRangePage.dateRangeFromyear(), 2015)
+         .setValue(DateRangePage.dateRangeToyear(), 2021)
+         .click(DateRangePage.submit())
+         .getText(DateRangePage.errorNumber(1)).should.eventually.contain('Enter a date after 2015.')
+         .getText(DateRangePage.errorNumber(2)).should.eventually.contain('Enter a date before 2021.');
+      });
+
+      it('When I enter a range too large, Then I should see a range validation error', function() {
+        return browser
+         .setValue(DateRangePage.dateRangeFromyear(), 2016)
+         .setValue(DateRangePage.dateRangeToyear(), 2020)
+         .click(DateRangePage.submit())
+         .getText(DateRangePage.errorNumber(1)).should.eventually.contain('Enter a reporting period less than or equal to 3 years.');
+      });
+
+      it('When I enter a range too small, Then I should see a range validation error', function() {
+        return browser
+         .setValue(DateRangePage.dateRangeFromyear(), 2016)
+         .setValue(DateRangePage.dateRangeToyear(), 2017)
+         .click(DateRangePage.submit())
+         .getText(DateRangePage.errorNumber(1)).should.eventually.contain('Enter a reporting period greater than or equal to 2 years.');
+      });
+
+      it('When I enter valid dates, Then I should see the summary page', function() {
+        return browser
+         .setValue(DateRangePage.dateRangeFromyear(), 2016)
+         // Min range
+         .setValue(DateRangePage.dateRangeToyear(), 2018)
+         .click(DateRangePage.submit())
+         .getText(SummaryPage.dateRange()).should.eventually.contain('2016 to 2018')
+
+         // Max range
+         .click(SummaryPage.dateRangeEdit())
+         .setValue(DateRangePage.dateRangeToyear(), 2019)
+         .click(DateRangePage.submit())
+         .getText(SummaryPage.dateRange()).should.eventually.contain('2016 to 2019');
+      });
+
+    });
+
+  });
+});

--- a/tests/integration/questionnaire/test_questionnaire_change_answer.py
+++ b/tests/integration/questionnaire/test_questionnaire_change_answer.py
@@ -21,10 +21,11 @@ class TestQuestionnaireChangeAnswer(IntegrationTestCase):
             'single-date-answer-month': '1',
             'single-date-answer-year': '2016',
 
-            # non-mandatory date answered
+            # non-mandatory dates answered
             'non-mandatory-date-answer-day': '22',
             'non-mandatory-date-answer-month': '2',
             'non-mandatory-date-answer-year': '2099',
+            'year-date-answer-year': '2017'
         }
 
         self.post(post_data)


### PR DESCRIPTION
Format YYYY only
Includes Min/Max on single entry
Includes Min/Max on date range

### What is the context of this PR?
As a user
I want to be able to enter a date in a year only format
So that I can give the correct information required by the survey

### How to review 
Test schema: `test_date_validation_yyyy_combined.json`

