### PR TITLE
Add confirmation pages to MBS for non employment

### DIFF
--- a/data/en/mbs_0106.json
+++ b/data/en/mbs_0106.json
@@ -230,6 +230,7 @@
                             "answers": [{
                                 "id": "turnover-answer",
                                 "label": "Total turnover excluding VAT",
+                                "description": "Enter value in full. For example, for 56 thousand you would enter 56,000",
                                 "type": "Currency",
                                 "currency": "GBP",
                                 "decimal_places": 2,
@@ -240,6 +241,47 @@
                             "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>total turnover</em>, excluding VAT?"
                         }],
                         "title": "Total turnover"
+                    },
+                    {
+                        "type": "ConfirmationQuestion",
+                        "title": "Total turnover",
+                        "id": "confirm-turnover-block",
+                        "questions": [{
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "confirm-turnover-answer",
+                                "q_code": "d40",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }],
+                            "id": "confirm-turnover-question",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "value": "No",
+                                        "id": "confirm-turnover-answer",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "changes-in-total-turnover-block"
+                                }
+                            }
+                        ]
                     },
                     {
                         "id": "changes-in-total-turnover-block",

--- a/data/en/mbs_0117.json
+++ b/data/en/mbs_0117.json
@@ -240,6 +240,7 @@
                             "answers": [{
                                 "id": "turnover-answer",
                                 "label": "Turnover excluding VAT",
+                                "description": "Enter value in full. For example, for 56 thousand you would enter 56,000",
                                 "type": "Currency",
                                 "currency": "GBP",
                                 "decimal_places": 2,
@@ -250,6 +251,47 @@
                             "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>turnover</em>, excluding VAT?"
                         }],
                         "title": "Turnover"
+                    },
+                    {
+                        "type": "ConfirmationQuestion",
+                        "title": "Turnover",
+                        "id": "confirm-turnover-block",
+                        "questions": [{
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "confirm-turnover-answer",
+                                "q_code": "d40",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }],
+                            "id": "confirm-turnover-question",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "value": "No",
+                                        "id": "confirm-turnover-answer",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "grants-funding-block"
+                                }
+                            }
+                        ]
                     },
                     {
                         "id": "grants-funding-block",

--- a/data/en/mbs_0123.json
+++ b/data/en/mbs_0123.json
@@ -202,6 +202,7 @@
                             "answers": [{
                                 "id": "commission-and-fees-answer",
                                 "label": "Total commission and fees excluding VAT",
+                                "description": "Enter value in full. For example, for 56 thousand you would enter 56,000",
                                 "type": "Currency",
                                 "currency": "GBP",
                                 "decimal_places": 2,
@@ -209,6 +210,47 @@
                                 "mandatory": true
                             }]
                         }]
