### PR TITLE
Add a repeating type of `until`

### DIFF
--- a/app/questionnaire/questionnaire_schema.py
+++ b/app/questionnaire/questionnaire_schema.py
@@ -191,7 +191,7 @@ class QuestionnaireSchema(object):  # pylint: disable=too-many-public-methods
         group = self.get_group(block['parent_id'])
 
         repeat_rule = self.get_repeat_rule(group)
-        return repeat_rule and repeat_rule['type'] in ['answer_count', 'answer_count_minus_one', 'answer_value']
+        return repeat_rule
 
     def _parse_schema(self):
         self._sections_by_id = self._get_sections_by_id()

--- a/data/en/test_routing_repeat_until.json
+++ b/data/en/test_routing_repeat_until.json
@@ -1,0 +1,180 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "023",
+    "title": "Test Repeat Until",
+    "description": "",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ru_name": {
+            "validator": "string"
+        }
+    },
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+                "id": "primary-group",
+                "title": "Your Details",
+                "blocks": [{
+                        "type": "Question",
+                        "id": "primary-name-block",
+                        "title": "",
+                        "description": "",
+                        "questions": [{
+                            "description": "",
+                            "id": "primary-name-question",
+                            "title": "Please enter your name",
+                            "type": "General",
+                            "answers": [{
+                                "id": "primary-name",
+                                "description": "",
+                                "label": "First Name",
+                                "mandatory": true,
+                                "type": "TextField"
+                            }]
+                        }]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "primary-anyone-else-block",
+                        "questions": [{
+                            "type": "General",
+                            "id": "primary-anyone-else-question",
+                            "title": "Does anyone else live here?",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "primary-anyone-else",
+                                "mandatory": true,
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    }
+                                ]
+                            }]
+
+                        }]
+                    }
+                ]
+            },
+            {
+                "id": "repeating-group",
+                "title": "Other Household Members",
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "primary-anyone-else",
+                        "condition": "equals",
+                        "value": "No"
+                    }]
+                }],
+                "routing_rules": [{
+                    "repeat": {
+                        "type": "until",
+                        "when": [{
+                            "id": "repeating-anyone-else",
+                            "condition": "equals",
+                            "value": "No"
+                        }]
+                    }
+                }],
+                "blocks": [{
+                        "type": "Question",
+                        "id": "repeating-name-block",
+                        "title": "",
+                        "description": "",
+                        "questions": [{
+                            "description": "",
+                            "id": "repeating-name-question",
+                            "title": "Who else lives here?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "repeating-name",
+                                "description": "",
+                                "label": "First Name",
+                                "mandatory": true,
+                                "type": "TextField"
+                            }]
+                        }]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "repeating-anyone-else-block",
+                        "questions": [{
+                            "type": "General",
+                            "id": "repeating-anyone-else-question",
+                            "title": "Does anyone else live here?",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "repeating-anyone-else",
+                                "mandatory": true,
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    }
+                                ]
+                            }]
+
+                        }]
+                    }
+                ]
+            },
+            {
+                "id": "sex-group",
+                "title": "Household Member Details",
+                "routing_rules": [{
+                    "repeat": {
+                        "type": "answer_count",
+                        "answer_id": "repeating-name",
+                        "offset": 1
+                    }
+                }],
+                "blocks": [{
+                    "type": "Question",
+                    "id": "sex-block",
+                    "questions": [{
+                        "id": "sex-question",
+                        "title": "What is {{( [answers['primary-name']] + answers['repeating-name']|default([]) )[group_instance] }}'s sex?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "sex-answer",
+                            "mandatory": true,
+                            "type": "Radio",
+                            "options": [{
+                                    "label": "Male",
+                                    "value": "Male"
+                                },
+                                {
+                                    "label": "Female",
+                                    "value": "Female"
+                                }
+                            ]
+                        }]
+                    }]
+                }]
+            },
+            {
+                "id": "summary-group",
+                "title": "",
+                "blocks": [{
+                    "type": "Summary",
+                    "id": "summary"
+                }]
+            }
+        ]
+    }]
+}

--- a/scripts/test_schemas.sh
+++ b/scripts/test_schemas.sh
@@ -6,8 +6,8 @@ if [ "$1" == "--local" ] || [ "$2" == "--local" ]; then
 fi
 
 if [ "$run_docker" == true ]; then
-    docker pull onsdigital/eq-schema-validator
-    validator="$(docker run -d -p 5001:5000 onsdigital/eq-schema-validator)"
+    docker pull onsdigital/eq-schema-validator:add_repeat_until
+    validator="$(docker run -d -p 5001:5000 onsdigital/eq-schema-validator:add_repeat_until)"
     sleep 3
 fi
 

