### PR TITLE
Rename test_request_context so it's not run as a test

### DIFF
--- a/tests/app/app_context_test_case.py
+++ b/tests/app/app_context_test_case.py
@@ -36,7 +36,7 @@ class AppContextTestCase(unittest.TestCase):
 
         self._ddb.stop()
 
-    def test_request_context(self, *args, **kwargs):
+    def app_request_context(self, *args, **kwargs):
         return self._app.test_request_context(*args, **kwargs)
 
 

--- a/tests/app/authentication/test_authenticator.py
+++ b/tests/app/authentication/test_authenticator.py
@@ -25,7 +25,7 @@ class TestAuthenticator(AppContextTestCase): # pylint: disable=too-many-public-m
         self.session_store = SessionStore('user_ik', 'pepper', 'eq_session_id')
 
     def test_check_session_with_user_id_in_session(self):
-        with self.test_request_context('/status'):
+        with self.app_request_context('/status'):
             with patch('app.authentication.authenticator.get_session_store', return_value=self.session_store):
                 # Given
                 self.session_store.create('eq_session_id', 'user_id', self.session_data)
@@ -39,7 +39,7 @@ class TestAuthenticator(AppContextTestCase): # pylint: disable=too-many-public-m
                 self.assertEqual(user.user_ik, 'user_ik')
 
     def test_check_session_with_no_user_id_in_session(self):
-        with self.test_request_context('/status'):
+        with self.app_request_context('/status'):
             with patch('app.authentication.authenticator.get_session_store', return_value=None):
                 # When
                 user = load_user()
@@ -48,7 +48,7 @@ class TestAuthenticator(AppContextTestCase): # pylint: disable=too-many-public-m
                 self.assertIsNone(user)
 
     def test_load_user(self):
-        with self.test_request_context('/status'):
+        with self.app_request_context('/status'):
             with patch('app.authentication.authenticator.get_session_store', return_value=self.session_store):
                 # Given
                 self.session_store.create('eq_session_id', 'user_id', self.session_data)
@@ -62,7 +62,7 @@ class TestAuthenticator(AppContextTestCase): # pylint: disable=too-many-public-m
                 self.assertEqual(user.user_ik, 'user_ik')
 
     def test_request_load_user(self):
-        with self.test_request_context('/status'):
+        with self.app_request_context('/status'):
             with patch('app.authentication.authenticator.get_session_store', return_value=self.session_store):
                 # Given
                 self.session_store.create('eq_session_id', 'user_id', self.session_data)

--- a/tests/app/data_model/test_session_store.py
+++ b/tests/app/data_model/test_session_store.py
@@ -59,7 +59,7 @@ class SessionStoreTest(AppContextTestCase):
             self.assertEqual(session_store.session_data.submitted_time, current_time)
 
     def test_should_not_delete_when_no_session(self):
-        with self.test_request_context('/status'):
+        with self.app_request_context('/status'):
             with patch('app.data_model.models.db.session.delete') as delete:
 
                 # Call clear with a valid user_id but no session in database

--- a/tests/app/forms/test_date_form.py
+++ b/tests/app/forms/test_date_form.py
@@ -21,7 +21,7 @@ class TestDateForm(AppContextTestCase):
 
         answers = schema.get_answers_by_id_for_block('date-block')
 
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             form = get_date_form(AnswerStore(), {}, answers['single-date-answer'], error_messages=error_messages)
 
         self.assertTrue(hasattr(form, 'day'))
@@ -34,7 +34,7 @@ class TestDateForm(AppContextTestCase):
 
         answers = schema.get_answers_by_id_for_block('date-block')
 
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             form = get_month_year_form(answers['month-year-answer'], {}, {}, error_messages=error_messages)
 
         self.assertFalse(hasattr(form, 'day'))
@@ -59,7 +59,7 @@ class TestDateForm(AppContextTestCase):
 
         answers = schema.get_answers_by_id_for_block('date-block')
 
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             form = get_date_form(AnswerStore(), {}, answers['single-date-answer'], error_messages=error_messages)
 
         self.assertIsNone(form().data)
@@ -70,7 +70,7 @@ class TestDateForm(AppContextTestCase):
 
         answers = schema.get_answers_by_id_for_block('date-block')
 
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             form = get_month_year_form(answers['month-year-answer'], {}, {}, error_messages=error_messages)
 
         self.assertIsNone(form().data)
