### PR TITLE
Fix submission dumping with repeating groups

### DIFF
--- a/app/forms/household_composition_form.py
+++ b/app/forms/household_composition_form.py
@@ -18,7 +18,7 @@ def get_name_form(schema, block_json, metadata, group_instance):
     for question in schema.get_questions_for_block(block_json):
         for answer in question['answers']:
             guidance = answer.get('guidance', '')
-            label = answer.get('label') or get_question_title(question, answer_store, metadata, group_instance)
+            label = answer.get('label') or get_question_title(question, answer_store, schema, metadata, group_instance)
 
             field = get_string_field(answer, label, guidance, schema.error_messages)
 

--- a/app/forms/questionnaire_form.py
+++ b/app/forms/questionnaire_form.py
@@ -256,7 +256,7 @@ class QuestionnaireForm(FlaskForm):
         return None
 
 
-def get_answer_fields(question, data, error_messages, answer_store, metadata, group_instance):
+def get_answer_fields(question, data, error_messages, schema, answer_store, metadata, group_instance):
     answer_fields = {}
     for answer in question.get('answers', []):
         if 'parent_answer_id' in answer and answer['parent_answer_id'] in data and \
@@ -264,7 +264,7 @@ def get_answer_fields(question, data, error_messages, answer_store, metadata, gr
             answer['mandatory'] = \
                 next(a['mandatory'] for a in question['answers'] if a['id'] == answer['parent_answer_id'])
 
-        name = answer.get('label') or get_question_title(question, answer_store, metadata, group_instance)
+        name = answer.get('label') or get_question_title(question, answer_store, schema, metadata, group_instance)
         answer_fields[answer['id']] = get_field(answer, name, error_messages, answer_store, metadata)
     return answer_fields
 
@@ -305,6 +305,7 @@ def generate_form(schema, block_json, answer_store, metadata, group_instance, da
             question,
             formdata if formdata is not None else data,
             schema.error_messages,
+            schema,
             answer_store,
             metadata,
             group_instance

--- a/app/helpers/schema_helpers.py
+++ b/app/helpers/schema_helpers.py
@@ -1,0 +1,26 @@
+from functools import wraps
+
+from app.globals import get_session_store
+from app.utilities.schema import load_schema_from_session_data
+
+
+def with_schema(function):
+    """Adds the survey schema as the first argument to the function being wrapped.
+    Use on flask request handlers or methods called by flask request handlers.
+
+    May error unless there is a `current_user`, so should be used as follows e.g.
+
+    ```python
+    @login_required
+    @with_schema
+    @full_routing_path_required
+    def get_block(routing_path, schema, *args):
+        ...
+    ```
+    """
+    @wraps(function)
+    def wrapped_function(*args, **kwargs):
+        session_data = get_session_store().session_data
+        schema = load_schema_from_session_data(session_data)
+        return function(schema, *args, **kwargs)
+    return wrapped_function

--- a/app/helpers/session_helpers.py
+++ b/app/helpers/session_helpers.py
@@ -1,0 +1,29 @@
+from functools import wraps
+
+from flask_login import current_user
+
+from app.globals import get_answer_store, get_metadata
+
+
+def with_answer_store(function):
+    """Adds the `answer_store` as an argument, where the `current_user` is defined.
+    Use on flask request handlers or methods called by flask request handlers.
+
+    May error unless there is a `current_user`."""
+    @wraps(function)
+    def wrapped_function(*args, **kwargs):
+        answer_store = get_answer_store(current_user)
+        return function(answer_store, *args, **kwargs)
+    return wrapped_function
+
+
+def with_metadata(function):
+    """Adds `metadata` as an argument, where the `current_user` is defined.
+    Use on flask request handlers or methods called by flask request handlers.
+
+    May error unless there is a `current_user`."""
+    @wraps(function)
+    def other_wrapped_function(*args, **kwargs):
+        metadata = get_metadata(current_user)
+        return function(metadata, *args, **kwargs)
+    return other_wrapped_function

--- a/app/helpers/template_helper.py
+++ b/app/helpers/template_helper.py
@@ -1,3 +1,5 @@
+from functools import wraps
+
 from flask import current_app, g
 from flask_login import current_user
 from flask_themes2 import render_theme_template
@@ -11,6 +13,7 @@ logger = get_logger()
 
 
 def with_session_timeout(func):
+    @wraps(func)
     def session_wrapper(*args, **kwargs):
         session_timeout = current_app.config['EQ_SESSION_TIMEOUT_SECONDS']
         schema_session_timeout = g.schema.json.get('session_timeout_in_seconds')
@@ -31,17 +34,19 @@ def with_session_timeout(func):
     return session_wrapper
 
 
-def with_metadata(func):
-    def metadata_wrapper(*args, **kwargs):
+def with_metadata_context(func):
+    @wraps(wraps)
+    def metadata_context_wrapper(*args, **kwargs):
         metadata = get_metadata(current_user)
         metadata_context = build_metadata_context(metadata)
 
         return func(*args, metadata=metadata_context, **kwargs)
 
-    return metadata_wrapper
+    return metadata_context_wrapper
 
 
 def with_analytics(func):
+    @wraps(func)
     def analytics_wrapper(*args, **kwargs):
         return func(*args, analytics_ua_id=current_app.config['EQ_UA_ID'], **kwargs)
 
@@ -49,6 +54,7 @@ def with_analytics(func):
 
 
 def with_questionnaire_url_prefix(func):
+    @wraps(func)
     def url_prefix_wrapper(*args, **kwargs):
         metadata = get_metadata(current_user)
         metadata_context = build_metadata_context(metadata)
@@ -65,6 +71,7 @@ def with_questionnaire_url_prefix(func):
 
 
 def with_legal_basis(func):
+    @wraps(func)
     def legal_basis_wrapper(*args, **kwargs):
         return func(*args, legal_basis=g.schema.json['legal_basis'], **kwargs)
 

--- a/app/questionnaire/completeness.py
+++ b/app/questionnaire/completeness.py
@@ -172,7 +172,7 @@ class Completeness:
     def _should_skip(self, group_or_block):
         return (
             'skip_conditions' in group_or_block and
-            evaluate_skip_conditions(group_or_block['skip_conditions'], self.metadata, self.answer_store)
+            evaluate_skip_conditions(group_or_block['skip_conditions'], self.schema, self.metadata, self.answer_store)
         )
 
     def _is_valid_for_completeness(self, block, location):

--- a/app/questionnaire/path_finder.py
+++ b/app/questionnaire/path_finder.py
@@ -50,7 +50,7 @@ class PathFinder:
                 this_location = Location(group['id'], 0, first_block_in_group)
 
             if 'skip_conditions' in group:
-                if evaluate_skip_conditions(group['skip_conditions'], self.metadata, self.answer_store):
+                if evaluate_skip_conditions(group['skip_conditions'], self.schema, self.metadata, self.answer_store):
                     continue
 
             no_of_repeats = get_number_of_repeats(group, self.schema, path, self.answer_store)
@@ -79,7 +79,7 @@ class PathFinder:
         for block in group['blocks']:
             skip_conditions = block.get('skip_conditions')
             if skip_conditions and evaluate_skip_conditions(
-                    skip_conditions, self.metadata, self.answer_store, instance_idx):
+                    skip_conditions, self.schema, self.metadata, self.answer_store, instance_idx):
                 continue
 
             yield {
@@ -128,7 +128,7 @@ class PathFinder:
 
     def _evaluate_routing_rules(self, this_location, blocks, block, block_index, path):
         for rule in filter(is_goto_rule, block['routing_rules']):
-            should_goto = evaluate_goto(rule['goto'], self.metadata, self.answer_store, this_location.group_instance)
+            should_goto = evaluate_goto(rule['goto'], self.schema, self.metadata, self.answer_store, this_location.group_instance)
 
             if should_goto:
                 return self._follow_routing_rule(this_location, rule, blocks, block_index, path)

--- a/app/templating/metadata_context.py
+++ b/app/templating/metadata_context.py
@@ -1,6 +1,7 @@
 from app.libs.utils import convert_tx_id
 from app.templating.schema_context import json_and_html_safe
 from app.templating.schema_context import build_schema_metadata
+from app.utilities.schema import load_schema_from_metadata
 
 
 def build_metadata_context(metadata):
@@ -17,7 +18,9 @@ def build_metadata_context(metadata):
         'tx_id': json_and_html_safe(metadata['tx_id'])
     }
 
-    eq_context.update(build_schema_metadata(metadata))
+    schema = load_schema_from_metadata(metadata)
+
+    eq_context.update(build_schema_metadata(metadata, schema))
 
     return eq_context
 

--- a/app/templating/schema_context.py
+++ b/app/templating/schema_context.py
@@ -1,30 +1,29 @@
 from jinja2 import escape
 
-from flask import g
 
-
-def build_schema_context(metadata, answer_store, answer_ids_on_path, group_instance=0):
+def build_schema_context(metadata, schema, answer_store, answer_ids_on_path, group_instance=0):
     """
     Build questionnaire schema context containing exercise and answers
     :param metadata: user metadata
+    :param schema: Survey schema
     :param answer_store: all the answers for the given questionnaire
     :param answer_ids_on_path: a list of the answer ids on the routing path
     :param group_instance: The group instance Id passed into the url route
     :return: questionnaire schema context
     """
     return {
-        'metadata': build_schema_metadata(metadata),
-        'answers': _build_answers(answer_store, answer_ids_on_path),
+        'metadata': build_schema_metadata(metadata, schema),
+        'answers': _build_answers(answer_store, schema, answer_ids_on_path),
         'group_instance': group_instance,
     }
 
 
-def _build_answers(answer_store, answer_ids_on_path):
+def _build_answers(answer_store, schema, answer_ids_on_path):
     answers = {}
 
     for answer_id in answer_ids_on_path:
-        is_repeating_answer = _get_is_repeating_answer(answer_id)
-        answer_is_in_repeating_group = _get_answer_is_in_repeating_group(answer_id)
+        is_repeating_answer = _get_is_repeating_answer(answer_id, schema)
+        answer_is_in_repeating_group = _get_answer_is_in_repeating_group(answer_id, schema)
 
         matching_answers = answer_store.filter(
             answer_ids=[answer_id], limit=True)
@@ -45,9 +44,9 @@ def _build_answers(answer_store, answer_ids_on_path):
     return answers
 
 
-def build_schema_metadata(metadata):
+def build_schema_metadata(metadata, schema):
 
-    schema_metadata = g.schema.json['metadata']
+    schema_metadata = schema.json['metadata']
     parsed = {key: json_and_html_safe(metadata[key]) for key in schema_metadata.keys() if key in metadata}
     trad_as = json_and_html_safe(metadata.get('trad_as'))
     ru_name = json_and_html_safe(metadata.get('ru_name'))
@@ -67,12 +66,12 @@ def json_and_html_safe(data):
     return data
 
 
-def _get_is_repeating_answer(answer_id):
-    return g.schema.is_repeating_answer_type(answer_id)
+def _get_is_repeating_answer(answer_id, schema):
+    return schema.is_repeating_answer_type(answer_id)
 
 
-def _get_answer_is_in_repeating_group(answer_id):
-    return g.schema.answer_is_in_repeating_group(answer_id)
+def _get_answer_is_in_repeating_group(answer_id, schema):
+    return schema.answer_is_in_repeating_group(answer_id)
 
 
 def _create_answers_list(answers, index_key):

--- a/app/templating/summary/block.py
+++ b/app/templating/summary/block.py
@@ -6,12 +6,12 @@ from app.templating.summary.question import Question
 
 class Block:
 
-    def __init__(self, block_schema, group_id, answer_store, metadata):
+    def __init__(self, block_schema, group_id, answer_store, metadata, schema):
         self.id = block_schema['id']
         self.title = block_schema.get('title')
         self.number = block_schema.get('number')
         self.link = self._build_link(block_schema, group_id, metadata)
-        self.questions = self._build_questions(block_schema, answer_store, metadata)
+        self.questions = self._build_questions(block_schema, answer_store, metadata, schema)
 
     @staticmethod
     def _build_link(block_schema, group_id, metadata):
@@ -24,12 +24,12 @@ class Block:
                        block_id=block_schema['id'])
 
     @staticmethod
-    def _build_questions(block_schema, answer_store, metadata):
+    def _build_questions(block_schema, answer_store, metadata, schema):
         questions = []
         for question_schema in block_schema.get('questions', []):
-            is_skipped = evaluate_skip_conditions(question_schema.get('skip_conditions'), metadata, answer_store)
+            is_skipped = evaluate_skip_conditions(question_schema.get('skip_conditions'), schema, metadata, answer_store)
             if not is_skipped:
-                question = Question(question_schema, answer_store, metadata).serialize()
+                question = Question(question_schema, answer_store, metadata, schema).serialize()
                 questions.append(question)
         return questions
 

--- a/app/templating/summary/group.py
+++ b/app/templating/summary/group.py
@@ -3,13 +3,13 @@ from app.templating.summary.block import Block
 
 class Group:
 
-    def __init__(self, group_schema, path, answer_store, metadata):
+    def __init__(self, group_schema, path, answer_store, metadata, schema):
         self.id = group_schema['id']
         self.title = group_schema['title']
-        self.blocks = self._build_blocks(group_schema, path, answer_store, metadata)
+        self.blocks = self._build_blocks(group_schema, path, answer_store, metadata, schema)
 
     @staticmethod
-    def _build_blocks(group_schema, path, answer_store, metadata):
+    def _build_blocks(group_schema, path, answer_store, metadata, schema):
         blocks = []
 
         block_ids_on_path = [location.block_id for location in path]
@@ -17,7 +17,7 @@ class Group:
         for block in group_schema['blocks']:
             if block['id'] in block_ids_on_path and \
                     block['type'] == 'Question':
-                blocks.extend([Block(block, group_schema['id'], answer_store, metadata).serialize()])
+                blocks.extend([Block(block, group_schema['id'], answer_store, metadata, schema).serialize()])
 
         return blocks
 

--- a/app/templating/summary/question.py
+++ b/app/templating/summary/question.py
@@ -6,14 +6,14 @@ from app.templating.utils import get_question_title
 
 class Question:
 
-    def __init__(self, question_schema, answer_store, metadata):
+    def __init__(self, question_schema, answer_store, metadata, schema):
         self.id = question_schema['id']
         self.type = question_schema['type']
 
         answer_schemas = iter(question_schema['answers'])
 
         # Using group instance as 0 for now as summary rendering context only has knowledge of current locations group instance (i.e. 0)
-        self.title = get_question_title(question_schema, answer_store, metadata, group_instance=0) or question_schema['answers'][0]['label']
+        self.title = get_question_title(question_schema, answer_store, schema, metadata, group_instance=0) or question_schema['answers'][0]['label']
         self.number = question_schema.get('number', None)
         self.answers = self._build_answers(answer_store, question_schema, answer_schemas)
 

--- a/app/templating/summary_context.py
+++ b/app/templating/summary_context.py
@@ -27,6 +27,6 @@ def build_summary_rendering_context(schema, sections, answer_store, metadata):
     for group in itertools.chain.from_iterable(group_lists):
         if group['id'] in group_ids_on_path \
                 and schema.group_has_questions(group['id']):
-            groups.extend([Group(group, path, answer_store, metadata).serialize()])
+            groups.extend([Group(group, path, answer_store, metadata, schema).serialize()])
 
     return groups

--- a/app/templating/utils.py
+++ b/app/templating/utils.py
@@ -1,7 +1,7 @@
 from app.questionnaire.rules import evaluate_when_rules
 
 
-def get_question_title(question_schema, answer_store, metadata, group_instance):
+def get_question_title(question_schema, answer_store, schema, metadata, group_instance):
     """Return the value that should be used as the title to a question
     May be from question.title or question.titles"""
 
@@ -10,13 +10,12 @@ def get_question_title(question_schema, answer_store, metadata, group_instance):
 
     titles = question_schema.get('titles')
 
-    return get_title_from_titles(metadata, answer_store, titles, group_instance)
+    return get_title_from_titles(metadata, schema, answer_store, titles, group_instance)
 
 
-def get_title_from_titles(metadata, answer_store, titles, group_instance):
+def get_title_from_titles(metadata, schema, answer_store, titles, group_instance):
     """returns a title from titles available by evaluating the when rules , if all fail returns default"""
-
     for when, value in ((title['when'], title['value']) for title in titles if 'when' in title):
-        if evaluate_when_rules(when, metadata, answer_store, group_instance):
+        if evaluate_when_rules(when, schema, metadata, answer_store, group_instance):
             return value
     return titles[-1]['value']

--- a/app/views/feedback.py
+++ b/app/views/feedback.py
@@ -86,6 +86,6 @@ def thank_you():
 
 @template_helper.with_session_timeout
 @template_helper.with_analytics
-@template_helper.with_metadata
+@template_helper.with_metadata_context
 def _render_template(template, **kwargs):
     return template_helper.render_template(template, **kwargs)

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -1,3 +1,4 @@
+from functools import wraps
 import re
 from collections import defaultdict
 from datetime import datetime, timedelta
@@ -18,7 +19,10 @@ from app.data_model.app_models import SubmittedResponse
 from app.globals import get_answer_store, get_completed_blocks, get_metadata, get_questionnaire_store
 from app.helpers.form_helper import post_form_for_location
 from app.helpers.path_finder_helper import path_finder, full_routing_path_required
-from app.helpers import template_helper
+from app.helpers.schema_helpers import with_schema
+from app.helpers.session_helpers import with_answer_store, with_metadata
+from app.helpers.template_helper import (with_session_timeout, with_metadata_context, with_analytics,
+                                         with_questionnaire_url_prefix, with_legal_basis, render_template)
 
 from app.questionnaire.location import Location
 from app.questionnaire.navigation import Navigation
@@ -38,7 +42,7 @@ from app.templating.summary_context import build_summary_rendering_context
 from app.templating.template_renderer import renderer, TemplateRenderer
 from app.templating.view_context import build_view_context
 
-from app.utilities.schema import load_schema_from_session_data, load_schema_from_metadata
+from app.utilities.schema import load_schema_from_session_data
 from app.views.errors import MultipleSurveyError
 from app.authentication.no_token_exception import NoTokenException
 
@@ -86,6 +90,7 @@ def before_post_submission_request():
         raise NoTokenException(401)
 
     session_data = session.session_data
+    g.schema = load_schema_from_session_data(session_data)
 
     logger.bind(tx_id=session_data.tx_id)
 
@@ -109,6 +114,7 @@ def add_cache_control(response):
 
 
 def save_questionnaire_store(func):
+    @wraps(func)
     def save_questionnaire_store_wrapper(*args, **kwargs):
         response = func(*args, **kwargs)
         if not current_user.is_anonymous:
@@ -123,83 +129,86 @@ def save_questionnaire_store(func):
 
 @questionnaire_blueprint.route('<group_id>/<int:group_instance>/<block_id>', methods=['GET'])
 @login_required
+@with_answer_store
+@with_metadata
+@with_schema
 @full_routing_path_required
-def get_block(routing_path, eq_id, form_type, collection_id, group_id, group_instance, block_id):  # pylint: disable=unused-argument,too-many-locals
+def get_block(routing_path, schema, metadata, answer_store, eq_id, form_type, collection_id, group_id,  # pylint: disable=too-many-locals
+              group_instance, block_id):
     current_location = Location(group_id, group_instance, block_id)
     completeness = get_completeness(current_user)
-    metadata = get_metadata(current_user)
-    schema = load_schema_from_metadata(metadata)
-
-    router = Router(g.schema, routing_path, completeness, current_location)
+    router = Router(schema, routing_path, completeness, current_location)
 
     if not router.can_access_location():
         next_location = router.get_next_location()
         return _redirect_to_location(collection_id, eq_id, form_type, next_location)
 
-    block = _get_block_json(current_location)
+    block = _get_block_json(current_location, schema, answer_store, metadata)
     context = _get_context(routing_path, block, current_location, schema)
 
-    return _render_page(block['type'], context, current_location, routing_path)
+    return _render_page(block['type'], context, current_location, schema, answer_store, metadata, routing_path)
 
 
 @questionnaire_blueprint.route('<group_id>/<int:group_instance>/<block_id>', methods=['POST'])
 @login_required
+@with_answer_store
+@with_metadata
+@with_schema
 @full_routing_path_required
