### PR TITLE
Route based on answer_count from repeating answer

### DIFF
--- a/app/questionnaire/rules.py
+++ b/app/questionnaire/rules.py
@@ -184,6 +184,8 @@ def evaluate_when_rules(when_rules, metadata, answer_store, group_instance):
             value = get_answer_store_value(when_rule['id'], answer_store, group_instance)
         elif 'meta' in when_rule:
             value = get_metadata_value(metadata, when_rule['meta'])
+        elif 'answer_count' in when_rule:
+            value = answer_store.filter(answer_ids=[when_rule['answer_count']]).count()
         else:
             return True
 

--- a/data/en/test_routing_answer_count.json
+++ b/data/en/test_routing_answer_count.json
@@ -1,0 +1,167 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "023",
+    "title": "Test Routing Answer Count",
+    "description": "",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ru_name": {
+            "validator": "string"
+        }
+    },
+    "sections": [{
+        "id": "intro-section",
+        "title": "Introduction",
+        "groups": [{
+                "blocks": [{
+                    "type": "Question",
+                    "id": "household-composition",
+                    "questions": [{
+                        "id": "household-composition-question",
+                        "title": "Who usually lives here?",
+                        "description": "<br> <div> <h3>Include:</h3> <ul> <li>Yourself, if this is your permanent or family home </li> <li>Family members including partners, children and babies born on or before 9 April 2017</li> <li>Students and/or school children who live away from home during term time</li> <li>Housemates, tenants or lodgers</li> </ul> </div>",
+                        "type": "RepeatingAnswer",
+                        "answers": [{
+                                "id": "first-name",
+                                "label": "First Name",
+                                "mandatory": false,
+                                "q_code": "1",
+                                "type": "TextField"
+                            },
+                            {
+                                "id": "last-name",
+                                "label": "Last Name",
+                                "mandatory": false,
+                                "q_code": "1",
+                                "type": "TextField"
+                            }
+                        ]
+                    }],
+                    "title": "Household",
+                    "routing_rules": [{
+                            "goto": {
+                                "group": "group-equal-2",
+                                "when": [{
+                                    "answer_count": "first-name",
+                                    "condition": "equals",
+                                    "value": 2
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "group": "group-greater-than-2",
+                                "when": [{
+                                    "answer_count": "first-name",
+                                    "condition": "greater than",
+                                    "value": 2
+                                }]
+                            }
+                        },
+                        {
+                            "goto": {
+                                "group": "group-less-than-2"
+                            }
+                        }
+                    ]
+                }],
+                "id": "multiple-questions-group",
+                "title": "Routing control group"
+            },
+            {
+                "id": "group-less-than-2",
+                "title": "This is Group 0 - You answered less than \"2\"",
+                "blocks": [{
+                    "type": "Question",
+                    "id": "group-less-than-2-block",
+                    "description": "",
+                    "title": "This is Group 0 - You answered less than \"2\"",
+                    "questions": [{
+                        "description": "",
+                        "id": "group-less-than-2-question",
+                        "title": "Did you want Group 0?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "group-less-than-2-answer",
+                            "label": "Why did you choose Group 0?",
+                            "mandatory": true,
+                            "type": "TextArea"
+                        }]
+                    }],
+                    "routing_rules": [{
+                        "goto": {
+                            "group": "summary-group"
+                        }
+                    }]
+                }]
+            },
+            {
+                "id": "group-equal-2",
+                "title": "This is Group 1 - you answered \"2\"",
+                "blocks": [{
+                    "type": "Question",
+                    "id": "group-equal-2-block",
+                    "description": "",
+                    "title": "This is Group 1 - you answered \"2\"",
+                    "questions": [{
+                        "description": "",
+                        "id": "group-equal-2-question",
+                        "title": "Did you want Group 1?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "group-equal-2-answer",
+                            "label": "Why did you choose Group 1?",
+                            "mandatory": true,
+                            "type": "TextArea"
+                        }]
+                    }],
+                    "routing_rules": [{
+                        "goto": {
+                            "group": "summary-group"
+                        }
+                    }]
+                }]
+            },
+            {
+                "id": "group-greater-than-2",
+                "title": "This is Group 2 - You answered greater than \"2\"",
+                "blocks": [{
+                    "type": "Question",
+                    "id": "group-greater-than-2-block",
+                    "routing_rules": [],
+                    "description": "",
+                    "title": "This is Group 2 - You answered greater than \"2\"",
+                    "questions": [{
+                        "description": "",
+                        "id": "group-greater-than-2-question",
+                        "title": "Did you want Group 2?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "group-greater-than-2-answer",
+                            "label": "Why did you choose Group 2?",
+                            "mandatory": true,
+                            "type": "TextArea"
+                        }]
+                    }]
+                }]
+            },
+            {
+                "blocks": [{
+                    "type": "Summary",
+                    "id": "summary"
+                }],
+                "id": "summary-group",
+                "title": ""
+            }
+        ]
+    }]
+}

