### PR TITLE
Added trading as to thank you and view submission

### DIFF
--- a/app/authentication/authenticator.py
+++ b/app/authentication/authenticator.py
@@ -78,6 +78,7 @@ def _create_session_data_from_metadata(metadata):
         ru_ref=metadata.get('ru_ref'),
         case_id=metadata.get('case_id'),
         case_ref=metadata.get('case_ref'),
+        trad_as=metadata.get('trad_as'),
         account_service_url=metadata.get('account_service_url')
     )
     return session_data

--- a/app/data_model/session_data.py
+++ b/app/data_model/session_data.py
@@ -1,4 +1,4 @@
-class SessionData(object):      # pylint: disable=too-many-locals
+class SessionData(object):
 
     def __init__(self,
                  tx_id,
@@ -14,7 +14,7 @@ class SessionData(object):      # pylint: disable=too-many-locals
                  account_service_url=None,
                  submitted_time=None,
                  trad_as=None,
-                 **_):
+                 **_):                  # pylint: disable=too-many-locals
         self.tx_id = tx_id
         self.eq_id = eq_id
         self.form_type = form_type

--- a/app/data_model/session_data.py
+++ b/app/data_model/session_data.py
@@ -1,4 +1,4 @@
-class SessionData(object):
+class SessionData(object):      # pylint: disable=too-many-locals
 
     def __init__(self,
                  tx_id,

--- a/app/data_model/session_data.py
+++ b/app/data_model/session_data.py
@@ -13,6 +13,7 @@ class SessionData(object):
                  case_ref=None,
                  account_service_url=None,
                  submitted_time=None,
+                 trad_as=None,
                  **_):
         self.tx_id = tx_id
         self.eq_id = eq_id
@@ -25,4 +26,5 @@ class SessionData(object):
         self.submitted_time = submitted_time
         self.case_id = case_id
         self.case_ref = case_ref
+        self.trad_as = trad_as
         self.account_service_url = account_service_url

--- a/app/data_model/session_store.py
+++ b/app/data_model/session_store.py
@@ -88,4 +88,3 @@ class SessionStore:
             logger.debug('eq_session_id not found in database', eq_session_id=self.eq_session_id)
 
         return self._eq_session
-

--- a/app/data_model/session_store.py
+++ b/app/data_model/session_store.py
@@ -17,7 +17,6 @@ class SessionStore:
         self.session_data = None
         self._eq_session = None
         self.pepper = pepper
-
         if eq_session_id:
             self._load()
 
@@ -89,3 +88,4 @@ class SessionStore:
             logger.debug('eq_session_id not found in database', eq_session_id=self.eq_session_id)
 
         return self._eq_session
+

--- a/app/templates/thank-you.html
+++ b/app/templates/thank-you.html
@@ -10,7 +10,9 @@
 
 <div class="u-mb-s">
     <div class="panel panel--simple panel--success panel--spacious">
-        <p class="mars">Your answers were submitted for <b>{{metadata.ru_name}}</b> on {{metadata.submitted_time|format_datetime}}</p>
+        <p class="mars">Your answers were submitted for <b>{{metadata.ru_name}}</b>
+            {% if metadata.trad_as %} ({{metadata.trad_as}}){% endif %}
+            on {{metadata.submitted_time|format_datetime}}</p>
         <p class="mars">Transaction ID: <b>{{metadata.tx_id}}</b></p>
     </div>
 </div>

--- a/app/templates/view-submission.html
+++ b/app/templates/view-submission.html
@@ -11,7 +11,8 @@
 
 <div class="u-mb-s">
     <div class="panel panel--simple panel--success panel--spacious">
-        <p class="mars">Your answers were submitted for <b>{{metadata.ru_name}}</b> on {{metadata.submitted_time|format_datetime}}</p>
+        <p class="mars">Your answers were submitted for <b>{{metadata.ru_name}}</b>{% if metadata.trad_as %} ({{metadata.trad_as}}){% endif %}
+         on {{metadata.submitted_time|format_datetime}}</p>
         <p class="mars">Transaction ID: <b>{{metadata.tx_id}}</b></p>
     </div>
 </div>