-def post_block(routing_path, eq_id, form_type, collection_id, group_id, group_instance, block_id):  # pylint: disable=too-many-locals
+def post_block(routing_path, schema, metadata, answer_store, eq_id, form_type, collection_id, group_id,  # pylint: disable=too-many-locals
+               group_instance, block_id):
     current_location = Location(group_id, group_instance, block_id)
-    answer_store = get_answer_store(current_user)
     completeness = get_completeness(current_user)
-    metadata = get_metadata(current_user)
-    schema = load_schema_from_metadata(metadata)
-
-    router = Router(g.schema, routing_path, completeness, current_location)
+    router = Router(schema, routing_path, completeness, current_location)
 
     if not router.can_access_location():
         next_location = router.get_next_location()
         return _redirect_to_location(collection_id, eq_id, form_type, next_location)
 
-    block = _get_block_json(current_location)
+    block = _get_block_json(current_location, schema, answer_store, metadata)
+
     schema_context = _get_schema_context(routing_path, current_location.group_instance, metadata, answer_store, schema)
 
     rendered_block = renderer.render(block, **schema_context)
 
-    form = _generate_wtf_form(request.form, rendered_block, current_location)
+    form = _generate_wtf_form(request.form, rendered_block, current_location, schema)
 
     if 'action[save_sign_out]' in request.form:
-        return _save_sign_out(routing_path, current_location, form)
+        return _save_sign_out(routing_path, current_location, form, schema, answer_store, metadata)
 
     if form.validate():
-        _update_questionnaire_store(current_location, form)
+        _update_questionnaire_store(current_location, form, schema)
         next_location = path_finder.get_next_location(current_location=current_location)
 
         if _is_end_of_questionnaire(block, next_location):
-            return submit_answers(routing_path, eq_id, form_type)
+            return submit_answers(routing_path, eq_id, form_type, schema)
 
         return redirect(_next_location_url(next_location))
 
     context = build_view_context(block['type'], metadata, schema, answer_store, schema_context, rendered_block, current_location, form)
 
-    return _render_page(block['type'], context, current_location, routing_path)
+    return _render_page(block['type'], context, current_location, schema, answer_store, metadata, routing_path)
 
 
 @questionnaire_blueprint.route('<group_id>/0/household-composition', methods=['POST'])
 @login_required
+@with_answer_store
+@with_metadata
+@with_schema
 @full_routing_path_required
-def post_household_composition(routing_path, **kwargs):
+def post_household_composition(routing_path, schema, metadata, answer_store, **kwargs):
     group_id = kwargs['group_id']
-    answer_store = get_answer_store(current_user)
-    metadata = get_metadata(current_user)
-    schema = load_schema_from_metadata(metadata)
-    if _household_answers_changed(answer_store):
-        _remove_repeating_on_household_answers(answer_store)
+
+    if _household_answers_changed(answer_store, schema):
+        _remove_repeating_on_household_answers(answer_store, schema)
 
     disable_mandatory = any(x in request.form for x in ['action[add_answer]', 'action[remove_answer]', 'action[save_sign_out]'])
 
     current_location = Location(group_id, 0, 'household-composition')
 
-    block = _get_block_json(current_location)
+    block = _get_block_json(current_location, schema, answer_store, metadata)
 
-    form = post_form_for_location(g.schema, block, current_location, answer_store, get_metadata(current_user),
+    form = post_form_for_location(schema, block, current_location, answer_store, metadata,
                                   request.form, disable_mandatory=disable_mandatory)
 
     form.validate()  # call validate here to keep errors in the form object on the context
@@ -208,37 +217,39 @@ def post_household_composition(routing_path, **kwargs):
     if 'action[add_answer]' in request.form:
         form.household.append_entry()
 
-        return _render_page(block['type'], context, current_location, routing_path)
+        return _render_page(block['type'], context, current_location, schema, answer_store, metadata, routing_path)
 
     if 'action[remove_answer]' in request.form:
         index_to_remove = int(request.form.get('action[remove_answer]'))
         form.remove_person(index_to_remove)
 
-        return _render_page(block['type'], context, current_location, routing_path)
+        return _render_page(block['type'], context, current_location, schema, answer_store, metadata, routing_path)
 
     if 'action[save_sign_out]' in request.form:
-        response = _save_sign_out(routing_path, current_location, form)
-        remove_empty_household_members_from_answer_store(answer_store)
+        response = _save_sign_out(routing_path, current_location, form, schema, answer_store, metadata)
+        remove_empty_household_members_from_answer_store(answer_store, schema)
 
         return response
 
     if form.validate():
         questionnaire_store = get_questionnaire_store(current_user.user_id, current_user.user_ik)
-        update_questionnaire_store_with_answer_data(questionnaire_store, current_location, form.serialise())
+        update_questionnaire_store_with_answer_data(questionnaire_store, current_location, form.serialise(), schema)
 
         metadata = get_metadata(current_user)
         next_location = path_finder.get_next_location(current_location=current_location)
 
         return redirect(next_location.url(metadata))
 
-    return _render_page(block['type'], context, current_location, routing_path)
+    return _render_page(block['type'], context, current_location, schema, answer_store, metadata, routing_path)
 
 
 @post_submission_blueprint.route('thank-you', methods=['GET'])
 @login_required
-def get_thank_you(eq_id, form_type):  # pylint: disable=unused-argument
+@with_metadata
+@with_schema
+def get_thank_you(schema, metadata, eq_id, form_type):  # pylint: disable=unused-argument
     session_data = get_session_store().session_data
-    g.schema = schema = load_schema_from_session_data(session_data)
+    completeness = get_completeness(current_user)
 
     if session_data.submitted_time:
         metadata_context = build_metadata_context_for_survey_completed(session_data)
@@ -254,18 +265,16 @@ def get_thank_you(eq_id, form_type):  # pylint: disable=unused-argument
                                      metadata=metadata_context,
                                      analytics_ua_id=current_app.config['EQ_UA_ID'],
                                      survey_id=schema.json['survey_id'],
-                                     survey_title=TemplateRenderer.safe_content(g.schema.json['title']),
+                                     survey_title=TemplateRenderer.safe_content(schema.json['title']),
                                      is_view_submitted_response_enabled=is_view_submitted_response_enabled(schema.json),
                                      view_submission_url=view_submission_url,
                                      view_submission_duration=view_submission_duration)
 
     routing_path = path_finder.get_full_routing_path()
-    completeness = get_completeness(current_user)
-    metadata = get_metadata(current_user)
 
     collection_id = metadata['collection_exercise_sid']
 
-    router = Router(g.schema, routing_path, completeness)
+    router = Router(schema, routing_path, completeness)
     next_location = router.get_next_location()
 
     return _redirect_to_location(collection_id, metadata.get('eq_id'), metadata.get('form_type'), next_location)
@@ -273,12 +282,12 @@ def get_thank_you(eq_id, form_type):  # pylint: disable=unused-argument
 
 @post_submission_blueprint.route('view-submission', methods=['GET'])
 @login_required
-def get_view_submission(eq_id, form_type):  # pylint: disable=unused-argument
+@with_schema
+def get_view_submission(schema, eq_id, form_type):  # pylint: disable=unused-argument
 
     session_data = get_session_store().session_data
-    g.schema = schema = load_schema_from_session_data(session_data)
 
-    if _is_submission_viewable(g.schema.json, session_data.submitted_time):
+    if _is_submission_viewable(schema.json, session_data.submitted_time):
         submitted_data = data_access.get_by_key(SubmittedResponse, session_data.tx_id)
 
         if submitted_data:
@@ -293,33 +302,33 @@ def get_view_submission(eq_id, form_type):  # pylint: disable=unused-argument
 
             metadata = submitted_data.get('metadata')
 
-            routing_path = PathFinder(g.schema, answer_store, metadata, []).get_full_routing_path()
+            routing_path = PathFinder(schema, answer_store, metadata, []).get_full_routing_path()
 
             schema_context = _get_schema_context(routing_path, 0, metadata, answer_store, schema)
-            rendered_schema = renderer.render(g.schema.json, **schema_context)
-            summary_rendered_context = build_summary_rendering_context(g.schema, rendered_schema['sections'], answer_store, metadata)
+            rendered_schema = renderer.render(schema.json, **schema_context)
+            summary_rendered_context = build_summary_rendering_context(schema, rendered_schema['sections'], answer_store, metadata)
 
             context = {
                 'summary': {
                     'groups': summary_rendered_context,
                     'answers_are_editable': False,
-                    'is_view_submission_response_enabled': is_view_submitted_response_enabled(g.schema.json),
+                    'is_view_submission_response_enabled': is_view_submitted_response_enabled(schema.json),
                 },
                 'variables': None
             }
 
-            return render_theme_template(g.schema.json['theme'],
+            return render_theme_template(schema.json['theme'],
                                          template_name='view-submission.html',
                                          metadata=metadata_context,
                                          analytics_ua_id=current_app.config['EQ_UA_ID'],
-                                         survey_id=g.schema.json['survey_id'],
-                                         survey_title=TemplateRenderer.safe_content(g.schema.json['title']),
+                                         survey_id=schema.json['survey_id'],
+                                         survey_title=TemplateRenderer.safe_content(schema.json['title']),
                                          content=context)
 
     return redirect(url_for('post_submission.get_thank_you', eq_id=eq_id, form_type=form_type))
 
 
-def _render_page(block_type, context, current_location, routing_path):
+def _render_page(block_type, context, current_location, schema, answer_store, metadata, routing_path):
     if request_wants_json():
         return jsonify(context)
 
@@ -327,14 +336,17 @@ def _render_page(block_type, context, current_location, routing_path):
         current_location,
         context,
         block_type,
+        schema,
+        answer_store,
+        metadata,
         routing_path=routing_path)
 
 
-def _generate_wtf_form(form, block, location):
+def _generate_wtf_form(form, block, location, schema):
     disable_mandatory = 'action[save_sign_out]' in form
 
     wtf_form = post_form_for_location(
-        g.schema,
+        schema,
         block,
         location,
         get_answer_store(current_user),
@@ -357,7 +369,17 @@ def _is_end_of_questionnaire(block, next_location):
     )
 
 
-def submit_answers(routing_path, eq_id, form_type):
+def _is_skipping_to_the_end(block, current_location):
+    latest_location = get_completeness(current_user).get_first_incomplete_location_in_survey()
+
+    return (
+        latest_location and
+        current_location != latest_location and
+        block['type'] in END_BLOCKS
+    )
+
+
+def submit_answers(routing_path, eq_id, form_type, schema):
     metadata = get_metadata(current_user)
     answer_store = get_answer_store(current_user)
 
@@ -368,7 +390,7 @@ def submit_answers(routing_path, eq_id, form_type):
 
     message = json.dumps(convert_answers(
         metadata,
-        g.schema,
+        schema,
         answer_store,
         routing_path,
     ))
@@ -387,7 +409,7 @@ def submit_answers(routing_path, eq_id, form_type):
 
     _store_submitted_time_in_session(submitted_time)
 
-    if is_view_submitted_response_enabled(g.schema.json):
+    if is_view_submitted_response_enabled(schema.json):
         _store_viewable_submission(answer_store.answers, metadata, submitted_time)
 
     get_questionnaire_store(current_user.user_id, current_user.user_ik).delete()
@@ -440,30 +462,28 @@ def _is_submission_viewable(schema, submitted_time):
     return False
 
 
-def _save_sign_out(routing_path, this_location, form):
+def _save_sign_out(routing_path, current_location, form, schema, answer_store, metadata):
     questionnaire_store = get_questionnaire_store(current_user.user_id, current_user.user_ik)
-    metadata = get_metadata(current_user)
-    schema = load_schema_from_metadata(metadata)
 
-    block = _get_block_json(this_location)
+    block = _get_block_json(current_location, schema, answer_store, metadata)
 
     if form.validate():
-        _update_questionnaire_store(this_location, form)
+        _update_questionnaire_store(current_location, form, schema)
 
-        if this_location in questionnaire_store.completed_blocks:
-            questionnaire_store.remove_completed_blocks(location=this_location)
+        if current_location in questionnaire_store.completed_blocks:
+            questionnaire_store.remove_completed_blocks(location=current_location)
             questionnaire_store.add_or_update()
 
         logout_user()
 
         return redirect(url_for('session.get_sign_out'))
 
-    context = _get_context(routing_path, block, this_location, schema, form)
-    return _render_page(block['type'], context, this_location, routing_path)
+    context = _get_context(routing_path, block, current_location, schema, form)
+    return _render_page(block['type'], context, current_location, schema, answer_store, metadata, routing_path)
 
 
-def _household_answers_changed(answer_store):
-    answer_ids = g.schema.get_answer_ids_for_block('household-composition')
+def _household_answers_changed(answer_store, schema):
+    answer_ids = schema.get_answer_ids_for_block('household-composition')
     household_answers = answer_store.filter(answer_ids)
     stripped_form = request.form.copy()
     del stripped_form['csrf_token']
@@ -488,25 +508,25 @@ def _household_answers_changed(answer_store):
     return False
 
 
-def _remove_repeating_on_household_answers(answer_store):
-    answer_ids = g.schema.get_answer_ids_for_block('household-composition')
+def _remove_repeating_on_household_answers(answer_store, schema):
+    answer_ids = schema.get_answer_ids_for_block('household-composition')
     answer_store.remove(answer_ids=answer_ids)
     questionnaire_store = get_questionnaire_store(
         current_user.user_id,
         current_user.user_ik,
     )
 
-    for answer in g.schema.get_answers_that_repeat_in_block('household-composition'):
-        groups_to_delete = g.schema.get_groups_that_repeat_with_answer_id(answer['id'])
+    for answer in schema.get_answers_that_repeat_in_block('household-composition'):
+        groups_to_delete = schema.get_groups_that_repeat_with_answer_id(answer['id'])
         for group in groups_to_delete:
-            answer_ids = g.schema.get_answer_ids_for_group(group['id'])
+            answer_ids = schema.get_answer_ids_for_group(group['id'])
             answer_store.remove(answer_ids=answer_ids)
             questionnaire_store.completed_blocks[:] = [b for b in questionnaire_store.completed_blocks if
                                                        b.group_id != group['id']]
 
 
-def remove_empty_household_members_from_answer_store(answer_store):
-    answer_ids = g.schema.get_answer_ids_for_block('household-composition')
+def remove_empty_household_members_from_answer_store(answer_store, schema):
+    answer_ids = schema.get_answer_ids_for_block('household-composition')
     household_answers = answer_store.filter(answer_ids=answer_ids)
     household_member_name = defaultdict(list)
     for household_answer in household_answers:
@@ -523,25 +543,25 @@ def remove_empty_household_members_from_answer_store(answer_store):
         answer_store.remove(answer_ids=answer_ids, answer_instance=instance_to_remove)
 
 
-def _update_questionnaire_store(current_location, form):
+def _update_questionnaire_store(current_location, form, schema):
     questionnaire_store = get_questionnaire_store(current_user.user_id, current_user.user_ik)
     if current_location.block_id in ['relationships', 'household-relationships']:
         update_questionnaire_store_with_answer_data(questionnaire_store, current_location,
-                                                    form.serialise())
+                                                    form.serialise(), schema)
     else:
-        update_questionnaire_store_with_form_data(questionnaire_store, current_location, form.data)
+        update_questionnaire_store_with_form_data(questionnaire_store, current_location, form.data, schema)
 
 
 @save_questionnaire_store
-def update_questionnaire_store_with_form_data(questionnaire_store, location, answer_dict):
+def update_questionnaire_store_with_form_data(questionnaire_store, location, answer_dict, schema):
 
-    survey_answer_ids = g.schema.get_answer_ids_for_block(location.block_id)
+    survey_answer_ids = schema.get_answer_ids_for_block(location.block_id)
 
     for answer_id, answer_value in answer_dict.items():
 
         # If answer is not answered then check for a schema specified default
         if answer_value is None:
-            answer_value = g.schema.get_answer(answer_id).get('default')
+            answer_value = schema.get_answer(answer_id).get('default')
 
         if answer_id in survey_answer_ids or location.block_id == 'household-composition':
             if answer_value is not None:
