### PR TITLE
support skipping a block in repeating group based on value from an ea…

### DIFF
--- a/data/en/test_skip_condition_block.json
+++ b/data/en/test_skip_condition_block.json
@@ -78,6 +78,23 @@
                                 "value": "Yes"
                             }]
                         }]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "a-non-skipped-block",
+                        "description": "an additional question within the same group",
+                        "title": "Additional Question",
+                        "questions": [{
+                            "id": "will-not-be-skipped-question",
+                            "title": "Always ask this question",
+                            "type": "General",
+                            "answers": [{
+                                "id": "will-not-be-skipped-answer",
+                                "label": "never skipped",
+                                "mandatory": true,
+                                "type": "TextArea"
+                            }]
+                        }]
                     }
                 ]
             },

--- a/data/en/test_skip_conditions_from_repeating_group_based_on_non_repeating_answer.json
+++ b/data/en/test_skip_conditions_from_repeating_group_based_on_non_repeating_answer.json
@@ -1,0 +1,135 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "001",
+    "title": "A Test Schema to test skip conditions in a non repeating  answer in a repeating group",
+    "description": "Tests skip conditions in repeating group when referencing a non repeating answer ",
+    "theme": "default",
+    "legal_basis": "Voluntary",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ru_name": {
+            "validator": "string"
+        }
+    },
+    "sections": [{
+            "id": "household-section",
+            "title": "About the household",
+            "groups": [{
+                "id": "about-household-group",
+                "title": "About the household",
+                "blocks": [{
+                    "id": "household-composition",
+                    "type": "Question",
+                    "description": "gather names of people",
+                    "questions": [{
+                        "id": "household-composition-question",
+                        "titles": [{
+                            "value": "What are the names of everyone who lives in the household?"
+                        }],
+                        "type": "RepeatingAnswer",
+                        "answers": [{
+                            "id": "first-name",
+                            "label": "First name",
+                            "mandatory": true,
+                            "type": "TextField",
+                            "validation": {
+                                "messages": {
+                                    "MANDATORY_TEXTFIELD": "Please enter a name or remove the person to continue"
+                                }
+                            }
+                        }]
+                    }]
+                }]
+            }]
+        },
+        {
+            "id": "non-repeating-answer-section",
+            "titles": "How many ",
+            "groups": [{
+                "id": "independent-answer-group",
+                "title": " ",
+                "blocks": [{
+                    "id": "non-repeating-question-block",
+                    "type": "Question",
+                    "description": "A block with a non repeating answer in a non repeating group",
+                    "questions": [{
+                        "id": "an-independent-question",
+                        "title": "Some non repeating question",
+                        "type": "General",
+                        "answers": [{
+                            "id": "an-independent-answer",
+                            "label": "Independent Answer",
+                            "mandatory": true,
+                            "type": "TextField"
+                        }]
+                    }]
+                }]
+            }]
+        },
+        {
+            "id": "repeating-group",
+            "title_from_answers": [
+                "first-name"
+            ],
+            "groups": [{
+                "id": "dependant-group",
+                "title": " ",
+                "routing_rules": [{
+                    "repeat": {
+                        "type": "answer_count",
+                        "answer_id": "first-name"
+                    }
+                }],
+                "blocks": [{
+                    "id": "additional-question-block",
+                    "type": "Question",
+                    "description": "skip the question if independent, non repeating, answer is 3",
+                    "skip_conditions": [{
+                        "when": [{
+                            "id": "an-independent-answer",
+                            "condition": "equals",
+                            "value": "3"
+                        }]
+                    }],
+                    "questions": [{
+                        "id": "some-additional-question",
+                        "title": "Some question for <em>{{answers['first-name'][group_instance]}}</em>",
+                        "type": "General",
+                        "answers": [{
+                            "id": "some-answer",
+                            "label": "Some answer",
+                            "mandatory": false,
+                            "type": "TextField"
+                        }]
+                    }]
+                }]
+            }]
+        },
+        {
+            "id": "submit-answers",
+            "title": "Submit answers",
+            "groups": [{
+                "id": "questionnaire-completed",
+                "title": "Submit answers",
+                "blocks": [{
+                    "type": "Confirmation",
+                    "id": "confirmation",
+                    "title": "",
+                    "questions": [{
+                        "id": "questionnaire-completed-question",
+                        "title": "Thank you, please submit your answers.",
+                        "type": "Content",
+                        "description": "<p>Please submit your responses by using the <em>Submit answers</em> button below.</p>"
+                    }]
+                }]
+            }]
+        }
+    ]
+}

