### PR TITLE
Bilingual: set the current locale in survey runner based on language_code

### DIFF
--- a/app/authentication/authenticator.py
+++ b/app/authentication/authenticator.py
@@ -2,7 +2,7 @@ from uuid import uuid4
 
 from blinker import ANY
 from flask import session as cookie_session, current_app
-from flask_login import LoginManager, user_logged_out
+from flask_login import LoginManager, user_logged_out, login_user
 from sdc.crypto.decrypter import decrypt
 from structlog import get_logger
 
@@ -110,6 +110,11 @@ def store_session(metadata):
     questionnaire_store = get_questionnaire_store(user_id, user_ik)
     questionnaire_store.metadata = metadata
     questionnaire_store.add_or_update()
+
+    # Set the user in Flask such that anyone calling current_user for the duration of this request doesn't have to
+    # load it from the db.
+    login_user(User(user_id, user_ik))
+
     logger.info('user authenticated')
 
 

--- a/app/authentication/user.py
+++ b/app/authentication/user.py
@@ -8,3 +8,6 @@ class User(UserMixin):
             self.user_ik = user_ik
         else:
             raise ValueError('No user_id or user_ik found in session')
+
+    def get_id(self):
+        return self.user_id

--- a/app/forms/date_form.py
+++ b/app/forms/date_form.py
@@ -5,10 +5,9 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
 from wtforms import Form, SelectField, StringField
-from flask_babel import gettext as _
+from flask_babel import gettext as _, get_locale
 from babel.dates import get_month_names
 
-from app.settings import BABEL_DEFAULT_LOCALE
 from app.forms.custom_fields import CustomIntegerField
 from app.questionnaire.rules import get_metadata_value, get_answer_store_value, convert_to_datetime
 from app.validation.validators import DateCheck, OptionalForm, DateRequired, MonthYearCheck, YearCheck, SingleDatePeriodCheck
@@ -129,7 +128,7 @@ def get_bespoke_message(answer, message_type):
 
 
 def get_month_selection_field(validate_with):
-    month_names = get_month_names(locale=BABEL_DEFAULT_LOCALE)
+    month_names = get_month_names(locale=get_locale())
     month_choices = [('', _('Select month'))] + [(str(key), month_names[key]) for key in range(1, 13)]
     return SelectField(choices=month_choices, default='', validators=validate_with)
 

--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -4,13 +4,13 @@ import string
 from datetime import datetime
 
 import flask
+import flask_babel
 from dateutil import relativedelta, tz
 from jinja2 import Markup, contextfunction, escape, evalcontextfilter, evalcontextfunction
 from jinja2.exceptions import UndefinedError
 
-from babel import units, numbers, dates
+from babel import units, numbers
 
-from app.settings import BABEL_DEFAULT_LOCALE
 from app.questionnaire.rules import convert_to_datetime
 from app.settings import DEFAULT_LOCALE
 
@@ -96,7 +96,8 @@ def format_date(context, value):
     if value and re.match(r'\d{4}$', value):
         date_format = 'YYYY'
     result = "<span class='date'>{date}</span>".format(
-        date=dates.format_date(convert_to_datetime(value), format=date_format, locale=BABEL_DEFAULT_LOCALE))
+        date=flask_babel.format_date(convert_to_datetime(value), format=date_format))
+
     return mark_safe(context, result)
 
 
@@ -104,10 +105,9 @@ def format_date(context, value):
 @blueprint.app_template_filter()
 def format_datetime(context, value, date_format="d MMMM YYYY 'at' HH:mm"):
 
-    london_date_time = as_london_tz(datetime.strptime(value, '%Y-%m-%dT%H:%M:%S.%f'))
-    result = "<span class='date'>{date}</span>".format(date=dates.format_datetime(london_date_time,
-                                                                                  format=date_format,
-                                                                                  locale=BABEL_DEFAULT_LOCALE))
+    london_date_time = datetime.strptime(value, '%Y-%m-%dT%H:%M:%S.%f')
+    result = "<span class='date'>{date}</span>".format(date=flask_babel.format_datetime(london_date_time,
+                                                                                        format=date_format))
     return mark_safe(context, result)
 
 

--- a/app/questionnaire/questionnaire_schema.py
+++ b/app/questionnaire/questionnaire_schema.py
@@ -1,12 +1,19 @@
 import itertools
 from collections import OrderedDict
+
+from flask_babel import force_locale
+
 from app.validation.error_messages import error_messages
 from app.questionnaire.answer_dependencies import get_dependencies
 
 
