### PR TITLE
Format schema validation output in test_schemas.sh

### DIFF
--- a/scripts/test_schemas.sh
+++ b/scripts/test_schemas.sh
@@ -52,7 +52,7 @@ for schema in $(find $file_path -name '*.json'); do
 
     result="$(curl -s -w 'HTTPSTATUS:%{http_code}' -X POST -H "Content-Type: application/json" -d @"$schema" http://localhost:5001/validate | tr -d '\n')"
     result_response="${result//*HTTPSTATUS:/}"
-    result_body="${result//HTTPSTATUS:*/}"
+    result_body=$(echo "${result//HTTPSTATUS:*/}" | python -m json.tool)
 
     if [ "$result_response" == "200" ] && [ "$result_body" == "{}" ]; then
         echo -e "${green}$schema - PASSED${default}"


### PR DESCRIPTION
This PR adds a prettifying step on the JSON response from the `eq-schema-validator`, in order to make the output more readable. This has been added to speed up reviewing and fixing schemas (or changing schemas as I was).

### What is the context of this PR?
Simply makes use of [`json.tool`](https://docs.python.org/2/library/json.html) in the python std library to format the JSON response from the validator. From looking in to it - this works on python2.6+, so it's not expected that there will be dev environments that don't meet this condition!

### How to review 
Try validating an invalid schema - e.g. by making a change to a questionnaire so that it's no longer valid to the schema and running the validator against it. e.g. edit `data/en/test_navigation.json`and run ` ./scripts/test_schemas.sh ./data/en/test_navigation.json` to see the improved output.