@@ -551,8 +571,8 @@ def update_questionnaire_store_with_form_data(questionnaire_store, location, ans
 
                 latest_answer_store_hash = questionnaire_store.answer_store.get_hash()
                 questionnaire_store.answer_store.add_or_update(answer)
-                if latest_answer_store_hash != questionnaire_store.answer_store.get_hash() and g.schema.dependencies[answer_id]:
-                    _remove_dependent_answers_from_completed_blocks(answer_id, location.group_instance, questionnaire_store)
+                if latest_answer_store_hash != questionnaire_store.answer_store.get_hash() and schema.dependencies[answer_id]:
+                    _remove_dependent_answers_from_completed_blocks(answer_id, location.group_instance, questionnaire_store, schema)
             else:
                 _remove_answer_from_questionnaire_store(
                     answer_id,
@@ -563,7 +583,7 @@ def update_questionnaire_store_with_form_data(questionnaire_store, location, ans
         questionnaire_store.completed_blocks.append(location)
 
 
-def _remove_dependent_answers_from_completed_blocks(answer_id, group_instance, questionnaire_store):
+def _remove_dependent_answers_from_completed_blocks(answer_id, group_instance, questionnaire_store, schema):
     """
     Gets a list of answers ids that are dependent on the answer_id passed in.
     Then for each dependent answer it will remove it's block from those completed.
@@ -573,15 +593,15 @@ def _remove_dependent_answers_from_completed_blocks(answer_id, group_instance, q
     :param questionnaire_store: holds the completed blocks
     :return: None
     """
-    answer_in_repeating_group = g.schema.answer_is_in_repeating_group(answer_id)
-    dependencies = g.schema.dependencies[answer_id]
+    answer_in_repeating_group = schema.answer_is_in_repeating_group(answer_id)
+    dependencies = schema.dependencies[answer_id]
 
     for dependency in dependencies:
-        dependency_in_repeating_group = g.schema.answer_is_in_repeating_group(dependency)
+        dependency_in_repeating_group = schema.answer_is_in_repeating_group(dependency)
 
-        answer = g.schema.get_answer(dependency)
-        question = g.schema.get_question(answer['parent_id'])
-        block = g.schema.get_block(question['parent_id'])
+        answer = schema.get_answer(dependency)
+        question = schema.get_question(answer['parent_id'])
+        block = schema.get_block(question['parent_id'])
 
         if dependency_in_repeating_group and not answer_in_repeating_group:
             questionnaire_store.remove_completed_blocks(group_id=block['parent_id'], block_id=block['id'])
@@ -599,9 +619,9 @@ def _remove_answer_from_questionnaire_store(answer_id, questionnaire_store,
 
 
 @save_questionnaire_store
-def update_questionnaire_store_with_answer_data(questionnaire_store, location, answers):
+def update_questionnaire_store_with_answer_data(questionnaire_store, location, answers, schema):
 
-    survey_answer_ids = g.schema.get_answer_ids_for_block(location.block_id)
+    survey_answer_ids = schema.get_answer_ids_for_block(location.block_id)
 
     for answer in [a for a in answers if a.answer_id in survey_answer_ids]:
         questionnaire_store.answer_store.add_or_update(answer)
@@ -617,10 +637,10 @@ def _check_same_survey(url_eq_id, url_form_type, url_collection_id, session_eq_i
         raise MultipleSurveyError
 
 
-def _evaluate_skip_conditions(block_json, location, answer_store, metadata):
-    for question in g.schema.get_questions_for_block(block_json):
+def _evaluate_skip_conditions(block_json, location, schema, answer_store, metadata):
+    for question in schema.get_questions_for_block(block_json):
         if 'skip_conditions' in question:
-            skip_question = evaluate_skip_conditions(question['skip_conditions'], g.schema, metadata, answer_store, location.group_instance)
+            skip_question = evaluate_skip_conditions(question['skip_conditions'], schema, metadata, answer_store, location.group_instance)
             question['skipped'] = skip_question
             for answer in question['answers']:
                 if answer['mandatory'] and skip_question:
@@ -656,15 +676,13 @@ def _get_context(full_routing_path, block, current_location, schema, form=None):
     return build_view_context(block['type'], metadata, schema, answer_store, schema_context, rendered_block, current_location, form=form)
 
 
-def _get_block_json(current_location):
-    metadata = get_metadata(current_user)
-    answer_store = get_answer_store(current_user)
-    block_json = g.schema.get_block(current_location.block_id)
-    return _evaluate_skip_conditions(block_json, current_location, answer_store, metadata)
+def _get_block_json(current_location, schema, answer_store, metadata):
+    block_json = schema.get_block(current_location.block_id)
+    return _evaluate_skip_conditions(block_json, current_location, schema, answer_store, metadata)
 
 
 def _get_schema_context(full_routing_path, group_instance, metadata, answer_store, schema):
-    answer_ids_on_path = get_answer_ids_on_routing_path(g.schema, full_routing_path)
+    answer_ids_on_path = get_answer_ids_on_routing_path(schema, full_routing_path)
 
     return build_schema_context(metadata=metadata,
                                 schema=schema,
@@ -673,11 +691,11 @@ def _get_schema_context(full_routing_path, group_instance, metadata, answer_stor
                                 answer_ids_on_path=answer_ids_on_path)
 
 
-def _get_front_end_navigation(answer_store, current_location, metadata, routing_path=None):
+def _get_front_end_navigation(answer_store, current_location, metadata, schema, routing_path=None):
     completed_blocks = get_completed_blocks(current_user)
-    navigation = Navigation(g.schema, answer_store, metadata, completed_blocks,
+    navigation = Navigation(schema, answer_store, metadata, completed_blocks,
                             routing_path, get_completeness(current_user))
-    block_json = g.schema.get_block(current_location.block_id)
+    block_json = schema.get_block(current_location.block_id)
     if block_json['type'] != 'Introduction':
         return navigation.build_navigation(current_location.group_id, current_location.group_instance)
 
@@ -705,25 +723,23 @@ def get_page_title_for_location(schema, current_location, context):
     return TemplateRenderer.safe_content(page_title)
 
 
-def _build_template(current_location, context, template, routing_path=None):
-    metadata = get_metadata(current_user)
-    answer_store = get_answer_store(current_user)
-    front_end_navigation = _get_front_end_navigation(answer_store, current_location, metadata, routing_path)
+def _build_template(current_location, context, template, schema, answer_store, metadata, routing_path=None):
+    front_end_navigation = _get_front_end_navigation(answer_store, current_location, metadata, schema, routing_path)
     previous_location = path_finder.get_previous_location(current_location)
     previous_url = previous_location.url(metadata) if previous_location is not None else None
 
     return _render_template(context, current_location, template, front_end_navigation, previous_url)
 
 
-@template_helper.with_session_timeout
-@template_helper.with_questionnaire_url_prefix
-@template_helper.with_metadata
-@template_helper.with_analytics
-@template_helper.with_legal_basis
+@with_session_timeout
+@with_questionnaire_url_prefix
+@with_metadata_context
+@with_analytics
+@with_legal_basis
 def _render_template(context, current_location, template, front_end_navigation, previous_url, **kwargs):
     page_title = get_page_title_for_location(g.schema, current_location, context)
 
-    return template_helper.render_template(
+    return render_template(
         template,
         content=context,
         current_location=current_location,

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -369,24 +369,9 @@ def _is_end_of_questionnaire(block, next_location):
     )
 
 
-def _is_skipping_to_the_end(block, current_location):
-    latest_location = get_completeness(current_user).get_first_incomplete_location_in_survey()
-
-    return (
-        latest_location and
-        current_location != latest_location and
-        block['type'] in END_BLOCKS
-    )
-
-
 def submit_answers(routing_path, eq_id, form_type, schema):
     metadata = get_metadata(current_user)
     answer_store = get_answer_store(current_user)
-
-    invalid_location = get_completeness(current_user).get_first_incomplete_location_in_survey()
-
-    if invalid_location:
-        return redirect(invalid_location.url(metadata))
 
     message = json.dumps(convert_answers(
         metadata,

--- a/tests/app/confirmation_page/test_confirmation_page.py
+++ b/tests/app/confirmation_page/test_confirmation_page.py
@@ -19,7 +19,7 @@ class TestConfirmationPage(AppContextTestCase):
         schema = load_schema_from_params('0', 'rogue_one')
         navigator = PathFinder(schema, answer_store, {}, [])
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
+        with patch('app.questionnaire.rules.evaluate_when_rules', return_value=True):
             next_location = navigator.get_next_location(Location('rogue-one', 0, 'film-takings'))
 
         self.assertEqual('summary', next_location.block_id)

--- a/tests/app/forms/test_household_composition.py
+++ b/tests/app/forms/test_household_composition.py
@@ -2,7 +2,7 @@ from wtforms import validators
 
 from app.forms.household_composition_form import generate_household_composition_form, deserialise_composition_answers
 from app.validation.validators import ResponseRequired
-from app.utilities.schema import load_schema_from_params
+from app.utilities.schema import load_schema_from_metadata
 
 from tests.app.app_context_test_case import AppContextTestCase
 
@@ -11,7 +11,12 @@ class TestHouseholdCompositionForm(AppContextTestCase):
     def setUp(self):
         super().setUp()
 
-        self.schema = load_schema_from_params('census', 'household')
+        # Schema is loaded through metadata
+        self.metadata = {
+            'eq_id': 'census',
+            'form_type': 'household',
+        }
+        self.schema = load_schema_from_metadata(self.metadata)
         self.block_json = self.schema.get_block('household-composition')
 
     @staticmethod
@@ -20,7 +25,7 @@ class TestHouseholdCompositionForm(AppContextTestCase):
 
     def test_get_name_form_generates_name_form(self):
         with self.app_request_context():
-            form = generate_household_composition_form(self.schema, self.block_json, {}, metadata={}, group_instance=0)
+            form = generate_household_composition_form(self.schema, self.block_json, {}, metadata=self.metadata, group_instance=0)
 
             self.assertEqual(len(form.household.entries), 1)
 
@@ -34,8 +39,7 @@ class TestHouseholdCompositionForm(AppContextTestCase):
 
     def test_form_errors_are_correctly_mapped(self):
         with self.app_request_context():
-            form = generate_household_composition_form(self.schema, self.block_json, {}, metadata={}, group_instance=0)
-
+            form = generate_household_composition_form(self.schema, self.block_json, {}, metadata=self.metadata, group_instance=0)
             form.validate()
 
             message = 'Please enter a name or remove the person to continue'
@@ -44,8 +48,7 @@ class TestHouseholdCompositionForm(AppContextTestCase):
 
     def test_answer_errors_are_mapped(self):
         with self.app_request_context():
-            form = generate_household_composition_form(self.schema, self.block_json, {}, metadata={}, group_instance=0)
-
+            form = generate_household_composition_form(self.schema, self.block_json, {}, metadata=self.metadata, group_instance=0)
             form.validate()
 
             message = 'Please enter a name or remove the person to continue'
@@ -59,7 +62,7 @@ class TestHouseholdCompositionForm(AppContextTestCase):
                 'household-0-last-name': 'Bloggs',
                 'household-1-first-name': 'Jane',
                 'household-1-last-name': 'Seymour',
-            }, metadata={}, group_instance=0)
+            }, metadata=self.metadata, group_instance=0)
 
             self.assertEqual(len(form.household.entries), 2)
             self.assertEqual(form.household.entries[0].data, {
@@ -78,7 +81,7 @@ class TestHouseholdCompositionForm(AppContextTestCase):
             form = generate_household_composition_form(self.schema, self.block_json, {
                 'household-0-first-name': '     ',
                 'household-0-last-name': 'Bloggs',
-            }, metadata={}, group_instance=0)
+            }, metadata=self.metadata, group_instance=0)
 
             form.validate()
 
@@ -110,8 +113,9 @@ class TestHouseholdCompositionForm(AppContextTestCase):
                           }]
                       }]}
 
+
         with self.app_request_context():
-            form = generate_household_composition_form(self.schema, block_json, {}, metadata={}, group_instance=0)
+            form = generate_household_composition_form(self.schema, block_json, {}, metadata=self.metadata, group_instance=0)
 
             self.assertEqual(len(form.household.entries), 1)
 
@@ -135,7 +139,7 @@ class TestHouseholdCompositionForm(AppContextTestCase):
                 'household-2-last-name': 'Bloggs',
                 'household-3-first-name': 'Jane',
                 'household-3-last-name': 'Seymour',
-            }, metadata={}, group_instance=0)
+            }, metadata=self.metadata, group_instance=0)
 
             form.remove_person(0)
 
@@ -169,7 +173,7 @@ class TestHouseholdCompositionForm(AppContextTestCase):
                 'household-2-last-name': 'Bloggs',
                 'household-3-first-name': 'Jane',
                 'household-3-last-name': 'Seymour',
-            }, metadata={}, group_instance=0)
+            }, metadata=self.metadata, group_instance=0)
 
             form.remove_person(2)
 
@@ -199,7 +203,7 @@ class TestHouseholdCompositionForm(AppContextTestCase):
                 'household-1-last-name': 'Seymour',
                 'household-2-first-name': 'Jane',
                 'household-2-last-name': 'Seymour',
-            }, metadata={}, group_instance=0)
+            }, metadata=self.metadata, group_instance=0)
 
             form.remove_person(2)
 
@@ -222,7 +226,7 @@ class TestHouseholdCompositionForm(AppContextTestCase):
                 'household-0-last-name': 'Bloggs',
                 'household-1-first-name': 'Bob',
                 'household-1-last-name': 'Seymour',
-            }, metadata={}, group_instance=0)
+            }, metadata=self.metadata, group_instance=0)
 
             self.assertEqual(len(form.household.entries), 2)
 
@@ -236,7 +240,7 @@ class TestHouseholdCompositionForm(AppContextTestCase):
                 'household-0-last-name': 'Bloggs',
                 'household-1-first-name': 'Bob',
                 'household-1-last-name': 'Seymour',
-            }, metadata={}, group_instance=0)
+            }, metadata=self.metadata, group_instance=0)
 
             answers = form.serialise()
 

--- a/tests/app/forms/test_questionnaire_form.py
+++ b/tests/app/forms/test_questionnaire_form.py
@@ -971,7 +971,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'age-answer': int('25'),
                 'sure-answer': 'yes'
             }
-            with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
+            with patch('app.questionnaire.path_finder.evaluate_goto', return_value=False):
                 form = generate_form(schema, block_json, store, metadata={}, group_instance=0, formdata=data)
 
             form.validate()

--- a/tests/app/questionnaire/test_completeness.py
+++ b/tests/app/questionnaire/test_completeness.py
@@ -261,7 +261,7 @@ class TestCompleteness(AppContextTestCase): # pylint: disable=too-many-public-me
 
         progress = Completeness(
             schema, AnswerStore(), completed_blocks, routing_path, metadata={})
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
+        with patch('app.questionnaire.path_finder.evaluate_skip_conditions', return_value=True):
             progress_value = progress.get_state_for_group('payment-details')
         self.assertEqual(Completeness.SKIPPED, progress_value)
 
@@ -442,7 +442,7 @@ class TestCompleteness(AppContextTestCase): # pylint: disable=too-many-public-me
         progress = Completeness(
             schema, answer_store, completed_blocks, routing_path, metadata={})
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
+        with patch('app.questionnaire.path_finder.evaluate_goto', return_value=True):
             invalid_location = progress.get_first_incomplete_location_in_survey()
         self.assertEqual(expected_location, invalid_location)
 
@@ -487,5 +487,5 @@ class TestCompleteness(AppContextTestCase): # pylint: disable=too-many-public-me
         ]
         progress = Completeness(
             schema, AnswerStore(), completed_blocks, routing_path, metadata={})
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
+        with patch('app.questionnaire.path_finder.evaluate_goto', return_value=False):
             self.assertFalse(progress.get_first_incomplete_location_in_survey())

--- a/tests/app/questionnaire/test_navigation.py
+++ b/tests/app/questionnaire/test_navigation.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock
 
 from app.data_model.answer_store import AnswerStore, Answer
 from app.questionnaire.completeness import Completeness
@@ -14,6 +14,7 @@ class TestNavigation(AppContextTestCase):
 
     def test_navigation_no_blocks_completed(self):
         schema = load_schema_from_params('test', 'navigation')
+        schema.answer_is_in_repeating_group = MagicMock(return_value=False)
         metadata = {
             'eq_id': '1',
             'collection_exercise_sid': '999',
@@ -52,11 +53,12 @@ class TestNavigation(AppContextTestCase):
                 'link_url': Location('skip-payment-group', 0, 'skip-payment').url(metadata)
             }
         ]
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
+        self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
 
     def test_non_repeating_block_completed(self):
         schema = load_schema_from_params('test', 'navigation')
+        schema.answer_is_in_repeating_group = MagicMock(return_value=True)
+
         metadata = {
             'eq_id': '1',
             'collection_exercise_sid': '999',
@@ -124,11 +126,12 @@ class TestNavigation(AppContextTestCase):
             }
 
         ]
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
+        self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
 
     def test_navigation_repeating_household_and_hidden_household_groups_completed(self):
         schema = load_schema_from_params('test', 'navigation')
+        schema.answer_is_in_repeating_group = MagicMock(return_value=True)
+
         metadata = {
             'eq_id': '1',
             'collection_exercise_sid': '999',
@@ -238,11 +241,12 @@ class TestNavigation(AppContextTestCase):
                 'link_url': Location('skip-payment-group', 0, 'skip-payment').url(metadata)
             }
         ]
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
+        self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
 
     def test_navigation_repeating_group_extra_answered_not_completed(self):
         schema = load_schema_from_params('test', 'navigation')
+        schema.answer_is_in_repeating_group = MagicMock(return_value=True)
+
         metadata = {
             'eq_id': '1',
             'collection_exercise_sid': '999',
@@ -341,11 +345,12 @@ class TestNavigation(AppContextTestCase):
             }
         ]
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
+        self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
 
     def test_navigation_repeating_group_extra_answered_completed(self):
         schema = load_schema_from_params('test', 'navigation')
+        schema.answer_is_in_repeating_group = MagicMock(return_value=True)
+
         metadata = {
             'eq_id': '1',
             'collection_exercise_sid': '999',
@@ -449,11 +454,13 @@ class TestNavigation(AppContextTestCase):
                 'link_url': Location('skip-payment-group', 0, 'skip-payment').url(metadata)
             }
         ]
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
+
+        self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
 
     def test_navigation_repeating_group_link_name_format(self):
         schema = load_schema_from_params('test', 'navigation')
+        schema.answer_is_in_repeating_group = MagicMock(return_value=True)
+
         metadata = {
             'eq_id': '1',
             'collection_exercise_sid': '999',
@@ -549,11 +556,11 @@ class TestNavigation(AppContextTestCase):
             }
         ]
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
+        self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
 
     def test_navigation_skip_condition_hide_group(self):
         schema = load_schema_from_params('test', 'navigation')
+        schema.answer_is_in_repeating_group = MagicMock(return_value=True)
 
         metadata = {
             'eq_id': '1',
@@ -573,14 +580,14 @@ class TestNavigation(AppContextTestCase):
         )
 
         answer_store.add(answer_1)
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            navigation = _create_navigation(schema, answer_store, metadata, completed_blocks, [])
-            user_navigation = navigation.build_navigation('property-details', 0)
-            link_names = [d['link_name'] for d in user_navigation]
-            self.assertNotIn('Property Interstitial', link_names)
+        navigation = _create_navigation(schema, answer_store, metadata, completed_blocks, [])
+        user_navigation = navigation.build_navigation('property-details', 0)
+        link_names = [d['link_name'] for d in user_navigation]
+        self.assertNotIn('Property Interstitial', link_names)
 
     def test_navigation_skip_condition_show_group(self):
         schema = load_schema_from_params('test', 'navigation')