@@ -93,7 +93,7 @@ class TestDateForm(AppContextTestCase):
 
         data = {'field': '2000-01-01'}
 
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             class TestForm(Form):
                 field = DateField(AnswerStore(), {}, answers['single-date-answer'], error_messages)
 
@@ -109,7 +109,7 @@ class TestDateForm(AppContextTestCase):
 
         data = {'field': '2000-01'}
 
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             class TestForm(Form):
                 field = MonthYearField(answers['month-year-answer'], {}, {}, error_messages)
 
@@ -139,7 +139,7 @@ class TestDateForm(AppContextTestCase):
 
         answers = schema.get_answers_by_id_for_block('date-range-block')
 
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             form = get_date_form(AnswerStore(), test_metadata, answers['date-range-from'], error_messages=error_messages)
 
         self.assertTrue(hasattr(form, 'day'))
@@ -168,7 +168,7 @@ class TestDateForm(AppContextTestCase):
         }
 
         with patch('app.questionnaire.questionnaire_schema.QuestionnaireSchema.get_answers_by_id_for_block',
-                   return_value=[answer]), self.test_request_context('/'):
+                   return_value=[answer]), self.app_request_context('/'):
             form = get_date_form(AnswerStore(), {}, answer, error_messages=error_messages)
 
             self.assertTrue(hasattr(form, 'day'))

--- a/tests/app/forms/test_duration_form.py
+++ b/tests/app/forms/test_duration_form.py
@@ -77,7 +77,7 @@ class TestDurationForm(AppContextTestCase):
             form.months.raw_data = [months]
             form.months.data = to_int(months)
 
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             self.assertEqual(form.validate(), valid)
 
             if error:

--- a/tests/app/forms/test_fields.py
+++ b/tests/app/forms/test_fields.py
@@ -151,7 +151,7 @@ class TestFields(AppContextTestCase):
             }
         }
 
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             unbound_field = get_field(date_json, date_json['label'], error_messages, self.answer_store,
                                       self.metadata)
 
@@ -176,7 +176,7 @@ class TestFields(AppContextTestCase):
             }
         }
 
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             unbound_field = get_field(date_json, date_json['label'], error_messages, self.answer_store,
                                       self.metadata)
 
@@ -201,7 +201,7 @@ class TestFields(AppContextTestCase):
             }
         }
 
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             unbound_field = get_field(date_json, date_json['label'], error_messages, self.answer_store,
                                       self.metadata)
 
@@ -227,7 +227,7 @@ class TestFields(AppContextTestCase):
             }
         }
 
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             unbound_field = get_field(date_json, date_json['label'], error_messages, self.answer_store,
                                       self.metadata)
 

--- a/tests/app/forms/test_household_composition.py
+++ b/tests/app/forms/test_household_composition.py
@@ -19,7 +19,7 @@ class TestHouseholdCompositionForm(AppContextTestCase):
         return any(a_id == answer_id and msg in ordered_errors for a_id, ordered_errors in mapped_errors)
 
     def test_get_name_form_generates_name_form(self):
-        with self.test_request_context():
+        with self.app_request_context():
             form = generate_household_composition_form(self.schema, self.block_json, {}, metadata={}, group_instance=0)
 
             self.assertEqual(len(form.household.entries), 1)
@@ -33,7 +33,7 @@ class TestHouseholdCompositionForm(AppContextTestCase):
             self.assertIsInstance(last_name_field.validators[0], validators.Optional)
 
     def test_form_errors_are_correctly_mapped(self):
-        with self.test_request_context():
+        with self.app_request_context():
             form = generate_household_composition_form(self.schema, self.block_json, {}, metadata={}, group_instance=0)
 
             form.validate()
@@ -43,7 +43,7 @@ class TestHouseholdCompositionForm(AppContextTestCase):
             self.assertTrue(self._error_exists('household-0-first-name', message, form.map_errors()))
 
     def test_answer_errors_are_mapped(self):
-        with self.test_request_context():
+        with self.app_request_context():
             form = generate_household_composition_form(self.schema, self.block_json, {}, metadata={}, group_instance=0)
 
             form.validate()
