### PR TITLE
Section summary only available if section complete

### DIFF
--- a/data/en/test_is_skipping_question.json
+++ b/data/en/test_is_skipping_question.json
@@ -1,0 +1,216 @@
+{
+    "data_version": "0.0.2",
+    "navigation": {
+        "visible": true
+    },
+    "view_submitted_response": {
+        "enabled": true,
+        "duration": 900
+    },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ru_name": {
+            "validator": "string"
+        }
+    },
+    "sections": [{
+            "id": "test-skipping-section",
+            "title": "Section 1",
+            "groups": [{
+                    "blocks": [{
+                            "id": "test-skipping-forced",
+                            "questions": [{
+                                "answers": [{
+                                    "id": "test-skipping-answer",
+                                    "mandatory": true,
+                                    "options": [{
+                                            "label": "Yes",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "No"
+                                        }
+                                    ],
+                                    "type": "Radio"
+                                }],
+                                "description": "",
+                                "id": "test-skipping-question",
+                                "title": "Were you forced to complete section 1?",
+                                "type": "General"
+                            }],
+                            "title": "This is section 1",
+                            "type": "Question",
+                            "routing_rules": [{
+                                    "goto": {
+                                        "block": "test-skipping-optional",
+                                        "when": [{
+                                            "id": "test-skipping-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        }]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "test-skipping-summary-group",
+                                        "when": [{
+                                            "id": "test-skipping-answer",
+                                            "condition": "equals",
+                                            "value": "No"
+                                        }]
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "test-skipping-optional",
+                            "title": "This is section 1",
+                            "type": "Question",
+                            "questions": [{
+                                "answers": [{
+                                    "id": "test-skipping-optional-answer",
+                                    "mandatory": true,
+                                    "options": [{
+                                            "label": "£5 Cash",
+                                            "value": "fiver"
+                                        },
+                                        {
+                                            "label": "£10 Amazon Voucher",
+                                            "value": "tenner"
+                                        }
+                                    ],
+                                    "type": "Checkbox"
+                                }],
+                                "id": "test-skipping-optional-question",
+                                "title": "What would incentivise you to complete this section?",
+                                "type": "General"
+                            }]
+                        }
+                    ],
+                    "id": "test-skipping-group",
+                    "title": "Section 1"
+                },
+                {
+                    "id": "test-skipping-summary-group",
+                    "title": "Section 1 Summary",
+                    "blocks": [{
+                        "id": "test-skipping-summary",
+                        "type": "SectionSummary"
+                    }]
+                }
+            ]
+        },
+        {
+            "id": "test-skipping-section-2",
+            "title": "Section 2",
+            "groups": [{
+                    "blocks": [{
+                            "id": "test-skipping-forced-2",
+                            "questions": [{
+                                "answers": [{
+                                    "id": "test-skipping-answer-2",
+                                    "mandatory": true,
+                                    "options": [{
+                                            "label": "Yes",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "No"
+                                        }
+                                    ],
+                                    "type": "Radio"
+                                }],
+                                "description": "",
+                                "id": "test-skipping-question-2",
+                                "title": "Were you forced to complete section 2?",
+                                "type": "General"
+                            }],
+                            "title": "This is section 2",
+                            "type": "Question",
+                            "routing_rules": [{
+                                    "goto": {
+                                        "block": "test-skipping-optional-2",
+                                        "when": [{
+                                            "id": "test-skipping-answer-2",
+                                            "condition": "equals",
+                                            "value": "yes"
+                                        }]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "test-skipping-summary-group-2",
+                                        "when": [{
+                                            "id": "test-skipping-answer-2",
+                                            "condition": "equals",
+                                            "value": "No"
+                                        }]
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "test-skipping-optional-2",
+                            "title": "This is section 2",
+                            "type": "Question",
+                            "questions": [{
+                                "answers": [{
+                                    "id": "test-skipping-optional-answer-2",
+                                    "mandatory": true,
+                                    "options": [{
+                                            "label": "£5 Cash",
+                                            "value": "fiver"
+                                        },
+                                        {
+                                            "label": "£10 Amazon Voucher",
+                                            "value": "tenner"
+                                        }
+                                    ],
+                                    "type": "Checkbox"
+                                }],
+                                "id": "test-skipping-optional-question-2",
+                                "title": "What would incentivise you to complete this section?",
+                                "type": "General"
+                            }]
+                        }
+                    ],
+                    "id": "test-skipping-group-2",
+                    "title": "Section 2"
+                },
+                {
+                    "id": "test-skipping-summary-group-2",
+                    "title": "Section 2 Summary",
+                    "blocks": [{
+                        "id": "test-skipping-summary-2",
+                        "type": "SectionSummary"
+                    }]
+                }
+            ]
+        },
+        {
+            "id": "summary-section",
+            "title": "Summary",
+            "groups": [{
+                "blocks": [{
+                    "type": "Summary",
+                    "id": "summary"
+                }],
+                "id": "summary-group",
+                "title": "Summary"
+            }]
+        }
+    ],
+    "legal_basis": "StatisticsOfTradeAct",
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "survey_id": "134",
+    "theme": "default",
+    "title": "Test Skipping Question"
+}

--- a/tests/integration/questionnaire/test_questionnaire_is_skipping_question.py
+++ b/tests/integration/questionnaire/test_questionnaire_is_skipping_question.py
@@ -1,0 +1,77 @@
+from tests.integration.integration_test_case import IntegrationTestCase
+
+
+class TestQuestionnaireChangeAnswer(IntegrationTestCase):
+
+    def test_section_summary_not_available_if_section_incomplete(self):
+
+        # Given I launched a survey and have not answered any questions
+        self.launchSurvey('test', 'is_skipping_question')
+
+        # When I try access a section summary
+        self.get('questionnaire/test/is_skipping_question/789/test-skipping-summary-group/0/test-skipping-summary')
+
+        # Then I should be redirected to the first incomplete question in that section
+        self.assertInPage('This is section 1')
+        self.assertInPage('Were you forced to complete section 1?')
+
+    def test_section_summary_not_available_after_invalidating_section(self):
+
+        # Given I launched a survey and have completed a section
+        self.launchSurvey('test', 'is_skipping_question')
+        self.post({'test-skipping-answer': 'No'})
+        self.assertInPage('This section is now complete')
+        self.assertInPage('Were you forced to complete section 1?')
+
+        # When I invalidate the section and try access it's section summary
+        self.get('questionnaire/test/is_skipping_question/789/test-skipping-group/0/test-skipping-forced#test-skipping-answer')
+        self.post({'test-skipping-answer': 'Yes'})
+        self.get('questionnaire/test/is_skipping_question/789/test-skipping-summary-group/0/test-skipping-summary')
+
+        # Then I should be redirected to the first incomplete question in that section
+        self.assertInPage('This is section 1')
+        self.assertInPage('What would incentivise you to complete this section?')
+
+    def test_final_summary_not_available_if_any_question_incomplete(self):
+
+        # Given I launched a survey and have not answered any questions
+        self.launchSurvey('test', 'is_skipping_question')
+
+        # When I try access the final summary
+        self.get('questionnaire/test/is_skipping_question/789/summary-group/0/summary')
+
+        # Then I should be redirected to the first incomplete question in the survey
+        self.assertInPage('This is section 1')
+        self.assertInPage('Were you forced to complete section 1?')
+
+    def test_final_summary_not_available_after_invalidating_section(self):
+
+        # Given I launched a survey and have answered all questions
+        self.launchSurvey('test', 'is_skipping_question')
+        self.post({'test-skipping-answer': 'No'})
+        self.assertInPage('This section is now complete')
+        self.assertInPage('Were you forced to complete section 1?')
+        self.post(action='save_continue')
+
+        self.post({'test-skipping-answer-2': 'No'})
+        self.assertInPage('This section is now complete')
+        self.assertInPage('Were you forced to complete section 2?')
+        self.post(action='save_continue')
+
+        self.assertInPage('Please check your answers carefully before submitting.')
+        self.assertInPage('Were you forced to complete section 1?')
+        self.assertInPage('Were you forced to complete section 2?')
+        self.assertInPage('Submit answers')
+
+        # When I invalidate any block and try access the final summary
+        self.get('questionnaire/test/is_skipping_question/789/test-skipping-group-2/0/test-skipping-forced-2#test-skipping-answer-2')
+        self.post({'test-skipping-answer-2': 'Yes'})
+
+        self.get('questionnaire/test/is_skipping_question/789/test-skipping-group/0/test-skipping-forced#test-skipping-answer')
+        self.post({'test-skipping-answer': 'Yes'})
+
+        self.get('questionnaire/test/is_skipping_question/789/summary-group/0/summary')
+
+        # Then I should be redirected to the first incomplete question in the survey
+        self.assertInPage('This is section 1')
+        self.assertInPage('What would incentivise you to complete this section?')


### PR DESCRIPTION
### What is the context of this PR?
Previously, section summary was accessible via the URL if a section was incomplete but was once complete.
This change ensures that if you try to access the section summary of a section, it redirects to the first incomplete block in that section if any.

***Expected behaviour:***
- If requesting section summary via URL then go to the first incomplete block within that section.
- If requesting final summary via URL then go to the first incomplete block within the survey.

### How to review 
-  Ensure the section summary and final summary behave as expected.