### PR TITLE
Add translation tags to html

### DIFF
--- a/app/templates/confirmation.html
+++ b/app/templates/confirmation.html
@@ -5,8 +5,8 @@
 {% block submit_button %}
 
 {% if content.summary and content.summary.summary_type == 'SectionSummary' %}
-    <button class="btn btn--loader js-btn-submit" data-qa="btn-submit">Continue</button>
+    <button class="btn btn--loader js-btn-submit" data-qa="btn-submit">{{ _("Continue") }}</button>
 {% else  %}
-    <button class="btn  btn--loader js-btn-submit" data-qa="btn-submit" data-loading-msg="Submitting&hellip;" type="submit">Submit answers</button>
+    <button class="btn  btn--loader js-btn-submit" data-qa="btn-submit" data-loading-msg='{{ _("Submitting") }}&hellip;' type="submit">{{ _("Submit answers") }}</button>
 {% endif %}
 {% endblock %}

--- a/app/templates/layouts/_base.html
+++ b/app/templates/layouts/_base.html
@@ -91,7 +91,7 @@
               {% with position = 'top' %}{% include 'partials/previous-link.html' %}{% endwith %}
               {% if navigation %}
               <div class="page__menubtn">
-              <button class="btn btn--menu js-menu-btn " data-close-label="Hide sections" type="button" id="menu-btn" aria-expanded="false" aria-controls="section-nav" aria-label="Toggle section menu" aria-haspopup="true">View sections</button>
+              <button class="btn btn--menu js-menu-btn " data-close-label="{{_('Hide sections')}}" type="button" id="menu-btn" aria-expanded="false" aria-controls="section-nav" aria-label="Toggle section menu" aria-haspopup="true">{{_('View sections')}}</button>
               </div>
               {% endif %}
             {% endblock subheader %}

--- a/app/templates/layouts/_questionnaire.html
+++ b/app/templates/layouts/_questionnaire.html
@@ -32,11 +32,11 @@
       {% endblock form_content %}
 
       {% block submit_button %}
-      <button class="btn" data-qa="btn-submit" type="submit" name="action[save_continue]">{{submit_btn_text or "Save and continue"}}</button>
+      <button class="btn" data-qa="btn-submit" type="submit" name="action[save_continue]">{{ _("Save and continue") }}</button>
       {% endblock %}
 
       <div class="u-mb-m">
-        <button class="btn btn--secondary js-btn-save" data-qa="btn-save-sign-out" type="submit" name="action[save_sign_out]" {{helpers.track('click', 'Navigation', 'Save and complete later click')}}>{% block save_sign_out_button_text %}Save and complete later{% endblock %}</button>
+        <button class="btn btn--secondary js-btn-save" data-qa="btn-save-sign-out" type="submit" name="action[save_sign_out]" {{helpers.track('click', 'Navigation', 'Save and complete later click')}}>{% block save_sign_out_button_text %}{{ _("Save and complete later") }}{% endblock %}</button>
       </div>
     </form>
 

--- a/app/templates/partials/feedback/expandable_inline.html
+++ b/app/templates/partials/feedback/expandable_inline.html
@@ -1,6 +1,6 @@
 <div class="feedback__inline js-feedback-inline is-collapsed">
     <div class="feedback__border">
         {% include theme('partials/feedback_form.html') %}
-        <button class="btn btn--secondary feedback__cancel js-feedback-cancel" data-qa="a-feedback-close" {{helpers.track('click', 'Feedback', 'Cancel feedback link click')}}>I don’t want to provide feedback</button>
+        <button class="btn btn--secondary feedback__cancel js-feedback-cancel" data-qa="a-feedback-close" {{helpers.track('click', 'Feedback', 'Cancel feedback link click')}}>{{ _("I don’t want to provide feedback") }}</button>
     </div>
 </div>

--- a/app/templates/partials/feedback_form.html
+++ b/app/templates/partials/feedback_form.html
@@ -21,5 +21,5 @@
             <input type="text" class="input js-feedback-email" name="email" id="feedback-email" value=""/>
         </div>
     </div>
-    <button class="btn js-feedback-submit" type="submit" name="action[send_feedback]" data-qa="btn-feedback-submit" data-ga="click" data-ga-category="Feedback" data-ga-action="Send">Send feedback</button>
+    <button class="btn js-feedback-submit" type="submit" name="action[send_feedback]" data-qa="btn-feedback-submit" data-ga="click" data-ga-category="Feedback" data-ga-action="Send">{{ _("Send feedback") }}</button>
 </form>

--- a/app/templates/partials/introduction/start-survey.html
+++ b/app/templates/partials/introduction/start-survey.html
@@ -2,5 +2,5 @@
 
     <form class="form" method="POST" autocomplete="off" novalidate>
         {{ content.csrf_token }}