@@ -53,7 +53,7 @@ class TestHouseholdCompositionForm(AppContextTestCase):
             self.assertIn(message, form.answer_errors('household-0-first-name'))
 
     def test_form_creation_with_data(self):
-        with self.test_request_context():
+        with self.app_request_context():
             form = generate_household_composition_form(self.schema, self.block_json, {
                 'household-0-first-name': 'Joe',
                 'household-0-last-name': 'Bloggs',
@@ -74,7 +74,7 @@ class TestHouseholdCompositionForm(AppContextTestCase):
             })
 
     def test_whitespace_in_first_name_invalid(self):
-        with self.test_request_context():
+        with self.app_request_context():
             form = generate_household_composition_form(self.schema, self.block_json, {
                 'household-0-first-name': '     ',
                 'household-0-last-name': 'Bloggs',
@@ -110,7 +110,7 @@ class TestHouseholdCompositionForm(AppContextTestCase):
                           }]
                       }]}
 
-        with self.test_request_context():
+        with self.app_request_context():
             form = generate_household_composition_form(self.schema, block_json, {}, metadata={}, group_instance=0)
 
             self.assertEqual(len(form.household.entries), 1)
@@ -124,7 +124,7 @@ class TestHouseholdCompositionForm(AppContextTestCase):
             self.assertIsInstance(last_name_field.validators[0], validators.Optional)
 
     def test_remove_first_person(self):
-        with self.test_request_context():
+        with self.app_request_context():
             form = generate_household_composition_form(self.schema, self.block_json, {
                 'household-0-first-name': 'Joe',
                 'household-0-last-name': 'Bloggs',
@@ -158,7 +158,7 @@ class TestHouseholdCompositionForm(AppContextTestCase):
             })
 
     def test_remove_middle_person(self):
-        with self.test_request_context():
+        with self.app_request_context():
             form = generate_household_composition_form(self.schema, self.block_json, {
                 'household-0-first-name': 'Joe',
                 'household-0-last-name': 'Bloggs',
@@ -191,7 +191,7 @@ class TestHouseholdCompositionForm(AppContextTestCase):
             })
 
     def test_remove_last_person(self):
-        with self.test_request_context():
+        with self.app_request_context():
             form = generate_household_composition_form(self.schema, self.block_json, {
                 'household-0-first-name': 'Joe',
                 'household-0-last-name': 'Bloggs',
@@ -216,7 +216,7 @@ class TestHouseholdCompositionForm(AppContextTestCase):
             })
 
     def test_remove_person(self):
