### PR TITLE
Fix LMS routing bug

### DIFF
--- a/data/en/lms_1.json
+++ b/data/en/lms_1.json
@@ -2617,7 +2617,7 @@
                         }],
                         "routing_rules": [{
                             "goto": {
-                                "block": "national-identity"
+                                "block": "national-identity-no-proxy"
                             }
                         }]
                     },


### PR DESCRIPTION
### What is the context of this PR?
This fixes a bug where it was possible to get the LMS questionnaire into a state where it could not be submitted.

### How to review 
To reproduce:

- do not answer on behalf of somebody else (no-proxy).
- set your country of birth to "other"
- answer yes to "Apart from holidays and short visits abroad, have you lived in the UK continuously "
- continue through the survey until the very end
- observe that when you submit the contact details form you are redirected to the "What was the main reason for you coming to the UK" question and cannot get past it

This fix should allow you to complete the survey