### PR TITLE
Pass current date for census intro page

### DIFF
--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -260,6 +260,11 @@ def get_answer_label(context, answer_id, question_id):
 
 
 @blueprint.app_context_processor
+def get_current_date_processor():
+    return dict(get_current_date=get_current_date)
+
+
+@blueprint.app_context_processor
 def get_question_title_processor():
     return dict(get_question_title=get_question_title)
 

--- a/app/themes/census/templates/introduction.html
+++ b/app/themes/census/templates/introduction.html
@@ -11,7 +11,7 @@
 <div>
   <h2 class="saturn">Welcome to the Census Test.</h2>
   <p class="mars">Include everyone living and staying overnight in your household. </p>
-<p> Fill it in as soon as possible, but answer it about 29 November 2017.</p>
+<p> Fill it in as soon as possible, but answer it about {{get_current_date()}}.</p>
 <p> The information helps councils and the government plan and fund
 services in your community - services like GPs, hospitals, schools and
 public transport. </p>


### PR DESCRIPTION
### What is the context of this PR?
Census intro page has a hard coded date for 29 November 2017. We wanted to change that so it is the current date

### How to review 
Launch Census household survey. On the intro page where it states `Fill it in as soon as possible, but answer it about`, is it followed by todays date?