+        schema.answer_is_in_repeating_group = MagicMock(return_value=True)
 
         metadata = {
             'eq_id': '1',
@@ -603,13 +610,13 @@ class TestNavigation(AppContextTestCase):
 
         navigation = _create_navigation(schema, answer_store, metadata, completed_blocks, [])
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            user_navigation = navigation.build_navigation('property-details', 0)
+        user_navigation = navigation.build_navigation('property-details', 0)
         link_names = [d['link_name'] for d in user_navigation]
         self.assertIn('Property Interstitial', link_names)
 
     def test_navigation_skip_condition_change_answer(self):
         schema = load_schema_from_params('test', 'navigation')
+        schema.answer_is_in_repeating_group = MagicMock(return_value=True)
 
         metadata = {
             'eq_id': '1',
@@ -631,24 +638,23 @@ class TestNavigation(AppContextTestCase):
         answer_store.add(answer_1)
         navigation = _create_navigation(schema, answer_store, metadata, completed_blocks, [])
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            user_navigation = navigation.build_navigation('property-details', 0)
-            link_names = [d['link_name'] for d in user_navigation]
-            self.assertIn('Property Interstitial', link_names)
+        user_navigation = navigation.build_navigation('property-details', 0)
+        link_names = [d['link_name'] for d in user_navigation]
+        self.assertIn('Property Interstitial', link_names)
 
-            change_answer = Answer(
-                value='Buildings',
-                group_instance=0,
-                answer_instance=0,
-                answer_id='insurance-type-answer'
-            )
+        change_answer = Answer(
+            value='Buildings',
+            group_instance=0,
+            answer_instance=0,
+            answer_id='insurance-type-answer'
+        )
 
-            answer_store.update(change_answer)
+        answer_store.update(change_answer)
 
-            user_navigation = navigation.build_navigation('property-details', 0)
+        user_navigation = navigation.build_navigation('property-details', 0)
 
-            link_names = [d['link_name'] for d in user_navigation]
-            self.assertNotIn('Property Interstitial', link_names)
+        link_names = [d['link_name'] for d in user_navigation]
+        self.assertNotIn('Property Interstitial', link_names)
 
     def test_build_navigation_returns_none_when_schema_navigation_is_false(self):
         # Given
@@ -681,7 +687,9 @@ class TestNavigation(AppContextTestCase):
     def test_build_navigation_returns_navigation_when_schema_navigation_is_true(self):
         # Given
         schema = load_schema_from_params('test', 'navigation')
+        schema.answer_is_in_repeating_group = MagicMock(return_value=True)
         schema.json['navigation'] = {'visible': True}
+
         completed_blocks = []
         metadata = {
             'eq_id': '1',
@@ -691,14 +699,15 @@ class TestNavigation(AppContextTestCase):
         navigation = _create_navigation(schema, AnswerStore(), metadata, completed_blocks, [])
 
         # When
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            nav_menu = navigation.build_navigation('group-1', 'group-instance-1')
+        nav_menu = navigation.build_navigation('group-1', 'group-instance-1')
 
         # Then
         self.assertIsNotNone(nav_menu)
 
     def test_build_navigation_summary_link_hidden_when_no_sections_completed(self):
         schema = load_schema_from_params('test', 'navigation')
+        schema.answer_is_in_repeating_group = MagicMock(return_value=True)
+
         metadata = {
             'eq_id': '1',
             'collection_exercise_sid': '999',
@@ -715,11 +724,12 @@ class TestNavigation(AppContextTestCase):
             'link_url': Location('summary-group', 0, 'summary').url(metadata)
         }
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            self.assertNotIn(confirmation_link, navigation.build_navigation('property-details', 0))
+        self.assertNotIn(confirmation_link, navigation.build_navigation('property-details', 0))
 
     def test_build_navigation_summary_link_hidden_when_not_all_sections_completed(self):
         schema = load_schema_from_params('test', 'navigation')
+        schema.answer_is_in_repeating_group = MagicMock(return_value=True)
+
         metadata = {
             'eq_id': '1',
             'collection_exercise_sid': '999',
@@ -744,13 +754,14 @@ class TestNavigation(AppContextTestCase):
             'link_url': Location('summary-group', 0, 'summary').url(metadata)
         }
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            navigation_links = navigation.build_navigation('property-details', 0)
+        navigation_links = navigation.build_navigation('property-details', 0)
         self.assertNotIn(confirmation_link, navigation_links)
         self.assertEqual(len(navigation_links), 4)
 
     def test_build_navigation_summary_link_visible_when_all_sections_complete(self):
         schema = load_schema_from_params('test', 'navigation')
+        schema.answer_is_in_repeating_group = MagicMock(return_value=True)
+
         metadata = {
             'eq_id': '1',
             'collection_exercise_sid': '999',
@@ -806,13 +817,14 @@ class TestNavigation(AppContextTestCase):
             'link_url': Location('summary-group', 0, 'summary').url(metadata)
         }
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            navigation_links = navigation.build_navigation('property-details', 0)
+        navigation_links = navigation.build_navigation('property-details', 0)
         self.assertIn(confirmation_link, navigation_links)
         self.assertEqual(len(navigation_links), 5)
 
     def test_build_navigation_submit_answers_link_not_visible_for_survey_with_summary(self):
         schema = load_schema_from_params('test', 'navigation')
+        schema.answer_is_in_repeating_group = MagicMock(return_value=True)
+
         metadata = {
             'eq_id': '1',
             'collection_exercise_sid': '999',
@@ -846,13 +858,14 @@ class TestNavigation(AppContextTestCase):
             'link_url': Location('confirmation-group', 0, 'confirmation').url(metadata)
         }
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            navigation_links = navigation.build_navigation('property-details', 0)
+        navigation_links = navigation.build_navigation('property-details', 0)
         self.assertNotIn(confirmation_link, navigation_links)
         self.assertEqual(len(navigation_links), 4)
 
     def test_build_navigation_submit_answers_link_hidden_when_no_sections_completed(self):
         schema = load_schema_from_params('test', 'navigation_confirmation')
+        schema.answer_is_in_repeating_group = MagicMock(return_value=True)
+
         metadata = {
             'eq_id': '1',
             'collection_exercise_sid': '999',
@@ -869,14 +882,15 @@ class TestNavigation(AppContextTestCase):
             'link_url': Location('confirmation-group', 0, 'confirmation').url(metadata)
         }
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            navigation_links = navigation.build_navigation('property-details', 0)
+        navigation_links = navigation.build_navigation('property-details', 0)
 
         self.assertNotIn(confirmation_link, navigation_links)
         self.assertEqual(len(navigation_links), 4)
 
     def test_build_navigation_submit_answers_link_hidden_when_not_all_sections_completed(self):
         schema = load_schema_from_params('test', 'navigation_confirmation')
+        schema.answer_is_in_repeating_group = MagicMock(return_value=True)
+
         metadata = {
             'eq_id': '1',
             'collection_exercise_sid': '999',
@@ -901,13 +915,14 @@ class TestNavigation(AppContextTestCase):
             'link_url': Location('confirmation-group', 0, 'confirmation').url(metadata)
         }
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            navigation_links = navigation.build_navigation('property-details', 0)
+        navigation_links = navigation.build_navigation('property-details', 0)
         self.assertNotIn(confirmation_link, navigation_links)
         self.assertEqual(len(navigation_links), 4)
 
     def test_build_navigation_submit_answers_link_visible_when_all_sections_complete(self):
         schema = load_schema_from_params('test', 'navigation_confirmation')
+        schema.answer_is_in_repeating_group = MagicMock(return_value=True)
+
         metadata = {
             'eq_id': '1',
             'collection_exercise_sid': '999',
@@ -958,13 +973,14 @@ class TestNavigation(AppContextTestCase):
             'completed': False,
             'link_url': Location('confirmation-group', 0, 'confirmation').url(metadata)
         }
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            navigation_links = navigation.build_navigation('property-details', 0)
+        navigation_links = navigation.build_navigation('property-details', 0)
         self.assertIn(confirmation_link, navigation_links)
         self.assertEqual(len(navigation_links), 5)
 
     def test_build_navigation_summary_link_not_visible_for_survey_with_confirmation(self):
         schema = load_schema_from_params('test', 'navigation_confirmation')
+        schema.answer_is_in_repeating_group = MagicMock(return_value=True)
+
         metadata = {
             'eq_id': '1',
             'collection_exercise_sid': '999',
@@ -998,11 +1014,11 @@ class TestNavigation(AppContextTestCase):
             'link_url': Location('summary-group', 0, 'summary').url(metadata)
         }
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            self.assertNotIn(confirmation_link, navigation.build_navigation('property-details', 0))
+        self.assertNotIn(confirmation_link, navigation.build_navigation('property-details', 0))
 
     def test_build_navigation_submit_answers_link_not_visible_when_no_completed_blocks(self):
         schema = load_schema_from_params('test', 'navigation')
+        schema.answer_is_in_repeating_group = MagicMock(return_value=True)
 
         metadata = {
             'eq_id': '1',
@@ -1023,13 +1039,14 @@ class TestNavigation(AppContextTestCase):
             'link_url': Location('summary-group', 0, 'summary').url(metadata)
         }
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            navigation_links = navigation.build_navigation('property-details', 0)
+        navigation_links = navigation.build_navigation('property-details', 0)
         self.assertNotIn(confirmation_link, navigation_links)
         self.assertEqual(len(navigation_links), 4)
 
     def test_build_navigation_summary_link_hidden_when_not_on_routing_path(self):
         schema = load_schema_from_params('test', 'navigation')
+        schema.answer_is_in_repeating_group = MagicMock(return_value=True)
+
         metadata = {
             'eq_id': '1',
             'collection_exercise_sid': '999',
@@ -1081,8 +1098,7 @@ class TestNavigation(AppContextTestCase):
             'link_url': Location('summary-group', 0, 'summary').url(metadata)
         }
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            navigation_links = navigation.build_navigation('property-details', 0)
+        navigation_links = navigation.build_navigation('property-details', 0)
         self.assertNotIn(confirmation_link, navigation_links)
         self.assertEqual(len(navigation_links), 4)
 
@@ -1141,115 +1157,116 @@ class TestNavigation(AppContextTestCase):
         self.assertEqual(len(navigation_links), 6)
 
     def test_build_navigation_repeated_blocks_independent_completeness(self):
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            schema = load_schema_from_params('test', 'navigation')
+        schema = load_schema_from_params('test', 'navigation')
+        schema.answer_is_in_repeating_group = MagicMock(return_value=True)
 
-            metadata = {
-                'eq_id': '1',
-                'collection_exercise_sid': '999',
-                'form_type': 'some_form'
-            }
+        metadata = {
+            'eq_id': '1',
+            'collection_exercise_sid': '999',
+            'form_type': 'some_form'
+        }
 
-            completed_blocks = [
-                Location('property-details', 0, 'insurance-type'),
-                Location('property-details', 0, 'insurance-address'),
-                Location('repeating-group', 0, 'repeating-block-1'),
-                Location('repeating-group', 0, 'repeating-block-2'),
-                Location('multiple-questions-group', 0, 'household-composition'),
-                Location('extra-cover', 0, 'extra-cover-block')
-                ]
-
-            answer_store = AnswerStore()
-
-            answer_store.add(Answer(
-                answer_instance=0,
-                answer_id='first-name',
-                group_instance=0,
-                value='Person1'
-                ))
-            answer_store.add(Answer(
-                answer_instance=1,
-                answer_id='first-name',
-                group_instance=0,
-                value='Person2'
-                ))
-            answer_store.add(Answer(
-                answer_instance=0,
-                answer_id='what-is-your-age',
-                group_instance=0,
-                value=42
-                ))
-            answer_store.add(Answer(
-                answer_instance=0,
-                answer_id='what-is-your-shoe-size',
-                group_instance=0,
-                value='Employed'
-                ))
-
-            routing_path = [
-                Location('property-details', 0, 'insurance-type'),
-                Location('property-details', 0, 'insurance-address'),
-                Location('repeating-group', 0, 'repeating-block-1'),
-                Location('repeating-group', 0, 'repeating-block-2'),
-                Location('repeating-group', 1, 'repeating-block-1'),
-                Location('repeating-group', 1, 'repeating-block-2'),
-                Location('multiple-questions-group', 0, 'household-composition'),
-                Location('extra-cover', 0, 'extra-cover-block'),
-                Location('extra-cover-items-group', 0, 'extra-cover-items'),
-                Location('skip-payment-group', 0, 'skip-payment'),
-                ]
-
-            navigation = _create_navigation(schema, answer_store, metadata, completed_blocks, routing_path)
-
-            user_navigation = [
-                {
-                    'completed': True,
-                    'highlight': True,
-                    'repeating': False,
-                    'link_name': 'Property Details',
-                    'link_url': Location('property-details', 0, 'insurance-type').url(metadata)
-                },
-                {
-                    'link_name': 'Household Composition',
-                    'highlight': False,
-                    'repeating': False,
-                    'completed': True,
-                    'link_url': Location('multiple-questions-group', 0, 'household-composition').url(metadata)
-                },
-                {
-                    'completed': True,
-                    'highlight': False,
-                    'repeating': True,
-                    'link_name': 'Person1',
-                    'link_url': Location('repeating-group', 0, 'repeating-block-1').url(metadata),
-                },
-                {
-                    'completed': False,
-                    'highlight': False,
-                    'repeating': True,
-                    'link_name': 'Person2',
-                    'link_url': Location('repeating-group', 1, 'repeating-block-1').url(metadata),
-                },
-                {
-                    'completed': True,
-                    'highlight': False,
-                    'repeating': False,
-                    'link_name': 'Extra Cover',
-                    'link_url': Location('extra-cover', 0, 'extra-cover-block').url(metadata),
-                },
-                {
-                    'completed': False,
-                    'highlight': False,
-                    'repeating': False,
-                    'link_name': 'Payment Details',
-                    'link_url': Location('skip-payment-group', 0, 'skip-payment').url(metadata),
-                }
+        completed_blocks = [
+            Location('property-details', 0, 'insurance-type'),
+            Location('property-details', 0, 'insurance-address'),
+            Location('repeating-group', 0, 'repeating-block-1'),
+            Location('repeating-group', 0, 'repeating-block-2'),
+            Location('multiple-questions-group', 0, 'household-composition'),
+            Location('extra-cover', 0, 'extra-cover-block')
             ]
 
-            self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
+        answer_store = AnswerStore()
+
+        answer_store.add(Answer(
+            answer_instance=0,
+            answer_id='first-name',
+            group_instance=0,
+            value='Person1'
+            ))
+        answer_store.add(Answer(
+            answer_instance=1,
+            answer_id='first-name',
+            group_instance=0,
+            value='Person2'
+            ))
+        answer_store.add(Answer(
+            answer_instance=0,
+            answer_id='what-is-your-age',
+            group_instance=0,
+            value=42
+            ))
+        answer_store.add(Answer(
+            answer_instance=0,
+            answer_id='what-is-your-shoe-size',
+            group_instance=0,
+            value='Employed'
+            ))
+
+        routing_path = [
+            Location('property-details', 0, 'insurance-type'),
+            Location('property-details', 0, 'insurance-address'),
+            Location('repeating-group', 0, 'repeating-block-1'),
+            Location('repeating-group', 0, 'repeating-block-2'),
+            Location('repeating-group', 1, 'repeating-block-1'),
+            Location('repeating-group', 1, 'repeating-block-2'),
+            Location('multiple-questions-group', 0, 'household-composition'),
+            Location('extra-cover', 0, 'extra-cover-block'),
+            Location('extra-cover-items-group', 0, 'extra-cover-items'),
+            Location('skip-payment-group', 0, 'skip-payment'),
+            ]
+
+        navigation = _create_navigation(schema, answer_store, metadata, completed_blocks, routing_path)
+
+        user_navigation = [
+            {
+                'completed': True,
+                'highlight': True,
+                'repeating': False,
+                'link_name': 'Property Details',
+                'link_url': Location('property-details', 0, 'insurance-type').url(metadata)
+            },
+            {
+                'link_name': 'Household Composition',
+                'highlight': False,
+                'repeating': False,
+                'completed': True,
+                'link_url': Location('multiple-questions-group', 0, 'household-composition').url(metadata)
+            },
+            {
+                'completed': True,
+                'highlight': False,
+                'repeating': True,
+                'link_name': 'Person1',
+                'link_url': Location('repeating-group', 0, 'repeating-block-1').url(metadata),
+            },
+            {
+                'completed': False,
+                'highlight': False,
+                'repeating': True,
+                'link_name': 'Person2',
+                'link_url': Location('repeating-group', 1, 'repeating-block-1').url(metadata),
+            },
+            {
+                'completed': True,
+                'highlight': False,
+                'repeating': False,
+                'link_name': 'Extra Cover',
+                'link_url': Location('extra-cover', 0, 'extra-cover-block').url(metadata),
+            },
+            {
+                'completed': False,
+                'highlight': False,
+                'repeating': False,
+                'link_name': 'Payment Details',
+                'link_url': Location('skip-payment-group', 0, 'skip-payment').url(metadata),
+            }
+        ]
+
+        self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
 
     def test_build_navigation_first_group_with_skip_condition_containing_repeating_group(self):
         schema = load_schema_from_params('test', 'navigation')
+        schema.answer_is_in_repeating_group = MagicMock(return_value=True)
 
         metadata = {
             'eq_id': '1',
@@ -1324,15 +1341,15 @@ class TestNavigation(AppContextTestCase):
                 'link_url': Location('skip-payment-group', 0, 'skip-payment').url(metadata),
             }
         ]
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            self.assertEqual(navigation.build_navigation(
-                'property-details', 0), user_navigation)
+        self.assertEqual(navigation.build_navigation(
+            'property-details', 0), user_navigation)
 
     def test_build_navigation_with_single_skipped_block_in_group(self):
         """A section containing a group which doesn't have all of its blocks skipped should
         have its navigation rendered
         """
         schema = load_schema_from_params('test', 'navigation')
+        schema.answer_is_in_repeating_group = MagicMock(return_value=True)
 
         metadata = {
             'eq_id': '1',
@@ -1408,48 +1425,47 @@ class TestNavigation(AppContextTestCase):
             }
         ]
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
+        self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
 
     def test_build_navigation_completed_section_with_summary_links_to_last_block(self):
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            schema = load_schema_from_params('test', 'navigation_confirmation')
+        schema = load_schema_from_params('test', 'navigation_confirmation')
+        schema.answer_is_in_repeating_group = MagicMock(return_value=True)
 
-            schema.json['sections'][0]['groups'][0]['blocks'].append({
-                'id': 'property-summary',
-                'type': 'SectionSummary'
-            })
+        schema.json['sections'][0]['groups'][0]['blocks'].append({
+            'id': 'property-summary',
+            'type': 'SectionSummary'
+        })
 
-            metadata = {
-                'eq_id': '1',
-                'collection_exercise_sid': '999',
-                'form_type': 'some_form'
-            }
+        metadata = {
+            'eq_id': '1',
+            'collection_exercise_sid': '999',
+            'form_type': 'some_form'
+        }
 
-            completed_blocks = [
-                Location('property-details', 0, 'insurance-type'),
-                Location('property-details', 0, 'insurance-address'),
-                Location('property-details', 0, 'property-interstitial'),
-            ]
+        completed_blocks = [
+            Location('property-details', 0, 'insurance-type'),
+            Location('property-details', 0, 'insurance-address'),
+            Location('property-details', 0, 'property-interstitial'),
+        ]
 
-            routing_path = [
-                Location('property-details', 0, 'insurance-type'),
-                Location('property-details', 0, 'insurance-address'),
-                Location('property-details', 0, 'property-interstitial'),
-                Location('property-details', 0, 'property-summary'),
-            ]
+        routing_path = [
+            Location('property-details', 0, 'insurance-type'),
+            Location('property-details', 0, 'insurance-address'),
+            Location('property-details', 0, 'property-interstitial'),
+            Location('property-details', 0, 'property-summary'),
+        ]
 
-            navigation = _create_navigation(schema, AnswerStore(), metadata, completed_blocks, routing_path)
+        navigation = _create_navigation(schema, AnswerStore(), metadata, completed_blocks, routing_path)
 
-            confirmation_link = {
-                'link_name': 'Property Details',
-                'highlight': True,
-                'repeating': False,
-                'completed': True,
-                'link_url': Location('property-details', 0, 'property-summary').url(metadata)
-            }
+        confirmation_link = {
+            'link_name': 'Property Details',
+            'highlight': True,
+            'repeating': False,
+            'completed': True,
+            'link_url': Location('property-details', 0, 'property-summary').url(metadata)
+        }
 
-            self.assertIn(confirmation_link, navigation.build_navigation('property-details', 0))
+        self.assertIn(confirmation_link, navigation.build_navigation('property-details', 0))
 
 
 def _create_navigation(schema, answer_store, metadata, completed_blocks, routing_path):

--- a/tests/app/questionnaire/test_rules.py
+++ b/tests/app/questionnaire/test_rules.py
@@ -411,6 +411,28 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         # Then
         self.assertTrue(goto)
 
+    def test_meta_comparison_missing(self):
+        # Given
+        goto_rule = {
+            'id': 'next-question',
+            'when': [
+                {
+                    'condition': 'equals',
+                    'meta': 'varient_flags.does_not_exist',
+                    'value': True
+                }
+            ]
+        }
+        answer_store = AnswerStore({})
+        answer_store.add(Answer(answer_id='my_answer', value='Yes'))
+        metadata = {'varient_flags': {'sexual_identity': True}}
+
+        # When
+        goto = evaluate_goto(goto_rule, get_schema_mock(), metadata, answer_store, 0)
+
+        # Then
+        self.assertFalse(goto)
+
     def test_should_not_go_to_next_question_when_second_condition_fails(self):
         # Given
         goto_rule = {

--- a/tests/app/questionnaire/test_rules.py
+++ b/tests/app/questionnaire/test_rules.py
@@ -418,7 +418,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
             'when': [
                 {
                     'condition': 'equals',
-                    'meta': 'varient_flags.does_not_exist',
+                    'meta': 'varient_flags.does_not_exist.does_not_exist',
                     'value': True
                 }
             ]

--- a/tests/app/questionnaire/test_rules.py
+++ b/tests/app/questionnaire/test_rules.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 from datetime import datetime
 
 from app.data_model.answer_store import AnswerStore, Answer
@@ -8,6 +8,11 @@ from app.questionnaire.rules import evaluate_rule, evaluate_date_rule, evaluate_
     evaluate_skip_conditions, evaluate_when_rules, get_answer_ids_on_routing_path
 from tests.app.app_context_test_case import AppContextTestCase
 
+
+def get_schema_mock(answer_is_in_repeating_group=False):
+    schema = QuestionnaireSchema({})
+    schema.answer_is_in_repeating_group = Mock(return_value=answer_is_in_repeating_group)
+    return schema
 
 class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
 
@@ -134,8 +139,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
 
         answer_store.add(Answer(answer_id='my_answer', value='Yes'))
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            self.assertTrue(evaluate_goto(goto, {}, answer_store, 0))
+        self.assertTrue(evaluate_goto(goto, get_schema_mock(), {}, answer_store, 0))
 
     def test_do_not_go_to_next_question_for_answer(self):
         # Given
@@ -153,8 +157,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
 
         answer_store.add(Answer(answer_id='my_answer', value='No'))
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            self.assertFalse(evaluate_goto(goto_rule, {}, answer_store, 0))
+        self.assertFalse(evaluate_goto(goto_rule, get_schema_mock(), {}, answer_store, 0))
 
     def test_evaluate_goto_returns_true_when_value_contained_in_list(self):
 
@@ -169,11 +172,9 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
             ]
         }
         answer_store = AnswerStore({})
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            answer_store.add(Answer(answer_id='my_answers', value=['answer1', 'answer2', 'answer3']))
+        answer_store.add(Answer(answer_id='my_answers', value=['answer1', 'answer2', 'answer3']))
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            self.assertTrue(evaluate_goto(goto, {}, answer_store, 0))
+        self.assertTrue(evaluate_goto(goto, get_schema_mock(), {}, answer_store, 0))
 
     def test_evaluate_goto_returns_true_when_value_not_contained_in_list(self):
 
@@ -190,8 +191,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         answer_store = AnswerStore({})
         answer_store.add(Answer(answer_id='my_answers', value=['answer2', 'answer3']))
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            self.assertTrue(evaluate_goto(goto, {}, answer_store, 0))
+        self.assertTrue(evaluate_goto(goto, get_schema_mock(), {}, answer_store, 0))
 
     def test_evaluate_skip_condition_returns_true_when_this_rule_true(self):
         # Given
@@ -219,8 +219,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         answer_store.add(Answer(answer_id='this', value='value'))
 
         # When
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            condition = evaluate_skip_conditions(skip_conditions, {}, answer_store)
+        condition = evaluate_skip_conditions(skip_conditions, get_schema_mock(), {}, answer_store)
 
         # Given
         self.assertTrue(condition)
@@ -251,8 +250,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
 
         answer_store.add(Answer(answer_id='that', value='other value'))
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            self.assertTrue(evaluate_skip_conditions(skip_conditions, {}, answer_store))
+        self.assertTrue(evaluate_skip_conditions(skip_conditions, get_schema_mock(), {}, answer_store))
 
     def test_evaluate_skip_condition_returns_true_when_more_than_one_rule_is_true(self):
         # Given
@@ -281,8 +279,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         answer_store.add(Answer(answer_id='that', value='other value'))
 
         # When
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            condition = evaluate_skip_conditions(skip_conditions, {}, answer_store)
+        condition = evaluate_skip_conditions(skip_conditions, get_schema_mock(), {}, answer_store)
 
         # Then
         self.assertTrue(condition)
@@ -314,8 +311,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         answer_store.add(Answer(answer_id='that', value='not correct'))
 
         # When
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            condition = evaluate_skip_conditions(skip_conditions, {}, answer_store)
+        condition = evaluate_skip_conditions(skip_conditions, get_schema_mock(), {}, answer_store)
 
         # Then
         self.assertFalse(condition)
@@ -325,7 +321,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         skip_conditions = None
 
         # When
-        condition = evaluate_skip_conditions(skip_conditions, {}, AnswerStore({}))
+        condition = evaluate_skip_conditions(skip_conditions, get_schema_mock(), {}, AnswerStore({}))
 
         # Then
         self.assertFalse(condition)
@@ -341,7 +337,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         }
         answer_store = AnswerStore({})
 
