### PR TITLE
Fix displaying of submitted response copy on summary page

### DIFF
--- a/app/templates/summary.html
+++ b/app/templates/summary.html
@@ -37,8 +37,8 @@
 
 {% include theme('partials/summary/summary.html') %}
 
-{% if content.is_view_submission_response_enabled %}
-  <div class="u-mb-s u-mb-m@s">
+{% if content.summary.is_view_submission_response_enabled %}
+  <div class="u-mb-s u-mb-m@s" data-qa="view-submission-text">
     <div class="venus">{{ _("You will have the opportunity to view and print a copy of your answers after submitting this questionnaire") }}</div>
   </div>
 {% endif %}

--- a/app/templating/view_context.py
+++ b/app/templating/view_context.py
@@ -125,7 +125,7 @@ def build_view_context_for_summary(metadata, answer_store, schema_context, block
 
 
 def is_view_submitted_response_enabled(schema):
-    if not is_dynamodb_enabled():
+    if is_dynamodb_enabled():
         view_submitted_response = schema.get('view_submitted_response')
         if view_submitted_response:
             return view_submitted_response['enabled']

--- a/tests/functional/pages/summary.page.js
+++ b/tests/functional/pages/summary.page.js
@@ -1,2 +1,15 @@
 const QuestionPage = require('./surveys/question.page');
-module.exports = new QuestionPage('summary');
+
+class ThankYouPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  viewSubmissionText() {
+    return '[data-qa="view-submission-text"]';
+  }
+
+}
+
+module.exports = new ThankYouPage();

--- a/tests/functional/spec/features/submitted_responses.spec.js
+++ b/tests/functional/spec/features/submitted_responses.spec.js
@@ -15,15 +15,15 @@ describe('Feature: Submitted Responses', function() {
           .click(RadioPage.bacon())
           .click(RadioPage.submit())
           .setValue(NumberBlockPage.testCurrency(), 123.45)
-          .click(NumberBlockPage.submit())
-          .click(SummaryPage.submit());
-
+          .click(NumberBlockPage.submit());
     });
   });
 
   describe('Check submitted responses', function() {
     it('Given I complete to Thank-You page, When I click the submitted answers link, Then I should be able to view my submitted answers', function() {
         return browser
+          .getText(SummaryPage.viewSubmissionText()).should.eventually.contain('opportunity to view and print a copy of your answers')
+          .click(SummaryPage.submit())
           .click(ThankYouPage.viewSubmitted())
           .getUrl().should.eventually.contain('view-submission')
           .getText(SubmissionPage.radioAnswer()).should.eventually.contain('Bacon')
@@ -32,6 +32,7 @@ describe('Feature: Submitted Responses', function() {
 
     it('Given I am viewing my submitted answers, When I click refresh after the timeout period, Then I should be routed back to Thank You page', function() {
         return browser
+          .click(SummaryPage.submit())
           .waitUntil(function () {
             return browser
               .refresh()
@@ -43,6 +44,7 @@ describe('Feature: Submitted Responses', function() {
   describe('Try to click view submission link after timeout', function() {
     it('Given I complete to Thank-You page, When I click the submitted answers link after the timeout period, Then I should not be able to view my submitted answers', function() {
         return browser
+          .click(SummaryPage.submit())
           .isVisible(ThankYouPage.viewSubmitted())
           .pause(5000)
           .click(ThankYouPage.viewSubmitted())
@@ -53,6 +55,7 @@ describe('Feature: Submitted Responses', function() {
   describe('Check view submission link has expired after timeout', function() {
     it('Given I complete to Thank-You page, When I refresh after the timeout period, Then I should not be able to view my submitted answers', function() {
         return browser
+          .click(SummaryPage.submit())
           .isVisible(ThankYouPage.viewSubmitted())
           .waitUntil(function () {
             return browser


### PR DESCRIPTION
### What is the context of this PR?
When viewing the summary page of a schema with submitted responses, there's supposed to be a bit of copy telling the user they can print/copy their answers

### How to review 
In `dev_settings.sh` set `EQ_DYNAMODB_ENABLED=True`. Run `test_view_submitted_response.json` and go through to the summary, at the bottom you should see the copy 'You will have the opportunity...'.  Try a different survey and see that the copy isn't there.
