### PR TITLE
Bump chromedriver version to work with latest chrome

### DIFF
--- a/tests/functional/chimp.js
+++ b/tests/functional/chimp.js
@@ -40,7 +40,7 @@ let config = {
         chrome: {
           // check for more recent versions of chrome driver here:
           // http://chromedriver.storage.googleapis.com/index.html
-          version: '2.32',
+          version: '2.37',
         }
       }
     }


### PR DESCRIPTION
### What is the context of this PR?
The chromedriver version set in chimp no longer works against the latest version of chrome