+DEFAULT_LANGUAGE_CODE = 'en'
+
+
 class QuestionnaireSchema(object):  # pylint: disable=too-many-public-methods
-    def __init__(self, questionnaire_json):
+    def __init__(self, questionnaire_json, language_code=DEFAULT_LANGUAGE_CODE):
         self.json = questionnaire_json
+        self.language_code = language_code
         self._parse_schema()
 
     @property
@@ -202,7 +209,10 @@ class QuestionnaireSchema(object):  # pylint: disable=too-many-public-methods
         )
 
     def _get_error_messages(self):
-        messages = error_messages.copy()
+        # Force translation of global error messages (stored as LazyString's) into the language of the schema.
+        with force_locale(self.language_code):
+            messages = {k: str(v) for k, v in error_messages.items()}
+
         if 'messages' in self.json:
             messages.update(self.json['messages'])
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -95,5 +95,3 @@ SQLALCHEMY_DATABASE_URI = os.getenv('SQLALCHEMY_DATABASE_URI')
 USER_IK = 'user_ik'
 EQ_SESSION_ID = 'eq-session-id'
 ACCOUNT_URL = 'account_url'
-
-BABEL_DEFAULT_LOCALE = 'en'

--- a/app/setup.py
+++ b/app/setup.py
@@ -24,6 +24,7 @@ from app.authentication.authenticator import login_manager
 from app.authentication.cookie_session import SHA256SecureCookieSessionInterface
 from app.authentication.user_id_generator import UserIDGenerator
 from app.data_model.models import EQSession, QuestionnaireState, db
+from app.globals import get_session_store
 from app.keys import KEY_PURPOSE_SUBMISSION
 from app.new_relic import setup_newrelic
 from app.secrets import SecretStore, validate_required_secrets
@@ -324,6 +325,20 @@ def setup_secure_cookies(application):
 def setup_babel(application):
     application.babel = Babel(application)
     application.jinja_env.add_extension('jinja2.ext.i18n')
+
+    @application.babel.localeselector
+    def get_locale():  # pylint: disable=unused-variable
+        session = get_session_store()
+
+        if not session:
+            return None
+
+        return session.session_data.language_code
+
+    @application.babel.timezoneselector
+    def get_timezone():  # pylint: disable=unused-variable
+        # For now regardless of locale we will show times in GMT/BST
+        return 'Europe/London'
 
 
 def add_safe_health_check(application):

--- a/app/templates/thank-you.html
+++ b/app/templates/thank-you.html
@@ -5,7 +5,7 @@
 {% block main %}
 
 <div class="u-mb-s">
-    <h1 class="saturn">{{ _("Submission successful") }}</h1>
+    <h1 class="saturn" data-qa="submission-successful-title">{{ _("Submission successful") }}</h1>
 </div>
 
 {% if metadata.trad_as %}

--- a/app/validation/validators.py
+++ b/app/validation/validators.py
@@ -2,15 +2,17 @@ from decimal import Decimal, InvalidOperation
 from datetime import datetime
 
 import re
-from babel import numbers, dates
+
+import flask_babel
 from flask_babel import lazy_gettext as _, ngettext
+from babel import numbers
 from dateutil.relativedelta import relativedelta
 from wtforms import validators
 from wtforms.compat import string_types
 from structlog import get_logger
 
 from app.jinja_filters import format_number, format_currency
-from app.settings import DEFAULT_LOCALE, BABEL_DEFAULT_LOCALE
+from app.settings import DEFAULT_LOCALE
 from app.validation.error_messages import error_messages
 from app.questionnaire.rules import convert_to_datetime
 
@@ -247,7 +249,7 @@ class SingleDatePeriodCheck:
 
     @staticmethod
     def _format_playback_date(date, date_format='d MMMM YYYY'):
-        return dates.format_date(date, format=date_format, locale=BABEL_DEFAULT_LOCALE)
+        return flask_babel.format_date(date, format=date_format)
 
 
 class DateRangeCheck:

--- a/app/views/dump.py
+++ b/app/views/dump.py
@@ -4,9 +4,9 @@ from flask import Blueprint, jsonify
 
 
 from app.authentication.roles import role_required
-from app.globals import get_answer_store, get_metadata, get_completed_blocks
+from app.globals import get_answer_store, get_metadata, get_completed_blocks, get_session_store
 from app.submitter.converter import convert_answers
-from app.utilities.schema import load_schema_from_metadata
+from app.utilities.schema import load_schema_from_session_data
 from app.questionnaire.path_finder import PathFinder
 
 
