### PR TITLE
Fix submission dumping for surveys with repeating groups and routing 

### DIFF
--- a/app/questionnaire/completeness.py
+++ b/app/questionnaire/completeness.py
@@ -184,7 +184,7 @@ class Completeness:
     def _should_skip(self, group_or_block):
         return (
             'skip_conditions' in group_or_block and
-            evaluate_skip_conditions(group_or_block['skip_conditions'], self.metadata, self.answer_store)
+            evaluate_skip_conditions(group_or_block['skip_conditions'], self.schema, self.metadata, self.answer_store)
         )
 
     def _is_valid_for_completeness(self, block, location):

--- a/app/questionnaire/path_finder.py
+++ b/app/questionnaire/path_finder.py
@@ -50,7 +50,7 @@ class PathFinder:
                 this_location = Location(group['id'], 0, first_block_in_group)
 
             if 'skip_conditions' in group:
-                if evaluate_skip_conditions(group['skip_conditions'], self.metadata, self.answer_store):
+                if evaluate_skip_conditions(group['skip_conditions'], self.schema, self.metadata, self.answer_store):
                     continue
 
             no_of_repeats = get_number_of_repeats(group, self.schema, path, self.answer_store)
@@ -71,7 +71,7 @@ class PathFinder:
         for block in group['blocks']:
             skip_conditions = block.get('skip_conditions')
             if skip_conditions and evaluate_skip_conditions(
-                    skip_conditions, self.metadata, self.answer_store):
+                    skip_conditions, self.schema, self.metadata, self.answer_store):
                 continue
 
             yield {
@@ -120,7 +120,7 @@ class PathFinder:
 
     def _evaluate_routing_rules(self, this_location, blocks, block, block_index, path):
         for rule in filter(is_goto_rule, block['routing_rules']):
-            should_goto = evaluate_goto(rule['goto'], self.metadata, self.answer_store, this_location.group_instance)
+            should_goto = evaluate_goto(rule['goto'], self.schema, self.metadata, self.answer_store, this_location.group_instance)
 
             if should_goto:
                 return self._follow_routing_rule(this_location, rule, blocks, block_index, path)

--- a/app/questionnaire/rules.py
+++ b/app/questionnaire/rules.py
@@ -2,7 +2,6 @@ import logging
 import re
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
-from flask import g
 
 MAX_REPEATS = 25
 

--- a/app/questionnaire/rules.py
+++ b/app/questionnaire/rules.py
@@ -93,17 +93,18 @@ def convert_to_datetime(value):
     return datetime.strptime(value, date_format) if value else None
 
 
-def evaluate_goto(goto_rule, metadata, answer_store, group_instance):
+def evaluate_goto(goto_rule, schema, metadata, answer_store, group_instance):
     """
     Determine whether a goto rule will be satisfied based on a given answer
     :param goto_rule: goto rule to evaluate
+    :param schema: survey schema
     :param metadata: metadata for evaluating rules with metadata conditions
     :param answer_store: store of answers to evaluate
     :param group_instance: when evaluating a when rule for a repeating group, defaults to 0 for non-repeating groups
     :return: True if the when condition has been met otherwise False
     """
     if 'when' in goto_rule.keys():
-        return evaluate_when_rules(goto_rule['when'], metadata, answer_store, group_instance)
+        return evaluate_when_rules(goto_rule['when'], schema, metadata, answer_store, group_instance)
     return True
 
 
@@ -146,10 +147,11 @@ def _get_answer_count(filtered_answers):
     return len(filtered_answers) - 1 if len(filtered_answers) > 0 else 0  # pylint: disable=len-as-condition
 
 
-def evaluate_skip_conditions(skip_conditions, metadata, answer_store, group_instance=0):
+def evaluate_skip_conditions(skip_conditions, schema, metadata, answer_store, group_instance=0):
     """
     Determine whether a skip condition will be satisfied based on a given answer
     :param skip_conditions: skip_conditions rule to evaluate
+    :param schema: survey schema
     :param metadata: metadata for evaluating rules with metadata conditions
     :param answer_store: store of answers to evaluate
     :param group_instance: when evaluating a when rule for a repeating group, defaults to 0 for non-repeating groups
@@ -161,16 +163,17 @@ def evaluate_skip_conditions(skip_conditions, metadata, answer_store, group_inst
         return False
 
     for when in skip_conditions:
-        condition = evaluate_when_rules(when['when'], metadata, answer_store, group_instance)
+        condition = evaluate_when_rules(when['when'], schema, metadata, answer_store, group_instance)
         if condition is True:
             return True
     return False
 
 
-def evaluate_when_rules(when_rules, metadata, answer_store, group_instance):
+def evaluate_when_rules(when_rules, schema, metadata, answer_store, group_instance):
     """
     Whether the skip condition has been met.
     :param when_rules: when rules to evaluate
+    :param schema: survey schema
     :param metadata: metadata for evaluating rules with metadata conditions
     :param answer_store: store of answers to evaluate
     :param group_instance: when evaluating a when rule for a repeating group
@@ -179,7 +182,7 @@ def evaluate_when_rules(when_rules, metadata, answer_store, group_instance):
     """
     for when_rule in when_rules:
         if 'id' in when_rule:
-            if group_instance > 0 and not _answer_is_in_repeating_group(when_rule['id']):
+            if group_instance > 0 and not schema.answer_is_in_repeating_group(when_rule['id']):
                 group_instance = 0
             value = get_answer_store_value(when_rule['id'], answer_store, group_instance)
         elif 'meta' in when_rule:
@@ -250,7 +253,3 @@ def _contains_in_dict(metadata, keys):
         return _contains_in_dict(metadata[key], rest)
 
     return keys in metadata
-
-
-def _answer_is_in_repeating_group(answer_id):
-    return g.schema.answer_is_in_repeating_group(answer_id)


### PR DESCRIPTION
### What is the context of this PR?
See https://trello.com/c/oWOJYmp1/2266-dump-submission-failing-on-schemas-with-repeating-groups-s

Fixes survey dumping (i.e. http://localhost:5000/dump/submission) for surveys which were previously throwing a 500 error due to dependence on global state which was not set for the /dump endpoint.

### How to review 
Previously failing surveys were `census_household` and `test_repeating_household_routing`.

