### PR TITLE
Apply new summary design to surveys

### DIFF
--- a/app/assets/favicons/browserconfig.xml
+++ b/app/assets/favicons/browserconfig.xml
@@ -2,7 +2,7 @@
 <browserconfig>
     <msapplication>
         <tile>
-            <square150x150logo src="https://cdn.ons.gov.uk/sdc/0bceacd/favicons/mstile-150x150.png"/>
+            <square150x150logo src="https://cdn.ons.gov.uk/sdc/v1.2.0/favicons/mstile-150x150.png"/>
             <TileColor>#da532c</TileColor>
         </tile>
     </msapplication>

--- a/app/assets/styles/partials/vars/_vars.scss
+++ b/app/assets/styles/partials/vars/_vars.scss
@@ -1,3 +1,3 @@
 $s: "/s";
-$cdn-version: "0bceacd";
+$cdn-version: "v1.2.0";
 $cdn-url-root: "https://cdn.ons.gov.uk/sdc/#{$cdn-version}";

--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -67,8 +67,7 @@ def format_multilined_string(context, value):
     escaped_value = escape(value)
     new_line_regex = r'(?:\r\n|\r|\n)+'
     value_with_line_break_tag = re.sub(new_line_regex, '<br>', escaped_value)
-    result = '<p>{}</p>'.format(value_with_line_break_tag)
-
+    result = '{}'.format(value_with_line_break_tag)
     return mark_safe(context, result)
 
 
@@ -168,6 +167,18 @@ def format_household_member_name_possessive(names):
         return name + '’'
 
     return name + '’s'
+
+
+@blueprint.app_template_filter()
+def answer_is_type(answer, target_answer_type):
+    """
+    :param answer:
+    :param target_answer_type:
+    :return: true if the answer type matches given input
+    'RepeatingAnswer' question type return 'answers' as an object, and dict for all other question types.
+    """
+    answer_type = answer['type'] if isinstance(answer, dict) else answer.type
+    return answer_type == target_answer_type.lower()
 
 
 @evalcontextfilter
@@ -272,6 +283,11 @@ def get_question_title_processor():
 @blueprint.app_context_processor
 def get_answer_label_processor():
     return dict(get_answer_label=get_answer_label)
+
+
+@blueprint.app_context_processor
+def answer_is_type_processor():
+    return dict(answer_is_type=answer_is_type)
 
 
 @blueprint.app_context_processor

--- a/app/templates/layouts/_base.html
+++ b/app/templates/layouts/_base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-{% set cdn_hash = "0bceacd" %}
+{% set cdn_hash = "v1.2.0" %}
 {% set cdn_url_prefix = "https://cdn.ons.gov.uk/sdc/"~cdn_hash %}
 <!--[if lt IE 7]>      <html lang="en-gb" dir="ltr" class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
 <!--[if IE 7]>         <html lang="en-gb" dir="ltr" class="no-js lt-ie10 lt-ie9 lt-ie8"> <![endif]-->

--- a/app/templates/partials/summary/answer.html
+++ b/app/templates/partials/summary/answer.html
@@ -1,0 +1,7 @@
+{% set not_answered = 'No answer provided' %}
+
+{%- if answer.value is none or answer.value == '' -%}
+    {{ not_answered }}
+{%- else -%}
+    {% include theme(['partials/summary/' ~ answer.type ~ '.html', 'partials/summary/default.html']) %}
+{%- endif -%}

--- a/app/templates/partials/summary/default.html
+++ b/app/templates/partials/summary/default.html
@@ -1,1 +1,1 @@
-<div class="summary__answer-break">{{(answer.value)}}</div>
+<div>{{(answer.value)}}</div>

--- a/app/templates/partials/summary/display-answer.html
+++ b/app/templates/partials/summary/display-answer.html
@@ -1,0 +1,5 @@
+<div class="grid__col col-8@xs {{ 'col-10@m' if is_textarea else 'col-4@m' }}">
+    <div class="summary__answer venus" id="{{ answer.id }}-answer" data-qa="{{ answer.id }}-answer">
+        {% include theme(['partials/summary/answer.html']) %}
+    </div>
+</div>

--- a/app/templates/partials/summary/display-question.html
+++ b/app/templates/partials/summary/display-question.html
@@ -1,0 +1,1 @@
+<div class="summary__question mars" id="{{ question.id }}" data-qa="summary-question-title">{{ question.number or ''}} {{question.title|striptags }}</div>

--- a/app/templates/partials/summary/edit-link.html
+++ b/app/templates/partials/summary/edit-link.html
@@ -1,0 +1,8 @@
+<div class="grid__col col-4@xs col-2@m">
+    <div class="summary__link mars">
+        <a href="{{ block.link }}#{{ answer.id }}" class="summary__edit-link" aria-describedby="{{ answer.id }} {{ answer.id }}-answer" data-qa="{{ answer.id }}-edit" {{ helpers.track('click', 'Summary', 'Edit click') }}>Change <span class="u-vh">
+        your answer for: {{ answer.label|striptags if has_multiple_answers else question.title|striptags }}. The current value is:
+        {% include theme(['partials/summary/answer.html']) %}
+    </span></a>
+    </div>
+</div>

