### PR TITLE
Update selenium chromedriver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 dist: trusty
 sudo: true
+addons:
+  apt:
+    sources:
+      - google-chrome
+    packages:
+      - google-chrome-stable
 language: node_js
 node_js: 6
 env:

--- a/tests/functional/chimp.js
+++ b/tests/functional/chimp.js
@@ -40,7 +40,7 @@ let config = {
         chrome: {
           // check for more recent versions of chrome driver here:
           // http://chromedriver.storage.googleapis.com/index.html
-          version: '2.34',
+          version: '2.38',
         }
       }
     }


### PR DESCRIPTION
### What is the context of this PR?
I've updated the chimp config to use chromedriver 2.38 as well as updating the version of travis used to the latest stable release (currently 67). 

This has been done so that the same, recent versions of chrome can be used both locally and remotely - saving the need to edit the chimp config in order to get the functional tests running.

### How to review 
There is a build demoing the change here: https://travis-ci.org/ONSdigital/eq-survey-runner/builds/405769286

The only thing to check for travis is that there are no security/reliability issues from using the travis `addons` section.

Also worth testing that the e2e tests run locally.
