### PR TITLE
Fix issue with summary layout on smaller devices

### DIFF
--- a/app/templates/partials/summary/display-answer.html
+++ b/app/templates/partials/summary/display-answer.html
@@ -1,5 +1,5 @@
 <div class="grid__col col-8@xs {{ 'col-10@m' if is_textarea else 'col-4@m' }}">
-    <div class="summary__answer venus" id="{{ answer.id }}-answer" data-qa="{{ answer.id }}-answer">
+    <div class="summary__answer {{ 'summary__answer--textarea' if is_textarea }} venus" id="{{ answer.id }}-answer" data-qa="{{ answer.id }}-answer">
         {% include theme(['partials/summary/answer.html']) %}
     </div>
 </div>

--- a/app/templates/partials/summary/display-question.html
+++ b/app/templates/partials/summary/display-question.html
@@ -1,1 +1,1 @@
-<div class="summary__question mars" id="{{ question.id }}" data-qa="summary-question-title">{{ question.number or ''}} {{question.title|striptags }}</div>
+<div class="summary__question mars u-pb-s" id="{{ question.id }}" data-qa="summary-question-title">{{ question.number or ''}} {{question.title|striptags }}</div>

--- a/app/templates/partials/summary/edit-link.html
+++ b/app/templates/partials/summary/edit-link.html
@@ -1,5 +1,5 @@
 <div class="grid__col col-4@xs col-2@m">
-    <div class="summary__link mars">
+    <div class="summary__link {{ 'summary__link--textarea' if is_textarea }} mars">
         <a href="{{ block.link }}#{{ answer.id }}" class="summary__edit-link" aria-describedby="{{ answer.id }} {{ answer.id }}-answer" data-qa="{{ answer.id }}-edit" {{ helpers.track('click', 'Summary', 'Edit click') }}>Change <span class="u-vh">
         your answer for: {{ answer.label|striptags if has_multiple_answers else question.title|striptags }}. The current value is:
         {% include theme(['partials/summary/answer.html']) %}

--- a/app/templates/partials/summary/question-multiple-answers.html
+++ b/app/templates/partials/summary/question-multiple-answers.html
@@ -12,22 +12,13 @@
             <div class="summary__label mars">{{ answer.label|striptags }}</div>
         </div>
 
-        {%- if not is_textarea -%}
-            {%- include theme(['partials/summary/display-answer.html']) -%}
-        {%- endif %}
+        {%- include theme(['partials/summary/display-answer.html']) -%}
 
         {%- if content.summary.answers_are_editable -%}
             {% include theme(['partials/summary/edit-link.html']) -%}
         {%- endif -%}
 
     </div>
-
-    {%- if is_textarea -%}
-        <div class="grid">
-            {%- include theme(['partials/summary/display-answer.html']) -%}
-        </div>
-    {%- endif -%}
-
 {%- endfor -%}
 
 </div>

--- a/app/templates/partials/summary/question-single-answer.html
+++ b/app/templates/partials/summary/question-single-answer.html
@@ -7,19 +7,11 @@
             {%- include theme(['partials/summary/display-question.html']) -%}
         </div>
 
-        {%- if not is_textarea -%}
-            {%- include theme(['partials/summary/display-answer.html']) -%}
-        {%- endif -%}
+        {%- include theme(['partials/summary/display-answer.html']) -%}
 
         {%- if content.summary.answers_are_editable -%}
             {%- include theme(['partials/summary/edit-link.html']) -%}
         {%- endif %}
 
     </div>
-
-    {%- if is_textarea -%}
-    <div class="grid u-mt-s">
-        {%- include theme(['partials/summary/display-answer.html']) -%}
-    </div>
-    {%- endif -%}
 </div>


### PR DESCRIPTION
### What is the context of this PR?
PR to fix issue with summary on smaller devices.
 *Before:*
<img width="210" alt="screen shot 2018-06-20 at 15 18 56" src="https://user-images.githubusercontent.com/35296336/41664420-9a919588-749d-11e8-9106-56f89230c5d8.png">

*After:*
<img width="211" alt="screen shot 2018-06-20 at 15 19 53" src="https://user-images.githubusercontent.com/35296336/41664423-9ce0f8b0-749d-11e8-82eb-cc717e6e2996.png">

*Note: There is still a very minor issue with inconsistent padding on textarea answers. This will be fixed in the pattern lib in a future update as it requires additional CSS changes.*

Also for textarea answers, the `Change` link is now displayed after the answer for voice over usability purposes.

### How to review 
- Ensure summary page is tablet/mobile responsive