--- a/tests/functional/pages/surveys/routing_repeat_until/primary-anyone-else-block.page.js
+++ b/tests/functional/pages/surveys/routing_repeat_until/primary-anyone-else-block.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class PrimaryAnyoneElseBlockPage extends QuestionPage {
+
+  constructor() {
+    super('primary-anyone-else-block');
+  }
+
+  yes() {
+    return '#primary-anyone-else-0';
+  }
+
+  yesLabel() { return '#label-primary-anyone-else-0'; }
+
+  no() {
+    return '#primary-anyone-else-1';
+  }
+
+  noLabel() { return '#label-primary-anyone-else-1'; }
+
+}
+module.exports = new PrimaryAnyoneElseBlockPage();

--- a/tests/functional/pages/surveys/routing_repeat_until/primary-name-block.page.js
+++ b/tests/functional/pages/surveys/routing_repeat_until/primary-name-block.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class PrimaryNameBlockPage extends QuestionPage {
+
+  constructor() {
+    super('primary-name-block');
+  }
+
+  answer() {
+    return '#primary-name';
+  }
+
+  answerLabel() { return '#label-primary-name'; }
+
+}
+module.exports = new PrimaryNameBlockPage();

--- a/tests/functional/pages/surveys/routing_repeat_until/repeating-anyone-else-block.page.js
+++ b/tests/functional/pages/surveys/routing_repeat_until/repeating-anyone-else-block.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class RepeatingAnyoneElseBlockPage extends QuestionPage {
+
+  constructor() {
+    super('repeating-anyone-else-block');
+  }
+
+  yes() {
+    return '#repeating-anyone-else-0';
+  }
+
+  yesLabel() { return '#label-repeating-anyone-else-0'; }
+
+  no() {
+    return '#repeating-anyone-else-1';
+  }
+
+  noLabel() { return '#label-repeating-anyone-else-1'; }
+
+}
+module.exports = new RepeatingAnyoneElseBlockPage();

--- a/tests/functional/pages/surveys/routing_repeat_until/repeating-name-block.page.js
+++ b/tests/functional/pages/surveys/routing_repeat_until/repeating-name-block.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class RepeatingNameBlockPage extends QuestionPage {
+
+  constructor() {
+    super('repeating-name-block');
+  }
+
+  answer() {
+    return '#repeating-name';
+  }
+
+  answerLabel() { return '#label-repeating-name'; }
+
+}
+module.exports = new RepeatingNameBlockPage();

--- a/tests/functional/pages/surveys/routing_repeat_until/sex-block.page.js
+++ b/tests/functional/pages/surveys/routing_repeat_until/sex-block.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class SexBlockPage extends QuestionPage {
+
+  constructor() {
+    super('sex-block');
+  }
+
+  male() {
+    return '#sex-answer-0';
+  }
+
+  maleLabel() { return '#label-sex-answer-0'; }
+
+  female() {
+    return '#sex-answer-1';
+  }
+
+  femaleLabel() { return '#label-sex-answer-1'; }
+
+}
+module.exports = new SexBlockPage();

