### PR TITLE
Fix CSRF missing errors that happen occasionally in tests

### DIFF
--- a/tests/integration/session/test_timeout.py
+++ b/tests/integration/session/test_timeout.py
@@ -11,6 +11,11 @@ class TestTimeout(IntegrationTestCase):
         settings.EQ_SESSION_TIMEOUT_GRACE_PERIOD_SECONDS = 0
         super().setUp()
 
+    def tearDown(self):
+        settings.EQ_SESSION_TIMEOUT_SECONDS = 45 * 60
+        settings.EQ_SESSION_TIMEOUT_GRACE_PERIOD_SECONDS = 30
+        super().tearDown()
+
     def test_timeout_continue_returns_200(self):
         self.launchSurvey('test', 'timeout')
         self.get('/timeout-continue')


### PR DESCRIPTION
### What is the context of this PR?
Intermittently some of the star wars integration tests will fail with CSRF missing errors

### How to review 
It's hard to reproduce on master, though happens reliably on #1657.  Maybe just review the code, or add a sleep into the star wars test to make it fail more consistently and see that this change stops it happening.