--- a/data/en/test_skip_conditions_on_blocks_repeating_group.json
+++ b/data/en/test_skip_conditions_on_blocks_repeating_group.json
@@ -1,0 +1,150 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "0",
+    "title": "A Test Schema to test skip conditions in a repeating group",
+    "description": "A survey that has an answer in one repeating group being the independent variable for a skip condition on a block in another repeating group ",
+    "theme": "default",
+    "legal_basis": "Voluntary",
+    "form_type": "1",
+    "navigation": {
+        "visible": true
+    },
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ru_name": {
+            "validator": "string"
+        }
+    },
+    "sections": [{
+            "id": "household-section",
+            "title": "About the household",
+            "groups": [{
+                "id": "about-household-group",
+                "title": "About the household",
+                "blocks": [{
+                    "id": "household-composition",
+                    "type": "Question",
+                    "description": "gather names of people",
+                    "questions": [{
+                        "id": "household-composition-question",
+                        "titles": [{
+                            "value": "What are the names of everyone who lives in the household?"
+                        }],
+                        "type": "RepeatingAnswer",
+                        "answers": [{
+                            "id": "first-name",
+                            "label": "First name",
+                            "mandatory": true,
+                            "type": "TextField",
+                            "validation": {
+                                "messages": {
+                                    "MANDATORY_TEXTFIELD": "Please enter a name or remove the person to continue"
+                                }
+                            }
+                        }]
+                    }]
+                }]
+            }]
+        },
+        {
+            "id": "household-members-section",
+            "title_from_answers": [
+                "first-name"
+            ],
+            "groups": [{
+                "id": "household-member-group",
+                "title": "Household Member Details",
+                "routing_rules": [{
+                    "repeat": {
+                        "type": "answer_count",
+                        "answer_id": "first-name"
+                    }
+                }],
+                "blocks": [{
+                    "type": "Question",
+                    "id": "date-of-birth",
+                    "description": "used to gather dob for each person from repeating question",
+                    "questions": [{
+                        "id": "date-of-birth-question",
+                        "titles": [{
+                            "value": "What is <em>{{answers['first-name'][group_instance]}}'s</em> date of birth?"
+                        }],
+                        "type": "General",
+                        "answers": [{
+                            "id": "date-of-birth-answer",
+                            "mandatory": false,
+                            "type": "Date",
+                            "maximum": {
+                                "value": "now"
+                            }
+                        }]
+                    }]
+                }]
+            }]
+        },
+        {
+            "id": "repeating-group",
+            "title_from_answers": [
+                "first-name"
+            ],
+            "groups": [{
+                "id": "dependant-group",
+                "title": " ",
+                "routing_rules": [{
+                    "repeat": {
+                        "type": "answer_count",
+                        "answer_id": "first-name"
+                    }
+                }],
+                "blocks": [{
+                    "id": "additional-question-block",
+                    "type": "Question",
+                    "description": "skip the question if no date of birth set for each person",
+                    "skip_conditions": [{
+                        "when": [{
+                            "id": "date-of-birth-answer",
+                            "condition": "not set"
+                        }]
+                    }],
+                    "questions": [{
+                        "id": "some-additional-question",
+                        "title": "Some question for <em>{{answers['first-name'][group_instance]}}</em>",
+                        "type": "General",
+                        "answers": [{
+                            "id": "some-answer",
+                            "label": "Some answer",
+                            "mandatory": false,
+                            "type": "TextField"
+                        }]
+                    }]
+                }]
+            }]
+        },
+        {
+            "id": "submit-answers",
+            "title": "Submit answers",
+            "groups": [{
+                "id": "questionnaire-completed",
+                "title": "Submit answers",
+                "blocks": [{
+                    "type": "Confirmation",
+                    "id": "confirmation",
+                    "title": "",
+                    "questions": [{
+                        "id": "questionnaire-completed-question",
+                        "title": "Thank you, please submit your answers.",
+                        "type": "Content",
+                        "description": "<p>Please submit your responses by using the <em>Submit answers</em> button below.</p>"
+                    }]
+                }]
+            }]
+        }
+    ]
+}

--- a/tests/functional/pages/features/skipping/additional-question-block.page.js
+++ b/tests/functional/pages/features/skipping/additional-question-block.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class AdditionalQuestionBlockPage extends QuestionPage {
+
+  constructor() {
+    super('additional-question-block');
+  }
+
+  answer() {
+    return '#some-answer';
+  }
+
+  answerLabel() { return '#label-some-answer'; }
+
+}
+module.exports = new AdditionalQuestionBlockPage();

--- a/tests/functional/pages/features/skipping/confirmation.page.js
+++ b/tests/functional/pages/features/skipping/confirmation.page.js
@@ -1,0 +1,11 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class ConfirmationPage extends QuestionPage {
+
+  constructor() {
+    super('confirmation');
+  }
+
+}
+module.exports = new ConfirmationPage();

--- a/tests/functional/pages/features/skipping/date-of-birth.page.js
+++ b/tests/functional/pages/features/skipping/date-of-birth.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class DateOfBirthPage extends QuestionPage {
+
+  constructor() {
+    super('date-of-birth');
+  }
+
+  day() {
+    return '#date-of-birth-answer-day';
+  }
+
+  month() {
+    return '#date-of-birth-answer-month';
+  }
+
+  year() {
+    return '#date-of-birth-answer-year';
+  }
+
+}
+module.exports = new DateOfBirthPage();