--- a/app/templates/partials/summary/question-multiple-answers.html
+++ b/app/templates/partials/summary/question-multiple-answers.html
@@ -1,0 +1,33 @@
+<div class="summary__item summary__item--multiple">
+    <div class="grid">
+        <div class="grid__col col-12@m">
+            {%- include theme(['partials/summary/display-question.html']) -%}
+        </div>
+    </div>
+
+{%- for answer in question.answers -%}
+    {% set is_textarea = answer_is_type(answer, 'textarea') %}
+    <div class="grid">
+        <div class="grid__col col-12@xs {{ 'col-10@m' if is_textarea else 'col-6@m' }}">
+            <div class="summary__label mars">{{ answer.label|striptags }}</div>
+        </div>
+
+        {%- if not is_textarea -%}
+            {%- include theme(['partials/summary/display-answer.html']) -%}
+        {%- endif %}
+
+        {%- if content.summary.answers_are_editable -%}
+            {% include theme(['partials/summary/edit-link.html']) -%}
+        {%- endif -%}
+
+    </div>
+
+    {%- if is_textarea -%}
+        <div class="grid">
+            {%- include theme(['partials/summary/display-answer.html']) -%}
+        </div>
+    {%- endif -%}
+
+{%- endfor -%}
+
+</div>

--- a/app/templates/partials/summary/question-single-answer.html
+++ b/app/templates/partials/summary/question-single-answer.html
@@ -1,0 +1,25 @@
+<div class="summary__item">
+    <div class="grid">
+        {% set answer = question.answers[0] %}
+        {% set is_textarea = answer_is_type(answer, 'textarea') %}
+
+        <div class="grid__col col-12@xs {{ 'col-10@m' if is_textarea else 'col-6@m' }}">
+            {%- include theme(['partials/summary/display-question.html']) -%}
+        </div>
+
+        {%- if not is_textarea -%}
+            {%- include theme(['partials/summary/display-answer.html']) -%}
+        {%- endif -%}
+
+        {%- if content.summary.answers_are_editable -%}
+            {%- include theme(['partials/summary/edit-link.html']) -%}
+        {%- endif %}
+
+    </div>
+
+    {%- if is_textarea -%}
+    <div class="grid u-mt-s">
+        {%- include theme(['partials/summary/display-answer.html']) -%}
+    </div>
+    {%- endif -%}
+</div>

--- a/app/templates/partials/summary/summary.html
+++ b/app/templates/partials/summary/summary.html
@@ -1,53 +1,24 @@
-{% set not_answered = 'No answer provided' %}
+<div class="summary">
+	{%- for group in content.summary.groups -%}
+        {%- if group.title -%}
+            <h2 class="summary__title neptune" id="{{ group.id }}">{{ group.title }}</h2>
+        {%- endif %}
 
-<div>
-  <div class="summary">
+        <div class="summary__block u-mb-l">
+            {%- for block in group.blocks -%}
+                {%- for question in block.questions -%}
 
-    {% for group in content.summary.groups %}
-      {% if group.title %}
-        <h2 class="summary__title saturn" id="{{group.id}}">{{group.title}}</h2>
-      {% endif %}
-      <div class="summary__block">
+                    {% set has_multiple_answers = question.answers|length > 1 %}
 
-        {% for block in group.blocks %}
-
-          <div class="summary__items">
-
-            {% for question in block.questions %}
-
-              <div class="summary__question" id="{{question.id}}" data-qa="summary-question-title">
-                {{question.number or ''}} {{question.title|striptags}}
-              </div>
-
-              {% for answer in question.answers %}
-                {% if question.answers|length > 1 and answer.label %}
-                  <div class="summary__question summary__question--sub">
-                    {{answer.label|striptags}}
-                  </div>
-                {% endif %}
-
-                <div class="summary__answer">
-                  <div class="summary__answer-text" id="{{answer.id}}-answer" data-qa="{{answer.id}}-answer">
-                    {%- if answer.value is none or answer.value == '' -%}
-                      {{not_answered}}
+                    {%- if has_multiple_answers -%}
+                        {%- include theme(['partials/summary/question-multiple-answers.html']) -%}
                     {%- else -%}
-                      {% include theme(['partials/summary/' ~ answer.type ~ '.html', 'partials/summary/default.html']) %}
-                     {%- endif -%}
-                   </div>
+                        {%- include theme(['partials/summary/question-single-answer.html']) -%}
+                    {%- endif -%}
 
