### PR TITLE
Add a checklist to the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,3 +3,8 @@ Describe what you have changed and why, link to other PRs or Issues as appropria
 
 ### How to review 
 Describe the steps required to test the changes (include screenshots if appropriate).
+
+### Checklist
+
+* [  ] New static content marked up for translation
+* [  ] Newly defined schema content included in eq-translations repo


### PR DESCRIPTION
This adds a short checklist to the PR template.

I only added points around translations for now. I don't think we should add generic well-ingrained practices (e.g. adding tests) as that could lead to the checklist proliferating.