--- a/tests/app/questionnaire/test_path_finder.py
+++ b/tests/app/questionnaire/test_path_finder.py
@@ -1011,3 +1011,32 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
 
         self.assertEqual(path_finder.completed_blocks, [completed_blocks[0]])
         self.assertEqual(len(path_finder.answer_store.answers), 1)
+
+    def test_route_based_on_answer_count(self):
+        schema = load_schema_from_params('test', 'routing_answer_count')
+
+        answer_group_id = 'first-name'
+
+        answer_store = AnswerStore({})
+        answer_store.add(Answer(
+            answer_id=answer_group_id,
+            answer_instance=0,
+            value='alice',
+        ))
+        answer_store.add(Answer(
+            answer_id=answer_group_id,
+            answer_instance=1,
+            value='bob',
+        ))
+
+        completed_blocks = [
+            Location('multiple-questions-group', 0, 'household-composition')
+        ]
+        expected_next_location = Location('group-equal-2', 0, 'group-equal-2-block')
+        should_not_be_present = Location('group-less-than-2', 0, 'group-less-than-2-block')
+
+        path_finder = PathFinder(schema, answer_store, metadata={}, completed_blocks=completed_blocks)
+        path = path_finder.build_path()
+
+        self.assertNotIn(should_not_be_present, path)
+        self.assertIn(expected_next_location, path)

--- a/tests/app/questionnaire/test_rules.py
+++ b/tests/app/questionnaire/test_rules.py
@@ -680,6 +680,100 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
                 evaluate_when_rules(when, {}, answer_store, 3)  # passed in group instance ignored if present in when
                 patch_val.assert_called_with('Some Id', answer_store, 0)
 
+    def test_id_when_rule_answer_count_equal_0(self):
+        """Assert that an `answer_count` can be used in a when block and the
+            correct value is fetched. """
+        answer_group_id = 'repeated-answer'
+        when = [{
+            'answer_count': answer_group_id,
+            'condition': 'equals',
+            'value': 0,
+        }]
+
+        answer_store = AnswerStore({})
+
+        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
+            self.assertTrue(evaluate_when_rules(when, {}, answer_store, 0))
+
+    def test_answer_count_when_rule_equal_1(self):
+        """Assert that an `answer_count` can be used in a when block and the
+            correct value is fetched. """
+        answer_group_id = 'repeated-answer'
+        when = [{
+            'answer_count': answer_group_id,
+            'condition': 'equals',
+            'value': 1,
+        }]
+
+        answer_store = AnswerStore({})
+        answer_store.add(Answer(
+            answer_id=answer_group_id,
+            group_instance=0,
+            value=10,
+        ))
+
+        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
+            self.assertTrue(evaluate_when_rules(when, {}, answer_store, 0))
+
+    def test_answer_count_when_rule_equal_2(self):
+        """Assert that an `answer_count` can be used in a when block and the
+            value is correctly matched """
+        answer_group_id = 'repeated-answer'
+        when = [{
+            'answer_count': answer_group_id,
+            'condition': 'equals',
+            'value': 2,
+        }]
+
+        answer_store = AnswerStore({})
+        answer_store.add(Answer(
+            answer_id=answer_group_id,
+            group_instance=0,
+            value=10,
+        ))
+        answer_store.add(Answer(
+            answer_id=answer_group_id,
+            group_instance=1,
+            value=20,
+        ))
+
+        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
+            self.assertTrue(evaluate_when_rules(when, {}, answer_store, 0))
+
+    def test_answer_count_when_rule_not_equal(self):  # pylint: disable=no-self-use
+        """Assert that an `answer_count` can be used in a when block and the
+            False is returned when the values do not match. """
+        answer_group_id = 'repeated-answer'
+        when = [{
+            'answer_count': answer_group_id,
+            'condition': 'equals',
+            'value': 1,
+        }]
+        answer_store = AnswerStore({})
+
+        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
+            self.assertFalse(evaluate_when_rules(when, {}, answer_store, 0))
+
+    def test_answer_count_when_rule_id_takes_precident(self):
+        """Assert that if somehow, both `id` and `answer_count` are present in a when clause
+            the `id` takes precident and no errors are thrown. """
+        answer_group_id = 'repeated-answer'
+        ref_id = 'just-a-regular-answer'
+        when = [{
+            'id': ref_id,
+            'answer_count': answer_group_id,
+            'condition': 'equals',
+            'value': 10,
+        }]
+        answer_store = AnswerStore({})
+        answer_store.add(Answer(
+            answer_id=ref_id,
+            group_instance=0,
+            value=10,
+        ))
+
+        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
+            self.assertTrue(evaluate_when_rules(when, {}, answer_store, 0))
 
 class TestDateRules(AppContextTestCase):
 

