### PR TITLE
Remove group_id & block_id from payload docstring

### DIFF
--- a/app/submitter/convert_payload_0_0_2.py
+++ b/app/submitter/convert_payload_0_0_2.py
@@ -4,25 +4,19 @@ def convert_answers_to_payload_0_0_2(answer_store, schema, routing_path):
     'data': [
         {
             'value': 'Joe Bloggs',
-            'block_id': 'household-composition',
             'answer_id': 'household-full-name',
-            'group_id': 'multiple-questions-group',
             'group_instance': 0,
             'answer_instance': 0
         },
         {
             'value': 'Fred Flintstone',
-            'block_id': 'household-composition',
             'answer_id': 'household-full-name',
-            'group_id': 'multiple-questions-group',
             'group_instance': 0,
             'answer_instance': 1
         },
         {
             'value': 'Husband or wife',
-            'block_id': 'relationships',
             'answer_id': 'who-is-related',
-            'group_id': 'household-relationships',
             'group_instance': 0,
             'answer_instance': 0
         }


### PR DESCRIPTION
We no longer pass the group_id or block_id in the 0.0.2 payload. Just updating the docstring to reflect this.