@@ -27,7 +27,8 @@ def dump_answers():
 def dump_submission():
     answer_store = get_answer_store(current_user)
     metadata = get_metadata(current_user)
-    schema = load_schema_from_metadata(metadata)
+    session_data = get_session_store().session_data
+    schema = load_schema_from_session_data(session_data)
     completed_blocks = get_completed_blocks(current_user)
     routing_path = PathFinder(schema, answer_store, metadata, completed_blocks).get_full_routing_path()
     response = {'submission': convert_answers(metadata, schema, answer_store, routing_path)}

--- a/app/views/feedback.py
+++ b/app/views/feedback.py
@@ -9,9 +9,9 @@ from structlog import get_logger
 from app.helpers import template_helper
 from app.keys import KEY_PURPOSE_SUBMISSION
 from app.submitter.submission_failed import SubmissionFailedException
-from app.globals import get_metadata
+from app.globals import get_metadata, get_session_store
 from app.submitter.converter import convert_feedback
-from app.utilities.schema import load_schema_from_metadata
+from app.utilities.schema import load_schema_from_session_data
 
 logger = get_logger()
 
@@ -30,10 +30,10 @@ class FeedbackForm(FlaskForm):
 def before_request():
     logger.info('feedback request', url_path=request.full_path)
 
-    metadata = get_metadata(current_user)
-    if metadata:
-        logger.bind(tx_id=metadata['tx_id'])
-        g.schema = load_schema_from_metadata(metadata)
+    session = get_session_store()
+    if session:
+        logger.bind(tx_id=session.session_data.tx_id)
+        g.schema = load_schema_from_session_data(session.session_data)
 
 
 @feedback_blueprint.route('', methods=['GET'])