-        with self.test_request_context():
+        with self.app_request_context():
             form = generate_household_composition_form(self.schema, self.block_json, {
                 'household-0-first-name': 'Joe',
                 'household-0-last-name': 'Bloggs',
@@ -230,7 +230,7 @@ class TestHouseholdCompositionForm(AppContextTestCase):
                 form.remove_person(3)
 
     def test_serialise_answers(self):
-        with self.test_request_context():
+        with self.app_request_context():
             form = generate_household_composition_form(self.schema, self.block_json, {
                 'household-0-first-name': 'Joe',
                 'household-0-last-name': 'Bloggs',

--- a/tests/app/forms/test_household_relationship_form.py
+++ b/tests/app/forms/test_household_relationship_form.py
@@ -65,7 +65,7 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
         self.assertEqual(expected_choices, choices)
 
     def test_generate_relationship_form_creates_empty_form(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'relationship_household')
             block_json = schema.get_block('relationships')
 
@@ -79,7 +79,7 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
             self.assertEqual(len(form.data[answer['id']]), 3)
 
     def test_generate_relationship_form_creates_form_from_data(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'relationship_household')
             block_json = schema.get_block('relationships')
 
@@ -99,7 +99,7 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
             self.assertEqual(form.data[answer['id']], expected_form_data)
 
     def test_generate_relationship_form_errors_are_correctly_mapped(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'relationship_household')
             block_json = schema.get_block('relationships')
 

--- a/tests/app/forms/test_questionnaire_form.py
+++ b/tests/app/forms/test_questionnaire_form.py
@@ -18,7 +18,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
         return any(a_id == answer_id and str(msg) in ordered_errors for a_id, ordered_errors in mapped_errors)
 
     def test_form_ids_match_block_answer_ids(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', '0102')
 
             block_json = schema.get_block('reporting-period')
@@ -29,7 +29,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 self.assertTrue(hasattr(form, answer['id']))
 
     def test_form_date_range_populates_data(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', '0102')
 
             block_json = schema.get_block('reporting-period')
@@ -53,7 +53,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             self.assertEqual(form.data, expected_form_data)
 
     def test_date_range_matching_dates_raises_question_error(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', '0102')
 
             block_json = schema.get_block('reporting-period')
@@ -80,7 +80,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                              ['INVALID_DATE_RANGE'])
 
     def test_date_range_to_precedes_from_raises_question_error(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', '0102')
 
             block_json = schema.get_block('reporting-period')
@@ -107,7 +107,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                              ['INVALID_DATE_RANGE'], AnswerStore())
 
     def test_date_range_too_large_period_raises_question_error(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'date_validation_range')
 
             block_json = schema.get_block('date-range-block')
@@ -134,7 +134,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                              ['DATE_PERIOD_TOO_LARGE'] % dict(max='1 month, 20 days'), AnswerStore())
 
     def test_date_range_too_small_period_raises_question_error(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'date_validation_range')
 
             block_json = schema.get_block('date-range-block')
@@ -161,7 +161,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                              ['DATE_PERIOD_TOO_SMALL'] % dict(min='23 days'), AnswerStore())
 
     def test_date_range_valid_period(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'date_validation_range')
 
             block_json = schema.get_block('date-range-block')
@@ -186,7 +186,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             self.assertEqual(form.data, expected_form_data)
 
     def test_date_combined_single_validation(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'date_validation_combined')
 
             block_json = schema.get_block('date-range-block')
@@ -221,7 +221,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                              schema.error_messages['SINGLE_DATE_PERIOD_TOO_LATE'] % dict(max='14 March 2017'))
 
     def test_date_combined_range_too_small_validation(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'date_validation_combined')
 
             block_json = schema.get_block('date-range-block')
@@ -253,7 +253,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                              schema.error_messages['DATE_PERIOD_TOO_SMALL'] % dict(min='10 days'))
 
     def test_date_combined_range_too_large_validation(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'date_validation_combined')
 
             block_json = schema.get_block('date-range-block')
@@ -285,7 +285,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                              schema.error_messages['DATE_PERIOD_TOO_LARGE'] % dict(max='50 days'))
 
     def test_date_mm_yyyy_combined_single_validation(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'date_validation_mm_yyyy_combined')
 
             block_json = schema.get_block('date-range-block')
@@ -318,7 +318,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                              schema.error_messages['SINGLE_DATE_PERIOD_TOO_LATE'] % dict(max='June 2017'))
 
     def test_date_mm_yyyy_combined_range_too_small_validation(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'date_validation_mm_yyyy_combined')
 
             block_json = schema.get_block('date-range-block')
@@ -348,7 +348,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                              schema.error_messages['DATE_PERIOD_TOO_SMALL'] % dict(min='2 months'))
 
     def test_date_mm_yyyy_combined_range_too_large_validation(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'date_validation_mm_yyyy_combined')
 
             block_json = schema.get_block('date-range-block')
@@ -378,7 +378,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                              schema.error_messages['DATE_PERIOD_TOO_LARGE'] % dict(max='3 months'))
 
     def test_date_yyyy_combined_single_validation(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'date_validation_yyyy_combined')
 
             block_json = schema.get_block('date-range-block')
@@ -403,7 +403,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                              schema.error_messages['SINGLE_DATE_PERIOD_TOO_LATE'] % dict(max='2021'))
 
     def test_date_yyyy_combined_range_too_small_validation(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'date_validation_yyyy_combined')
 
             block_json = schema.get_block('date-range-block')
@@ -425,7 +425,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                              schema.error_messages['DATE_PERIOD_TOO_SMALL'] % dict(min='2 years'))
 
     def test_date_yyyy_combined_range_too_large_validation(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'date_validation_yyyy_combined')
 
             block_json = schema.get_block('date-range-block')
@@ -447,7 +447,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                              schema.error_messages['DATE_PERIOD_TOO_LARGE'] % dict(max='3 years'))
 
     def test_bespoke_message_for_date_validation_range(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'date_validation_range')
 
             block_json = schema.get_block('date-range-block')
