### PR TITLE
Fix keyerror when answers missing from content question.

### DIFF
--- a/app/questionnaire/questionnaire_schema.py
+++ b/app/questionnaire/questionnaire_schema.py
@@ -223,7 +223,7 @@ class QuestionnaireSchema(object):  # pylint: disable=too-many-public-methods
 
         return {
             answer['id']: answer
-            for answer in question['answers']
+            for answer in question.get('answers', [])
         }
 
     def get_answer_ids_for_question(self, question_id):


### PR DESCRIPTION
### What is the context of this PR?
A change recently went in to publisher to create confirmation pages using a content question type.

This causes a 500 error to be thrown in survey runner due to the question missing the answers key when the dependencies are enumerated within survey runner.

This PR aims to fix this issue by defaulting answers to an empty list if the key does not exist.

### How to review 
Review of code change is required.
All tests and checks should continue to pass.