--- a/data/cy/test_language.json
+++ b/data/cy/test_language.json
@@ -21,13 +21,26 @@
     "sections": [{
         "id": "default-section",
         "groups": [{
-            "id": "welsh-group",
+            "id": "language-group",
             "title": "",
             "blocks": [{
-                    "type": "Interstitial",
-                    "id": "welsh-block",
-                    "title": "Holiadur Cymraeg",
-                    "questions": []
+                    "type": "Question",
+                    "id": "language-block",
+                    "description": "",
+                    "questions": [{
+                        "answers": [{
+                            "id": "month-year-answer",
+                            "label": "Dyddiad",
+                            "mandatory": true,
+                            "q_code": "11",
+                            "type": "MonthYearDate"
+                        }],
+                        "description": "",
+                        "id": "month-year-question",
+                        "title": "Dyddiad gyda mis a blwyddyn",
+                        "type": "General"
+                    }],
+                    "title": "Holiadur Cymraeg"
                 },
                 {
                     "type": "Summary",

--- a/data/en/test_language.json
+++ b/data/en/test_language.json
@@ -21,13 +21,26 @@
     "sections": [{
         "id": "default-section",
         "groups": [{
-            "id": "english-group",
+            "id": "language-group",
             "title": "",
             "blocks": [{
-                    "type": "Interstitial",
-                    "id": "english-block",
-                    "title": "English language schema",
-                    "questions": []
+                    "type": "Question",
+                    "id": "language-block",
+                    "description": "",
+                    "questions": [{
+                        "answers": [{
+                            "id": "month-year-answer",
+                            "label": "Date",
+                            "mandatory": true,
+                            "q_code": "11",
+                            "type": "MonthYearDate"
+                        }],
+                        "description": "",
+                        "id": "month-year-question",
+                        "title": "Date with month and year",
+                        "type": "General"
+                    }],
+                    "title": "English Questionnaire"
                 },
                 {
                     "type": "Summary",

--- a/data/schema/feedback_v1.json
+++ b/data/schema/feedback_v1.json
@@ -1,76 +1,76 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema",
-  "$id": "https://edc.ons.gov.uk/schemas/feedback_v1.json",
-  "type": "object",
-  "properties": {
-    "tx_id": {
-      "type": "string",
-      "description": "Survey transaction identifier. This will be the same for all feedback during a survey session.",
-      "pattern": "^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$"
-    },
-    "type": {
-      "type": "string",
-      "pattern": "^uk.gov.ons.edc.eq:feedback$"
-    },
-    "version": {
-      "type": "string",
-      "pattern": "^0.0.1$"
-    },
-    "origin": {
-      "type": "string",
-      "pattern": "^uk.gov.ons.edc.eq$"
-    },
-    "survey_id": {
-      "type": "string",
-      "description": "The ONS id of the survey derived from the inquiry code already in use for that survey.",
-      "pattern": "^[0-9]{3}$"
-    },
-    "collection": {
-      "type": "object",
-      "properties": {
-        "exercise_sid": {
-          "type": "string"
+    "$schema": "http://json-schema.org/draft-06/schema",
+    "$id": "https://edc.ons.gov.uk/schemas/feedback_v1.json",
+    "type": "object",
+    "properties": {
+        "tx_id": {
+            "type": "string",
+            "description": "Survey transaction identifier. This will be the same for all feedback during a survey session.",
+            "pattern": "^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$"
         },
-        "instrument_id":{
-          "type": "string"
+        "type": {
+            "type": "string",
+            "pattern": "^uk.gov.ons.edc.eq:feedback$"
         },
-        "period": {
-          "type": "string"
+        "version": {
+            "type": "string",
+            "pattern": "^0.0.1$"
+        },
+        "origin": {
+            "type": "string",
+            "pattern": "^uk.gov.ons.edc.eq$"
+        },
+        "survey_id": {
+            "type": "string",
+            "description": "The ONS id of the survey derived from the inquiry code already in use for that survey.",
+            "pattern": "^[0-9]{3}$"
+        },
+        "collection": {
+            "type": "object",
+            "properties": {
+                "exercise_sid": {
+                    "type": "string"
+                },
+                "instrument_id": {
+                    "type": "string"
+                },
+                "period": {
+                    "type": "string"
+                }
+            }
+        },
+        "submitted_at": {
+            "type": "string",
+            "description": "Time at which survey feedback was submitted.",
+            "format": "date-time"
+        },
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string"
+                },
+                "ru_ref": {
+                    "type": "string"
+                }
+            }
+        },
+        "data": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
         }
-      }
-    },
-    "submitted_at": {
-      "type": "string",
-      "description": "Time at which survey feedback was submitted.",
-      "format": "date-time"
-    },
-    "metadata": {
-      "type": "object",
-      "properties": {
-        "user_id": {
-          "type": "string"
-        },
-        "ru_ref": {
-          "type": "string"
-        }
-      }
-    },
-    "data": {
-      "type": "object",
-      "properties": {
-        "message": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "email": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        }
-      }
     }
-  }
 }

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -4,7 +4,6 @@ import del from 'del'
 import yargs from 'yargs'
 import prettify from 'gulp-jsbeautifier'
 import diff from 'gulp-diff'
-import merge from 'merge-stream'
 
 import { paths } from './gulp/paths'
 import { copyScripts, bundle, lint as lintScripts, lintFunctionalTests } from './gulp/scripts'
@@ -172,7 +171,7 @@ gulp.task('lint', ['lint:styles', 'lint:scripts', 'lint:json', 'lint:tests'])
 
 gulp.task('lint:json', () => {
   return gulp
-    .src(['./data/en/*.json'])
+    .src(['./data/*/*.json'])
     .pipe(prettify({end_with_newline: true}))
     .pipe(diff())
     .pipe(
@@ -188,15 +187,8 @@ gulp.task('lint:json', () => {
 })
 
 gulp.task('format:json', () => {
-  let schemas = gulp
-    .src(['./data/en/*.json'])
+  return gulp
+    .src(['./data/*/*.json'])
     .pipe(prettify({end_with_newline: true}))
-    .pipe(gulp.dest('./data/en/'))
-
-  let schemaDef = gulp
-    .src(['./data/schema/schema-v1.json'])
-    .pipe(prettify({end_with_newline: true}))
-    .pipe(gulp.dest('./data/schema'))
-
-  return merge(schemas, schemaDef)
+    .pipe(gulp.dest('./data/'))
 })

--- a/tests/app/forms/test_date_form.py
+++ b/tests/app/forms/test_date_form.py
@@ -20,7 +20,8 @@ class TestDateForm(AppContextTestCase):
 
         answers = schema.get_answers_by_id_for_block('date-block')
 
-        form = get_date_form(AnswerStore(), {}, answers['single-date-answer'], error_messages=error_messages)
+        with self.test_request_context('/'):
+            form = get_date_form(AnswerStore(), {}, answers['single-date-answer'], error_messages=error_messages)
 
         self.assertTrue(hasattr(form, 'day'))
         self.assertTrue(hasattr(form, 'month'))
@@ -32,7 +33,8 @@ class TestDateForm(AppContextTestCase):
 
         answers = schema.get_answers_by_id_for_block('date-block')
 
-        form = get_month_year_form(answers['month-year-answer'], {}, {}, error_messages=error_messages)
+        with self.test_request_context('/'):
+            form = get_month_year_form(answers['month-year-answer'], {}, {}, error_messages=error_messages)
 
         self.assertFalse(hasattr(form, 'day'))
         self.assertTrue(hasattr(form, 'month'))
@@ -50,7 +52,6 @@ class TestDateForm(AppContextTestCase):
         self.assertFalse(hasattr(form, 'month'))
         self.assertTrue(hasattr(form, 'year'))
 
-
     def test_generate_date_form_validates_single_date_period(self):
         schema = load_schema_from_params('test', 'date_validation_single')
         error_messages = schema.error_messages
@@ -58,7 +59,8 @@ class TestDateForm(AppContextTestCase):
 
         answers = schema.get_answers_by_id_for_block('date-range-block')
 
-        form = get_date_form(AnswerStore(), test_metadata, answers['date-range-from'], error_messages=error_messages)
+        with self.test_request_context('/'):
+            form = get_date_form(AnswerStore(), test_metadata, answers['date-range-from'], error_messages=error_messages)
 
         self.assertTrue(hasattr(form, 'day'))
         self.assertTrue(hasattr(form, 'month'))
@@ -86,7 +88,7 @@ class TestDateForm(AppContextTestCase):
         }
 
         with patch('app.questionnaire.questionnaire_schema.QuestionnaireSchema.get_answers_by_id_for_block',
-                   return_value=[answer]):
+                   return_value=[answer]), self.test_request_context('/'):
             form = get_date_form(AnswerStore(), {}, answer, error_messages=error_messages)
 
             self.assertTrue(hasattr(form, 'day'))

--- a/tests/app/forms/test_fields.py
+++ b/tests/app/forms/test_fields.py
@@ -1,5 +1,3 @@
-import unittest
-
 from wtforms import validators, StringField, FormField, SelectField, SelectMultipleField
 
 from app.forms.custom_fields import MaxTextAreaField
@@ -7,12 +5,14 @@ from app.forms.fields import CustomIntegerField, CustomDecimalField, get_field, 
 from app.validation.error_messages import error_messages
 from app.validation.validators import ResponseRequired, MutuallyExclusive
 from app.data_model.answer_store import AnswerStore
+from tests.app.app_context_test_case import AppContextTestCase
 
 
 # pylint: disable=no-member, too-many-public-methods
-class TestFields(unittest.TestCase):
+class TestFields(AppContextTestCase):
 
     def setUp(self):
+        super().setUp()
         self.answer_store = AnswerStore()
         self.metadata = {
             'user_id': '789473423',
@@ -31,6 +31,7 @@ class TestFields(unittest.TestCase):
         }
 
     def tearDown(self):
+        super().tearDown()
         self.answer_store.clear()
         self.metadata.clear()
 
@@ -149,8 +150,9 @@ class TestFields(unittest.TestCase):
             }
         }
 
-        unbound_field = get_field(date_json, date_json['label'], error_messages, self.answer_store,
-                                  self.metadata)
+        with self.test_request_context('/'):
+            unbound_field = get_field(date_json, date_json['label'], error_messages, self.answer_store,
+                                      self.metadata)
 
         self.assertEqual(unbound_field.field_class, FormField)
         self.assertEqual(unbound_field.kwargs['label'], date_json['label'])
@@ -173,8 +175,9 @@ class TestFields(unittest.TestCase):
             }
         }
 
-        unbound_field = get_field(date_json, date_json['label'], error_messages, self.answer_store,
-                                  self.metadata)
+        with self.test_request_context('/'):
+            unbound_field = get_field(date_json, date_json['label'], error_messages, self.answer_store,
+                                      self.metadata)
 
         self.assertEqual(unbound_field.field_class, FormField)
         self.assertEqual(unbound_field.kwargs['label'], date_json['label'])
@@ -197,8 +200,9 @@ class TestFields(unittest.TestCase):
             }
         }
 
-        unbound_field = get_field(date_json, date_json['label'], error_messages, self.answer_store,
-                                  self.metadata)
+        with self.test_request_context('/'):
+            unbound_field = get_field(date_json, date_json['label'], error_messages, self.answer_store,
+                                      self.metadata)
 
         self.assertEqual(unbound_field.field_class, FormField)
         self.assertEqual(unbound_field.kwargs['label'], date_json['label'])

--- a/tests/app/templating/test_template_renderer.py
+++ b/tests/app/templating/test_template_renderer.py
@@ -3,12 +3,12 @@
 # pylint: disable=too-many-public-methods
 
 import datetime
-import unittest
 
 from app.templating.template_renderer import TemplateRenderer
+from tests.app.app_context_test_case import AppContextTestCase
 
 
-class TestTemplateRenderer(unittest.TestCase):
+class TestTemplateRenderer(AppContextTestCase):
     def test_render_schema_item(self):
         title = 'Hello {{name}}'
         context = {'name': 'Joe Bloggs'}
@@ -21,7 +21,8 @@ class TestTemplateRenderer(unittest.TestCase):
         date = '{{date|format_date}}'
         context = {'date': '2017-01-01'}
 
-        rendered = TemplateRenderer().render(date, **context)
+        with self.test_request_context('/'):
+            rendered = TemplateRenderer().render(date, **context)
 
         self.assertEqual(rendered, "<span class='date'>1 January 2017</span>")
 
@@ -29,7 +30,8 @@ class TestTemplateRenderer(unittest.TestCase):
         date = '{{date|format_date}}'
         context = {'date': '2017-01'}
 
-        rendered = TemplateRenderer().render(date, **context)
+        with self.test_request_context('/'):
+            rendered = TemplateRenderer().render(date, **context)
 
         self.assertEqual(rendered, "<span class='date'>January 2017</span>")
 

--- a/tests/app/test_jinja_filters.py
+++ b/tests/app/test_jinja_filters.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 from types import SimpleNamespace
-from unittest import TestCase
 
 from datetime import datetime, timedelta
 
@@ -18,9 +17,10 @@ from app.jinja_filters import (
     calculate_years_difference, get_current_date, as_london_tz, max_value,
     min_value, get_question_title, get_answer_label
 )
+from tests.app.app_context_test_case import AppContextTestCase
 
 
-class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
+class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-methods
     def setUp(self):
         self.autoescape_context = Mock(autoescape=True)
         super(TestJinjaFilters, self).setUp()
@@ -132,7 +132,8 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         date = '2017-01-01'
 
         # When
-        format_value = format_date(self.autoescape_context, date)
+        with self.test_request_context('/'):
+            format_value = format_date(self.autoescape_context, date)
 
         # Then
         self.assertEqual(format_value, "<span class='date'>1 January 2017</span>")
@@ -142,7 +143,8 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         date = '2017-01'
 
         # When
-        format_value = format_date(self.autoescape_context, date)
+        with self.test_request_context('/'):
+            format_value = format_date(self.autoescape_context, date)
 
         # Then
         self.assertEqual(format_value, "<span class='date'>January 2017</span>")
@@ -152,7 +154,8 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         date = [Markup('2017-01')]
 
         # When
-        format_value = format_date(self.autoescape_context, date)
+        with self.test_request_context('/'):
+            format_value = format_date(self.autoescape_context, date)
 
         # Then
         self.assertEqual(format_value, "<span class='date'>January 2017</span>")
@@ -183,7 +186,8 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         date_format = "d MMMM YYYY 'at' HH:mm"
 
         # When
-        format_value = format_datetime(self.autoescape_context, date_time, date_format)
+        with self.test_request_context('/'):
+            format_value = format_datetime(self.autoescape_context, date_time, date_format)
 
         # Then
         self.assertEqual(format_value, "<span class='date'>29 March 2018 at 12:59</span>")
@@ -194,7 +198,8 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         date_format = "d MMMM YYYY 'at' HH:mm:ss"
 
         # When
-        format_value = format_datetime(self.autoescape_context, date_time, date_format)
+        with self.test_request_context('/'):
+            format_value = format_datetime(self.autoescape_context, date_time, date_format)
 
         # Then
         self.assertEqual(format_value, "<span class='date'>28 October 2018 at 11:59:13</span>")
@@ -232,14 +237,15 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
                     (None, '2017-12-24', '24 December 2017')]
 
         # When
-        for triple in datelist:
-            date1 = triple[0]
-            date2 = triple[1]
+        with self.test_request_context('/'):
+            for triple in datelist:
+                date1 = triple[0]
+                date2 = triple[1]
 
-            format_value = format_conditional_date(self.autoescape_context, date1, date2)
+                format_value = format_conditional_date(self.autoescape_context, date1, date2)
 
-            # Then
-            self.assertEqual(format_value, "<span class='date'>{date}</span>".format(date=triple[2]))
+                # Then
+                self.assertEqual(format_value, "<span class='date'>{date}</span>".format(date=triple[2]))
 
     def test_calculate_years_difference(self):
         # Given
@@ -277,7 +283,8 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         end_date = '2017-01-31'
 
         # When
-        format_value = format_date_range(self.autoescape_context, start_date, end_date)
+        with self.test_request_context('/'):
+            format_value = format_date_range(self.autoescape_context, start_date, end_date)
 
         # Then
         self.assertEqual(format_value, "<span class='date'>1 January 2017</span> to <span class='date'>31 January 2017</span>")
@@ -287,7 +294,8 @@ class TestJinjaFilters(TestCase):  # pylint: disable=too-many-public-methods
         start_date = '2017-01-01'
 
         # When
-        format_value = format_date_range(self.autoescape_context, start_date)
+        with self.test_request_context('/'):
+            format_value = format_date_range(self.autoescape_context, start_date)
 
         # Then
         self.assertEqual(format_value, "<span class='date'>1 January 2017</span>")

--- a/tests/app/validation/test_single_date_range_validator.py
+++ b/tests/app/validation/test_single_date_range_validator.py
@@ -1,13 +1,13 @@
-import unittest
 from unittest.mock import Mock
 from wtforms.validators import ValidationError
 
 from app.questionnaire.rules import convert_to_datetime
 from app.validation.error_messages import error_messages
 from app.validation.validators import SingleDatePeriodCheck
+from tests.app.app_context_test_case import AppContextTestCase
 
 
-class TestDateRangeValidator(unittest.TestCase):
+class TestDateRangeValidator(AppContextTestCase):
 
     def test_invalid_single_date_period_minimum_date(self):
         minimum_date = convert_to_datetime('2016-03-31')
@@ -22,10 +22,11 @@ class TestDateRangeValidator(unittest.TestCase):
 
         mock_field = Mock()
 
-        with self.assertRaises(ValidationError) as ite:
-            validator(mock_form, mock_field)
+        with self.test_request_context('/'):
+            with self.assertRaises(ValidationError) as ite:
+                validator(mock_form, mock_field)
 
-        self.assertEqual(error_messages['SINGLE_DATE_PERIOD_TOO_EARLY'] % dict(min='30 March 2016'), str(ite.exception))
+            self.assertEqual(error_messages['SINGLE_DATE_PERIOD_TOO_EARLY'] % dict(min='30 March 2016'), str(ite.exception))
 
     def test_invalid_single_date_period_maximum_date(self):
         maximum_date = convert_to_datetime('2016-03-31')
@@ -40,11 +41,12 @@ class TestDateRangeValidator(unittest.TestCase):
 
         mock_field = Mock()
 
-        with self.assertRaises(ValidationError) as ite:
-            validator(mock_form, mock_field)
+        with self.test_request_context('/'):
+            with self.assertRaises(ValidationError) as ite:
+                validator(mock_form, mock_field)
 
-        self.assertEqual(error_messages['SINGLE_DATE_PERIOD_TOO_LATE'] % dict(max='1 April 2016'),
-                         str(ite.exception))
+            self.assertEqual(error_messages['SINGLE_DATE_PERIOD_TOO_LATE'] % dict(max='1 April 2016'),
+                             str(ite.exception))
 
     def test_invalid_single_date_period_with_bespoke_message(self):
         maximum_date = convert_to_datetime('2016-03-31')
@@ -60,10 +62,11 @@ class TestDateRangeValidator(unittest.TestCase):
 
         mock_field = Mock()
 
-        with self.assertRaises(ValidationError) as ite:
-            validator(mock_form, mock_field)
+        with self.test_request_context('/'):
+            with self.assertRaises(ValidationError) as ite:
+                validator(mock_form, mock_field)
 
-        self.assertEqual('Test 1 April 2016', str(ite.exception))
+            self.assertEqual('Test 1 April 2016', str(ite.exception))
 
     @staticmethod
     def test_valid_single_date_period():

--- a/tests/functional/helpers.js
+++ b/tests/functional/helpers.js
@@ -20,8 +20,8 @@ const startCensusQuestionnaire = (schema, sexualIdentity = false, region = 'GB-E
   });
 };
 
-function openQuestionnaire(schema, userId = getRandomString(10), collectionId = getRandomString(10), periodId = '201605', periodStr = 'May 2016') {
-  return generateToken(schema, userId, collectionId, periodId, periodStr)
+function openQuestionnaire(schema, userId = getRandomString(10), collectionId = getRandomString(10), periodId = '201605', periodStr = 'May 2016', region = 'GB-ENG', language = 'en') {
+  return generateToken(schema, userId, collectionId, periodId, periodStr, region, language)
     .then(function(token) {
       return browser.url('/session?token=' + token);
     });

--- a/tests/functional/pages/surveys/language_code/language-block.page.js
+++ b/tests/functional/pages/surveys/language_code/language-block.page.js
@@ -1,0 +1,19 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class LanguageBlockPage extends QuestionPage {
+
+  constructor() {
+    super('language-block');
+  }
+
+  Month() {
+    return '#month-year-answer-month';
+  }
+
+  answerYear() {
+    return '#month-year-answer-year';
+  }
+
+}
+module.exports = new LanguageBlockPage();

--- a/tests/functional/pages/surveys/language_code/summary.page.js
+++ b/tests/functional/pages/surveys/language_code/summary.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  monthYearAnswer() { return '#month-year-answer-answer'; }
+
+  monthYearAnswerEdit() { return '[data-qa="month-year-answer-edit"]'; }
+
+  languageGroupTitle() { return '#language-group'; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/pages/thank-you.page.js
+++ b/tests/functional/pages/thank-you.page.js
@@ -6,6 +6,10 @@ class ThankYouPage extends QuestionPage {
     super('thank-you');
   }
 
+  submissionSuccessfulTitle() {
+    return '[data-qa="submission-successful-title"]';
+  }
+
   viewSubmitted() {
     return '[data-qa="view-submission"]';
   }

--- a/tests/functional/spec/language_code.spec.js
+++ b/tests/functional/spec/language_code.spec.js
@@ -1,0 +1,47 @@
+const helpers = require('../helpers');
+const LanguagePage = require('../pages/surveys/language_code/language-block.page');
+const SummaryPage = require('../pages/surveys/language_code/summary.page');
+const ThankYouPage = require('../pages/thank-you.page.js');
+
+describe('Language Code', function() {
+
+  it('Given the language code cy is specified I should see Welsh text', function() {
+
+    return helpers.openQuestionnaire('test_language.json', helpers.getRandomString(10), helpers.getRandomString(10), '201605', 'May 2016', 'GB-ENG', 'cy').then(() => {
+
+      return browser
+        .getText(LanguagePage.displayedName()).should.eventually.equal('Holiadur Cymraeg')
+        .selectByValue(LanguagePage.Month(), 4)
+        .setValue(LanguagePage.answerYear(), 2018)
+        .click(LanguagePage.submit())
+
+        .getUrl().should.eventually.contain(SummaryPage.pageName)
+        .getText(SummaryPage.monthYearAnswer()).should.eventually.contain('Ebrill 2018')
+        .click(SummaryPage.submit());
+
+        // We can only test this once we have a proper welsh translation file committed
+        //.getUrl().should.eventually.contain('thank-you')
+        //.getText(ThankYouPage.submissionSuccessfulTitle()).should.eventually.contain("Cyflwyno'n llwyddiannus")
+    });
+  });
+
+  it('Given the language code en is specified I should see English text', function() {
+
+    return helpers.openQuestionnaire('test_language.json', helpers.getRandomString(10), helpers.getRandomString(10), '201605', 'May 2016', 'GB-ENG', 'en').then(() => {
+
+      return browser
+        .getText(LanguagePage.displayedName()).should.eventually.equal('English Questionnaire')
+        .selectByValue(LanguagePage.Month(), 4)
+        .setValue(LanguagePage.answerYear(), 2018)
+        .click(LanguagePage.submit())
+
+        .getUrl().should.eventually.contain(SummaryPage.pageName)
+        .getText(SummaryPage.monthYearAnswer()).should.eventually.contain('April 2018')
+        .click(SummaryPage.submit())
+
+        .getUrl().should.eventually.contain('thank-you')
+        .getText(ThankYouPage.submissionSuccessfulTitle()).should.eventually.contain('Submission successful');
+    });
+  });
+
+});

--- a/tests/integration/session/test_login.py
+++ b/tests/integration/session/test_login.py
@@ -126,7 +126,7 @@ class TestLogin(IntegrationTestCase):
     @staticmethod
     @urlmatch(netloc=r'eq-survey-register', path=r'\/my-test-schema')
     def survey_url_mock(_url, _request):
-        schema_path = get_schema_file_path('test_textarea.json')
+        schema_path = get_schema_file_path('test_textarea.json', 'en')
 
         with open(schema_path, encoding='utf8') as json_data:
             return json_data.read()


### PR DESCRIPTION
Requires #1660 for the tests to reliably pass.

### What is the context of this PR?
We want babel to use the language specified in the metadata, rather than a global default

### How to review 
Run `test_language_cy.json`, the template text (not survey question text) should be in English.  Change `language_code` to `cy` in survey runner and run again, the template text should be in Welsh.