@@ -495,7 +495,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 self.assertIn(form.question_errors['date-range-question'], 'Test Message')
 
     def test_invalid_minimum_period_limit_and_single_date_periods(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'date_validation_range')
 
             block_json = schema.get_block('date-range-block')
@@ -551,7 +551,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                     self.assertEqual('The schema has invalid period_limits for date-range-question', str(ite.exception))
 
     def test_invalid_maximum_period_limit_and_single_date_periods(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'date_validation_range')
 
             block_json = schema.get_block('date-range-block')
@@ -607,7 +607,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                     self.assertEqual('The schema has invalid period_limits for date-range-question', str(ite.exception))
 
     def test_invalid_date_range_and_single_date_periods(self):
-        with self.test_request_context():
+        with self.app_request_context():
             store = AnswerStore()
             test_answer_id = Answer(
                 answer_id='date',
@@ -678,7 +678,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
 
         store.add(answer_total)
 
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'sum_equal_validation_against_total')
 
             block_json = schema.get_block('breakdown-block')
@@ -733,7 +733,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
 
         store.add(answer_total)
 
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'sum_equal_validation_against_total')
 
             block_json = schema.get_block('breakdown-block')
@@ -792,7 +792,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
 
         store.add(answer_total)
 
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'sum_equal_validation_against_total')
 
             block_json = schema.get_block('breakdown-block')
@@ -830,7 +830,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
 
         store.add(answer_total)
 
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'sum_equal_validation_against_total')
 
             block_json = schema.get_block('breakdown-block')
@@ -866,7 +866,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
 
         store.add(answer_total)
 
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'sum_equal_validation_against_total')
 
             block_json = schema.get_block('breakdown-block')
@@ -904,7 +904,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
 
         store.add(answer_total)
 
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'sum_multi_validation_against_total')
 
             block_json = schema.get_block('breakdown-block')
@@ -954,7 +954,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
 
         store.add(conditional_answer)
 
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'titles')
 
             block_json = schema.get_block('multiple-question-versions-block')