-        self.assertTrue(evaluate_when_rules(when, {}, answer_store, 0))
+        self.assertTrue(evaluate_when_rules(when, get_schema_mock(), {}, answer_store, 0))
 
     def test_go_to_next_question_for_multiple_answers(self):
         # Given
@@ -364,8 +360,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         answer_store.add(Answer(answer_id='my_answer', value='Yes'))
         answer_store.add(Answer(answer_id='my_other_answer', value='2'))
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            self.assertTrue(evaluate_goto(goto, {}, answer_store, 0))
+        self.assertTrue(evaluate_goto(goto, get_schema_mock(), {}, answer_store, 0))
 
     def test_do_not_go_to_next_question_for_multiple_answers(self):
         # Given
@@ -387,8 +382,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         answer_store = AnswerStore({})
         answer_store.add(Answer(answer_id='my_answer', value='No'))
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            self.assertFalse(evaluate_goto(goto_rule, {}, answer_store, 0))
+        self.assertFalse(evaluate_goto(goto_rule, get_schema_mock(), {}, answer_store, 0))
 
     def test_should_go_to_next_question_when_condition_is_meta_and_answer_type(self):
         # Given
@@ -412,8 +406,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         metadata = {'sexual_identity': True}
 
         # When
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            goto = evaluate_goto(goto_rule, metadata, answer_store, 0)
+        goto = evaluate_goto(goto_rule, get_schema_mock(), metadata, answer_store, 0)
 
         # Then
         self.assertTrue(goto)
@@ -440,8 +433,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         metadata = {'sexual_identity': True}
 
         # When
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            goto = evaluate_goto(goto_rule, metadata, answer_store, 0)
+        goto = evaluate_goto(goto_rule, get_schema_mock(), metadata, answer_store, 0)
 
         # Then
         self.assertFalse(goto)
@@ -718,8 +710,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
 
         # When
         with self.assertRaises(Exception) as err:
-            with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-                evaluate_when_rules(when['when'], None, answer_store, 0)
+            evaluate_when_rules(when['when'], get_schema_mock(), None, answer_store, 0)
         self.assertEqual('Multiple answers (2) found evaluating when rule for answer (my_answers)', str(err.exception))
 
     def test_id_when_rule_uses_passed_in_group_instance_if_present(self):  # pylint: disable=no-self-use
@@ -730,9 +721,8 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
 
         answer_store = AnswerStore({})
         with patch('app.questionnaire.rules.get_answer_store_value', return_value=False) as patch_val:
-            with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-                evaluate_when_rules(when, {}, answer_store, 3)  # passed in group instance ignored if present in when
-                patch_val.assert_called_with('Some Id', answer_store, 0)
+            evaluate_when_rules(when, get_schema_mock(), {}, answer_store, 3)  # passed in group instance ignored if present in when
+            patch_val.assert_called_with('Some Id', answer_store, 0)
 
     def test_id_when_rule_answer_count_equal_0(self):
         """Assert that an `answer_count` can be used in a when block and the
@@ -745,9 +735,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         }]
 
         answer_store = AnswerStore({})
-
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            self.assertTrue(evaluate_when_rules(when, {}, answer_store, 0))
+        self.assertTrue(evaluate_when_rules(when, get_schema_mock(), {}, answer_store, 0))
 
     def test_answer_count_when_rule_equal_1(self):
         """Assert that an `answer_count` can be used in a when block and the
@@ -766,8 +754,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
             value=10,
         ))
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            self.assertTrue(evaluate_when_rules(when, {}, answer_store, 0))
+        self.assertTrue(evaluate_when_rules(when, get_schema_mock(), {}, answer_store, 0))
 
     def test_answer_count_when_rule_equal_2(self):
         """Assert that an `answer_count` can be used in a when block and the
@@ -791,8 +778,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
             value=20,
         ))
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            self.assertTrue(evaluate_when_rules(when, {}, answer_store, 0))
+        self.assertTrue(evaluate_when_rules(when, get_schema_mock(), {}, answer_store, 0))
 
     def test_answer_count_when_rule_not_equal(self):  # pylint: disable=no-self-use
         """Assert that an `answer_count` can be used in a when block and the