--- a/tests/functional/pages/features/routing/answer_count/group-equal-2-block.page.js
+++ b/tests/functional/pages/features/routing/answer_count/group-equal-2-block.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class GroupEqual2BlockPage extends QuestionPage {
+
+  constructor() {
+    super('group-equal-2-block');
+  }
+
+  answer() {
+    return '#group-equal-2-answer';
+  }
+
+  answerLabel() { return '#label-group-equal-2-answer'; }
+
+}
+module.exports = new GroupEqual2BlockPage();

--- a/tests/functional/pages/features/routing/answer_count/group-greater-than-2-block.page.js
+++ b/tests/functional/pages/features/routing/answer_count/group-greater-than-2-block.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class GroupGreaterThan2BlockPage extends QuestionPage {
+
+  constructor() {
+    super('group-greater-than-2-block');
+  }
+
+  answer() {
+    return '#group-greater-than-2-answer';
+  }
+
+  answerLabel() { return '#label-group-greater-than-2-answer'; }
+
+}
+module.exports = new GroupGreaterThan2BlockPage();

--- a/tests/functional/pages/features/routing/answer_count/group-less-than-2-block.page.js
+++ b/tests/functional/pages/features/routing/answer_count/group-less-than-2-block.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class GroupLessThan2BlockPage extends QuestionPage {
+
+  constructor() {
+    super('group-less-than-2-block');
+  }
+
+  answer() {
+    return '#group-less-than-2-answer';
+  }
+
+  answerLabel() { return '#label-group-less-than-2-answer'; }
+
+}
+module.exports = new GroupLessThan2BlockPage();

--- a/tests/functional/pages/features/routing/answer_count/household-composition.page.js
+++ b/tests/functional/pages/features/routing/answer_count/household-composition.page.js
@@ -1,0 +1,31 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class HouseholdCompositionPage extends QuestionPage {
+
+  constructor() {
+    super('household-composition');
+  }
+
+  addPerson() {
+    return 'button[name="action[add_answer]"]';
+  }
+
+  removePerson(index = 0) {
+    return 'div.question__answer:nth-child('+ (index+1) + ') > h3 > small > span > button';
+    // Have to check whether it's visible in test code
+  }
+
+  personLegend(index = 1) {
+    return 'div.question__answer:nth-child(' + index + ') > fieldset > legend';
+  }
+  firstName(index = '') {
+    return '#household-0-first-name' + index;
+  }
+
+  lastName(index = '') {
+    return '#household-0-last-name' + index;
+  }
+
+}
+module.exports = new HouseholdCompositionPage();