--- a/app/templating/metadata_context.py
+++ b/app/templating/metadata_context.py
@@ -27,7 +27,8 @@ def build_metadata_context_for_survey_completed(session_data):
     metadata_context = {
         'submitted_time': session_data.submitted_time,
         'tx_id': convert_tx_id(session_data.tx_id),
-        'ru_ref': session_data.ru_ref
+        'ru_ref': session_data.ru_ref,
+        'trad_as': session_data.trad_as
     }
 
     if session_data.period_str:

--- a/tests/app/data_model/test_session_store.py
+++ b/tests/app/data_model/test_session_store.py
@@ -1,5 +1,5 @@
 from datetime import timedelta, datetime
-
+import simplejson
 from mock import patch
 
 from app.data_model.session_store import SessionStore
@@ -111,3 +111,120 @@ class SessionStoreTest(AppContextTestCase):
 
             self.assertFalse(hasattr(session_store.session_data, 'additional_value'))
             self.assertFalse(hasattr(session_store.session_data, 'second_additional_value'))
+
+    def test_session_store_stores_trading_as_value_if_present(self):
+        session_data = SessionData(
+            tx_id='tx_id',
+            eq_id='eq_id',
+            form_type='form_type',
+            period_str='period_str',
+            language_code=None,
+            survey_url=None,
+            ru_name='ru_name',
+            ru_ref='ru_ref',
+            trad_as='trading_as'
+        )
+        with self._app.test_request_context():
+            self.session_store.create('eq_session_id', 'test', session_data).save()
+
+            session_store = SessionStore('user_ik', 'pepper', 'eq_session_id')
+
+            self.assertTrue(hasattr(session_store.session_data, 'trad_as'))
+
+    def test_session_store_stores_none_for_trading_as_if_not_present(self):
+        session_data = SessionData(
+            tx_id='tx_id',
+            eq_id='eq_id',
+            form_type='form_type',
+            period_str='period_str',
+            language_code=None,
+            survey_url=None,
+            ru_name='ru_name',
+            ru_ref='ru_ref'
+        )
+        with self._app.test_request_context():
+            self.session_store.create('eq_session_id', 'test', session_data).save()
+
+            session_store = SessionStore('user_ik', 'pepper', 'eq_session_id')
+
+            self.assertIsNone(session_store.session_data.trad_as)
+
+    def test_session_store_reads_data_saved_without_trading_as_but_read_expecting_trading_as(self):
+        old_session_data = SessionData(
+            tx_id='tx_id',
+            eq_id='eq_id',
+            form_type='form_type',
+            period_str='period_str',
+            language_code=None,
+            survey_url=None,
+            ru_name='ru_name',
+            ru_ref='ru_ref'
+        )
+        delattr(old_session_data, 'trad_as')   # Make class look like old style class
+        with self._app.test_request_context():
+            self.session_store.create('eq_session_id', 'test', old_session_data).save()
+
+            session_store = SessionStore('user_ik', 'pepper', 'eq_session_id')
+
+            self.assertIsNone(session_store.session_data.trad_as)
+
+    def test_session_store_reads_data_saved_with_trading_as_but_read_not_expecting_trading_as(self):
+        """This test simulates the case where a session is created using a new session store that holds trading as
+            but this gets read in an old session that does NOT support trading as """
+
+        original_loads_func = simplejson.loads
+
+        class OldSessionData(object):
+            """class representing what old sessions expect ( no trading as) """
+            def __init__(self,
+                         tx_id,
+                         eq_id,
+                         form_type,
+                         period_str,
+                         language_code,
+                         survey_url,
+                         ru_name,
+                         ru_ref,
+                         case_id=None,
+                         case_ref=None,
+                         account_service_url=None,
+                         submitted_time=None,
+                         **_):
+                self.tx_id = tx_id
+                self.eq_id = eq_id
+                self.form_type = form_type
+                self.period_str = period_str
+                self.language_code = language_code
+                self.survey_url = survey_url
+                self.ru_name = ru_name
+                self.ru_ref = ru_ref
+                self.submitted_time = submitted_time
+                self.case_id = case_id
+                self.case_ref = case_ref
+                self.account_service_url = account_service_url
+
+        def old_json_loader(raw, object_hook):
+            """replacement for json.loads to decode to old format ( no trading as) """
+
+            old_data = original_loads_func(raw, object_hook=lambda d: OldSessionData(**d))   # call original json loads but with a hook pointing to an old class
+            return old_data
+
+        session_data = SessionData(
+            tx_id='tx_id',
+            eq_id='eq_id',
+            form_type='form_type',
+            period_str='period_str',
+            language_code=None,
+            survey_url=None,
+            ru_name='ru_name',
+            ru_ref='ru_ref',
+            trad_as='trading_as_name'
+        )
+        with self._app.test_request_context():
+
+            with patch('app.data_model.session_store.json.loads', old_json_loader):  # patch json.loads to use old_json_loader above
+                self.session_store.create('eq_session_id', 'test', session_data).save()
+
+                session_store = SessionStore('user_ik', 'pepper', 'eq_session_id')
+
+                self.assertFalse(hasattr(session_store.session_data, 'trad_as'))

