### PR TITLE
Make section summary not accessible if section not complete

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,8 +3,3 @@ Describe what you have changed and why, link to other PRs or Issues as appropria
 
 ### How to review 
 Describe the steps required to test the changes (include screenshots if appropriate).
-
-### Checklist
-
-* [  ] New static content marked up for translation
-* [  ] Newly defined schema content included in eq-translations repo

--- a/app/questionnaire/router.py
+++ b/app/questionnaire/router.py
@@ -1,0 +1,52 @@
+class Router:
+
+    _first_incomplete_block_in_section = None
+    _first_incomplete_block_in_survey = None
+    _section = None
+    _block = None
+
+    def __init__(self, current_location, routing_path, completness):
+        self.current_location = current_location
+        self.routing_path = routing_path
+        self.completness = completness
+
+    def is_valid_location(self):
+        return self.current_location in self.routing_path
+
+    def can_access_location(self, section, block):
+        self._section = section
+        self._block = block
+
+        is_skipping_to_end_of_section = self._get_first_incomplete_block_in_section()
+        if is_skipping_to_end_of_section:
+            return False
+
+        self._block = block
+        is_skipping_to_end_of_survey = self._get_first_incomplete_block_in_survey()
+        if is_skipping_to_end_of_survey:
+            return False
+
+        return True
+
+    def get_next_location(self):
+        if not self.is_valid_location():
+            next_location = self.completness.get_latest_location()
+            return next_location
+
+        return self._first_incomplete_block_in_section or self._first_incomplete_block_in_survey
+
+    def _get_first_incomplete_block_in_section(self):
+        latest_location = self.completness.get_first_incomplete_location_in_section(self._section)
+
+        if self._block['type'] == 'SectionSummary' and self.current_location != latest_location:
+            self._first_incomplete_block_in_section = latest_location
+
+        return self._first_incomplete_block_in_section
+
+    def _get_first_incomplete_block_in_survey(self):
+        latest_location = self.completness.get_first_incomplete_location_in_survey()
+
+        if self._block['type'] in ['Confirmation', 'Summary'] and self.current_location != latest_location:
+            self._first_incomplete_block_in_survey = latest_location
+
+        return self._first_incomplete_block_in_survey

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -23,6 +23,7 @@ from app.helpers import template_helper
 from app.questionnaire.location import Location
 from app.questionnaire.navigation import Navigation
 from app.questionnaire.path_finder import PathFinder
+from app.questionnaire.router import Router
 from app.questionnaire.rules import get_answer_ids_on_routing_path
 
 from app.questionnaire.rules import evaluate_skip_conditions
@@ -125,14 +126,19 @@ def save_questionnaire_store(func):
 @full_routing_path_required
 def get_block(routing_path, eq_id, form_type, collection_id, group_id, group_instance, block_id):  # pylint: disable=unused-argument,too-many-locals
     current_location = Location(group_id, group_instance, block_id)
+    completeness = get_completeness(current_user)
+    route = Router(current_location, routing_path, completeness)
 
-    if not _is_valid_location(routing_path, current_location):
-        return _redirect_to_latest_location(collection_id, eq_id, form_type)
+    if not route.is_valid_location():
+        next_location = route.get_next_location()
+        return _redirect_to_location(collection_id, eq_id, form_type, next_location)
 
+    section = _get_section_json(current_location)
     block = _get_block_json(current_location)
 
-    if _is_skipping_to_the_end(block, current_location):
-        return _redirect_to_latest_location(collection_id, eq_id, form_type)
+    if not route.can_access_location(section, block):
+        next_location = route.get_next_location()
+        return _redirect_to_location(collection_id, eq_id, form_type, next_location)
 
     context = _get_context(routing_path, block, current_location)
     return _render_page(block['type'], context, current_location, routing_path)
@@ -346,16 +352,6 @@ def _is_end_of_questionnaire(block, next_location):
     return (
         block['type'] in END_BLOCKS and
         next_location is None
-    )
-
-
-def _is_skipping_to_the_end(block, current_location):
-    latest_location = get_completeness(current_user).get_first_incomplete_location_in_survey()
-
-    return (
-        latest_location and
-        current_location != latest_location and
-        block['type'] in END_BLOCKS
     )
 
 