@@ -978,7 +978,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             self.assertEqual(form.data, expected_form_data)
 
     def test_form_errors_are_correctly_mapped(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', '0112')
 
             block_json = schema.get_block('total-retail-turnover')
@@ -993,7 +993,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                                                mapped_errors))
 
     def test_form_subfield_errors_are_correctly_mapped(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', '0102')
 
             block_json = schema.get_block('reporting-period')
@@ -1007,7 +1007,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             self.assertTrue(self._error_exists('period-from', schema.error_messages['MANDATORY_DATE'], mapped_errors))
 
     def test_answer_with_child_inherits_mandatory_from_parent(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'radio_mandatory_with_mandatory_other')
 
             block_json = schema.get_block('radio-mandatory')
@@ -1021,7 +1021,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             self.assertIsInstance(child_field.validators[0], ResponseRequired)
 
     def test_answer_with_child_errors_are_correctly_mapped(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'radio_mandatory_with_mandatory_other')
 
             block_json = schema.get_block('radio-mandatory')
@@ -1039,7 +1039,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                                                 mapped_errors))
 
     def test_answer_errors_are_interpolated(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', '0112')
 
             block_json = schema.get_block('number-of-employees')
@@ -1053,7 +1053,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             self.assertIn(schema.error_messages['NUMBER_TOO_SMALL'] % dict(min='0'), answer_errors)
 
     def test_option_has_other(self):
-        with self.test_request_context():
+        with self.app_request_context():
             # STANDARD CHECKBOX
             schema = load_schema_from_params('test', 'checkbox')
             block_json = schema.get_block('mandatory-checkbox')
@@ -1073,7 +1073,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             self.assertTrue(form.option_has_other('mandatory-checkbox-answer', 5))
 
     def test_get_other_answer(self):
-        with self.test_request_context():
+        with self.app_request_context():
             # STANDARD CHECKBOX
             schema = load_schema_from_params('test', 'checkbox')
             block_json = schema.get_block('mandatory-checkbox')
@@ -1099,7 +1099,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             self.assertEqual('Some data', field.data)
 
     def test_get_other_answer_invalid(self):
-        with self.test_request_context():
+        with self.app_request_context():
             # STANDARD CHECKBOX
             schema = load_schema_from_params('test', 'checkbox')
             block_json = schema.get_block('mandatory-checkbox')

--- a/tests/app/helpers/test_form_helper.py
+++ b/tests/app/helpers/test_form_helper.py
@@ -13,7 +13,7 @@ from app.validation.validators import DateRequired, OptionalForm
 class TestFormHelper(AppContextTestCase):
 
     def test_get_form_for_block_location(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', '0102')
 
             block_json = schema.get_block('reporting-period')
@@ -33,7 +33,7 @@ class TestFormHelper(AppContextTestCase):
             self.assertIsInstance(period_to_field.month.validators[0], DateRequired)
 
     def test_get_form_and_disable_mandatory_answers(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', '0102')
 
             block_json = schema.get_block('reporting-period')
@@ -54,7 +54,7 @@ class TestFormHelper(AppContextTestCase):
             self.assertIsInstance(period_to_field.month.validators[0], OptionalForm)
 
     def test_post_form_for_block_location(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', '0102')
 
             block_json = schema.get_block('reporting-period')
@@ -84,7 +84,7 @@ class TestFormHelper(AppContextTestCase):
             self.assertEqual(period_to_field.data, '2017-09-01')
 
     def test_post_form_and_disable_mandatory(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', '0102')
 
             block_json = schema.get_block('reporting-period')
@@ -105,7 +105,7 @@ class TestFormHelper(AppContextTestCase):
             self.assertIsInstance(period_to_field.month.validators[0], OptionalForm)
 
     def test_get_form_for_household_composition(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('census', 'household')
 
             block_json = schema.get_block('household-composition')
@@ -124,7 +124,7 @@ class TestFormHelper(AppContextTestCase):
             self.assertTrue(hasattr(first_field_entry, 'last-name'))
 
     def test_post_form_for_household_composition(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('census', 'household')
 
             block_json = schema.get_block('household-composition')
@@ -150,7 +150,7 @@ class TestFormHelper(AppContextTestCase):
             })
 
     def test_get_form_for_household_relationship(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('census', 'household')
 
             block_json = schema.get_block('household-relationships')
@@ -200,7 +200,7 @@ class TestFormHelper(AppContextTestCase):
             self.assertEqual(len(field_list.entries), 1)
 
     def test_post_form_for_household_relationship(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('census', 'household')
 
             block_json = schema.get_block('household-relationships')
@@ -246,7 +246,7 @@ class TestFormHelper(AppContextTestCase):
             self.assertEqual(field_list.entries[0].data, '3')
 
     def test_post_form_for_radio_other_not_selected(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'radio_mandatory_with_mandatory_other')
 
             block_json = schema.get_block('radio-mandatory')
@@ -277,7 +277,7 @@ class TestFormHelper(AppContextTestCase):
             self.assertEqual(other_text_field.data, '')
 
     def test_post_form_for_radio_other_selected(self):
-        with self.test_request_context():
+        with self.app_request_context():
             schema = load_schema_from_params('test', 'radio_mandatory_with_mandatory_other')
 
             block_json = schema.get_block('radio-mandatory')

--- a/tests/app/helpers/test_path_finder_helper.py
+++ b/tests/app/helpers/test_path_finder_helper.py
@@ -21,7 +21,7 @@ class TestPathFinderHelper(AppContextTestCase):
         # attribute access. We use an example of a fake
         # method call to check the mock (which will be the PathFinder
         # class outside of this test) is only called once.
-        with self.test_request_context():
+        with self.app_request_context():
             path_finder.some_method_call()
             path_finder.some_method_call()
 

--- a/tests/app/templating/test_template_renderer.py
+++ b/tests/app/templating/test_template_renderer.py
@@ -21,7 +21,7 @@ class TestTemplateRenderer(AppContextTestCase):
         date = '{{date|format_date}}'
         context = {'date': '2017-01-01'}
 
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             rendered = TemplateRenderer().render(date, **context)
 
         self.assertEqual(rendered, "<span class='date'>1 January 2017</span>")
@@ -30,7 +30,7 @@ class TestTemplateRenderer(AppContextTestCase):
         date = '{{date|format_date}}'
         context = {'date': '2017-01'}
 
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             rendered = TemplateRenderer().render(date, **context)
 
         self.assertEqual(rendered, "<span class='date'>January 2017</span>")

--- a/tests/app/test_jinja_filters.py
+++ b/tests/app/test_jinja_filters.py
@@ -132,7 +132,7 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
         date = '2017-01-01'
 
         # When
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             format_value = format_date(self.autoescape_context, date)
 
         # Then
@@ -143,7 +143,7 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
         date = '2017-01'
 
         # When
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             format_value = format_date(self.autoescape_context, date)
 
         # Then
@@ -154,7 +154,7 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
         date = [Markup('2017-01')]
 
         # When
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             format_value = format_date(self.autoescape_context, date)
 
         # Then
@@ -186,7 +186,7 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
         date_format = "d MMMM YYYY 'at' HH:mm"
 
         # When
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             format_value = format_datetime(self.autoescape_context, date_time, date_format)
 
         # Then
@@ -198,7 +198,7 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
         date_format = "d MMMM YYYY 'at' HH:mm:ss"
 
         # When
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             format_value = format_datetime(self.autoescape_context, date_time, date_format)
 
         # Then
@@ -237,7 +237,7 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
                     (None, '2017-12-24', '24 December 2017')]
 
         # When
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             for triple in datelist:
                 date1 = triple[0]
                 date2 = triple[1]
@@ -283,7 +283,7 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
         end_date = '2017-01-31'
 
         # When
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             format_value = format_date_range(self.autoescape_context, start_date, end_date)
 
         # Then
@@ -294,7 +294,7 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
         start_date = '2017-01-01'
 
         # When
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             format_value = format_date_range(self.autoescape_context, start_date)
 
         # Then
@@ -455,7 +455,7 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
         self.assertEqual(format_unit('volume-megaliter', 100), '100 Ml')
 
     def test_format_year_month_duration(self):
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             self.assertEqual(format_duration({'years': 5, 'months': 4}), '5 years 4 months')
             self.assertEqual(format_duration({'years': 5, 'months': 0}), '5 years')
             self.assertEqual(format_duration({'years': 0, 'months': 4}), '4 months')
@@ -463,13 +463,13 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
             self.assertEqual(format_duration({'years': 0, 'months': 0}), '0 months')
 
     def test_format_year_duration(self):
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             self.assertEqual(format_duration({'years': 5}), '5 years')
             self.assertEqual(format_duration({'years': 1}), '1 year')
             self.assertEqual(format_duration({'years': 0}), '0 years')
 
     def test_format_month_duration(self):
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             self.assertEqual(format_duration({'months': 5}), '5 months')
             self.assertEqual(format_duration({'months': 1}), '1 month')
             self.assertEqual(format_duration({'months': 0}), '0 months')

--- a/tests/app/validation/test_single_date_range_validator.py
+++ b/tests/app/validation/test_single_date_range_validator.py
@@ -18,7 +18,7 @@ class TestDateRangeValidator(AppContextTestCase):
 
         mock_field = Mock()
 
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             with self.assertRaises(ValidationError) as ite:
                 validator(mock_form, mock_field)
 
@@ -33,7 +33,7 @@ class TestDateRangeValidator(AppContextTestCase):
 
         mock_field = Mock()
 
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             with self.assertRaises(ValidationError) as ite:
                 validator(mock_form, mock_field)
 
@@ -50,7 +50,7 @@ class TestDateRangeValidator(AppContextTestCase):
 
         mock_field = Mock()
 
-        with self.test_request_context('/'):
+        with self.app_request_context('/'):
             with self.assertRaises(ValidationError) as ite:
                 validator(mock_form, mock_field)
 


### PR DESCRIPTION
### What is the context of this PR?
Renames `test_request_context` to `app_request_context`, since it meant that pytest collected `test_request_context` as a test in every test class which inherited from `AppContextTestCase`. This is not desirable because it's a helper, not a test.

I've not spent any time getting to the bottom of this, but it seems that it was being collected twice - e.g. `tests/app/questionnaire/test_location.py` goes from 4 tests to 2 with this change (2 is what you'd expect given the file).

This makes the total count of unit tests drop from 824 to 758, however those weren't actually tests in the first place.

### How to review 
Ensure that tests still run correctly. Nothing was asserted in `test_request_context` so this will not affect the function of the tests. It should have no effect on coverage either.