+                    },
+                    {
+                        "type": "ConfirmationQuestion",
+                        "title": "Commission and fees",
+                        "id": "confirm-commission-and-fees-block",
+                        "questions": [{
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "confirm-commission-and-fees-answer",
+                                "q_code": "d40",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }],
+                            "id": "confirm-commission-and-fees-question",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total commission and fees was <em>{{answers['commission-and-fees-answer']|format_currency}}</em>, is this correct?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "value": "No",
+                                        "id": "confirm-commission-and-fees-answer",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "commission-and-fees-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "sales-on-own-account-block"
+                                }
+                            }
+                        ]
                     },
                     {
                         "id": "sales-on-own-account-block",

--- a/data/en/mbs_0201.json
+++ b/data/en/mbs_0201.json
@@ -237,6 +237,7 @@
                             "answers": [{
                                 "id": "turnover-answer",
                                 "label": "Total turnover excluding VAT",
+                                "description": "Enter value in full. For example, for 56 thousand you would enter 56,000",
                                 "type": "Currency",
                                 "currency": "GBP",
                                 "decimal_places": 2,
@@ -251,19 +252,12 @@
                     {
                         "type": "ConfirmationQuestion",
                         "title": "Total turnover",
-                        "id": "confirm-zero-turnover-block",
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "turnover-answer",
-                                "condition": "greater than",
-                                "value": 0
-                            }]
-                        }],
+                        "id": "confirm-turnover-block",
                         "questions": [{
                             "type": "General",
                             "answers": [{
                                 "type": "Radio",
-                                "id": "confirm-zero-turnover-answer",
+                                "id": "confirm-turnover-answer",
                                 "q_code": "d40",
                                 "options": [{
                                         "label": "Yes this is correct",
@@ -276,17 +270,27 @@
                                 ],
                                 "mandatory": true
                             }],
-                            "id": "confirm-zero-turnover-question",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>£0</em>, is this correct?"
+                            "id": "confirm-turnover-question",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
                         }],
                         "routing_rules": [{
                                 "goto": {
                                     "when": [{
                                         "value": "No",
-                                        "id": "confirm-zero-turnover-answer",
+                                        "id": "confirm-turnover-answer",
                                         "condition": "equals"
                                     }],
                                     "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "when": [{
+                                        "id": "turnover-answer",
+                                        "condition": "greater than",
+                                        "value": 0
+                                    }],
+                                    "block": "exports-block"
                                 }
                             },
                             {

--- a/data/en/mbs_0202.json
+++ b/data/en/mbs_0202.json
@@ -237,6 +237,7 @@
                             "answers": [{
                                 "id": "turnover-answer",
                                 "label": "Total turnover excluding VAT",
+                                "description": "Enter value in full. For example, for 56 thousand you would enter 56,000",
                                 "type": "Currency",
                                 "currency": "GBP",
                                 "decimal_places": 2,
@@ -251,19 +252,12 @@
                     {
                         "type": "ConfirmationQuestion",
                         "title": "Total turnover",
-                        "id": "confirm-zero-turnover-block",
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "turnover-answer",
-                                "condition": "greater than",
-                                "value": 0
-                            }]
-                        }],
+                        "id": "confirm-turnover-block",
                         "questions": [{
                             "type": "General",
                             "answers": [{
                                 "type": "Radio",
-                                "id": "confirm-zero-turnover-answer",
+                                "id": "confirm-turnover-answer",
                                 "q_code": "d40",
                                 "options": [{
                                         "label": "Yes this is correct",
@@ -276,17 +270,27 @@
                                 ],
                                 "mandatory": true
                             }],
-                            "id": "confirm-zero-turnover-question",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>£0</em>, is this correct?"
+                            "id": "confirm-turnover-question",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
                         }],
                         "routing_rules": [{
                                 "goto": {
                                     "when": [{
                                         "value": "No",
-                                        "id": "confirm-zero-turnover-answer",
+                                        "id": "confirm-turnover-answer",
                                         "condition": "equals"
                                     }],
                                     "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "when": [{
+                                        "id": "turnover-answer",
+                                        "condition": "greater than",
+                                        "value": 0
+                                    }],
+                                    "block": "exports-block"
                                 }
                             },
                             {

--- a/data/en/mbs_0205.json
+++ b/data/en/mbs_0205.json
@@ -236,6 +236,7 @@
                             "answers": [{
                                 "id": "turnover-answer",
                                 "label": "Turnover excluding VAT",
+                                "description": "Enter value in full. For example, for 56 thousand you would enter 56,000",
                                 "type": "Currency",
                                 "currency": "GBP",
                                 "decimal_places": 2,
@@ -246,6 +247,47 @@
                             "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>turnover</em>, excluding VAT?"
                         }],
                         "title": "Turnover"
+                    },
+                    {
+                        "type": "ConfirmationQuestion",
+                        "title": "Turnover",
+                        "id": "confirm-turnover-block",
+                        "questions": [{
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "confirm-turnover-answer",
+                                "q_code": "d40",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }],
+                            "id": "confirm-turnover-question",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "value": "No",
+                                        "id": "confirm-turnover-answer",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "exports-block"
+                                }
+                            }
+                        ]
                     },
                     {
                         "id": "exports-block",

--- a/data/en/mbs_0817.json
+++ b/data/en/mbs_0817.json
@@ -226,6 +226,7 @@
                             "answers": [{
                                 "id": "turnover-answer",
                                 "label": "Total turnover excluding VAT",
+                                "description": "Enter value in full. For example, for 56 thousand you would enter 56,000",
                                 "type": "Currency",
                                 "currency": "GBP",
                                 "decimal_places": 2,
@@ -236,6 +237,47 @@
                             "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>total turnover</em>, excluding VAT?"
                         }],
                         "title": "Total turnover"
+                    },
+                    {
+                        "type": "ConfirmationQuestion",
+                        "title": "Total turnover",
+                        "id": "confirm-turnover-block",
+                        "questions": [{
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "confirm-turnover-answer",
+                                "q_code": "d40",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }],
+                            "id": "confirm-turnover-question",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "value": "No",
+                                        "id": "confirm-turnover-answer",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "changes-in-turnover-block"
+                                }
+                            }
+                        ]
                     },
                     {
                         "id": "changes-in-turnover-block",


### PR DESCRIPTION
### What is the context of this PR?
Add confirmation pages after turnover type questions to avoid users missing "thousands" (000s) from their answer.
### How to review 
Added to surveys mbs_0106.json, mbs_0117.json, mbs_0123.json, mbs_0201.json, mbs_0202.json, mbs_0205.json, mbs_0817.json,
