### PR TITLE
Add confirmation pages to MBS Employement Schemas

### DIFF
--- a/data/en/mbs_0173.json
+++ b/data/en/mbs_0173.json
@@ -254,6 +254,7 @@
                             "answers": [{
                                 "id": "commission-and-fees-answer",
                                 "label": "Total commission and fees excluding VAT",
+                                "description": "Enter value in full. For example, for 56 thousand you would enter 56,000",
                                 "type": "Currency",
                                 "currency": "GBP",
                                 "decimal_places": 2,
@@ -261,6 +262,47 @@
                                 "mandatory": true
                             }]
                         }]
+                    },
+                    {
+                        "type": "ConfirmationQuestion",
+                        "title": "Turnover",
+                        "id": "confirm-turnover-block",
+                        "questions": [{
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "confirm-turnover-answer",
+                                "q_code": "d40",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }],
+                            "id": "confirm-turnover-question",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total commission and fees was <em>{{answers['commission-and-fees-answer']|format_currency}}</em>, is this correct?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "value": "No",
+                                        "id": "confirm-turnover-answer",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "commission-and-fees-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "sales-on-own-account-block"
+                                }
+                            }
+                        ]
                     },
                     {
                         "id": "sales-on-own-account-block",

--- a/data/en/mbs_0251.json
+++ b/data/en/mbs_0251.json
@@ -294,6 +294,7 @@
                             "answers": [{
                                 "id": "turnover-answer",
                                 "label": "Total turnover excluding VAT",
+                                "description": "Enter value in full. For example, for 56 thousand you would enter 56,000",
                                 "type": "Currency",
                                 "currency": "GBP",
                                 "decimal_places": 2,
@@ -309,13 +310,6 @@
                         "type": "ConfirmationQuestion",
                         "title": "Total turnover",
                         "id": "confirm-zero-turnover-block",
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "turnover-answer",
-                                "condition": "greater than",
-                                "value": 0
-                            }]
-                        }],
                         "questions": [{
                             "type": "General",
                             "answers": [{
@@ -334,7 +328,7 @@
                                 "mandatory": true
                             }],
                             "id": "confirm-zero-turnover-question",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>£0</em>, is this correct?"
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -344,6 +338,16 @@
                                         "condition": "equals"
                                     }],
                                     "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "when": [{
+                                        "id": "turnover-answer",
+                                        "condition": "greater than",
+                                        "value": 0
+                                    }],
+                                    "block": "exports-block"
                                 }
                             },
                             {

--- a/data/en/mbs_0255.json
+++ b/data/en/mbs_0255.json
@@ -295,6 +295,7 @@
                             "answers": [{
                                 "id": "turnover-answer",
                                 "label": "Turnover excluding VAT",
+                                "description": "Enter value in full. For example, for 56 thousand you would enter 56,000",
                                 "type": "Currency",
                                 "currency": "GBP",
                                 "decimal_places": 2,
@@ -305,6 +306,47 @@
                             "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>turnover</em>, excluding VAT?"
                         }],
                         "title": "Turnover"
+                    },
+                    {
+                        "type": "ConfirmationQuestion",
+                        "title": "Turnover",
+                        "id": "confirm-turnover-block",
+                        "questions": [{
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "confirm-turnover-answer",
+                                "q_code": "d40",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }],
+                            "id": "confirm-turnover-question",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "value": "No",
+                                        "id": "confirm-turnover-answer",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "exports-block"
+                                }
+                            }
+                        ]
                     },
                     {
                         "id": "exports-block",

--- a/data/en/mbs_0867.json
+++ b/data/en/mbs_0867.json
@@ -283,6 +283,7 @@
                             "answers": [{
                                 "id": "turnover-answer",
                                 "label": "Total turnover excluding VAT",
+                                "description": "Enter value in full. For example, for 56 thousand you would enter 56,000",
                                 "type": "Currency",
                                 "currency": "GBP",
                                 "decimal_places": 2,
@@ -293,6 +294,47 @@
                             "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>total turnover</em>, excluding VAT?"
                         }],
                         "title": "Total turnover"
+                    },
+                    {
+                        "type": "ConfirmationQuestion",
+                        "title": "Total turnover",
+                        "id": "confirm-turnover-block",
+                        "questions": [{
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "confirm-turnover-answer",
+                                "q_code": "d40",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }],
+                            "id": "confirm-turnover-question",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "value": "No",
+                                        "id": "confirm-turnover-answer",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "number-of-employees-total-block"
+                                }
+                            }
+                        ]
                     },
                     {
                         "id": "number-of-employees-total-block",


### PR DESCRIPTION
### What is the context of this PR?
Add confirmation pages after turnover type questions to avoid users missing "thousands" (000s) from their answer.

### How to review 
Added to surveys `mbs_0173.json`, `mbs_0251.json`, `mbs_0255.json`, `mbs_0867.json`
MBS 0251 also had additional routing based on zero response.
