### PR TITLE
Add playback block to MBS 0111

### DIFF
--- a/data/en/mbs_0111.json
+++ b/data/en/mbs_0111.json
@@ -230,6 +230,7 @@
                             "answers": [{
                                 "id": "turnover-answer",
                                 "label": "Total turnover excluding VAT",
+                                "description": "Enter value in full. For example, for 56 thousand you would enter 56,000",
                                 "type": "Currency",
                                 "currency": "GBP",
                                 "decimal_places": 2,
@@ -240,6 +241,47 @@
                             "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>total turnover</em>, excluding VAT?"
                         }],
                         "title": "Total Turnover"
+                    },
+                    {
+                        "type": "ConfirmationQuestion",
+                        "title": "Total turnover",
+                        "id": "confirm-turnover-block",
+                        "questions": [{
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "confirm-turnover-answer",
+                                "q_code": "d40",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }],
+                            "id": "confirm-turnover-question",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "value": "No",
+                                        "id": "confirm-turnover-answer",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "changes-in-turnover-block"
+                                }
+                            }
+                        ]
                     },
                     {
                         "id": "changes-in-turnover-block",


### PR DESCRIPTION
### What is the context of this PR?
Adds a playback/confirmation block to MBS 0111.

### How to review 
Run MBS 0111. Check that the question "For the period {{start date}} to {{end date}} ,the value of the total turnover was {total_turnover}, is this correct?" is shown.

If "No" then user should be taken back to the turnover question. If "Yes" they should continue to the changes in total turnover question.