@@ -703,6 +699,11 @@ def _get_block_json(current_location):
     answer_store = get_answer_store(current_user)
     block_json = g.schema.get_block(current_location.block_id)
     return _evaluate_skip_conditions(block_json, current_location, answer_store, metadata)
+
+
+def _get_section_json(current_location):
+    section_json = g.schema.get_section_by_block_id(current_location.block_id)
+    return section_json
 
 
 def _get_schema_context(full_routing_path, group_instance, metadata, answer_store):

--- a/data/en/test_is_skipping_question.json
+++ b/data/en/test_is_skipping_question.json
@@ -1,0 +1,206 @@
+{
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "137",
+    "theme": "default",
+    "title": "Test Skipping Question",
+    "legal_basis": "StatisticsOfTradeAct",
+    "mime_type": "application/json/ons/eq",
+    "navigation": {
+        "visible": true
+    },
+    "view_submitted_response": {
+        "enabled": true,
+        "duration": 900
+    },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ru_name": {
+            "validator": "string"
+        }
+    },
+    "sections": [{
+            "id": "test-skipping-section",
+            "title": "Section 1",
+            "groups": [{
+                    "blocks": [{
+                            "id": "test-skipping-forced",
+                            "questions": [{
+                                "answers": [{
+                                    "id": "test-skipping-answer",
+                                    "mandatory": true,
+                                    "options": [{
+                                            "label": "Yes",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "No"
+                                        }
+                                    ],
+                                    "type": "Radio"
+                                }],
+                                "description": "",
+                                "id": "test-skipping-question",
+                                "title": "Were you forced to complete section 1?",
+                                "type": "General"
+                            }],
+                            "title": "This is section 1",
+                            "type": "Question",
+                            "routing_rules": [{
+                                    "goto": {
+                                        "block": "test-skipping-optional",
+                                        "when": [{
+                                            "id": "test-skipping-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        }]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "test-skipping-section-summary-group"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "test-skipping-optional",
+                            "title": "This is section 1",
+                            "type": "Question",
+                            "questions": [{
+                                "answers": [{
+                                    "id": "test-skipping-optional-answer",
+                                    "mandatory": true,
+                                    "options": [{
+                                            "label": "£5 Cash",
+                                            "value": "fiver"
+                                        },
+                                        {
+                                            "label": "£10 Amazon Voucher",
+                                            "value": "tenner"
+                                        }
+                                    ],
+                                    "type": "Checkbox"
+                                }],
+                                "id": "test-skipping-optional-question",
+                                "title": "What would incentivise you to complete this section?",
+                                "type": "General"
+                            }]
+                        }
+                    ],
+                    "id": "test-skipping-group",
+                    "title": "Section 1"
+                },
+                {
+                    "id": "test-skipping-section-summary-group",
+                    "title": "Section 1 Summary",
+                    "blocks": [{
+                        "id": "test-skipping-section-summary",
+                        "type": "SectionSummary"
+                    }]
+                }
+            ]
+        },
+        {
+            "id": "test-skipping-section-2",
+            "title": "Section 2",
+            "groups": [{
+                    "blocks": [{
+                            "id": "test-skipping-forced-2",
+                            "questions": [{
+                                "answers": [{
+                                    "id": "test-skipping-answer-2",
+                                    "mandatory": true,
+                                    "options": [{
+                                            "label": "Yes",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "No"
+                                        }
+                                    ],
+                                    "type": "Radio"
+                                }],
+                                "description": "",
+                                "id": "test-skipping-question-2",
+                                "title": "Were you forced to complete section 2?",
+                                "type": "General"
+                            }],
+                            "title": "This is section 2",
+                            "type": "Question",
+                            "routing_rules": [{
+                                    "goto": {
+                                        "block": "test-skipping-optional-2",
+                                        "when": [{
+                                            "id": "test-skipping-answer-2",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        }]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "test-skipping-section-summary-group-2"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "test-skipping-optional-2",
+                            "title": "This is section 2",
+                            "type": "Question",
+                            "questions": [{
+                                "answers": [{
+                                    "id": "test-skipping-optional-answer-2",
+                                    "mandatory": true,
+                                    "options": [{
+                                            "label": "£5 Cash",
+                                            "value": "fiver"
+                                        },
+                                        {
+                                            "label": "£10 Amazon Voucher",
+                                            "value": "tenner"
+                                        }
+                                    ],
+                                    "type": "Checkbox"
+                                }],
+                                "id": "test-skipping-optional-question-2",
+                                "title": "What would incentivise you to complete this section?",
+                                "type": "General"
+                            }]
+                        }
+                    ],
+                    "id": "test-skipping-group-2",
+                    "title": "Section 2"
+                },
+                {
+                    "id": "test-skipping-section-summary-group-2",
+                    "title": "Section 2 Summary",
+                    "blocks": [{
+                        "id": "test-skipping-section-summary-2",
+                        "type": "SectionSummary"
+                    }]
+                }
+            ]
+        },
+        {
+            "id": "summary-section",
+            "title": "Summary",
+            "groups": [{
+                "blocks": [{
+                    "type": "Summary",
+                    "id": "summary"
+                }],
+                "id": "summary-group",
+                "title": "Summary"
+            }]
+        }
+    ]
+}

--- a/tests/app/questionnaire/test_router.py
+++ b/tests/app/questionnaire/test_router.py
@@ -1,0 +1,214 @@
+from unittest.mock import MagicMock
+
+from tests.app.app_context_test_case import AppContextTestCase
+from app.questionnaire.router import Router
+from app.questionnaire.location import Location
+from app.questionnaire.completeness import Completeness
+from app.utilities.schema import load_schema_from_params
+
+
+class TestRouter(AppContextTestCase):
+    def test_location_is_valid_and_accessible(self):
+        schema = load_schema_from_params('test', 'is_skipping_question')
+        section = schema.get_section_by_block_id('test-skipping-section-summary')
+        block = schema.get_block('test-skipping-section-summary')
+
+        current_location = Location('test-skipping-group', 0, 'test-skipping-forced')
+
+        routing_path = [
+            Location('test-skipping-group', 0, 'test-skipping-forced'),
+            Location('test-skipping-section-summary-group', 0, 'test-skipping-section-summary'),
+            Location('summary-group', 0, 'summary')
+        ]
+
+        completness = Completeness(schema, answer_store=MagicMock(), completed_blocks=[], routing_path=routing_path, metadata={})
+        route = Router(current_location, routing_path, completness)
+
+        self.assertTrue(route.is_valid_location())
+        self.assertTrue(route.can_access_location(section, block))
+
+    def test_is_not_valid_location(self):
+        schema = load_schema_from_params('test', 'is_skipping_question')
+        current_location = Location('not-in-path', 0, 'not-in-path')
+
+        routing_path = [
+            Location('test-skipping-group', 0, 'test-skipping-forced'),
+            Location('test-skipping-section-summary-group', 0, 'test-skipping-section-summary'),
+            Location('summary-group', 0, 'summary')
+        ]
+
+        completness = Completeness(schema, answer_store=MagicMock(), completed_blocks=[], routing_path=routing_path, metadata={})
+        route = Router(current_location, routing_path, completness)
+
+        self.assertFalse(route.is_valid_location())
+
+    def test_skipping_to_end_of_section(self):
+        schema = load_schema_from_params('test', 'is_skipping_question')
+        section = schema.get_section_by_block_id('test-skipping-section-summary')
+        block = schema.get_block('test-skipping-section-summary')
+
+        current_location = Location('test-skipping-section-summary-group', 0, 'test-skipping-section-summary')
+
+        routing_path = [
+            Location('test-skipping-group', 0, 'test-skipping-forced'),
+            Location('test-skipping-section-summary-group', 0, 'test-skipping-section-summary'),
+            Location('summary-group', 0, 'summary')
+        ]
+
+        completness = Completeness(schema, answer_store=MagicMock(), completed_blocks=[], routing_path=routing_path, metadata={})
+        route = Router(current_location, routing_path, completness)
+
+        self.assertFalse(route.can_access_location(section, block))
+
+    def test_skipping_to_end_of_survey(self):
+        schema = load_schema_from_params('test', 'is_skipping_question')
+        section = schema.get_section_by_block_id('test-skipping-section-summary')
+        block = schema.get_block('test-skipping-section-summary')
+
+        current_location = Location('summary-group', 0, 'summary')
+
+        routing_path = [
+            Location('test-skipping-group', 0, 'test-skipping-forced'),
+            Location('test-skipping-section-summary-group', 0, 'test-skipping-section-summary'),
+            Location('summary-group', 0, 'summary')
+        ]
+
+        completness = Completeness(schema, answer_store=MagicMock(), completed_blocks=[], routing_path=routing_path, metadata={})
+        route = Router(current_location, routing_path, completness)
+
+        self.assertFalse(route.can_access_location(section, block))
+
+    def test_get_next_location_invalid_current_location(self):
+        schema = load_schema_from_params('test', 'is_skipping_question')
+        current_location = Location('not-in-path', 0, 'not-in-path')
+        expected_location = Location('test-skipping-group', 0, 'test-skipping-forced')
+
+        routing_path = [
+            expected_location,
+            Location('test-skipping-section-summary-group', 0, 'test-skipping-section-summary'),
+            Location('summary-group', 0, 'summary')
+        ]
+
+        completness = Completeness(schema, answer_store=MagicMock(), completed_blocks=[], routing_path=routing_path, metadata={})
+        route = Router(current_location, routing_path, completness)
+
+        self.assertEqual(expected_location, route.get_next_location())
+
+    def test_get_first_incomplete_block_in_section_when_skipping_to_section_summary(self):
+        schema = load_schema_from_params('test', 'is_skipping_question')
+        section = schema.get_section_by_block_id('test-skipping-section-summary-2')
+        block = schema.get_block('test-skipping-section-summary-2')
+
+        current_location = Location('test-skipping-section-summary-group-2', 0, 'test-skipping-section-summary-2')
+        expected_location = Location('test-skipping-group-2', 0, 'test-skipping-optional-2')
+
+        routing_path = [
+            Location('test-skipping-group', 0, 'test-skipping-forced'),
+            Location('test-skipping-group', 0, 'test-skipping-optional'),
+            Location('test-skipping-section-summary-group', 0, 'test-skipping-section-summary'),
+            Location('test-skipping-group-2', 0, 'test-skipping-forced-2'),
+            Location('test-skipping-group-2', 0, 'test-skipping-optional-2'),
+            Location('test-skipping-section-summary-group-2', 0, 'test-skipping-section-summary-2'),
+            Location('summary-group', 0, 'summary')
+        ]
+
+        completed_blocks = [
+            Location('test-skipping-group', 0, 'test-skipping-forced'),
+            Location('test-skipping-group-2', 0, 'test-skipping-forced-2')
+        ]
+
+        completness = Completeness(schema, answer_store=MagicMock(), completed_blocks=completed_blocks, routing_path=routing_path, metadata={})
+        route = Router(current_location, routing_path, completness)
+
+        self.assertFalse(route.can_access_location(section, block))
+        self.assertEqual(expected_location, route.get_next_location())
+
+    def test_get_first_incomplete_block_in_survey_when_skipping_to_end_of_survey(self):
+        schema = load_schema_from_params('test', 'is_skipping_question')
+        section = schema.get_section_by_block_id('summary')
+        block = schema.get_block('summary')
+
+        current_location = Location('summary-group', 0, 'summary')
+        expected_location = Location('test-skipping-group', 0, 'test-skipping-optional')
+
+        routing_path = [
+            Location('test-skipping-group', 0, 'test-skipping-forced'),
+            Location('test-skipping-group', 0, 'test-skipping-optional'),
+            Location('test-skipping-section-summary-group', 0, 'test-skipping-section-summary'),
+            Location('test-skipping-group-2', 0, 'test-skipping-forced-2'),
+            Location('test-skipping-group-2', 0, 'test-skipping-optional-2'),
+            Location('test-skipping-section-summary-group-2', 0, 'test-skipping-section-summary-2'),
+            Location('summary-group', 0, 'summary')
+        ]
+
+        completed_blocks = [
+            Location('test-skipping-group', 0, 'test-skipping-forced'),
+            Location('test-skipping-group-2', 0, 'test-skipping-forced-2')
+        ]
+
+        completness = Completeness(schema, answer_store=MagicMock(), completed_blocks=completed_blocks, routing_path=routing_path, metadata={})
+        route = Router(current_location, routing_path, completness)
+
+        self.assertFalse(route.can_access_location(section, block))
+        self.assertEqual(expected_location, route.get_next_location())
+
+    def test_section_summary_accessible_when_section_complete(self):
+        schema = load_schema_from_params('test', 'is_skipping_question')
+        section = schema.get_section_by_block_id('test-skipping-section-summary-2')
+        block = schema.get_block('test-skipping-section-summary-2')
+
+        current_location = Location('test-skipping-section-summary-group-2', 0, 'test-skipping-section-summary-2')
+
+        routing_path = [
+            Location('test-skipping-group', 0, 'test-skipping-forced'),
+            Location('test-skipping-group', 0, 'test-skipping-optional'),
+            Location('test-skipping-section-summary-group', 0, 'test-skipping-section-summary'),
+            Location('test-skipping-group-2', 0, 'test-skipping-forced-2'),
+            Location('test-skipping-group-2', 0, 'test-skipping-optional-2'),
+            Location('test-skipping-section-summary-group-2', 0, 'test-skipping-section-summary-2'),
+            Location('summary-group', 0, 'summary')
+        ]
+
+        completed_blocks = [
+            Location('test-skipping-group', 0, 'test-skipping-forced'),
+            Location('test-skipping-group-2', 0, 'test-skipping-forced-2'),
+            Location('test-skipping-group-2', 0, 'test-skipping-optional-2'),
+            Location('test-skipping-section-summary-group-2', 0, 'test-skipping-section-summary-2')
+        ]
+
+        completness = Completeness(schema, answer_store=MagicMock(), completed_blocks=completed_blocks, routing_path=routing_path, metadata={})
+        route = Router(current_location, routing_path, completness)
+
+        self.assertTrue(route.can_access_location(section, block))
+
+    def test_final_summary_accessible_when_survey_complete(self):
+        schema = load_schema_from_params('test', 'is_skipping_question')
+        section = schema.get_section_by_block_id('summary')
+        block = schema.get_block('summary')
+
+        current_location = Location('summary', 0, 'summary')
+
+        routing_path = [
+            Location('test-skipping-group', 0, 'test-skipping-forced'),
+            Location('test-skipping-group', 0, 'test-skipping-optional'),
+            Location('test-skipping-section-summary-group', 0, 'test-skipping-section-summary'),
+            Location('test-skipping-group-2', 0, 'test-skipping-forced-2'),
+            Location('test-skipping-group-2', 0, 'test-skipping-optional-2'),
+            Location('test-skipping-section-summary-group-2', 0, 'test-skipping-section-summary-2'),
+            Location('summary-group', 0, 'summary')
+        ]
+
+        completed_blocks = [
+            Location('test-skipping-group', 0, 'test-skipping-forced'),
+            Location('test-skipping-group', 0, 'test-skipping-forced'),
+            Location('test-skipping-group', 0, 'test-skipping-optional'),
+            Location('test-skipping-section-summary-group', 0, 'test-skipping-section-summary'),
+            Location('test-skipping-group-2', 0, 'test-skipping-forced-2'),
+            Location('test-skipping-group-2', 0, 'test-skipping-optional-2'),
+            Location('test-skipping-section-summary-group-2', 0, 'test-skipping-section-summary-2')
+        ]
+
+        completness = Completeness(schema, answer_store=MagicMock(), completed_blocks=completed_blocks, routing_path=routing_path, metadata={})
+        route = Router(current_location, routing_path, completness)
+
+        self.assertTrue(route.can_access_location(section, block))

--- a/tests/integration/questionnaire/test_questionnaire_is_skipping_question.py
+++ b/tests/integration/questionnaire/test_questionnaire_is_skipping_question.py
@@ -1,0 +1,77 @@
+from tests.integration.integration_test_case import IntegrationTestCase
+
+
+class TestQuestionnaireChangeAnswer(IntegrationTestCase):
+
+    def test_section_summary_not_available_if_section_incomplete(self):
+
+        # Given I launched a survey and have not answered any questions
+        self.launchSurvey('test', 'is_skipping_question')
+
+        # When I try access a section summary
+        self.get('questionnaire/test/is_skipping_question/789/test-skipping-section-summary-group/0/test-skipping-section-summary')
+
+        # Then I should be redirected to the first incomplete question in that section
+        self.assertInPage('This is section 1')
+        self.assertInPage('Were you forced to complete section 1?')
+
+    def test_section_summary_not_available_after_invalidating_section(self):
+
+        # Given I launched a survey and have completed a section
+        self.launchSurvey('test', 'is_skipping_question')
+        self.post({'test-skipping-answer': 'No'})
+        self.assertInPage('This section is now complete')
+        self.assertInPage('Were you forced to complete section 1?')
+
+        # When I invalidate the section and try access it's section summary
+        self.get('questionnaire/test/is_skipping_question/789/test-skipping-group/0/test-skipping-forced#test-skipping-answer')
+        self.post({'test-skipping-answer': 'Yes'})
+        self.get('questionnaire/test/is_skipping_question/789/test-skipping-section-summary-group/0/test-skipping-section-summary')
+
+        # Then I should be redirected to the first incomplete question in that section
+        self.assertInPage('This is section 1')
+        self.assertInPage('What would incentivise you to complete this section?')
+
+    def test_final_summary_not_available_if_any_question_incomplete(self):
+
+        # Given I launched a survey and have not answered any questions
+        self.launchSurvey('test', 'is_skipping_question')
+
+        # When I try access the final summary
+        self.get('questionnaire/test/is_skipping_question/789/summary-group/0/summary')
+
+        # Then I should be redirected to the first incomplete question in the survey
+        self.assertInPage('This is section 1')
+        self.assertInPage('Were you forced to complete section 1?')
+
+    def test_final_summary_not_available_after_invalidating_section(self):
+
+        # Given I launched a survey and have answered all questions
+        self.launchSurvey('test', 'is_skipping_question')
+        self.post({'test-skipping-answer': 'No'})
+        self.assertInPage('This section is now complete')
+        self.assertInPage('Were you forced to complete section 1?')
+        self.post(action='save_continue')
+
+        self.post({'test-skipping-answer-2': 'No'})
+        self.assertInPage('This section is now complete')
+        self.assertInPage('Were you forced to complete section 2?')
+        self.post(action='save_continue')
+
+        self.assertInPage('Please check your answers carefully before submitting.')
+        self.assertInPage('Were you forced to complete section 1?')
+        self.assertInPage('Were you forced to complete section 2?')
+        self.assertInPage('Submit answers')
+
+        # When I invalidate any block and try access the final summary
+        self.get('questionnaire/test/is_skipping_question/789/test-skipping-group-2/0/test-skipping-forced-2#test-skipping-answer-2')
+        self.post({'test-skipping-answer-2': 'Yes'})
+
+        self.get('questionnaire/test/is_skipping_question/789/test-skipping-group/0/test-skipping-forced#test-skipping-answer')
+        self.post({'test-skipping-answer': 'Yes'})
+
+        self.get('questionnaire/test/is_skipping_question/789/summary-group/0/summary')
+
+        # Then I should be redirected to the first incomplete question in the survey
+        self.assertInPage('This is section 1')
+        self.assertInPage('What would incentivise you to complete this section?')


### PR DESCRIPTION
### What is the context of this PR?
Previously, section summary was accessible via the URL if a section was incomplete but was once complete.
This change ensures that if you try to access the section summary of a section, it redirects to the first incomplete block in that section if any.

Added a new `Router` class to help refactor out some of the logic currently in our views. Others logic still exists in the views that can to be refactored out in a future PR, didn't want to make this PR too messy.

***Expected behaviour:***
- If requesting section summary via URL then go to the first incomplete block within that section.
- If requesting final summary via URL then go to the first incomplete block within the survey.

### How to review 
-  Ensure the section summary and final summary behave as expected.

### Checklist

* [x] New static content marked up for translation
* [x] Newly defined schema content included in eq-translations repo