--- a/tests/app/data_model/test_session_store.py
+++ b/tests/app/data_model/test_session_store.py
@@ -203,10 +203,10 @@ class SessionStoreTest(AppContextTestCase):
                 self.case_ref = case_ref
                 self.account_service_url = account_service_url
 
-        def old_json_loader(raw, object_hook):
+        def old_json_loader(raw, object_hook):  # pylint: disable=unused-argument
             """replacement for json.loads to decode to old format ( no trading as) """
 
-            old_data = original_loads_func(raw, object_hook=lambda d: OldSessionData(**d))   # call original json loads but with a hook pointing to an old class
+            old_data = original_loads_func(raw, object_hook=lambda d: OldSessionData(**d))   # call json.loads ,hook pointing to an old class
             return old_data
 
         session_data = SessionData(

--- a/tests/integration/views/test_thank_you.py
+++ b/tests/integration/views/test_thank_you.py
@@ -1,0 +1,130 @@
+from mock import patch
+
+from tests.integration.integration_test_case import IntegrationTestCase
+
+
+class TestThankYou(IntegrationTestCase):
+
+    def setUp(self):
+        super().SetUpWithDynamoDB()
+
+    def test_thank_you_page_shows_trading_as_if_present(self):
+        self.launchSurvey('test', 'currency')
+
+        # check we're on first page
+        self.assertInPage('Currency Input Test')
+
+        # We fill in our answers
+        form_data = {
+            # Food choice
+            'answer': '12',
+            'answer-usd': '345',
+            'answer-eur': '67.89',
+            'answer-jpy': '0',
+        }
+
+        # We submit the form
+        self.post(form_data)
+
+        # There are no validation errors
+        self.assertInUrl('summary')
+
+        # Submit answers
+        self.post(action=None)
+
+        # check we're on the thank you page and that the trading as is displayed
+        self.assertInUrl('thank-you')
+        self.assertInPage('(Integration Tests)')
+
+    def test_thank_you_page_does_not_show_empty_parenthesis_if_trading_as_if_not_present(self):
+        no_trading_as_payload = {
+            'user_id': 'integration-test',
+            'period_str': 'April 2016',
+            'period_id': '201604',
+            'collection_exercise_sid': '789',
+            'ru_ref': '123456789012A',
+            'ru_name': 'Integration Testing',
+            'ref_p_start_date': '2016-04-01',
+            'ref_p_end_date': '2016-04-30',
+            'return_by': '2016-05-06',
+            'employment_date': '1983-06-02',
+            'variant_flags': None,
+            'region_code': 'GB-ENG',
+            'language_code': 'en',
+            'roles': []
+        }
+        with patch('tests.integration.create_token.PAYLOAD', no_trading_as_payload):
+            self.launchSurvey('test', 'currency')
+
+            # check we're on first page
+            self.assertInPage('Currency Input Test')
+
+            # We fill in our answers
+            form_data = {
+                # Food choice
+                'answer': '12',
+                'answer-usd': '345',
+                'answer-eur': '67.89',
+                'answer-jpy': '0',
+            }
+
+            # We submit the form
+            self.post(form_data)
+
+            # There are no validation errors
+            self.assertInUrl('summary')
+
+            # Submit answers
+            self.post(action=None)
+
+            # check we're on the thank you page and that the trading as parenthesis are not displayed
+            self.assertInUrl('thank-you')
+            self.assertNotInPage('(Integration Tests)')
+            self.assertNotInPage('()')
+
+    def test_thank_you_page_does_not_show_empty_parenthesis_if_trading_as_is_empty(self):
+        empty_trading_as_payload = {
+            'user_id': 'integration-test',
+            'period_str': 'April 2016',
+            'period_id': '201604',
+            'collection_exercise_sid': '789',
+            'ru_ref': '123456789012A',
+            'ru_name': 'Integration Testing',
+            'ref_p_start_date': '2016-04-01',
+            'ref_p_end_date': '2016-04-30',
+            'return_by': '2016-05-06',
+            'employment_date': '1983-06-02',
+            'variant_flags': None,
+            'region_code': 'GB-ENG',
+            'language_code': 'en',
+            'trad_as': '',
+            'roles': []
+        }
+        with patch('tests.integration.create_token.PAYLOAD', empty_trading_as_payload):
+            self.launchSurvey('test', 'currency')
+
+            # check we're on first page
+            self.assertInPage('Currency Input Test')
+
+            # We fill in our answers
+            form_data = {
+                # Food choice
+                'answer': '12',
+                'answer-usd': '345',
+                'answer-eur': '67.89',
+                'answer-jpy': '0',
+            }
+
+            # We submit the form
+            self.post(form_data)
+
+            # There are no validation errors
+            self.assertInUrl('summary')
+
+            # Submit answers
+            self.post(action=None)
+
+            # check we're on the thank you page and that the trading as parenthesis are not displayed
+            self.assertInUrl('thank-you')
+            self.assertNotInPage('(Integration Tests)')
+            self.assertNotInPage('()')

--- a/tests/integration/views/test_view_submission.py
+++ b/tests/integration/views/test_view_submission.py
@@ -1,4 +1,5 @@
 import mock
+from mock import patch
 
 from tests.integration.integration_test_case import IntegrationTestCase
 
@@ -118,3 +119,175 @@ class TestViewSubmission(IntegrationTestCase):
 
         # check we're redirected back to first page
         self.assertInPage('What is your favourite breakfast food')
+
+    def test_view_submission_shows_trading_as_if_present(self):
+        self.launchSurvey('test', 'view_submitted_response')
+
+        # check we're on first page
+        self.assertInPage('What is your favourite breakfast food')
+
+        # We fill in our answer
+        form_data = {
+            # Food choice
+            'radio-answer': 'Bacon',
+        }
+
+        # We submit the form
+        self.post(form_data)
+
+        # check we're on second page
+        self.assertInPage('Please enter test values (none mandatory)')
+
+        # We fill in our answers
+        form_data = {
+            # Food choice
+            'test-currency': '12',
+            'square-kilometres': '345',
+            'test-decimal': '67.89',
+        }
+
+        # We submit the form
+        self.post(form_data)
+
+        # Submit answers
+        with mock.patch('app.data_model.submitted_responses.put_item',
+                        return_value={'ResponseMetadata': {'HTTPStatusCode': 200}}) as put_item:
+            self.post(action=None)
+
+            item = put_item.call_args[0][0]
+
+        # go to the view submission page
+        with mock.patch('app.data_model.submitted_responses.get_item',
+                        return_value=item):
+            self.get('questionnaire/test/view_submitted_response/view-submission')
+
+        # check we're on the view submission page, and trading as value is displayed
+        self.assertInUrl('view-submission')
+        self.assertInPage('(Integration Tests)')
+
+    def test_view_submission_does_not_show_parenthesis_if_no_trading_as(self):
+        no_trading_as_payload = {
+            'user_id': 'integration-test',
+            'period_str': 'April 2016',
+            'period_id': '201604',
+            'collection_exercise_sid': '789',
+            'ru_ref': '123456789012A',
+            'ru_name': 'Integration Testing',
+            'ref_p_start_date': '2016-04-01',
+            'ref_p_end_date': '2016-04-30',
+            'return_by': '2016-05-06',
+            'employment_date': '1983-06-02',
+            'variant_flags': None,
+            'region_code': 'GB-ENG',
+            'language_code': 'en',
+            'roles': []
+        }
+        with patch('tests.integration.create_token.PAYLOAD', no_trading_as_payload):
+            self.launchSurvey('test', 'view_submitted_response')
+
+            # check we're on first page
+            self.assertInPage('What is your favourite breakfast food')
+
+            # We fill in our answer
+            form_data = {
+                # Food choice
+                'radio-answer': 'Bacon',
+            }
+
+            # We submit the form
+            self.post(form_data)
+
+            # check we're on second page
+            self.assertInPage('Please enter test values (none mandatory)')
+
+            # We fill in our answers
+            form_data = {
+                # Food choice
+                'test-currency': '12',
+                'square-kilometres': '345',
+                'test-decimal': '67.89',
+            }
+
+            # We submit the form
+            self.post(form_data)
+
+            # Submit answers
+            with mock.patch('app.data_model.submitted_responses.put_item',
+                            return_value={'ResponseMetadata': {'HTTPStatusCode': 200}}) as put_item:
+                self.post(action=None)
+
+                item = put_item.call_args[0][0]
+
+            # go to the view submission page
+            with mock.patch('app.data_model.submitted_responses.get_item',
+                            return_value=item):
+                self.get('questionnaire/test/view_submitted_response/view-submission')
+
+            # check we're on the view submission page, and trading as value is displayed
+            self.assertInUrl('view-submission')
+            self.assertNotInPage('(Integration Tests)')
+            self.assertNotInPage('()')
+
+    def test_view_submission_does_not_show_parenthesis_trading_as_is_empty_string(self):
+        no_trading_as_payload = {
+            'user_id': 'integration-test',
+            'period_str': 'April 2016',
+            'period_id': '201604',
+            'collection_exercise_sid': '789',
+            'ru_ref': '123456789012A',
+            'ru_name': 'Integration Testing',
+            'ref_p_start_date': '2016-04-01',
+            'ref_p_end_date': '2016-04-30',
+            'return_by': '2016-05-06',
+            'employment_date': '1983-06-02',
+            'variant_flags': None,
+            'region_code': 'GB-ENG',
+            'language_code': 'en',
+            'roles': [],
+            'trad_as': ''
+        }
+        with patch('tests.integration.create_token.PAYLOAD', no_trading_as_payload):
+            self.launchSurvey('test', 'view_submitted_response')
+
+            # check we're on first page
+            self.assertInPage('What is your favourite breakfast food')
+
+            # We fill in our answer
+            form_data = {
+                # Food choice
+                'radio-answer': 'Bacon',
+            }
+
+            # We submit the form
+            self.post(form_data)
+
+            # check we're on second page
+            self.assertInPage('Please enter test values (none mandatory)')
+
+            # We fill in our answers
+            form_data = {
+                # Food choice
+                'test-currency': '12',
+                'square-kilometres': '345',
+                'test-decimal': '67.89',
+            }
+
+            # We submit the form
+            self.post(form_data)
+
+            # Submit answers
+            with mock.patch('app.data_model.submitted_responses.put_item',
+                            return_value={'ResponseMetadata': {'HTTPStatusCode': 200}}) as put_item:
+                self.post(action=None)
+
+                item = put_item.call_args[0][0]
+
+            # go to the view submission page
+            with mock.patch('app.data_model.submitted_responses.get_item',
+                            return_value=item):
+                self.get('questionnaire/test/view_submitted_response/view-submission')
+
+            # check we're on the view submission page, and trading as value is displayed
+            self.assertInUrl('view-submission')
+            self.assertNotInPage('(Integration Tests)')
+            self.assertNotInPage('()')


### PR DESCRIPTION

There is a requirement to show trading as on the thank you and view submission page . 

### How to review 
Launch any survey from go launcher with 2 test cases 1 with a trading as string set to something different to ru , and with zero length string as trading as . if there is a trading as it will be displayed on the thank you page after ru name in parenthesis . If there is an empty string then there should be no 
parenthesis. Repeat for a survey that show view submission and validate same cases in the view submission page. e.g test_view_submitted_response