-        <button class="btn qa-btn-get-started" type="submit" name="action[start_questionnaire]">Start survey</button>
+        <button class="btn qa-btn-get-started" type="submit" name="action[start_questionnaire]">{{ _("Start survey") }}</button>
     </form>

--- a/app/templates/partials/timeout.html
+++ b/app/templates/partials/timeout.html
@@ -23,9 +23,9 @@
       </div>
 
       <form class="" action="/" method="post">
-        <button class="btn btn--loader js-timeout-continue" type="button" data-loading-msg="Continuing&hellip;">Continue survey</button>
+        <button class="btn btn--loader js-timeout-continue" type="button" data-loading-msg='{{ _("Continuing") }}&hellip;'>{{ _("Continue survey") }}</button>
         <br/>
-        <button class="btn btn--secondary js-timeout-save" type="submit">Save and sign out</button>
+        <button class="btn btn--secondary js-timeout-save" type="submit">{{ _("Save and sign out") }}</button>
       </form>
     </div>
   </div>

--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-06-28 17:16+0100\n"
+"POT-Creation-Date: 2018-07-11 14:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.4.0\n"
 
-#: app/forms/date_form.py:133
+#: app/forms/date_form.py:132
 msgid "Select month"
 msgstr ""
 
@@ -26,7 +26,6 @@ msgid "Submit answers"
 msgstr ""
 
 #: app/templates/confirmation.html:8
-#: app/templates/layouts/_questionnaire.html:35
 msgid "Continue"
 msgstr ""
 
@@ -250,6 +249,10 @@ msgstr ""
 msgid "Your system information"
 msgstr ""
 
+#: app/templates/layouts/_questionnaire.html:35
+msgid "Save and continue"
+msgstr ""
+
 #: app/templates/layouts/_questionnaire.html:39
 msgid "Save and complete later"
 msgstr ""
@@ -431,13 +434,13 @@ msgstr ""
 msgid "Start survey"
 msgstr ""
 
-#: app/templates/partials/questions/repeatinganswer.html:15
+#: app/templates/partials/questions/repeatinganswer.html:16
 #: app/templates/partials/questions/repeatinganswer.html:21
 msgid "Remove"
 msgstr ""
 
-#: app/templates/partials/questions/repeatinganswer.html:16
-#: app/templates/partials/questions/repeatinganswer.html:28
+#: app/templates/partials/questions/repeatinganswer.html:17
+#: app/templates/partials/questions/repeatinganswer.html:27
 msgid "Person "
 msgstr ""
 
@@ -449,7 +452,7 @@ msgstr ""
 msgid "Person"
 msgstr ""
 
-#: app/templates/partials/questions/repeatinganswer.html:50
+#: app/templates/partials/questions/repeatinganswer.html:49
 msgid "Add another person"
 msgstr ""
 
@@ -476,15 +479,15 @@ msgid "Select all that apply"
 msgstr ""
 
 #: app/templates/partials/widgets/multiple_choice_widget.html:20
-#: app/templates/partials/widgets/multiple_choice_widget.html:51
+#: app/templates/partials/widgets/multiple_choice_widget.html:55
 msgid "Or"
 msgstr ""
 
-#: app/templates/partials/widgets/multiple_choice_widget.html:51
+#: app/templates/partials/widgets/multiple_choice_widget.html:55
 msgid "Selecting this will uncheck all other checkboxes"
 msgstr ""
 
-#: app/templates/partials/widgets/multiple_choice_widget.html:55
+#: app/templates/partials/widgets/multiple_choice_widget.html:59
 msgid "deselected"
 msgstr ""
 
@@ -1282,7 +1285,7 @@ msgid ""
 "location"
 msgstr ""
 
-#: app/templating/view_context.py:101
+#: app/templating/view_context.py:100
 msgid "Your answers"
 msgstr ""
 
@@ -1399,28 +1402,28 @@ msgstr ""
 msgid "Uncheck %(non_exclusives)s or \"%(exclusive)s\" to continue"
 msgstr ""
 
-#: app/validation/validators.py:299
+#: app/validation/validators.py:302
 #, python-format
 msgid "%(num)s year"
 msgid_plural "%(num)s years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: app/validation/validators.py:302
+#: app/validation/validators.py:304
 #, python-format
 msgid "%(num)s month"
 msgid_plural "%(num)s months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: app/validation/validators.py:305
+#: app/validation/validators.py:307
 #, python-format
 msgid "%(num)s day"
 msgid_plural "%(num)s days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: app/validation/validators.py:396
+#: app/validation/validators.py:388
 msgid "and"
 msgstr ""
 


### PR DESCRIPTION
### What is the context of this PR?
The Links and Buttons PR removed some static translation tags from a few conflicting files.

### How to review 
New messages.pot file should include the same static content as before including the newly named Save and continue button.
Compare with https://github.com/ONSdigital/eq-survey-runner/pull/1643