@@ -805,8 +791,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         }]
         answer_store = AnswerStore({})
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            self.assertFalse(evaluate_when_rules(when, {}, answer_store, 0))
+        self.assertFalse(evaluate_when_rules(when, get_schema_mock(), {}, answer_store, 0))
 
     def test_answer_count_when_rule_id_takes_precident(self):
         """Assert that if somehow, both `id` and `answer_count` are present in a when clause
@@ -826,8 +811,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
             value=10,
         ))
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            self.assertTrue(evaluate_when_rules(when, {}, answer_store, 0))
+        self.assertTrue(evaluate_when_rules(when, get_schema_mock(), {}, answer_store, 0))
 
 class TestDateRules(AppContextTestCase):
 
@@ -959,5 +943,4 @@ class TestDateRules(AppContextTestCase):
         answer_store = AnswerStore({})
         answer_store.add(Answer(answer_id='date_answer', value='2018-02-01'))
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            self.assertFalse(evaluate_goto(goto_rule, {}, answer_store, 0))
+        self.assertFalse(evaluate_goto(goto_rule, get_schema_mock(), {}, answer_store, 0))

--- a/tests/app/templating/summary/test_block.py
+++ b/tests/app/templating/summary/test_block.py
@@ -1,8 +1,6 @@
-from mock import MagicMock
-from mock import patch
-from app.data_model.answer_store import Answer, AnswerStore
+from unittest import TestCase
+from mock import MagicMock, patch
 from app.templating.summary.block import Block
-from tests.app.app_context_test_case import AppContextTestCase
 
 
 def build_block_schema(question_schema):
@@ -14,86 +12,67 @@ def build_block_schema(question_schema):
     }
     return block_schema
 
+def get_mock_question(placeholder):
+    """Returns a mocked question, which returns `placeholder` from the serialize method"""
+    question = MagicMock()
+    question.serialize = MagicMock(return_value=placeholder)
+    return question
 
-def build_question_schema(_id, answer_schemas):
-    return {'id': _id, 'answers': answer_schemas, 'skipped': False, 'title': 'title', 'type': 'GENERAL'}
+class TestSection(TestCase):
 
-
-class TestSection(AppContextTestCase):
+    def setUp(self):
+        self.answer_store = MagicMock()
+        self.metadata = MagicMock()
+        self.schema = MagicMock()
 
     def test_create_block(self):
         # Given
-
-        answer_schema = MagicMock()
-        question_schema = build_question_schema('question_id', [answer_schema])
-        block_schema = build_block_schema([question_schema])
-        answer_store = MagicMock()
-        metadata = MagicMock()
+        block_schema = build_block_schema([{'id': 'mock_question_schema'}])
 
         # When
-        block = Block(block_schema, 'group_id', answer_store, metadata)
+        with patch('app.templating.summary.block.Question', return_value=get_mock_question('A Question')), \
+                patch('app.templating.summary.block.evaluate_skip_conditions', return_value=False), \
+                patch('app.templating.summary.block.url_for', return_value='http://a.url/'):
+            block = Block(block_schema, 'group_id', self.answer_store, self.metadata, self.schema)
 
         # Then
         self.assertEqual(block.id, 'block_id')
         self.assertEqual(block.title, 'A section title')
         self.assertEqual(block.number, '1')
         self.assertEqual(len(block.questions), 1)
+        self.assertEqual(block.questions[0], 'A Question')
 
     def test_create_section_with_multiple_questions(self):
         # Given
-        first_answer_schema = MagicMock()
-        second_answer_schema = MagicMock()
-        first_question_schema = build_question_schema('question_1', [first_answer_schema])
-        second_question_schema = build_question_schema('question_2', [second_answer_schema])
-        block_schema = build_block_schema([first_question_schema, second_question_schema])
-        answer_store = MagicMock()
-        metadata = MagicMock()
+        block_schema = build_block_schema([{'id': 'mock_question_schema'}, {'id': 'mock_question_schema'}])
 
         # When
-        block = Block(block_schema, 'group_id', answer_store, metadata)
+        with patch('app.templating.summary.block.Question',
+                   side_effect=[get_mock_question('A Question'), get_mock_question('A Second Question')]), \
+                patch('app.templating.summary.block.evaluate_skip_conditions', return_value=False), \
+                patch('app.templating.summary.block.url_for', return_value='http://a.url/'):
+            block = Block(block_schema, 'group_id', self.answer_store, self.metadata, self.schema)
 
         # Then
         self.assertEqual(len(block.questions), 2)
+        self.assertEqual(block.questions[0], 'A Question')
+        self.assertEqual(block.questions[1], 'A Second Question')
 
     def test_question_should_be_skipped(self):
         # Given
-        answer = Answer(
-            answer_id='answer_1',
-            value='skip me',
-        )
-        answer_store = AnswerStore()
-        answer_store.add(answer)
-        metadata = MagicMock()
-        answer_schema = {'id': 'answer_1', 'title': '', 'type': '', 'label': ''}
-        skip_conditions = [{'when': [{'id': 'answer_1', 'condition': 'equals', 'value': 'skip me'}]}]
-        question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema],
-                           'skip_conditions': skip_conditions}
+        block_schema = build_block_schema([
+            {'id': 'mock_question_schema', 'skip_conditions': 'mocked'},
+            {'id': 'mock_question_schema'}
+        ])
 
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            second_question_schema = build_question_schema('question_2', [MagicMock()])
-            block_schema = build_block_schema([question_schema, second_question_schema])
-
+        with patch('app.templating.summary.block.Question',
+                   side_effect=[get_mock_question('A Second Question')]) as patched_question_context, \
+                patch('app.templating.summary.block.evaluate_skip_conditions', side_effect=[False, True]), \
+                patch('app.templating.summary.block.url_for', return_value='http://a.url/'):
             # When
-            block = Block(block_schema, 'group_id', answer_store, metadata)
+            block = Block(block_schema, 'group_id', self.answer_store, self.metadata, self.schema)
 
-            # Then
-            self.assertTrue(len(block.questions) == 1)
-
-    def test_question_with_no_answers_should_not_be_skipped(self):
-        # Given
-        answer_store = AnswerStore()
-        metadata = MagicMock()
-        answer_schema = {'id': 'answer_1', 'title': '', 'type': '', 'label': ''}
-        skip_conditions = [{'when': [{'id': 'answer_1', 'condition': 'equals', 'value': 'skip me'}]}]
-        question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema],
-                           'skip_conditions': skip_conditions}
-        second_question_schema = build_question_schema('question_2', [MagicMock()])
-
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            block_schema = build_block_schema([question_schema, second_question_schema])
-
-            # When
-            block = Block(block_schema, 'group_id', answer_store, metadata)
-
-            # Then
-            self.assertTrue(len(block.questions) == 2)
+        # Then
+        patched_question_context.assert_called_once()
+        self.assertTrue(len(block.questions) == 1)
+        self.assertEqual(block.questions[0], 'A Second Question')

--- a/tests/app/templating/summary/test_question.py
+++ b/tests/app/templating/summary/test_question.py
@@ -1,74 +1,66 @@
-import mock
-from mock import patch
+from unittest import TestCase
+from mock import MagicMock, patch
 from app.templating.summary.question import Question
-from app.data_model.answer_store import AnswerStore
-from tests.app.app_context_test_case import AppContextTestCase
+from app.data_model.answer_store import AnswerStore, Answer
 
 
-class TestQuestion(AppContextTestCase):
+class TestQuestion(TestCase):
+
+    def setUp(self):
+        self.answer_schema = MagicMock()
+        self.answer_store = AnswerStore()
+        self.schema = MagicMock()
+        self.metadata = {}
 
     def test_create_question(self):
         # Given
-        answer_schema = mock.MagicMock()
-        answer_store = AnswerStore()
-        question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
+        question_title = 'question_title'
+        question_schema = {'id': 'question_id', 'title': question_title, 'type': 'GENERAL', 'answers': [self.answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store, {})
+        with patch('app.templating.summary.question.get_question_title', return_value=question_title):
+            question = Question(question_schema, self.answer_store, self.metadata, self.schema)
 
         # Then
         self.assertEqual(question.id, 'question_id')
-        self.assertEqual(question.title, 'question_title')
+        self.assertEqual(question.title, question_title)
         self.assertEqual(len(question.answers), 1)
 
     def test_create_question_with_no_answers(self):
         # Given
-        answer_schema = mock.MagicMock()
-        answer_store = AnswerStore()
-        question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
+        question_title = 'question_title'
+        question_schema = {'id': 'question_id', 'title': question_title, 'type': 'GENERAL', 'answers': []}
 
         # When
-        question = Question(question_schema, answer_store, {})
+        with patch('app.templating.summary.question.get_question_title', return_value=question_title):
+            question = Question(question_schema, self.answer_store, self.metadata, self.schema)
 
         # Then
         self.assertEqual(question.id, 'question_id')
-        self.assertEqual(question.title, 'question_title')
-        self.assertEqual(len(question.answers), 1)
-
-    def test_create_question_with_default_title(self):
-        # Given
-        answer_schema = mock.MagicMock()
-        answer_store = AnswerStore()
-        question_schema = {'id': 'question_id', 'titles': [{'value': 'question_title'}], 'type': 'GENERAL', 'answers': [answer_schema]}
-
-        # When
-        question = Question(question_schema, answer_store, {})
-
-        # Then
-        self.assertEqual(question.id, 'question_id')
-        self.assertEqual(question.title, 'question_title')
-        self.assertEqual(len(question.answers), 1)
+        self.assertEqual(question.title, question_title)
+        self.assertEqual(len(question.answers), 0)
 
     def test_create_question_with_conditional_title(self):
         # Given
-        answer_store = AnswerStore([{
-            'answer_id': 'answer_1',
-            'block_id': '',
-            'value': 'Han',
-            'answer_instance': 0,
-            'group_instance': 0
-        }])
-        answer_schema = mock.MagicMock()
-        question_schema = {'id': 'question_id', 'titles': [{'value': 'conditional_title', 'when': [{'id': 'answer_1',
-                                                                                                    'condition': 'equals',
-                                                                                                    'value': 'Han'}]},
-                                                           {'value': 'question_title'}], 'type': 'GENERAL', 'answers': [answer_schema]}
+        self.answer_store.add(Answer(
+            answer_id='answer_1',
+            value='Han',
+        ))
+
+        title_when = [{
+            'id': 'answer_1',
+            'condition': 'equals',
+            'value': 'Han'
+            }]
+        question_schema = {'id': 'question_id', 'titles': [{'value': 'conditional_title', 'when': title_when},
+                                                           {'value': 'question_title'}], 'type': 'GENERAL', 'answers': [self.answer_schema]}
 
         # When
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            question = Question(question_schema, answer_store, {})
+        with patch('app.templating.utils.evaluate_when_rules', side_effect=[True, False]) as evaluate_when_rules:
+            question = Question(question_schema, self.answer_store, self.metadata, self.schema)
 
         # Then
+        evaluate_when_rules.assert_called_once_with(title_when, self.schema, self.metadata, self.answer_store, 0)
         self.assertEqual(question.id, 'question_id')
         self.assertEqual(question.title, 'conditional_title')
         self.assertEqual(len(question.answers), 1)
@@ -76,11 +68,11 @@ class TestQuestion(AppContextTestCase):
     def test_create_question_with_answer_label_when_empty_title(self):
         # Given
         answer_schema = {'type': 'Number', 'id': 'age-answer', 'mandatory': True, 'label': 'Age'}
-        answer_store = AnswerStore()
         question_schema = {'id': 'question_id', 'title': '', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store, {})
+        with patch('app.templating.summary.question.get_question_title', return_value=False):
+            question = Question(question_schema, self.answer_store, self.metadata, self.schema)
 
         # Then
         self.assertEqual(question.title, 'Age')
@@ -88,24 +80,30 @@ class TestQuestion(AppContextTestCase):
 
     def test_create_question_with_multiple_answers(self):
         # Given
-        answer_store = AnswerStore([{
-            'answer_id': 'answer_1',
-            'block_id': '',
-            'value': 'Han',
-            'answer_instance': 0,
-        }, {
-            'answer_id': 'answer_2',
-            'block_id': '',
-            'value': 'Solo',
-            'answer_instance': 0,
-        }])
-        first_answer_schema = {'id': 'answer_1', 'label': 'First name', 'type': 'text'}
-        second_answer_schema = {'id': 'answer_2', 'label': 'Surname', 'type': 'text'}
+        self.answer_store.add(Answer(
+            answer_id='answer_1',
+            value='Han',
+        ))
+        self.answer_store.add(Answer(
+            answer_id='answer_2',
+            value='Solo',
+        ))
+        first_answer_schema = {
+            'id': 'answer_1',
+            'label': 'First name',
+            'type': 'text'
+        }
+        second_answer_schema = {
+            'id': 'answer_2',
+            'label': 'Surname',
+            'type': 'text'
+        }
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL',
                            'answers': [first_answer_schema, second_answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store, {})
+        with patch('app.templating.summary.question.get_question_title', return_value=False):
+            question = Question(question_schema, self.answer_store, self.metadata, self.schema)
 
         # Then
         self.assertEqual(len(question.answers), 2)
@@ -114,24 +112,22 @@ class TestQuestion(AppContextTestCase):
 
     def test_merge_date_range_answers(self):
         # Given
-        answer_store = AnswerStore([{
-            'answer_id': 'answer_1',
-            'block_id': '',
-            'value': '13/02/2016',
-            'answer_instance': 0,
-        }, {
-            'answer_id': 'answer_2',
-            'block_id': '',
-            'value': '13/09/2016',
-            'answer_instance': 0,
-        }])
+        self.answer_store.add(Answer(
+            answer_id='answer_1',
+            value='13/02/2016',
+        ))
+        self.answer_store.add(Answer(
+            answer_id='answer_2',
+            value='13/09/2016',
+        ))
         first_date_answer_schema = {'id': 'answer_1', 'label': 'From', 'type': 'date'}
         second_date_answer_schema = {'id': 'answer_2', 'label': 'To', 'type': 'date'}
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'DateRange',
                            'answers': [first_date_answer_schema, second_date_answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store, {})
+        with patch('app.templating.summary.question.get_question_title', return_value=False):
+            question = Question(question_schema, self.answer_store, self.metadata, self.schema)
 
         # Then
         self.assertEqual(len(question.answers), 1)
@@ -140,27 +136,23 @@ class TestQuestion(AppContextTestCase):
 
     def test_merge_multiple_date_range_answers(self):
         # Given
-        answer_store = AnswerStore([{
-            'answer_id': 'answer_1',
-            'block_id': '',
-            'value': '13/02/2016',
-            'answer_instance': 0,
-        }, {
-            'answer_id': 'answer_2',
-            'block_id': '',
-            'value': '13/09/2016',
-            'answer_instance': 0,
-        }, {
-            'answer_id': 'answer_3',
-            'block_id': '',
-            'value': '13/03/2016',
-            'answer_instance': 0,
-        }, {
-            'answer_id': 'answer_4',
-            'block_id': '',
-            'value': '13/10/2016',
-            'answer_instance': 0,
-        }])
+        self.answer_store.add(Answer(
+            answer_id='answer_1',
+            value='13/02/2016',
+        ))
+        self.answer_store.add(Answer(
+            answer_id='answer_2',
+            value='13/09/2016',
+        ))
+        self.answer_store.add(Answer(
+            answer_id='answer_3',
+            value='13/03/2016',
+        ))
+        self.answer_store.add(Answer(
+            answer_id='answer_4',
+            value='13/10/2016',
+        ))
+
         first_date_answer_schema = {'id': 'answer_1', 'label': 'From', 'type': 'date'}
         second_date_answer_schema = {'id': 'answer_2', 'label': 'To', 'type': 'date'}
         third_date_answer_schema = {'id': 'answer_3', 'label': 'First period', 'type': 'date'}
@@ -169,7 +161,7 @@ class TestQuestion(AppContextTestCase):
                            [first_date_answer_schema, second_date_answer_schema, third_date_answer_schema, fourth_date_answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store, {})
+        question = Question(question_schema, self.answer_store, self.metadata, self.schema)
 
         # Then
         self.assertEqual(len(question.answers), 2)
@@ -180,39 +172,37 @@ class TestQuestion(AppContextTestCase):
 
     def test_checkbox_button_options(self):
         # Given
-        answer_store = AnswerStore([{
-            'answer_id': 'answer_1',
-            'block_id': '',
-            'value': ['Light Side', 'Dark Side'],
-            'answer_instance': 0,
-        }])
+        self.answer_store.add(Answer(
+            answer_id='answer_1',
+            value=['Light Side', 'Dark Side'],
+        ))
 
         options = [{
-            'label': 'Light Side',
+            'label': 'Light Side label',
             'value': 'Light Side',
         }, {
-            'label': 'Dark Side',
+            'label': 'Dark Side label',
             'value': 'Dark Side',
         }]
         answer_schema = {'id': 'answer_1', 'label': 'Which side?', 'type': 'Checkbox', 'options': options}
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store, {})
+        with patch('app.templating.summary.question.get_question_title', return_value=False):
+            question = Question(question_schema, self.answer_store, self.metadata, self.schema)
 
         # Then
         self.assertEqual(len(question.answers[0]['value']), 2)
-        self.assertEqual(question.answers[0]['value'][0].label, 'Light Side')
-        self.assertEqual(question.answers[0]['value'][1].label, 'Dark Side')
+        self.assertEqual(question.answers[0]['value'][0].label, 'Light Side label')
+        self.assertEqual(question.answers[0]['value'][1].label, 'Dark Side label')
 
     def test_checkbox_button_other_option_empty(self):
         # Given
-        answer_store = AnswerStore([{
-            'answer_id': 'answer_1',
-            'block_id': '',
-            'value': ['other', ''],
-            'answer_instance': 0,
-        }])
+        self.answer_store.add(Answer(
+            answer_id='answer_1',
+            value=['other', ''],
+        ))
+
         options = [{
             'label': 'Light Side',
             'value': 'Light Side',
@@ -227,7 +217,8 @@ class TestQuestion(AppContextTestCase):
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store, {})
+        with patch('app.templating.summary.question.get_question_title', return_value=False):
+            question = Question(question_schema, self.answer_store, self.metadata, self.schema)
 
         # Then
         self.assertEqual(len(question.answers[0]['value']), 1)
@@ -236,17 +227,15 @@ class TestQuestion(AppContextTestCase):
 
     def test_checkbox_answer_with_other_value_returns_the_value(self):
         # Given
-        answer_store = AnswerStore([{
-            'answer_id': 'answer_1',
-            'block_id': '',
-            'value': ['Light Side', 'Other'],
-            'answer_instance': 0,
-        }, {
-            'answer_id': 'child_answer',
-            'block_id': '',
-            'value': 'Test',
-            'answer_instance': 0,
-        }])
+        self.answer_store.add(Answer(
+            answer_id='answer_1',
+            value=['Light Side', 'Other'],
+        ))
+        self.answer_store.add(Answer(
+            answer_id='child_answer',
+            value='Test',
+        ))
+
         options = [{
             'label': 'Light Side',
             'value': 'Light Side',
@@ -269,7 +258,8 @@ class TestQuestion(AppContextTestCase):
                            'answers': answer_schema}
 
         # When
-        question = Question(question_schema, answer_store, {})
+        with patch('app.templating.summary.question.get_question_title', return_value=False):
+            question = Question(question_schema, self.answer_store, self.metadata, self.schema)
 
         # Then
         self.assertEqual(len(question.answers[0]['value']), 2)
@@ -277,17 +267,14 @@ class TestQuestion(AppContextTestCase):
 
     def test_checkbox_button_other_option_text(self):
         # Given
-        answer_store = AnswerStore([{
-            'answer_id': 'answer_1',
-            'block_id': '',
-            'value': ['Light Side', 'other'],
-            'answer_instance': 0,
-        }, {
-            'answer_id': 'child_answer',
-            'block_id': '',
-            'value': 'Neither',
-            'answer_instance': 0,
-        }])
+        self.answer_store.add(Answer(
+            answer_id='answer_1',
+            value=['Light Side', 'other'],
+        ))
+        self.answer_store.add(Answer(
+            answer_id='child_answer',
+            value='Neither',
+        ))
         options = [{
             'label': 'Light Side',
             'value': 'Light Side',
@@ -300,7 +287,8 @@ class TestQuestion(AppContextTestCase):
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store, {})
+        with patch('app.templating.summary.question.get_question_title', return_value=False):
+            question = Question(question_schema, self.answer_store, self.metadata, self.schema)
 
         # Then
         self.assertEqual(len(question.answers[0]['value']), 2)
@@ -309,12 +297,10 @@ class TestQuestion(AppContextTestCase):
 
     def test_checkbox_button_none_selected_should_be_none(self):
         # Given
-        answer_store = AnswerStore([{
-            'answer_id': 'answer_1',
-            'block_id': '',
-            'value': [],
-            'answer_instance': 0,
-        }])
+        self.answer_store.add(Answer(
+            answer_id='answer_1',
+            value=[],
+        ))
         options = [{
             'label': 'Light Side',
             'value': 'Light Side',
@@ -323,19 +309,18 @@ class TestQuestion(AppContextTestCase):
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store, {})
+        with patch('app.templating.summary.question.get_question_title', return_value=False):
+            question = Question(question_schema, self.answer_store, self.metadata, self.schema)
 
         # Then
         self.assertEqual(question.answers[0]['value'], None)
 
     def test_radio_button_other_option_empty(self):
         # Given
-        answer_store = AnswerStore([{
-            'answer_id': 'answer_1',
-            'block_id': '',
-            'value': '',
-            'answer_instance': 0,
-        }])
+        self.answer_store.add(Answer(
+            answer_id='answer_1',
+            value='',
+        ))
         options = [{
             'label': 'Light Side',
             'value': 'Light Side',
@@ -350,19 +335,18 @@ class TestQuestion(AppContextTestCase):
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store, {})
+        with patch('app.templating.summary.question.get_question_title', return_value=False):
+            question = Question(question_schema, self.answer_store, self.metadata, self.schema)
 
         # Then
         self.assertEqual(question.answers[0]['value'], 'Other option label')
 
     def test_radio_button_other_option_text(self):
         # Given
-        answer_store = AnswerStore([{
-            'answer_id': 'answer_1',
-            'block_id': '',
-            'value': 'I want to be on the dark side',
-            'answer_instance': 0,
-        }])
+        self.answer_store.add(Answer(
+            answer_id='answer_1',
+            value='I want to be on the dark side',
+        ))
         options = [{
             'label': 'Light Side',
             'value': 'Light Side',
@@ -377,19 +361,14 @@ class TestQuestion(AppContextTestCase):
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store, {})
+        with patch('app.templating.summary.question.get_question_title', return_value=False):
+            question = Question(question_schema, self.answer_store, self.metadata, self.schema)
 
         # Then
         self.assertEqual(question.answers[0]['value'], 'I want to be on the dark side')
 
     def test_radio_button_none_selected_should_be_none(self):
         # Given
-        answer_store = AnswerStore([{
-            'answer_id': 'answer_1',
-            'block_id': '',
-            'value': None,
-            'answer_instance': 0,
-        }])
         options = [{
             'label': 'Light Side',
             'value': 'Light Side',
@@ -398,24 +377,22 @@ class TestQuestion(AppContextTestCase):
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store, {})
+        with patch('app.templating.summary.question.get_question_title', return_value=False):
+            question = Question(question_schema, self.answer_store, self.metadata, self.schema)
 
         # Then
         self.assertEqual(question.answers[0]['value'], None)
 
     def test_radio_answer_with_other_value_returns_the_value(self):
         # Given
-        answer_store = AnswerStore([{
-            'answer_id': 'answer_1',
-            'block_id': '',
-            'value': 'Other',
-            'answer_instance': 0,
-        }, {
-            'answer_id': 'child_answer',
-            'block_id': '',
-            'value': 'Test',
-            'answer_instance': 0,
-        }])
+        self.answer_store.add(Answer(
+            answer_id='answer_1',
+            value='Other',
+        ))
+        self.answer_store.add(Answer(
+            answer_id='child_answer',
+            value='Test',
+        ))
         options = [{
             'label': 'Other',
             'value': 'Other',
@@ -435,35 +412,35 @@ class TestQuestion(AppContextTestCase):
                            'answers': answer_schema}
 
         # When
-        question = Question(question_schema, answer_store, {})
+        with patch('app.templating.summary.question.get_question_title', return_value=False):
+            question = Question(question_schema, self.answer_store, self.metadata, self.schema)
 
         # Then
         self.assertEqual(question.answers[0]['child_answer_value'], 'Test')
 
     def test_build_answers_repeating_answers(self):
         # Given
-        answer_store = AnswerStore([{
-            'answer_id': 'answer',
-            'block_id': '',
-            'value': 'value',
-            'answer_instance': 0,
-        }, {
-            'answer_id': 'answer',
-            'block_id': '',
-            'value': 'value1',
-            'answer_instance': 0,
-        }, {
-            'answer_id': 'answer',
-            'block_id': '',
-            'value': 'value2',
-            'answer_instance': 0,
-        }])
+        self.answer_store.add(Answer(
+            answer_id='answer',
+            value='Value',
+        ))
+        self.answer_store.add(Answer(
+            answer_id='answer',
+            value='Value 2',
+            group_instance=1,
+        ))
+        self.answer_store.add(Answer(
+            answer_id='answer',
+            value='Value 3',
+            group_instance=2,
+        ))
         answer_schema = {'id': 'answer', 'title': '', 'type': '', 'label': ''}
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'RepeatingAnswer',
                            'answers': [answer_schema]}
 
         # When
-        question = Question(question_schema, answer_store, {})
+        with patch('app.templating.summary.question.get_question_title', return_value=False):
+            question = Question(question_schema, self.answer_store, self.metadata, self.schema)
 
         # Then
         self.assertEqual(len(question.answers), 3)

--- a/tests/app/templating/test_schema_context.py
+++ b/tests/app/templating/test_schema_context.py
@@ -1,15 +1,13 @@
-import mock
-from flask import g
-from app.data_model.answer_store import AnswerStore
-from app.questionnaire.location import Location
-from app.templating.schema_context import build_schema_context
-from app.utilities.schema import load_schema_from_params
-from tests.app.app_context_test_case import AppContextTestCase
+from unittest import TestCase
+from mock import MagicMock, patch
+from app.data_model.answer_store import AnswerStore, Answer
+from app.templating.schema_context import build_schema_context, _build_answers, build_schema_metadata
+from app.utilities.schema import _load_schema_file
+from app.questionnaire.questionnaire_schema import QuestionnaireSchema, DEFAULT_LANGUAGE_CODE
 
-
-class TestSchemaContext(AppContextTestCase):  # pylint: disable=too-many-public-methods
-
-    metadata = {
+def get_metadata_sample():
+    """Returns a metadata sample"""
+    return {
         'user_id': 'Steve',
         'ref_p_start_date': '2016-10-13',
         'ref_p_end_date': '2016-10-14',
@@ -23,357 +21,208 @@ class TestSchemaContext(AppContextTestCase):  # pylint: disable=too-many-public-
         'form_type': 'schema_context'
     }
 
+def get_test_schema():
+    test_json = _load_schema_file('test_schema_context.json', DEFAULT_LANGUAGE_CODE)
+    schema = QuestionnaireSchema(test_json, DEFAULT_LANGUAGE_CODE)
+
+    schema.is_repeating_answer_type = MagicMock(return_value=False)
+    schema.answer_is_in_repeating_group = MagicMock(return_value=False)
+    return schema
+
+class TestBuildSchemaContext(TestCase):  # pylint: disable=too-many-public-methods
+
     def setUp(self):
-        super().setUp()
-        g.schema = load_schema_from_params(self.metadata['eq_id'], self.metadata['form_type'])
-
-        self.answer_store = AnswerStore([])
-
-        self.routing_path = [Location('group1', 0, 'block1')]
-
-        self._get_is_repeating_answer_patcher = mock.patch('app.templating.schema_context._get_is_repeating_answer', return_value=False)
-        self._get_is_repeating_answer = self._get_is_repeating_answer_patcher.start()
-
-        self._get_answer_is_in_repeating_group_patcher = mock.patch(
-            'app.templating.schema_context._get_answer_is_in_repeating_group',
-            return_value=False)
-        self._get_answer_is_in_repeating_group = self._get_answer_is_in_repeating_group_patcher.start()
-
-    def tearDown(self):
-        self._get_is_repeating_answer_patcher.stop()
-        self._get_answer_is_in_repeating_group_patcher.stop()
-        super().tearDown()
+        self.answer_store = AnswerStore()
+        self.metadata = get_metadata_sample()
+        self.schema = get_test_schema()
 
     def test_build_schema_context(self):
-        schema_context = build_schema_context(self.metadata, AnswerStore([]), [])
+        # Given
+        with patch('app.templating.schema_context.build_schema_metadata', return_value='schema_metadata'), \
+                patch('app.templating.schema_context._build_answers', return_value='answer_context'):
+            # When
+            schema_context = build_schema_context(self.metadata, self.schema, self.answer_store, [])
 
+        # Then
         self.assertIn('metadata', schema_context)
+        self.assertEqual(schema_context['metadata'], 'schema_metadata')
         self.assertIn('answers', schema_context)
+        self.assertEqual(schema_context['answers'], 'answer_context')
 
-    def test_build_schema_metadata(self):
-        schema_context = build_schema_context(self.metadata, AnswerStore([]), [])
 
-        metadata = schema_context['metadata']
-        self.assertEqual('2016-10-13', metadata['ref_p_start_date'])
-        self.assertEqual('2016-10-14', metadata['ref_p_end_date'])
-        self.assertEqual('201610', metadata['period_id'])
-        self.assertEqual('2016-10-19', metadata['employment_date'])
-        self.assertEqual('Steve', metadata['user_id'])
+class TestBuildAnswersContext(TestCase):
+
+    def setUp(self):
+        self.answer_store = AnswerStore()
+        self.metadata = get_metadata_sample()
+        self.schema = get_test_schema()
 
     def test_build_answers(self):
-        answers = [{
-            'group_id': 'group1',
-            'group_instance': 0,
-            'block_id': 'block1',
-            'answer_id': 'first_name',
-            'answer_instance': 0,
-            'value': 'Joe Bloggs',
-        }]
-
+        # Given
+        self.answer_store.add(Answer(
+            answer_id='first_name',
+            value='Joe Bloggs',
+        ))
         answer_ids_on_path = ['first_name']
 
-        schema_context = build_schema_context(self.metadata, AnswerStore(answers), answer_ids_on_path)
+        # When
+        context_answers = _build_answers(self.answer_store, self.schema, answer_ids_on_path)
 
-        context_answers = schema_context['answers']
+        # Then
         self.assertEqual(len(context_answers), 1)
         self.assertEqual(context_answers['first_name'], 'Joe Bloggs')
 
-    def test_build_schema_context_repeating_answers(self):
-        answers = [
-            {
-                'group_id': 'group1',
-                'group_instance': 0,
-                'block_id': 'block1',
-                'answer_id': 'full_name_answer',
-                'answer_instance': 0,
-                'value': 'Person One',
-            },
-            {
-                'group_id': 'group1',
-                'group_instance': 0,
-                'block_id': 'block1',
-                'answer_id': 'full_name_answer',
-                'answer_instance': 1,
-                'value': 'Person Two',
-            },
-            {
-                'group_id': 'group1',
-                'group_instance': 0,
-                'block_id': 'block1',
-                'answer_id': 'full_name_answer',
-                'answer_instance': 2,
-                'value': 'Person Three',
-            }
-        ]
-
+    def test_build_answers_context_repeating_answers(self):
+        # Given
+        self.answer_store.add(Answer(
+            answer_id='full_name_answer',
+            value='Person One',
+        ))
+        self.answer_store.add(Answer(
+            answer_id='full_name_answer',
+            value='Person Two',
+            answer_instance=1,
+        ))
+        self.answer_store.add(Answer(
+            answer_id='full_name_answer',
+            value='Person One',
+            answer_instance=2
+        ))
         answer_ids_on_path = ['full_name_answer']
 
-        self._get_is_repeating_answer.return_value = True
-        schema_context = build_schema_context(self.metadata, AnswerStore(answers), answer_ids_on_path)
+        # When
+        self.schema.is_repeating_answer_type = MagicMock(return_value=True)
+        context_answers = _build_answers(self.answer_store, self.schema, answer_ids_on_path)
 
-        context_answers = schema_context['answers']
+        # Then
         self.assertIsInstance(context_answers['full_name_answer'], list)
         self.assertEqual(len(context_answers['full_name_answer']), 3)
         self.assertEqual(len(context_answers), 1)
 
-    def test_build_schema_context_single_answer_should_not_return_list(self):
-        answers = [{
-            'group_id': 'group1',
-            'group_instance': 0,
-            'block_id': 'block1',
-            'answer_id': 'full_name_answer',
-            'answer_instance': 0,
-            'value': 'Person One',
-        }]
-
+    def test_build_answers_single_answer_should_not_return_list(self):
+        # Given
+        self.answer_store.add(Answer(
+            answer_id='full_name_answer',
+            value='Person One',
+        ))
         answer_ids_on_path = ['full_name_answer']
 
-        schema_context = build_schema_context(self.metadata, AnswerStore(answers), answer_ids_on_path)
+        # When
+        context_answers = _build_answers(self.answer_store, self.schema, answer_ids_on_path)
 
-        context_answers = schema_context['answers']
-        self.assertEqual(len(answers), 1)
+        # Then
+        self.assertEqual(len(context_answers), 1)
         self.assertEqual(context_answers['full_name_answer'], 'Person One')
 
-    def test_alias_for_repeating_answer_returns_list(self):
-        answers = [{
-            'group_id': 'group1',
-            'group_instance': 0,
-            'block_id': 'block1',
-            'answer_id': 'repeating_answer_id',
-            'answer_instance': 0,
-            'value': 'Some Value',
-        }]
-
+    def test_build_answers_alias_for_repeating_answer_returns_list(self):
+        # Given
+        self.answer_store.add(Answer(
+            answer_id='repeating_answer_id',
+            value='Some Value',
+        ))
         answer_ids_on_path = ['repeating_answer_id']
 
-        self._get_is_repeating_answer.return_value = True
-        schema_context = build_schema_context(self.metadata, AnswerStore(answers), answer_ids_on_path)
+        # When
+        self.schema.is_repeating_answer_type = MagicMock(return_value=True)
+        context_answers = _build_answers(self.answer_store, self.schema, answer_ids_on_path)
 
-        context_answers = schema_context['answers']
+        # Then
         self.assertIsInstance(context_answers['repeating_answer_id'], list)
 
     def test_alias_for_non_repeating_answer_returns_string(self):
-        answers = [{
-            'group_id': 'group1',
-            'group_instance': 0,
-            'block_id': 'block1',
-            'answer_id': 'non_repeating_answer_id',
-            'answer_instance': 0,
-            'value': 'Some Value',
-        }]
-
+        # Given
+        self.answer_store.add(Answer(
+            answer_id='non_repeating_answer_id',
+            value='Some Value',
+        ))
         answer_ids_on_path = ['non_repeating_answer_id']
 
-        schema_context = build_schema_context(self.metadata, AnswerStore(answers), answer_ids_on_path)
+        # When
+        context_answers = _build_answers(self.answer_store, self.schema, answer_ids_on_path)
 
-        context_answers = schema_context['answers']
+        # Then
         self.assertIsInstance(context_answers['non_repeating_answer_id'], str)
         self.assertEqual(context_answers['non_repeating_answer_id'], 'Some Value')
 
     def test_alias_for_answer_in_repeating_group_returns_list(self):
-        answers = [{
-            'group_id': 'group1',
-            'group_instance': 0,
-            'block_id': 'block1',
-            'answer_id': 'answer_id',
-            'answer_instance': 0,
-            'value': 'Some Value',
-        }]
-
+        # Given
+        self.answer_store.add(Answer(
+            answer_id='answer_id',
+            value='Some Value',
+        ))
         answer_ids_on_path = ['answer_id']
 
-        self._get_answer_is_in_repeating_group.return_value = True
-        schema_context = build_schema_context(self.metadata,
-                                              AnswerStore(answers),
-                                              answer_ids_on_path)
+        # When
+        self.schema.is_repeating_answer_type = MagicMock(return_value=True)
+        context_answers = _build_answers(self.answer_store, self.schema, answer_ids_on_path)
 
-        context_answers = schema_context['answers']
+        # Then
         self.assertIsInstance(context_answers['answer_id'], list)
 
     def test_maximum_answers_must_be_limited_to_system_max(self):
-        answers = [{
-            'group_id': 'group1',
-            'group_instance': 0,
-            'block_id': 'block1',
-            'answer_id': 'repeating_answer_id',
-            'answer_instance': instance,
-            'value': 'Some Value',
-        } for instance in range(26)]
-
+        # Given
+        for instance in range(26):
+            self.answer_store.add(Answer(
+                answer_id='repeating_answer_id',
+                value='Some Value',
+                answer_instance=instance,
+            ))
         answer_ids_on_path = ['repeating_answer_id']
 
-        self._get_is_repeating_answer.return_value = True
-        schema_context = build_schema_context(self.metadata, AnswerStore(answers), answer_ids_on_path)
+        # When
+        self.schema.is_repeating_answer_type = MagicMock(return_value=True)
+        context_answers = _build_answers(self.answer_store, self.schema, answer_ids_on_path)
 
-        context_answers = schema_context['answers']
+        # Then
+        print(context_answers)
         self.assertEqual(len(context_answers['repeating_answer_id']), 25)
 
-    def test_metadata_display_name_is_trad_as_when_trad_as_supplied(self):
-        answer_ids_on_path = []
-        schema_context = build_schema_context(self.metadata, self.answer_store, answer_ids_on_path)
-
-        self.assertEqual(schema_context['metadata']['trad_as_or_ru_name'], self.metadata['trad_as'])
-
-    def test_metadata_display_name_is_ru_name_as_when_trad_as_not_supplied(self):
-        metadata = self.metadata.copy()
-        metadata['trad_as'] = None
-
-        answer_ids_on_path = []
-
-        schema_context = build_schema_context(metadata, self.answer_store, answer_ids_on_path)
-
-        self.assertEqual(schema_context['metadata']['trad_as_or_ru_name'], metadata['ru_name'])
-
-    def test_metadata_display_name_is_ru_name_as_when_trad_as_empty(self):
-        metadata = self.metadata.copy()
-        metadata['trad_as'] = ''
-
-        answer_ids_on_path = []
-
-        schema_context = build_schema_context(metadata, self.answer_store, answer_ids_on_path)
-
-        self.assertEqual(schema_context['metadata']['trad_as_or_ru_name'], metadata['ru_name'])
-
-    def test_given_quotes_in_trading_name_when_create_context_then_quotes_are_html_encoded(self):
-        # Given
-        metadata = self.metadata.copy()
-        metadata['trad_as'] = '\"trading name\"'
-
-        answer_ids_on_path = []
-
-        # When
-        schema_context = build_schema_context(metadata, self.answer_store, answer_ids_on_path)
-
-        # Then
-        self.assertEqual(schema_context['metadata']['trad_as'], r'&#34;trading name&#34;')
-
-    def test_given_backslash_in_trading_name_when_create_context_then_backslash_are_escaped(self):
-        # Given
-        metadata = self.metadata.copy()
-        metadata['trad_as'] = '\\trading name\\'
-
-        answer_ids_on_path = []
-
-        # When
-        schema_context = build_schema_context(metadata, self.answer_store, answer_ids_on_path)
-
-        # Then
-        self.assertEqual(schema_context['metadata']['trad_as'], r'\\trading name\\')
-
-    def test_given_quotes_in_ru_name_when_create_context_then_quotes_are_html_encoded(self):
-        # Given
-        metadata = self.metadata.copy()
-        metadata['ru_name'] = '\"ru name\"'
-
-        answer_ids_on_path = []
-
-        # When
-        schema_context = build_schema_context(metadata, self.answer_store, answer_ids_on_path)
-
-        # Then
-        self.assertEqual(schema_context['metadata']['ru_name'], r'&#34;ru name&#34;')
-
-    def test_given_backslash_in_ru_name_when_create_context_then_backslash_are_escaped(self):
-        # Given
-        metadata = self.metadata.copy()
-        metadata['ru_name'] = '\\ru name\\'
-
-        answer_ids_on_path = []
-
-        # When
-        schema_context = build_schema_context(metadata, self.answer_store, answer_ids_on_path)
-
-        # Then
-        self.assertEqual(schema_context['metadata']['ru_name'], r'\\ru name\\')
-
-    def test_given_quotes_in_ru_name_or_trading_name_when_create_context_then_quotes_are_html_encoded(self):
-        # Given
-        metadata = self.metadata.copy()
-        metadata['ru_name'] = '\"ru_name\"'
-        metadata['trad_as'] = None
-
-        answer_ids_on_path = []
-
-        # When
-        schema_context = build_schema_context(metadata, self.answer_store, answer_ids_on_path)
-
-        # Then
-        self.assertEqual(schema_context['metadata']['trad_as_or_ru_name'], r'&#34;ru_name&#34;')
-
-    def test_given_backslash_in_ru_name_or_trading_name_when_create_context_then_backslash_are_escaped(self):
-        # Given
-        metadata = self.metadata.copy()
-        metadata['trad_as'] = '\\trading name\\'
-
-        answer_ids_on_path = []
-
-        # When
-        schema_context = build_schema_context(metadata, self.answer_store, answer_ids_on_path)
-
-        # Then
-        self.assertEqual(schema_context['metadata']['trad_as_or_ru_name'], r'\\trading name\\')
-
     def test_given_quotes_in_answers_when_create_context_quotes_then_are_html_encoded(self):
-        answers = [{
-            'group_id': 'group1',
-            'group_instance': 0,
-            'block_id': 'block1',
-            'answer_id': 'first_name',
-            'answer_instance': 0,
-            'value': '"',
-        }]
-
+        # Given
+        self.answer_store.add(Answer(
+            answer_id='first_name',
+            value='"'
+        ))
         answer_ids_on_path = ['first_name']
 
-        schema_context = build_schema_context(self.metadata, AnswerStore(answers), answer_ids_on_path)
+        # When
+        context_answers = _build_answers(self.answer_store, self.schema, answer_ids_on_path)
 
-        context_answers = schema_context['answers']
+        # Then
         self.assertEqual(len(context_answers), 1)
         self.assertEqual(context_answers['first_name'], r'&#34;')
 
     def test_given_backslash_in_answers_when_create_context_then_backslash_are_escaped(self):
-        answers = [{
-            'group_id': 'group1',
-            'group_instance': 0,
-            'block_id': 'block1',
-            'answer_id': 'first_name',
-            'answer_instance': 0,
-            'value': '\\',
-        }]
-
+        # Given
+        self.answer_store.add(Answer(
+            answer_id='first_name',
+            value='\\'
+        ))
         answer_ids_on_path = ['first_name']
 
-        schema_context = build_schema_context(self.metadata, AnswerStore(answers), answer_ids_on_path)
+        # When
+        context_answers = _build_answers(self.answer_store, self.schema, answer_ids_on_path)
 
-        context_answers = schema_context['answers']
+        # Then
         self.assertEqual(len(context_answers), 1)
         self.assertEqual(context_answers['first_name'], r'\\')
 
     def test_build_answers_excludes_answers_not_in_routing_path(self):
-        answers = [
-            {
-                'group_id': 'group1',
-                'group_instance': 0,
-                'block_id': 'block1',
-                'answer_id': 'first_name',
-                'answer_instance': 0,
-                'value': 'Joe',
-            },
-            {
-                'group_id': 'group2',
-                'group_instance': 0,
-                'block_id': 'block2',
-                'answer_id': 'last_name',
-                'answer_instance': 0,
-                'value': 'Bloggs',
-            }
-        ]
-
+        # Given
+        self.answer_store.add(Answer(
+            answer_id='first_name',
+            value='Joe',
+        ))
+        self.answer_store.add(Answer(
+            answer_id='lastname',
+            value='Bloggs',
+        ))
         answer_ids_on_path = ['first_name']
 
-        schema_context = build_schema_context(self.metadata, AnswerStore(answers), answer_ids_on_path)
+        # When
+        context_answers = _build_answers(self.answer_store, self.schema, answer_ids_on_path)
 
-        context_answers = schema_context['answers']
+        # Then
         self.assertEqual(len(context_answers), 1)
         self.assertEqual(context_answers['first_name'], 'Joe')
 
@@ -381,22 +230,20 @@ class TestSchemaContext(AppContextTestCase):  # pylint: disable=too-many-public-
         """Tests that repeating answers get put in a padded list in the
         correct position
         """
-        answers = [{
-            'group_id': 'group1',
-            'group_instance': 1,
-            'block_id': 'block1',
-            'answer_id': 'first_name',
-            'answer_instance': 0,
-            'value': 'Joe',
-        }]
-
+        # Given
+        self.answer_store.add(Answer(
+            answer_id='first_name',
+            value='Joe',
+            group_instance=1,
+        ))
         answer_ids_on_path = ['first_name']
-        self._get_answer_is_in_repeating_group.return_value = True
-        schema_context = build_schema_context(self.metadata,
-                                              AnswerStore(answers),
-                                              answer_ids_on_path)
 
-        context_answers = schema_context['answers']
+        # When
+        self.schema.answer_is_in_repeating_group = MagicMock(return_value=True)
+        context_answers = _build_answers(self.answer_store, self.schema, answer_ids_on_path)
+
+        # Then
+        print(context_answers)
         self.assertEqual(len(context_answers), 1)
         self.assertEqual(context_answers['first_name'], ['', 'Joe'])
 
@@ -404,50 +251,148 @@ class TestSchemaContext(AppContextTestCase):  # pylint: disable=too-many-public-
         """Tests that repeating answers get put in a padded list in the
         correct position
         """
-        answers = [{
-            'group_id': 'group1',
-            'group_instance': 0,
-            'block_id': 'block1',
-            'answer_id': 'first_name',
-            'answer_instance': 1,
-            'value': 'Joe',
-        }]
-
+        # Given
+        self.answer_store.add(Answer(
+            answer_id='first_name',
+            value='Joe',
+            answer_instance=1,
+        ))
         answer_ids_on_path = ['first_name']
-        self._get_is_repeating_answer.return_value = True
-        schema_context = build_schema_context(self.metadata,
-                                              AnswerStore(answers),
-                                              answer_ids_on_path)
 
-        context_answers = schema_context['answers']
+        # When
+        self.schema.is_repeating_answer_type = MagicMock(return_value=True)
+        context_answers = _build_answers(self.answer_store, self.schema, answer_ids_on_path)
+
+        # Then
         self.assertEqual(len(context_answers), 1)
         self.assertEqual(context_answers['first_name'], ['', 'Joe'])
 
     def test_build_answers_puts_answers_in_repeating_group(self):
-        answers = [
-            {
-                'group_id': 'group1',
-                'group_instance': 0,
-                'block_id': 'block1',
-                'answer_id': 'first_name',
-                'answer_instance': 1,
-                'value': 'Bloggs',
-            }, {
-                'group_id': 'group1',
-                'group_instance': 0,
-                'block_id': 'block1',
-                'answer_id': 'first_name',
-                'answer_instance': 0, # answer_instance deliberately in inverse order
-                'value': 'Joe',
-            }
-        ]
-
+        # Given
+        self.answer_store.add(Answer(
+            answer_id='first_name',
+            value='Bloggs',
+            answer_instance=1,
+        ))
+        self.answer_store.add(Answer(
+            answer_id='first_name',
+            value='Joe',
+            answer_instance=0, # answer_instance deliberately in inverse order
+        ))
         answer_ids_on_path = ['first_name']
-        self._get_is_repeating_answer.return_value = True
-        schema_context = build_schema_context(self.metadata,
-                                              AnswerStore(answers),
-                                              answer_ids_on_path)
 
-        context_answers = schema_context['answers']
+        # When
+        self.schema.is_repeating_answer_type = MagicMock(return_value=True)
+        context_answers = _build_answers(self.answer_store, self.schema, answer_ids_on_path)
+
+        # Then
         self.assertEqual(len(context_answers), 1)
         self.assertEqual(context_answers['first_name'], ['Joe', 'Bloggs'])
+
+
+class TestBuildSchemaMetadata(TestCase):
+
+    def setUp(self):
+        self.metadata = get_metadata_sample()
+        self.schema = get_test_schema()
+
+    def test_build_schema_metadata(self):
+        # When
+        metadata_context = build_schema_metadata(self.metadata, self.schema)
+
+        # Then
+        self.assertEqual('2016-10-13', metadata_context['ref_p_start_date'])
+        self.assertEqual('2016-10-14', metadata_context['ref_p_end_date'])
+        self.assertEqual('201610', metadata_context['period_id'])
+        self.assertEqual('2016-10-19', metadata_context['employment_date'])
+        self.assertEqual('Steve', metadata_context['user_id'])
+
+    def test_metadata_display_name_is_trad_as_when_trad_as_supplied(self):
+        # Given
+
+        # When
+        metadata_context = build_schema_metadata(self.metadata, self.schema)
+
+        # Then
+        self.assertEqual(metadata_context['trad_as_or_ru_name'], self.metadata['trad_as'])
+
+    def test_metadata_display_name_is_ru_name_as_when_trad_as_not_supplied(self):
+        # Given
+        self.metadata['trad_as'] = None
+
+        # When
+        metadata_context = build_schema_metadata(self.metadata, self.schema)
+
+        # Then
+        self.assertEqual(metadata_context['trad_as_or_ru_name'], self.metadata['ru_name'])
+
+    def test_metadata_display_name_is_ru_name_as_when_trad_as_empty(self):
+        # Given
+        self.metadata['trad_as'] = ''
+
+        # When
+        metadata_context = build_schema_metadata(self.metadata, self.schema)
+
+        # Then
+        self.assertEqual(metadata_context['trad_as_or_ru_name'], self.metadata['ru_name'])
+
+    def test_given_quotes_in_trading_name_when_create_context_then_quotes_are_html_encoded(self):
+        # Given
+        self.metadata['trad_as'] = '\"trading name\"'
+
+        # When
+        metadata_context = build_schema_metadata(self.metadata, self.schema)
+
+        # Then
+        self.assertEqual(metadata_context['trad_as'], r'&#34;trading name&#34;')
+
+    def test_given_backslash_in_trading_name_when_create_context_then_backslash_are_escaped(self):
+        # Given
+        self.metadata['trad_as'] = '\\trading name\\'
+
+        # When
+        metadata_context = build_schema_metadata(self.metadata, self.schema)
+
+        # Then
+        self.assertEqual(metadata_context['trad_as'], r'\\trading name\\')
+
+    def test_given_quotes_in_ru_name_when_create_context_then_quotes_are_html_encoded(self):
+        # Given
+        self.metadata['ru_name'] = '\"ru name\"'
+
+        # When
+        metadata_context = build_schema_metadata(self.metadata, self.schema)
+
+        # Then
+        self.assertEqual(metadata_context['ru_name'], r'&#34;ru name&#34;')
+
+    def test_given_backslash_in_ru_name_when_create_context_then_backslash_are_escaped(self):
+        # Given
+        self.metadata['ru_name'] = '\\ru name\\'
+
+        # When
+        metadata_context = build_schema_metadata(self.metadata, self.schema)
+
+        # Then
+        self.assertEqual(metadata_context['ru_name'], r'\\ru name\\')
+
+    def test_given_quotes_in_ru_name_or_trading_name_when_create_context_then_quotes_are_html_encoded(self):
+        # Given
+        self.metadata['ru_name'] = '\"ru_name\"'
+        self.metadata['trad_as'] = None
+
+        # When
+        metadata_context = build_schema_metadata(self.metadata, self.schema)
+
+        # Then
+        self.assertEqual(metadata_context['trad_as_or_ru_name'], r'&#34;ru_name&#34;')
+
+    def test_given_backslash_in_ru_name_or_trading_name_when_create_context_then_backslash_are_escaped(self):
+        # Given
+        self.metadata['trad_as'] = '\\trading name\\'
+
+        # When
+        metadata_context = build_schema_metadata(self.metadata, self.schema)
+
+        # Then
+        self.assertEqual(metadata_context['trad_as_or_ru_name'], r'\\trading name\\')

--- a/tests/app/templating/test_summary_context.py
+++ b/tests/app/templating/test_summary_context.py
@@ -1,4 +1,3 @@
-from flask import g
 from mock import MagicMock, Mock, patch
 
 from app.data_model.answer_store import AnswerStore
@@ -115,16 +114,14 @@ class TestSectionSummaryContext(AppContextTestCase):
         csrf_token = None
         variables = None
 
-        g.schema = load_schema_from_params('test', 'section_summary')
-
-        section = g.schema.json
+        section = self.schema.json
         current_location = Location(
             block_id='property-details-summary',
             group_id='property-details',
             group_instance=0,
         )
 
-        context = build_view_context_for_summary(self.metadata, self.answer_store, section, block_type, variables,
+        context = build_view_context_for_summary(self.metadata, self.schema, self.answer_store, section, block_type, variables,
                                                  csrf_token, current_location)
 
         self.assertEqual(len(context), 3)

--- a/tests/app/templating/test_templating_utils.py
+++ b/tests/app/templating/test_templating_utils.py
@@ -9,7 +9,7 @@ class TestTemplatingUtils(unittest.TestCase):
         expected_value = ''
         test_schema = {'title': expected_value}
 
-        actual_value = get_question_title(test_schema, None, None, None)
+        actual_value = get_question_title(test_schema, None, None, None, None)
 
         self.assertEqual(expected_value, actual_value)
 
@@ -18,14 +18,14 @@ class TestTemplatingUtils(unittest.TestCase):
         test_schema = {}
 
         with patch('app.templating.utils.get_title_from_titles', return_value='TitlesElement'):
-            actual_value = get_question_title(test_schema, None, None, None)
+            actual_value = get_question_title(test_schema, None, None, None, None)
             self.assertEqual(expected_value, actual_value)
 
     def test_get_question_title_title_returned_if_present(self):
         expected_value = 'MyTitle'
         test_schema = {'title': expected_value}
 
-        actual_value = get_question_title(test_schema, None, None, None)
+        actual_value = get_question_title(test_schema, None, None, None, None)
 
         self.assertEqual(expected_value, actual_value)
 
@@ -33,7 +33,7 @@ class TestTemplatingUtils(unittest.TestCase):
         expected_value = 'MyTitle'
         test_schema = {'titles': [{'value': expected_value}]}
 
-        actual_value = get_question_title(test_schema, None, None, None)
+        actual_value = get_question_title(test_schema, None, None, None, None)
         self.assertEqual(expected_value, actual_value)
 
     def test_evaluates_when_rule_if_present(self):
@@ -51,5 +51,5 @@ class TestTemplatingUtils(unittest.TestCase):
             }
 
         with patch('app.templating.utils.evaluate_when_rules', return_value=True):
-            actual_value = get_question_title(test_schema, None, None, None)
+            actual_value = get_question_title(test_schema, None, None, None, None)
             self.assertEqual(expected_value, actual_value)

--- a/tests/integration/census/test_census_communal_submission_data.py
+++ b/tests/integration/census/test_census_communal_submission_data.py
@@ -1,18 +1,16 @@
-from unittest.mock import patch
 from tests.integration.integration_test_case import IntegrationTestCase
 
 
 class TestCensusCommunalSubmissionData(IntegrationTestCase):
 
     def test_census_communal_data_matches_census_communal(self):
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            self.complete_survey('census', 'communal')
+        self.complete_survey('census', 'communal')
 
-            # Only verifying 'data'
-            actual_downstream_data = self.dumpSubmission()['submission']['data']
-            expected_downstream_data = self.get_expected_submission_data()
+        # Only verifying 'data'
+        actual_downstream_data = self.dumpSubmission()['submission']['data']
+        expected_downstream_data = self.get_expected_submission_data()
 
-            self.assertCountEqual(actual_downstream_data, expected_downstream_data)
+        self.assertCountEqual(actual_downstream_data, expected_downstream_data)
 
     @staticmethod
     def get_expected_submission_data():

--- a/tests/integration/census/test_census_household_submission_data.py
+++ b/tests/integration/census/test_census_household_submission_data.py
@@ -1,19 +1,17 @@
-from unittest.mock import patch
 from tests.integration.integration_test_case import IntegrationTestCase
 
 
 # pylint: disable=too-many-lines
 class TestCensusHouseholdSubmissionData(IntegrationTestCase):
     def test_census_household_data_matches_census_individual(self):
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=True):
-            self.complete_survey('census', 'household')
+        self.complete_survey('census', 'household')
 
-            # Only verifying 'data'
-            actual_downstream_data = self.dumpSubmission()['submission']['data']
+        # Only verifying 'data'
+        actual_downstream_data = self.dumpSubmission()['submission']['data']
 
-            expected_downstream_data = self.get_expected_submission_data()
+        expected_downstream_data = self.get_expected_submission_data()
 
-            self.assertCountEqual(actual_downstream_data, expected_downstream_data)
+        self.assertCountEqual(actual_downstream_data, expected_downstream_data)
 
     @staticmethod
     def get_expected_submission_data():

--- a/tests/integration/census/test_census_individual_submission_data.py
+++ b/tests/integration/census/test_census_individual_submission_data.py
@@ -1,18 +1,16 @@
-from unittest.mock import patch
 from tests.integration.integration_test_case import IntegrationTestCase
 
 
 class TestCensusIndividualSubmissionData(IntegrationTestCase):
 
     def test_census_individual_data_matches_census_individual(self):
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            self.complete_survey('census', 'individual')
+        self.complete_survey('census', 'individual')
 
-            # Only verifying 'data'
-            actual_downstream_data = self.dumpSubmission()['submission']['data']
-            expected_downstream_data = self.get_expected_submission_data()
+        # Only verifying 'data'
+        actual_downstream_data = self.dumpSubmission()['submission']['data']
+        expected_downstream_data = self.get_expected_submission_data()
 
-            self.assertCountEqual(actual_downstream_data, expected_downstream_data)
+        self.assertCountEqual(actual_downstream_data, expected_downstream_data)
 
     @staticmethod
     def get_expected_submission_data():

--- a/tests/integration/mci/test_backwards_navigation_after_submission.py
+++ b/tests/integration/mci/test_backwards_navigation_after_submission.py
@@ -1,11 +1,13 @@
 from tests.integration.mci import mci_test_urls
-from .test_happy_path import TestHappyPath
+from tests.integration.integration_test_case import IntegrationTestCase
+
+from .test_happy_path import HappyPathHelperMixin
 
 
-class TestBackwardsNavigationAfterSubmission(TestHappyPath):
+class TestBackwardsNavigationAfterSubmission(IntegrationTestCase, HappyPathHelperMixin):
 
     def test_backwards_navigation_205(self):
-        self.test_happy_path_205()
+        self._happy_path('0205', 'test')
         self.backwards_navigation()
 
     def backwards_navigation(self):

--- a/tests/integration/mci/test_happy_path.py
+++ b/tests/integration/mci/test_happy_path.py
@@ -1,13 +1,6 @@
 from tests.integration.integration_test_case import IntegrationTestCase
 
-
-class TestHappyPath(IntegrationTestCase):
-
-    def test_happy_path_203(self):
-        self._happy_path('0203', 'test')
-
-    def test_happy_path_205(self):
-        self._happy_path('0205', 'test')
+class HappyPathHelperMixin():
 
     def _happy_path(self, form_type_id, eq_id):
         self.launchSurvey(eq_id, form_type_id)
@@ -58,3 +51,10 @@ class TestHappyPath(IntegrationTestCase):
 
         # We are on the thank you page
         self.assertRegexPage('(?s)Monthly Business Survey - Retail Sales Index.*?Monthly Business Survey - Retail Sales Index')
+
+class TestHappyPath(IntegrationTestCase, HappyPathHelperMixin):
+    def test_happy_path_203(self):
+        self._happy_path('0203', 'test')
+
+    def test_happy_path_205(self):
+        self._happy_path('0205', 'test')

--- a/tests/integration/qbs/test_qbs_submission_data.py
+++ b/tests/integration/qbs/test_qbs_submission_data.py
@@ -1,11 +1,9 @@
-from unittest.mock import patch
 from tests.integration.integration_test_case import IntegrationTestCase
 
 
 class TestQbsSubmissionData(IntegrationTestCase):
     def test_submission_data_2_0001(self):
-        with patch('app.questionnaire.rules._answer_is_in_repeating_group', return_value=False):
-            self.submission_data('2', '0001')
+        self.submission_data('2', '0001')
 
     def submission_data(self, eq_id, form_type_id):
         self.launchSurvey(eq_id, form_type_id, roles=['dumper'])

--- a/tests/integration/questionnaire/test_questionnaire_json_output.py
+++ b/tests/integration/questionnaire/test_questionnaire_json_output.py
@@ -1,0 +1,18 @@
+from tests.integration.integration_test_case import IntegrationTestCase
+import simplejson as json
+
+class TestQuestionnaireJSONOutput(IntegrationTestCase):
+
+    def test_questionnaire_json_response(self):
+
+        # Given
+        self.launchSurvey('test', 'final_confirmation')
+
+        # When
+        #import ipdb; ipdb.set_trace()
+        self.get('/questionnaire/test/final_confirmation/789/final-confirmation/0/introduction', headers={'Accept': 'application/json'})
+
+        # Then
+        data = json.loads(self.getResponseData())
+        self.assertIn('block', data)
+

--- a/tests/integration/questionnaire/test_questionnaire_json_output.py
+++ b/tests/integration/questionnaire/test_questionnaire_json_output.py
@@ -1,5 +1,6 @@
-from tests.integration.integration_test_case import IntegrationTestCase
 import simplejson as json
+from tests.integration.integration_test_case import IntegrationTestCase
+
 
 class TestQuestionnaireJSONOutput(IntegrationTestCase):
 
@@ -15,4 +16,3 @@ class TestQuestionnaireJSONOutput(IntegrationTestCase):
         # Then
         data = json.loads(self.getResponseData())
         self.assertIn('block', data)
-

--- a/tests/integration/views/test_questionnaire.py
+++ b/tests/integration/views/test_questionnaire.py
@@ -523,18 +523,18 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
 
     def test_build_view_context_for_question(self):
         # Given
-        g.schema = load_schema_from_params('test', 'titles')
+        g.schema = schema = load_schema_from_params('test', 'titles')
         block = g.schema.get_block('single-title-block')
         full_routing_path = [Location('group', 0, 'single-title-block'),
                              Location('group', 0, 'who-is-answer-block'),
                              Location('group', 0, 'multiple-question-versions-block'),
                              Location('group', 0, 'Summary')]
-        schema_context = _get_schema_context(full_routing_path, 0, {}, AnswerStore())
+        schema_context = _get_schema_context(full_routing_path, 0, {}, AnswerStore(), schema)
         current_location = Location('group', 0, 'single-title-block')
 
         # When
         with self._application.test_request_context():
-            question_view_context = build_view_context('Question', {}, AnswerStore(), schema_context, block,
+            question_view_context = build_view_context('Question', {}, schema, AnswerStore(), schema_context, block,
                                                        current_location, form=None)
 
         # Then

--- a/tests/integration/views/test_questionnaire.py
+++ b/tests/integration/views/test_questionnaire.py
@@ -35,7 +35,7 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
 
     def test_update_questionnaire_store_with_form_data(self):
 
-        g.schema = load_schema_from_params('test', '0112')
+        schema = load_schema_from_params('test', '0112')
 
         location = Location('rsi', 0, 'total-retail-turnover')
 
@@ -44,7 +44,7 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         }
 
         with self._application.test_request_context():
-            update_questionnaire_store_with_form_data(self.question_store, location, form_data)
+            update_questionnaire_store_with_form_data(self.question_store, location, form_data, schema)
 
         self.assertEqual(self.question_store.completed_blocks, [location])
 
@@ -57,7 +57,7 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
 
     def test_update_questionnaire_store_with_default_value(self):
 
-        g.schema = load_schema_from_params('test', 'default')
+        schema = load_schema_from_params('test', 'default')
 
         location = Location('group', 0, 'number-question')
 
@@ -67,7 +67,7 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         }
 
         with self._application.test_request_context():
-            update_questionnaire_store_with_form_data(self.question_store, location, form_data)
+            update_questionnaire_store_with_form_data(self.question_store, location, form_data, schema)
 
         self.assertEqual(self.question_store.completed_blocks, [location])
 
@@ -79,7 +79,7 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         }, self.question_store.answer_store.answers)
 
     def test_update_questionnaire_store_with_answer_data(self):
-        g.schema = load_schema_from_params('census', 'household')
+        schema = load_schema_from_params('census', 'household')
 
         location = Location('who-lives-here', 0, 'household-composition')
 
@@ -118,7 +118,7 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         ]
 
         with self._application.test_request_context():
-            update_questionnaire_store_with_answer_data(self.question_store, location, answers)
+            update_questionnaire_store_with_answer_data(self.question_store, location, answers, schema)
 
         self.assertEqual(self.question_store.completed_blocks, [location])
 
@@ -126,7 +126,7 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
             self.assertIn(answer.__dict__, self.question_store.answer_store.answers)
 
     def test_remove_empty_household_members_from_answer_store(self):
-        g.schema = load_schema_from_params('census', 'household')
+        schema = load_schema_from_params('census', 'household')
 
         answers = [
             Answer(
@@ -165,13 +165,13 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         for answer in answers:
             self.question_store.answer_store.add_or_update(answer)
 
-        remove_empty_household_members_from_answer_store(self.question_store.answer_store)
+        remove_empty_household_members_from_answer_store(self.question_store.answer_store, schema)
 
         for answer in answers:
             self.assertIsNone(self.question_store.answer_store.find(answer))
 
     def test_remove_empty_household_members_values_entered_are_stored(self):
-        g.schema = load_schema_from_params('census', 'household')
+        schema = load_schema_from_params('census', 'household')
 
         answered = [
             Answer(
@@ -218,7 +218,7 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         for answer in answers:
             self.question_store.answer_store.add_or_update(answer)
 
-        remove_empty_household_members_from_answer_store(self.question_store.answer_store)
+        remove_empty_household_members_from_answer_store(self.question_store.answer_store, schema)
 
         for answer in answered:
             self.assertIsNotNone(self.question_store.answer_store.find(answer))
@@ -227,7 +227,7 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
             self.assertIsNone(self.question_store.answer_store.find(answer))
 
     def test_remove_empty_household_members_partial_answers_are_stored(self):
-        g.schema = load_schema_from_params('census', 'household')
+        schema = load_schema_from_params('census', 'household')
 
         answered = [
             Answer(
@@ -289,7 +289,7 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         for answer in answers:
             self.question_store.answer_store.add_or_update(answer)
 
-        remove_empty_household_members_from_answer_store(self.question_store.answer_store)
+        remove_empty_household_members_from_answer_store(self.question_store.answer_store, schema)
 
         for answer in answered:
             self.assertIsNotNone(self.question_store.answer_store.find(answer))
@@ -298,7 +298,7 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
             self.assertIsNotNone(self.question_store.answer_store.find(answer))
 
     def test_remove_empty_household_members_middle_name_only_not_stored(self):
-        g.schema = load_schema_from_params('census', 'household')
+        schema = load_schema_from_params('census', 'household')
 
         unanswered = [
             Answer(
@@ -322,7 +322,7 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         for answer in unanswered:
             self.question_store.answer_store.add_or_update(answer)
 
-        remove_empty_household_members_from_answer_store(self.question_store.answer_store)
+        remove_empty_household_members_from_answer_store(self.question_store.answer_store, schema)
 
         for answer in unanswered:
             self.assertIsNone(self.question_store.answer_store.find(answer))
@@ -381,7 +381,7 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
 
     def test_updating_questionnaire_store_removes_completed_block_for_min_dependencies(self):
 
-        g.schema = load_schema_from_params('test', 'dependencies_min_value')
+        schema = load_schema_from_params('test', 'dependencies_min_value')
 
         min_answer_location = Location('group', 0, 'min-block')
         dependent_location = Location('group', 0, 'dependent-block')
@@ -395,10 +395,10 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         }
 
         with self._application.test_request_context():
-            update_questionnaire_store_with_form_data(self.question_store, min_answer_location, min_answer_data)
+            update_questionnaire_store_with_form_data(self.question_store, min_answer_location, min_answer_data, schema)
 
         with self._application.test_request_context():
-            update_questionnaire_store_with_form_data(self.question_store, dependent_location, dependent_data)
+            update_questionnaire_store_with_form_data(self.question_store, dependent_location, dependent_data, schema)
 
         self.assertIn(min_answer_location, self.question_store.completed_blocks)
         self.assertIn(dependent_location, self.question_store.completed_blocks)
@@ -408,13 +408,13 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         }
 
         with self._application.test_request_context():
-            update_questionnaire_store_with_form_data(self.question_store, min_answer_location, min_answer_data)
+            update_questionnaire_store_with_form_data(self.question_store, min_answer_location, min_answer_data, schema)
 
         self.assertNotIn(dependent_location, self.question_store.completed_blocks)
 
     def test_updating_questionnaire_store_removes_completed_block_for_max_dependencies(self):
 
-        g.schema = load_schema_from_params('test', 'dependencies_max_value')
+        schema = load_schema_from_params('test', 'dependencies_max_value')
 
         max_answer_location = Location('group', 0, 'max-block')
         dependent_location = Location('group', 0, 'dependent-block')
@@ -428,10 +428,10 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         }
 
         with self._application.test_request_context():
-            update_questionnaire_store_with_form_data(self.question_store, max_answer_location, max_answer_data)
+            update_questionnaire_store_with_form_data(self.question_store, max_answer_location, max_answer_data, schema)
 
         with self._application.test_request_context():
-            update_questionnaire_store_with_form_data(self.question_store, dependent_location, dependent_data)
+            update_questionnaire_store_with_form_data(self.question_store, dependent_location, dependent_data, schema)
 
         self.assertIn(max_answer_location, self.question_store.completed_blocks)
         self.assertIn(dependent_location, self.question_store.completed_blocks)
@@ -441,13 +441,13 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         }
 
         with self._application.test_request_context():
-            update_questionnaire_store_with_form_data(self.question_store, max_answer_location, max_answer_data)
+            update_questionnaire_store_with_form_data(self.question_store, max_answer_location, max_answer_data, schema)
 
         self.assertNotIn(dependent_location, self.question_store.completed_blocks)
 
     def test_updating_questionnaire_store_removes_completed_block_for_calculation_dependencies(self):
 
-        g.schema = load_schema_from_params('test', 'dependencies_calculation')
+        schema = load_schema_from_params('test', 'dependencies_calculation')
 
         calculation_answer_location = Location('group', 0, 'total-block')
         dependent_location = Location('group', 0, 'breakdown-block')
@@ -464,10 +464,10 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         }
 
         with self._application.test_request_context():
-            update_questionnaire_store_with_form_data(self.question_store, calculation_answer_location, calculation_answer_data)
+            update_questionnaire_store_with_form_data(self.question_store, calculation_answer_location, calculation_answer_data, schema)
 
         with self._application.test_request_context():
-            update_questionnaire_store_with_form_data(self.question_store, dependent_location, dependent_data)
+            update_questionnaire_store_with_form_data(self.question_store, dependent_location, dependent_data, schema)
 
         self.assertIn(calculation_answer_location, self.question_store.completed_blocks)
         self.assertIn(dependent_location, self.question_store.completed_blocks)
@@ -477,13 +477,12 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         }
 
         with self._application.test_request_context():
-            update_questionnaire_store_with_form_data(self.question_store, calculation_answer_location, calculation_answer_data)
+            update_questionnaire_store_with_form_data(self.question_store, calculation_answer_location, calculation_answer_data, schema)
 
         self.assertNotIn(dependent_location, self.question_store.completed_blocks)
 
     def test_updating_questionnaire_store_specific_group(self):
-        g.schema = load_schema_from_params('test',
-                                           'repeating_household_routing')
+        schema = load_schema_from_params('test', 'repeating_household_routing')
         answers = [
             Answer(
                 group_instance=0,
@@ -515,7 +514,7 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         location = Location('household-member-group', 1, 'date-of-birth')
         with self._application.test_request_context():
             update_questionnaire_store_with_form_data(
-                self.question_store, location, answer_form_data)
+                self.question_store, location, answer_form_data, schema)
 
         self.assertIsNone(self.question_store.answer_store.find(answers[3]))
         for answer in answers[:2]:
@@ -545,14 +544,18 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         validate that when the independent variable is set a call is made to remove all instances of
         the dependant variables
         """