--- a/tests/functional/pages/features/routing/answer_count/summary.page.js
+++ b/tests/functional/pages/features/routing/answer_count/summary.page.js
@@ -1,0 +1,37 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  lastName() { return '#last-name-answer'; }
+
+  lastNameEdit() { return '[data-qa="last-name-edit"]'; }
+
+  multipleQuestionsGroupTitle() { return '#multiple-questions-group'; }
+
+  groupLessThan2Answer() { return '#group-less-than-2-answer-answer'; }
+
+  groupLessThan2AnswerEdit() { return '[data-qa="group-less-than-2-answer-edit"]'; }
+
+  groupLessThan2Title() { return '#group-less-than-2'; }
+
+  groupEqual2Answer() { return '#group-equal-2-answer-answer'; }
+
+  groupEqual2AnswerEdit() { return '[data-qa="group-equal-2-answer-edit"]'; }
+
+  groupEqual2Title() { return '#group-equal-2'; }
+
+  groupGreaterThan2Answer() { return '#group-greater-than-2-answer-answer'; }
+
+  groupGreaterThan2AnswerEdit() { return '[data-qa="group-greater-than-2-answer-edit"]'; }
+
+  groupGreaterThan2Title() { return '#group-greater-than-2'; }
+
+  summaryGroupTitle() { return '#summary-group'; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/spec/features/routing/answer_count.spec.js
+++ b/tests/functional/spec/features/routing/answer_count.spec.js
@@ -1,0 +1,47 @@
+const helpers = require('../../../helpers');
+
+const HouseholdCompositionPage = require('../../../pages/features/routing/answer_count/household-composition.page.js');
+const GroupLessThan2 = require('../../../pages/features/routing/answer_count/group-less-than-2-block.page.js');
+const GroupEqual2 = require('../../../pages/features/routing/answer_count/group-equal-2-block.page.js');
+const GroupGreaterThan2 = require('../../../pages/features/routing/answer_count/group-greater-than-2-block.page.js');
+
+const test_questionnaire_name = 'test_routing_answer_count.json';
+
+it('Given I have a household with two members, When I enter both household members, Then I am routed to the Equals 2 Group page', function() {
+    return helpers.openQuestionnaire(test_questionnaire_name).then(() => {
+        return browser
+          .setValue(HouseholdCompositionPage.firstName(),'Alpha')
+          .setValue(HouseholdCompositionPage.lastName(),'One')
+          .click(HouseholdCompositionPage.addPerson())
+          .setValue(HouseholdCompositionPage.firstName('_1'),'Bravo')
+          .setValue(HouseholdCompositionPage.lastName('_1'),'Two')
+          .click(HouseholdCompositionPage.submit())
+          .getUrl().should.eventually.contain(GroupEqual2.pageName);
+    });
+});
+
+it('Given I have a household with three members, When I enter three household members, Then I am routed to the greater than 2 Group page', function() {
+    return helpers.openQuestionnaire(test_questionnaire_name).then(() => {
+        return browser
+          .setValue(HouseholdCompositionPage.firstName(),'Alpha')
+          .setValue(HouseholdCompositionPage.lastName(),'One')
+          .click(HouseholdCompositionPage.addPerson())
+          .setValue(HouseholdCompositionPage.firstName('_1'),'Bravo')
+          .setValue(HouseholdCompositionPage.lastName('_1'),'Two')
+          .click(HouseholdCompositionPage.addPerson())
+          .setValue(HouseholdCompositionPage.firstName('_1'),'Charlie')
+          .setValue(HouseholdCompositionPage.lastName('_1'),'Three')
+          .click(HouseholdCompositionPage.submit())
+          .getUrl().should.eventually.contain(GroupGreaterThan2.pageName);
+    });
+});
+
+it('Given I have a household with one member, When I enter a single household member, Then i am routed to the Less than 2 Group page', function() {
+    return helpers.openQuestionnaire(test_questionnaire_name).then(() => {
+        return browser
+          .setValue(HouseholdCompositionPage.firstName(),'Alpha')
+          .setValue(HouseholdCompositionPage.lastName(),'One')
+          .click(HouseholdCompositionPage.submit())
+          .getUrl().should.eventually.contain(GroupLessThan2.pageName);
+    });
+});

--- a/tests/integration/household_composition/test_repeating_household_routing.py
+++ b/tests/integration/household_composition/test_repeating_household_routing.py
@@ -133,3 +133,40 @@ class TestRepeatingHouseholdRouting(IntegrationTestCase):
         self.assertEqual(len(joes_dob), 1, 'There should be a date-of-birth '
                                            'answer in group instance 0')
         self.assertEqual(joes_dob[0]['value'], '1990-03-12')
+
+class TestHouseholdWhenRouting(IntegrationTestCase):
+    """Test repeating household with routing.
+
+    Tests goto clauses which use `answer_count` in the `when` clause
+    """
+    def setUp(self):
+        super().setUp()
+        self.launchSurvey('test', 'routing_answer_count',
+                          roles=['dumper'])
+        self.household_composition_url = self.last_url
+
+    def test_routes_based_on_answer_count(self):
+        """ Asserts that the routing rule is followed based on the
+        number of answers to a household composition question.
+        """
+        form_data = MultiDict()
+        form_data.add('household-0-first-name', 'Joe')
+        form_data.add('household-0-middle-names', '')
+        form_data.add('household-0-last-name', 'Bloggs')
+        form_data.add('household-1-first-name', 'Jane')
+        form_data.add('household-1-middle-names', '')
+        form_data.add('household-1-last-name', 'Doe')
+        self.post(form_data)
+
+        self.assertInPage('This is Group 1 - you answered "2"')
+
+    def test_routes_based_on_answer_count_false_condition(self):
+        """Asserts that the goto is ignored when the condition is false
+        """
+        form_data = MultiDict()
+        form_data.add('household-0-first-name', 'Joe')
+        form_data.add('household-0-middle-names', '')
+        form_data.add('household-0-last-name', 'Bloggs')
+        self.post(form_data)
+
+        self.assertInPage('This is Group 0 - You answered less than "2"')


### PR DESCRIPTION
### What is the context of this PR?
The new functionality allows redirecting to a different part of the survey base on the number of responses to a `RepeatingAnswer`.

Relates to: https://trello.com/c/g7sCaR9Q/2123-route-on-answer-count

The schema's for a the `answer_count` key in a `when` clause were added in: https://github.com/ONSdigital/eq-schema-validator/pull/66

The new test case questionnaire was added in: https://github.com/ONSdigital/go-launch-a-survey/pull/103

### How to review 
This PR and the other 2 referenced will need to be checked out (or the others need merging first). At this point the new functionality can be tested by running the `test_routing_answer_count` survey.