--- a/tests/functional/pages/surveys/routing_repeat_until/summary.page.js
+++ b/tests/functional/pages/surveys/routing_repeat_until/summary.page.js
@@ -1,0 +1,39 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  primaryName() { return '#primary-name-answer'; }
+
+  primaryNameEdit() { return '[data-qa="primary-name-edit"]'; }
+
+  primaryAnyoneElse() { return '#primary-anyone-else-answer'; }
+
+  primaryAnyoneElseEdit() { return '[data-qa="primary-anyone-else-edit"]'; }
+
+  primaryGroupTitle() { return '#primary-group'; }
+
+  repeatingName() { return '#repeating-name-answer'; }
+
+  repeatingNameEdit() { return '[data-qa="repeating-name-edit"]'; }
+
+  repeatingAnyoneElse() { return '#repeating-anyone-else-answer'; }
+
+  repeatingAnyoneElseEdit() { return '[data-qa="repeating-anyone-else-edit"]'; }
+
+  repeatingGroupTitle() { return '#repeating-group'; }
+
+  sexAnswer() { return '#sex-answer-answer'; }
+
+  sexAnswerEdit() { return '[data-qa="sex-answer-edit"]'; }
+
+  sexGroupTitle() { return '#sex-group'; }
+
+  summaryGroupTitle() { return '#summary-group'; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/spec/routing_repeat_until.spec.js
+++ b/tests/functional/spec/routing_repeat_until.spec.js
@@ -1,0 +1,103 @@
+const helpers = require('../helpers');
+
+const PrimaryNamePage = require('../pages/surveys/routing_repeat_until/primary-name-block.page.js');
+const PrimaryAnyoneElsePage = require('../pages/surveys/routing_repeat_until/primary-anyone-else-block.page.js');
+const RepeatingNamePage = require('../pages/surveys/routing_repeat_until/repeating-name-block.page.js');
+const RepeatingAnyoneElsePage = require('../pages/surveys/routing_repeat_until/repeating-anyone-else-block.page.js');
+const SexPage = require('../pages/surveys/routing_repeat_until/sex-block.page.js');
+const SummaryPage = require('../pages/surveys/routing_repeat_until/summary.page.js');
+
+describe('Routing Repeat Until', function() {
+
+  it('Given the test_routing_repeat_until survey is selected when one additional member is entered we are asked about the the sex of them and the primary member', function() {
+
+    return helpers.openQuestionnaire('test_routing_repeat_until.json').then(() => {
+
+      return browser
+        .setValue(PrimaryNamePage.answer(), 'Bob')
+        .click(PrimaryNamePage.submit())
+
+        .click(PrimaryAnyoneElsePage.yes())
+        .click(PrimaryAnyoneElsePage.submit())
+
+        .setValue(RepeatingNamePage.answer(), 'Alice')
+        .click(RepeatingNamePage.submit())
+
+        .click(RepeatingAnyoneElsePage.no())
+        .click(RepeatingAnyoneElsePage.submit())
+
+        .getText(SexPage.questionText()).should.eventually.contain('Bob')
+        .click(SexPage.male())
+        .click(SexPage.submit())
+
+        .getText(SexPage.questionText()).should.eventually.contain('Alice')
+        .click(SexPage.female())
+        .click(SexPage.submit())
+
+        .getUrl().should.eventually.contain(SummaryPage.pageName)
+        .click(SummaryPage.submit());
+    });
+  });
+
+  it('Given the test_routing_repeat_until survey is selected when multiple additional members are entered we are asked about the sex of all of them and the primary member', function() {
+
+    return helpers.openQuestionnaire('test_routing_repeat_until.json').then(() => {
+
+      return browser
+        .setValue(PrimaryNamePage.answer(), 'Bob')
+        .click(PrimaryNamePage.submit())
+
+        .click(PrimaryAnyoneElsePage.yes())
+        .click(PrimaryAnyoneElsePage.submit())
+
+        .setValue(RepeatingNamePage.answer(), 'Alice')
+        .click(RepeatingNamePage.submit())
+
+        .click(RepeatingAnyoneElsePage.yes())
+        .click(RepeatingAnyoneElsePage.submit())
+
+        .setValue(RepeatingNamePage.answer(), 'John')
+        .click(RepeatingNamePage.submit())
+
+        .click(RepeatingAnyoneElsePage.no())
+        .click(RepeatingAnyoneElsePage.submit())
+
+        .getText(SexPage.questionText()).should.eventually.contain('Bob')
+        .click(SexPage.male())
+        .click(SexPage.submit())
+
+        .getText(SexPage.questionText()).should.eventually.contain('Alice')
+        .click(SexPage.female())
+        .click(SexPage.submit())
+
+        .getText(SexPage.questionText()).should.eventually.contain('John')
+        .click(SexPage.male())
+        .click(SexPage.submit())
+
+        .getUrl().should.eventually.contain(SummaryPage.pageName)
+        .click(SummaryPage.submit());
+    });
+  });
+
+  it('Given the test_routing_repeat_until survey is selected when no additional members are entered we are asked about the sex of the primary member', function() {
+
+    return helpers.openQuestionnaire('test_routing_repeat_until.json').then(() => {
+
+      return browser
+        .setValue(PrimaryNamePage.answer(), 'Bob')
+        .click(PrimaryNamePage.submit())
+
+        .click(PrimaryAnyoneElsePage.no())
+        .click(PrimaryAnyoneElsePage.submit())
+
+        .getText(SexPage.questionText()).should.eventually.contain('Bob')
+        .click(SexPage.male())
+        .click(SexPage.submit())
+
+        .getUrl().should.eventually.contain(SummaryPage.pageName)
+        .click(SummaryPage.submit());
+    });
+  });
+
+});
+


### PR DESCRIPTION
### What is the context of this PR?
Add a repeating type of `until`.  See also ONSdigital/go-launch-a-survey#106 and ONSdigital/eq-schema-validator#67.

### How to review 
Run `test_routing_repeat_until.json` , fill in some names and choose yes/no for the more people question at various stages.  See that you get asked about the sex of all the people's names you entered.  Note that the summary page only displays the first person in the repeating group, fixing this isn't within the scope of this PR.