-        g.schema = load_schema_from_params('test', 'titles_repeating_non_repeating_dependency')
+        # Given
+        schema = load_schema_from_params('test', 'titles_repeating_non_repeating_dependency')
         colour_answer_location = Location('colour-group', 0, 'favourite-colour')
         colour_answer = {'fav-colour-answer': 'blue'}
 
+        # When
         with self._application.test_request_context():
             with patch('app.data_model.questionnaire_store.QuestionnaireStore.remove_completed_blocks') as patch_remove:
-                update_questionnaire_store_with_form_data(self.question_store, colour_answer_location, colour_answer)
-                patch_remove.assert_called_with(group_id='repeating-group', block_id='repeating-block-3')
+                update_questionnaire_store_with_form_data(self.question_store, colour_answer_location, colour_answer, schema)
+
+        # Then
+        patch_remove.assert_called_with(group_id='repeating-group', block_id='repeating-block-3')
 
     def test_remove_completed_by_group_and_block(self):
         for i in range(10):


### PR DESCRIPTION
### What is the context of this PR?

1. A minor fix to dumping the submission, because an unset global was relied on. Adds a test for this case.
2. As part of 1, reduces (but doesn't entirely remove) use of `g.schema` throughout. This means passing the schema as an argument a lot more, particularly in the templating where this wasn't done before. This appears to be because until repeating groups were added, there was no need for knowledge of the schema in these places. 
3. Due to the reduced use of `g.schema`, `_answer_is_in_repeating_group` has been removed from `rules.py`, which has required modification of a boat load of tests since this was mocked in many places. In general, I've tried to patch a higher level call - i.e. mock out `evaluate_goto` instead of the low level one. This is to try to isolate units more.
4. A couple of tests have been removed, either were they were testing another unit by proxy, and in one case there was an identical test under two names.
5. A couple of tests have been added - these are unrelated to the fix, however this PR was failing on code coverage, due to removing tested code (which increased the percentage of lines which were not tested).

This PR has ended up being bigger than intended. Some of the unit tests in templating have changed more than they strictly had to, however since I needed to change all the call signatures anyway, I wanted to isolate the units more whist I was understanding what each test did.

### How to review 
1. Tests should all pass!
2. Running `census_household.json` or other surveys with repeating groups should allow dumping of the submission on `/dump/submission`. To ensure the fix works, test one is failing on master first (should return a 500 error)