--- a/tests/functional/pages/features/skipping/household-composition.page.js
+++ b/tests/functional/pages/features/skipping/household-composition.page.js
@@ -1,0 +1,27 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class HouseholdCompositionPage extends QuestionPage {
+
+  constructor() {
+    super('household-composition');
+  }
+
+  addPerson() {
+    return 'button[name="action[add_answer]"]';
+  }
+
+  removePerson(index = 0) {
+    return 'div.question__answer:nth-child('+ (index+1) + ') > h3 > small > span > button';
+    // Have to check whether it's visible in test code
+  }
+
+  personLegend(index = 1) {
+    return 'div.question__answer:nth-child(' + index + ') > fieldset > legend';
+  }
+  answer(index = '') {
+    return '#household-0-first-name' + index;
+  }
+
+}
+module.exports = new HouseholdCompositionPage();

--- a/tests/functional/spec/features/skipping/skipping_blocks_in_repeating_groups.js
+++ b/tests/functional/spec/features/skipping/skipping_blocks_in_repeating_groups.js
@@ -1,0 +1,56 @@
+const helpers = require('../../../helpers');
+
+
+describe('Feature: Skipping in block in repeating group based on repeating answer', function() {
+  var AdditionalQuestionPage = require('../../../pages/features/skipping/additional-question-block.page');
+  var DobPage = require('../../../pages/features/skipping/date-of-birth.page');
+  var HouseholdCompositionPage = require('../../../pages/features/skipping/household-composition.page');
+  var ConfirmationPage = require('../../../pages/features/skipping/confirmation.page');
+
+  beforeEach(function() {
+      return helpers.openQuestionnaire('test_skip_conditions_on_blocks_repeating_group.json');
+  });
+
+  describe('Given I enter 3 people and give the date of birth (dob) of the first person only', function() {
+    it('I should only be asked supplemental question for the one with the dob', function () {
+      return browser
+        .setValue(HouseholdCompositionPage.answer(), 'aaa')
+        .click(HouseholdCompositionPage.addPerson())
+        .setValue(HouseholdCompositionPage.answer('_1'),'bbb')
+        .click(HouseholdCompositionPage.addPerson())
+        .setValue(HouseholdCompositionPage.answer('_2'),'ccc')
+        .click(HouseholdCompositionPage.submit())
+        .setValue(DobPage.day(), 15)
+        .setValue(DobPage.year(), '1962')
+        .selectByValue(DobPage.month(), 2)
+        .click(DobPage.submit())
+        .click(DobPage.submit())
+        .click(DobPage.submit())
+        .getText(AdditionalQuestionPage.questionText()).should.eventually.contain('Some question for aaa')
+        .setValue(AdditionalQuestionPage.answer(), 'random answer')
+        .click(AdditionalQuestionPage.submit())
+        .getText(ConfirmationPage.questionText()).should.eventually.contain('Thank you, please submit your answers.');
+
+    });
+  });
+
+  describe('Given I enter 3 people and give the date of birth (dob) of the last person only', function() {
+    it('I should only be asked supplemental question for the one with the dob', function () {
+      return browser
+        .setValue(HouseholdCompositionPage.answer(), 'aaa')
+        .click(HouseholdCompositionPage.addPerson())
+        .setValue(HouseholdCompositionPage.answer('_1'),'bbb')
+        .click(HouseholdCompositionPage.addPerson())
+        .setValue(HouseholdCompositionPage.answer('_2'),'ccc')
+        .click(HouseholdCompositionPage.submit())
+        .click(DobPage.submit())
+        .click(DobPage.submit())
+        .setValue(DobPage.day(), 15)
+        .setValue(DobPage.year(), '1962')
+        .selectByValue(DobPage.month(), 2)
+        .click(DobPage.submit())
+        .getText(AdditionalQuestionPage.questionText()).should.eventually.contain('Some question for ccc');
+    });
+  });
+});
+


### PR DESCRIPTION
Block Skip conditions not working if independent variable is in a repeating group 

For LMS we have to ascertain how many people are in the house , then for each we ask them they their age , and then for each if that age is over 16 we ask them personal questions. Then if they are over 16 we ask  them questions about working. This means that we need to gather the people in a house. (Repeating Answer) then for each we determine their age in a repeating group . Then we have a dependancy on that repeating group from another repeating group. It was this that was not working.

This code also highlighted another issue that is since skip conditions are evaluated on entry , we can have the situation where the first or many group instances may be skipped, so now we cannot assume that the first group instance in a repeating group is zero as that may be skipped.

### How to review 
Run test_skip_conditions_on_blocks_repeating_group using go launcher. Enter 3 people.  When you are asked for date of birth do not enter a value for some people . Validate that you only get asked the 
additional question 'Some question for <name>' for those people who you entered a date of birth for. 
Run this using a value for the first user and not entering a value for the first user. This is because the existing code defaulted to group instance zero . 

### Checklist

* [  ] New static content marked up for translation - NA
* [  ] Newly defined schema content included in eq-translations repo - NA
