### PR TITLE
Add Turnover guidance and confirmation to MBS surveys

### DIFF
--- a/data/en/mbs_0216.json
+++ b/data/en/mbs_0216.json
@@ -236,6 +236,7 @@
                             "answers": [{
                                 "id": "turnover-answer",
                                 "label": "Turnover excluding VAT",
+                                "description": "Enter value in full. For example, for 56 thousand you would enter 56,000",
                                 "type": "Currency",
                                 "currency": "GBP",
                                 "decimal_places": 2,
@@ -246,6 +247,47 @@
                             "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>turnover</em>, excluding VAT?"
                         }],
                         "title": "Turnover"
+                    },
+                    {
+                        "type": "ConfirmationQuestion",
+                        "title": "Turnover",
+                        "id": "confirm-turnover-block",
+                        "questions": [{
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "confirm-turnover-answer",
+                                "q_code": "d40",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }],
+                            "id": "confirm-turnover-question",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "value": "No",
+                                        "id": "confirm-turnover-answer",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "exports-block"
+                                }
+                            }
+                        ]
                     },
                     {
                         "id": "exports-block",

--- a/data/en/mbs_0823.json
+++ b/data/en/mbs_0823.json
@@ -226,6 +226,7 @@
                             "answers": [{
                                 "id": "turnover-answer",
                                 "label": "Total turnover excluding VAT",
+                                "description": "Enter value in full. For example, for 56 thousand you would enter 56,000",
                                 "type": "Currency",
                                 "currency": "GBP",
                                 "decimal_places": 2,
@@ -236,6 +237,47 @@
                             "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>total turnover</em>, excluding VAT?"
                         }],
                         "title": "Total Turnover"
+                    },
+                    {
+                        "type": "ConfirmationQuestion",
+                        "title": "Total turnover",
+                        "id": "confirm-turnover-block",
+                        "questions": [{
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "confirm-turnover-answer",
+                                "q_code": "d40",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }],
+                            "id": "confirm-turnover-question",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "value": "No",
+                                        "id": "confirm-turnover-answer",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "changes-in-turnover-block"
+                                }
+                            }
+                        ]
                     },
                     {
                         "id": "changes-in-turnover-block",

--- a/data/en/mbs_0873.json
+++ b/data/en/mbs_0873.json
@@ -283,6 +283,7 @@
                             "answers": [{
                                 "id": "turnover-answer",
                                 "label": "Total turnover excluding VAT",
+                                "description": "Enter value in full. For example, for 56 thousand you would enter 56,000",
                                 "type": "Currency",
                                 "currency": "GBP",
                                 "decimal_places": 2,
@@ -293,6 +294,47 @@
                             "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}’s <em>total turnover</em>, excluding VAT?"
                         }],
                         "title": "Total Turnover"
+                    },
+                    {
+                        "type": "ConfirmationQuestion",
+                        "title": "Total turnover",
+                        "id": "confirm-turnover-block",
+                        "questions": [{
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "confirm-turnover-answer",
+                                "q_code": "d40",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }],
+                            "id": "confirm-turnover-question",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "value": "No",
+                                        "id": "confirm-turnover-answer",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "number-of-employees-total-block"
+                                }
+                            }
+                        ]
                     },
                     {
                         "id": "number-of-employees-total-block",


### PR DESCRIPTION
### What is the context of this PR?
Add confirmation pages after turnover type questions to avoid users missing "thousands" (000s) from their answer.
Description (guidance) added to Turnover question above answer field.

### How to review
Added to surveys mbs_0216.json, mbs_0823.json and mbs_00873.json.