-                  {% if content.summary.answers_are_editable %}
-                    <div class="summary__edit">
-                      <a href="{{ block.link }}#{{answer.id}}" class="summary__edit-link" aria-describedby="{{answer.id}} {{answer.id}}-answer" data-qa="{{answer.id}}-edit" {{helpers.track('click', 'Summary', 'Edit click')}}>Edit <span class="u-vh">your answer</span></a>
-                    </div>
-                  {% endif %}
-                </div>
-              {% endfor %}
-            {% endfor %}
+                {%- endfor -%}
+            {%- endfor -%}
+        </div>
 
-          </div>
-
-        {% endfor %}
-      </div>
-    {% endfor %}
-  </div>
+	{%- endfor -%}
 </div>

--- a/app/templates/partials/summary/textarea.html
+++ b/app/templates/partials/summary/textarea.html
@@ -1,1 +1,1 @@
-<div class="summary__answer-break">{{answer.value|format_multilined_string}}</div>
+<div>{{answer.value|format_multilined_string}}</div>

--- a/app/templates/summary.html
+++ b/app/templates/summary.html
@@ -17,10 +17,10 @@
 {% if content.summary.summary_type == 'Summary' %}
 <div>
   <h1 class="saturn">{{content.summary.title}}</h1>
-  <div class="print__message panel panel--simple panel--error">
+  <div class="print__message panel panel--simple panel--error u-mb-l">
     <h2 class="saturn">Please remember to submit these answers.</h2>
   </div>
-  <div class="print__hidden panel panel--simple panel--warn">
+  <div class="print__hidden panel panel--simple panel--warn u-mb-l">
     <h2 class="neptune">Please check your answers carefully before submitting.</h2>
   </div>
 </div>
@@ -28,7 +28,7 @@
 <div>
     {% set group = content.summary.groups %}
     <h1 class="saturn">{{content.summary.title}}</h1>
-    <div class="print__hidden panel panel--simple panel--success">
+    <div class="print__hidden panel panel--simple panel--success u-mb-l">
         <strong>This section is now complete</strong>
         <p>You can review your answers below</p>
     </div>

--- a/tests/app/test_jinja_filters.py
+++ b/tests/app/test_jinja_filters.py
@@ -74,7 +74,7 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         # When
         format_value = format_multilined_string(self.autoescape_context, new_line)
 
-        self.assertEqual(format_value, '<p>this is on a new<br>line</p>')
+        self.assertEqual(format_value, 'this is on a new<br>line')
 
     def test_format_multilined_string_matches_new_line(self):
         # Given
@@ -84,7 +84,7 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         format_value = format_multilined_string(self.autoescape_context,
                                                 new_line)
 
-        self.assertEqual(format_value, '<p>this is on a new<br>line</p>')
+        self.assertEqual(format_value, 'this is on a new<br>line')
 
     def test_format_multilined_string_matches_carriage_return_new_line(self):
         # Given
@@ -93,7 +93,7 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         # When
         format_value = format_multilined_string(self.autoescape_context, new_line)
 
-        self.assertEqual(format_value, '<p>this is on a new<br>line</p>')
+        self.assertEqual(format_value, 'this is on a new<br>line')
 
     def test_format_multilined_string(self):
         # Given
@@ -103,7 +103,7 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         format_value = format_multilined_string(self.autoescape_context,
                                                 new_line)
 
-        self.assertEqual(format_value, '<p>this is<br>on a<br>new<br>line</p>')
+        self.assertEqual(format_value, 'this is<br>on a<br>new<br>line')
 
     def test_format_multilined_string_auto_escape(self):
         # Given
@@ -112,7 +112,7 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         # When
         format_value = format_multilined_string(self.autoescape_context, new_line)
 
-        self.assertEqual(str(format_value), '<p>&lt;</p>')
+        self.assertEqual(str(format_value), '&lt;')
 
     def test_get_current_date(self):
         # Given

--- a/tests/integration/widget/test_render_percentage_widget.py
+++ b/tests/integration/widget/test_render_percentage_widget.py
@@ -34,7 +34,7 @@ class TestRenderPercentageWidget(IntegrationTestCase):
         self.post({'answer': '50'})
         self.assertStatusOK()
         self.assertInUrl('summary')
-        self.assertRegexPage(r'summary\_\_answer-text.+\>50\%\<\/div\>')
+        self.assertRegexPage(r'summary__answer.+\">\n +50%\n +</div>')
 
     def test_description_label_is_rendered(self):
         self.assertInPage('Enter percentage of growth')


### PR DESCRIPTION
### What is the context of this PR?
Updates pattern library to [v1.2.0](https://github.com/ONSdigital/sdc-global-design-patterns/releases/tag/v1.2.0) and fixes the breaking change to summary pages.
[Card](https://trello.com/c/KCYOLcBk/1297-apply-new-summary-design-surveys-without-sections-m) for context.
[Summary Design - Pattern Library](https://sdc-global-design-patterns.netlify.com/components/detail/summary.html)
This takes in all changes from pattern library since 5th of March till `v1.2.0`

### How to review 
1. Make sure that summary looks and behaves as expected.
2. Ensure the templating is correct.
3. Ensure all assets and styles are as expected.