### PR TITLE
Don't show checkbox as a list on summary if only one box is checked

### DIFF
--- a/app/templates/partials/summary/checkbox.html
+++ b/app/templates/partials/summary/checkbox.html
@@ -1,18 +1,26 @@
 {% set not_answered = 'No answer provided' %}
-<ul class="u-m-no">
-      {% for selected_answer in answer.value %}
-        <li>{{selected_answer.label}}
-            {%- if answer.child_answer_value is not none and selected_answer.should_display_other %}
-            <ul>
-                <li>
-                    {%- if answer.child_answer_value == ''  -%}
-                        {{not_answered}}
-                    {%- else -%}
-                        {{ answer.child_answer_value }}
-                    {%- endif -%}
-                </li>
-            </ul>
+
+{% macro answer_with_child(selected_answer) %}
+    {{selected_answer.label}}
+    {%- if answer.child_answer_value is not none and selected_answer.should_display_other %}
+    <ul>
+        <li>
+            {%- if answer.child_answer_value == ''  -%}
+                {{not_answered}}
+            {%- else -%}
+                {{ answer.child_answer_value }}
             {%- endif -%}
         </li>
-      {% endfor %}
-</ul>
+    </ul>
+    {%- endif -%}
+{% endmacro %}
+
+{%- if answer.value|length > 1 -%}
+    <ul class="u-m-no">
+        {% for selected_answer in answer.value %}
+            <li>{{ answer_with_child(selected_answer) }}</li>
+        {% endfor %}
+    </ul>
+{%- else -%}
+    {{ answer_with_child(answer.value[0]) }}
+{%- endif -%}

--- a/tests/functional/spec/checkbox.spec.js
+++ b/tests/functional/spec/checkbox.spec.js
@@ -113,4 +113,31 @@ describe('Checkbox with "other" option', function() {
 
   });
 
+  it('Given a mandatory checkbox answer, when the user selects only one option, then the answer should not be displayed as a list on the summary screen', function() {
+    // Given
+    return helpers.openQuestionnaire(checkbox_schema).then(() => {
+      return browser
+      // When
+        .click(MandatoryCheckboxPage.ham())
+        .click(MandatoryCheckboxPage.submit())
+        .click(NonMandatoryCheckboxPage.submit())
+      // Then
+        .element(SummaryPage.mandatoryAnswer()).elements('li').then(result => result.value).should.eventually.be.empty;
+    });
+  });
+
+    it('Given a mandatory checkbox answer, when the user selects more than one option, then the answer should be displayed as a list on the summary screen', function() {
+    // Given
+    return helpers.openQuestionnaire(checkbox_schema).then(() => {
+      return browser
+      // When
+        .click(MandatoryCheckboxPage.ham())
+        .click(MandatoryCheckboxPage.cheese())
+        .click(MandatoryCheckboxPage.submit())
+        .click(NonMandatoryCheckboxPage.submit())
+      // Then
+        .element(SummaryPage.mandatoryAnswer()).elements('li').then(result => result.value.length).should.eventually.be.equal(2);
+    });
+  });
+
 });


### PR DESCRIPTION
### What is the context of this PR?
On the summary page for a set of checkboxes we no longer want to show it as a list if only one box is checked

### How to review 
Check one item, see that there's not a bullet point next to it, check two items, see that there is a bullet point next to each.
