### PR TITLE
Add a repeat type of 'group'

### DIFF
--- a/app/data_model/answer_store.py
+++ b/app/data_model/answer_store.py
@@ -6,11 +6,12 @@ import simplejson as json
 
 
 class Answer:
-    def __init__(self, answer_id, value, group_instance=0, answer_instance=0):
+    def __init__(self, answer_id, value, group_instance_id=None, group_instance=0, answer_instance=0):
         if answer_id is None or value is None:
             raise ValueError("Both 'answer_id' and 'value' must be set for Answer")
 
         self.answer_id = answer_id
+        self.group_instance_id = group_instance_id
         self.group_instance = group_instance
         self.answer_instance = answer_instance
         self.value = value
@@ -18,13 +19,13 @@ class Answer:
     def matches(self, answer):
         """
         Check to see if two answers match.
-        Two answers are considered to match if they share the same block_id, answer, answer_instance, group_id and group_instance.
+        Two answers are considered to match if they share the same answer_id, answer_instance and group_instance_id.
 
         :param answer: An answer to compare
         :return: True if both answers match, otherwise False.
         """
         return self.answer_id == answer.answer_id and \
-            self.group_instance == answer.group_instance and \
+            self.group_instance_id == answer.group_instance_id and \
             self.answer_instance == answer.answer_instance
 
     def matches_dict(self, answer_dict):
@@ -38,6 +39,7 @@ class Answer:
         return self.matches(Answer(
             answer_dict['answer_id'],
             answer_dict['value'],
+            answer_dict['group_instance_id'],
             answer_dict['group_instance'],
             answer_dict['answer_instance'],
         ))
@@ -155,14 +157,14 @@ class AnswerStore:
             escaped.append(answer)
         return self.__class__(existing_answers=escaped)
 
-    def filter(self, answer_ids, group_instance=None, answer_instance=None,
-               limit=None):
+    def filter(self, answer_ids=None, group_instance=None, group_instance_id=None, answer_instance=None, limit=None):
         """
         Find all answers in the answer store for a given set of filter parameter matches.
         If no filter parameters are passed it returns a copy of the instance.
 
         :param answer_ids: The answer ids to filter results by
         :param answer_instance: The answer instance to filter results by
+        :param group_instance_id: The group instance ID to filter results by
         :param group_instance: The group instance to filter results by
         :param limit: True | False Limit the number of answers returned
         :return: Return a new AnswerStore object with filtered answers for chaining
@@ -172,6 +174,7 @@ class AnswerStore:
         filter_vars = {
             'answer_id': answer_ids,
             'answer_instance': answer_instance,
+            'group_instance_id': group_instance_id,
             'group_instance': group_instance,
         }
 
@@ -201,7 +204,7 @@ class AnswerStore:
         :param answer_instance: The answer instance to filter results to remove
         :param group_instance: The group instance to filter results to remove
         """
-        for answer in self.filter(answer_ids, group_instance, answer_instance):
+        for answer in self.filter(answer_ids, group_instance=group_instance, answer_instance=answer_instance):
             self.answers.remove(answer)
 
     def get_hash(self):

--- a/app/forms/household_relationship_form.py
+++ b/app/forms/household_relationship_form.py
@@ -56,7 +56,7 @@ def build_relationship_choices(answer_store, group_instance):  # pylint: disable
     return choices
 
 
-def serialise_relationship_answers(answer_id, listfield_data, group_instance):
+def serialise_relationship_answers(answer_id, listfield_data, group_instance, group_instance_id):
     answers = []
 
     for index, listfield_value in enumerate(listfield_data):
@@ -64,6 +64,7 @@ def serialise_relationship_answers(answer_id, listfield_data, group_instance):
             answer_id=answer_id,
             answer_instance=index,
             group_instance=group_instance,
+            group_instance_id=group_instance_id,
             value=listfield_value,
         )
         answers.append(answer)
@@ -83,7 +84,7 @@ def deserialise_relationship_answers(answers):
     return relationships
 
 
-def generate_relationship_form(schema, block_json, relationship_choices, data, group_instance):
+def generate_relationship_form(schema, block_json, relationship_choices, data, group_instance, group_instance_id):
 
     answer = schema.get_answers_for_block(block_json['id'])[0]
 
@@ -112,7 +113,7 @@ def generate_relationship_form(schema, block_json, relationship_choices, data, g
             """
             list_field = getattr(self, answer['id'])
 
-            return serialise_relationship_answers(answer['id'], list_field.data, group_instance)
+            return serialise_relationship_answers(answer['id'], list_field.data, group_instance, group_instance_id)
 
     choices = [('', 'Select relationship')] + build_choices(answer['options'])
 

--- a/app/helpers/form_helper.py
+++ b/app/helpers/form_helper.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+
 from structlog import get_logger
 from werkzeug.datastructures import MultiDict
 
@@ -7,6 +8,7 @@ from app.data_model.answer_store import natural_order
 from app.forms.household_composition_form import generate_household_composition_form, deserialise_composition_answers
 from app.forms.household_relationship_form import build_relationship_choices, deserialise_relationship_answers, generate_relationship_form
 from app.forms.questionnaire_form import generate_form
+from app.helpers.schema_helpers import get_group_instance_id
 
 logger = get_logger()
 
@@ -34,6 +36,8 @@ def get_form_for_location(schema, block_json, location, answer_store, metadata, 
 
         return generate_household_composition_form(schema, block_json, data, metadata, location.group_instance)
 
+    group_instance_id = get_group_instance_id(schema, answer_store, location)
+
     if location.block_id in ['relationships', 'household-relationships']:
         answer_ids = schema.get_answer_ids_for_block(location.block_id)
         answers = answer_store.filter(answer_ids, location.group_instance)
@@ -42,14 +46,14 @@ def get_form_for_location(schema, block_json, location, answer_store, metadata, 
 
         relationship_choices = build_relationship_choices(answer_store, location.group_instance)
 
-        form = generate_relationship_form(schema, block_json, relationship_choices, data, location.group_instance)
+        form = generate_relationship_form(schema, block_json, relationship_choices, data, location.group_instance, group_instance_id)
 
         return form
 
     mapped_answers = get_mapped_answers(
         schema,
         answer_store,
-        group_instance=location.group_instance,
+        group_instance_id=group_instance_id,
         block_id=location.block_id,
     )
 
@@ -76,7 +80,8 @@ def post_form_for_location(schema, block_json, location, answer_store, metadata,
 
     if location.block_id in ['relationships', 'household-relationships']:
         relationship_choices = build_relationship_choices(answer_store, location.group_instance)
-        form = generate_relationship_form(schema, block_json, relationship_choices, request_form, location.group_instance)
+        group_instance_id = get_group_instance_id(schema, answer_store, location)
+        form = generate_relationship_form(schema, block_json, relationship_choices, request_form, location.group_instance, group_instance_id)
 
         return form
 
@@ -114,7 +119,7 @@ def clear_other_text_field(data, questions_for_block):
     return form_data
 
 
-def get_mapped_answers(schema, answer_store, block_id, group_instance):
+def get_mapped_answers(schema, answer_store, block_id, group_instance_id):
     """
     Maps the answers in an answer store to a dictionary of key, value answers. Keys include instance
     id's when the instance id is non zero.
@@ -130,7 +135,7 @@ def get_mapped_answers(schema, answer_store, block_id, group_instance):
 
     result = {}
     for answer in answer_store.filter(answer_ids=answer_ids,
-                                      group_instance=group_instance):
+                                      group_instance_id=group_instance_id):
         answer_id = answer['answer_id']
         answer_id += '_' + str(answer['answer_instance']) if answer['answer_instance'] > 0 else ''
 

--- a/app/helpers/schema_helpers.py
+++ b/app/helpers/schema_helpers.py
@@ -1,4 +1,5 @@
 from functools import wraps
+from uuid import uuid4
 
 from app.globals import get_session_store
 from app.utilities.schema import load_schema_from_session_data
@@ -24,3 +25,46 @@ def with_schema(function):
         schema = load_schema_from_session_data(session_data)
         return function(schema, *args, **kwargs)
     return wrapped_function
+
+
+def get_group_instance_id(schema, answer_store, location):
+    repeat_rule = _get_group_repeat_rule(schema, location)
+    if repeat_rule:
+        group_instance_ids = []
+        for group_id in repeat_rule['group_ids']:
+            group_answer_ids = schema.get_answer_ids_for_group(group_id)
+            group_instance_ids += _get_group_instance_ids(answer_store, group_answer_ids)
+
+        return group_instance_ids[location.group_instance]
+
+    group_answer_ids = schema.get_answer_ids_for_group(location.group_id)
+    existing_answers = answer_store.filter(answer_ids=group_answer_ids, group_instance=location.group_instance)
+    if existing_answers:
+        return existing_answers[0]['group_instance_id']
+
+    return '-'.join([location.group_id, str(uuid4())])
+
+
+def _get_group_repeat_rule(schema, location):
+    group = schema.get_group(location.group_id)
+
+    for routing_rule in group.get('routing_rules', []):
+        if 'repeat' in routing_rule:
+            repeat_rule = routing_rule['repeat']
+            if repeat_rule['type'] == 'group':
+                return repeat_rule
+
+
+def _get_group_instance_ids(answer_store, group_answer_ids):
+    group_instance_ids = []
+
+    group_instances = 0
+    for answer in list(answer_store.filter(answer_ids=group_answer_ids)):
+        group_instances = max(group_instances, answer['group_instance'])
+
+    for i in range(group_instances + 1):
+        answers = list(answer_store.filter(answer_ids=group_answer_ids, group_instance=i))
+        if answers:
+            group_instance_ids.append(answers[0]['group_instance_id'])
+
+    return group_instance_ids

--- a/app/questionnaire/navigation.py
+++ b/app/questionnaire/navigation.py
@@ -82,7 +82,7 @@ class Navigation:
     def _build_repeating_navigation(self, repeating_rule, section, current_group_id, current_group_instance):
         groups = section['groups']
         answer_ids_on_path = get_answer_ids_on_routing_path(self.schema, self.routing_path)
-        no_of_repeats = evaluate_repeat(repeating_rule, self.answer_store, answer_ids_on_path)
+        no_of_repeats = evaluate_repeat(self.schema, repeating_rule, self.answer_store, answer_ids_on_path)
 
         repeating_nav = []
         if repeating_rule['type'] == 'answer_count':

--- a/app/submitter/convert_payload_0_0_2.py
+++ b/app/submitter/convert_payload_0_0_2.py
@@ -1,3 +1,5 @@
+
+
 def convert_answers_to_payload_0_0_2(answer_store, schema, routing_path):
     """
     Convert answers into the data format below

--- a/app/templating/schema_context.py
+++ b/app/templating/schema_context.py
@@ -1,20 +1,25 @@
+from collections import defaultdict
+
 from jinja2 import escape
 
 
-def build_schema_context(metadata, schema, answer_store, answer_ids_on_path, group_instance=0):
+def build_schema_context(metadata, schema, answer_store, answer_ids_on_path, group_instance=0, group_instance_id=None):
     """
     Build questionnaire schema context containing exercise and answers
     :param metadata: user metadata
     :param schema: Survey schema
     :param answer_store: all the answers for the given questionnaire
     :param answer_ids_on_path: a list of the answer ids on the routing path
-    :param group_instance: The group instance Id passed into the url route
+    :param group_instance: The group instance passed into the url route
+    :param group_instance_id: The group instance Id passed into the url route
     :return: questionnaire schema context
     """
     return {
         'metadata': build_schema_metadata(metadata, schema),
         'answers': _build_answers(answer_store, schema, answer_ids_on_path),
+        'group_instances': _build_group_instances(answer_store, answer_ids_on_path),
         'group_instance': group_instance,
+        'group_instance_id': group_instance_id,
     }
 
 
@@ -42,6 +47,18 @@ def _build_answers(answer_store, schema, answer_ids_on_path):
         answers[answer_id] = value
 
     return answers
+
+
+def _build_group_instances(answer_store, answer_ids_on_path):
+    groups = defaultdict(dict)
+
+    for answer_id in answer_ids_on_path:
+        matching_answers = answer_store.filter(answer_ids=[answer_id], limit=True)
+
+        for answer in matching_answers:
+            groups[answer['group_instance_id']][answer_id] = answer['value']
+
+    return groups
 
 
 def build_schema_metadata(metadata, schema):

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -19,7 +19,7 @@ from app.data_model.app_models import SubmittedResponse
 from app.globals import get_answer_store, get_completed_blocks, get_metadata, get_questionnaire_store
 from app.helpers.form_helper import post_form_for_location
 from app.helpers.path_finder_helper import path_finder, full_routing_path_required
-from app.helpers.schema_helpers import with_schema
+from app.helpers.schema_helpers import with_schema, get_group_instance_id
 from app.helpers.session_helpers import with_answer_store, with_metadata
 from app.helpers.template_helper import (with_session_timeout, with_metadata_context, with_analytics,
                                          with_questionnaire_url_prefix, with_legal_basis, render_template)
@@ -167,7 +167,7 @@ def post_block(routing_path, schema, metadata, answer_store, eq_id, form_type, c
 
     block = _get_block_json(current_location, schema, answer_store, metadata)
 
-    schema_context = _get_schema_context(routing_path, current_location.group_instance, metadata, answer_store, schema)
+    schema_context = _get_schema_context(routing_path, current_location, metadata, answer_store, schema)
 
     rendered_block = renderer.render(block, **schema_context)
 
@@ -304,7 +304,7 @@ def get_view_submission(schema, eq_id, form_type):  # pylint: disable=unused-arg
 
             routing_path = PathFinder(schema, answer_store, metadata, []).get_full_routing_path()
 
-            schema_context = _get_schema_context(routing_path, 0, metadata, answer_store, schema)
+            schema_context = _get_schema_context(routing_path, None, metadata, answer_store, schema)
             rendered_schema = renderer.render(schema.json, **schema_context)
             summary_rendered_context = build_summary_rendering_context(schema, rendered_schema['sections'], answer_store, metadata)
 
@@ -530,6 +530,7 @@ def remove_empty_household_members_from_answer_store(answer_store, schema):
 
 def _update_questionnaire_store(current_location, form, schema):
     questionnaire_store = get_questionnaire_store(current_user.user_id, current_user.user_ik)
+
     if current_location.block_id in ['relationships', 'household-relationships']:
         update_questionnaire_store_with_answer_data(questionnaire_store, current_location,
                                                     form.serialise(), schema)
@@ -552,6 +553,7 @@ def update_questionnaire_store_with_form_data(questionnaire_store, location, ans
             if answer_value is not None:
                 answer = Answer(answer_id=answer_id,
                                 value=answer_value,
+                                group_instance_id=get_group_instance_id(schema, questionnaire_store.answer_store, location),
                                 group_instance=location.group_instance)
 
                 latest_answer_store_hash = questionnaire_store.answer_store.get_hash()
@@ -655,7 +657,7 @@ def _redirect_to_location(collection_id, eq_id, form_type, location):
 def _get_context(full_routing_path, block, current_location, schema, form=None):
     metadata = get_metadata(current_user)
     answer_store = get_answer_store(current_user)
-    schema_context = _get_schema_context(full_routing_path, current_location.group_instance, metadata, answer_store, schema)
+    schema_context = _get_schema_context(full_routing_path, current_location, metadata, answer_store, schema)
     rendered_block = renderer.render(block, **schema_context)
 
     return build_view_context(block['type'], metadata, schema, answer_store, schema_context, rendered_block, current_location, form=form)
@@ -666,13 +668,15 @@ def _get_block_json(current_location, schema, answer_store, metadata):
     return _evaluate_skip_conditions(block_json, current_location, schema, answer_store, metadata)
 
 
-def _get_schema_context(full_routing_path, group_instance, metadata, answer_store, schema):
+def _get_schema_context(full_routing_path, location, metadata, answer_store, schema):
     answer_ids_on_path = get_answer_ids_on_routing_path(schema, full_routing_path)
+    group_instance_id = get_group_instance_id(schema, answer_store, location) if location else None
 
     return build_schema_context(metadata=metadata,
                                 schema=schema,
                                 answer_store=answer_store,
-                                group_instance=group_instance,
+                                group_instance=location.group_instance if location else 0,
+                                group_instance_id=group_instance_id,
                                 answer_ids_on_path=answer_ids_on_path)
 
 

--- a/data/en/test_routing_repeat_until.json
+++ b/data/en/test_routing_repeat_until.json
@@ -125,9 +125,11 @@
             "title": "Household Member Details",
             "routing_rules": [{
                 "repeat": {
-                    "type": "answer_count",
-                    "answer_id": "repeating-name",
-                    "offset": 1
+                    "type": "group",
+                    "group_ids": [
+                        "primary-group",
+                        "repeating-group"
+                    ]
                 }
             }],
             "blocks": [{
@@ -135,7 +137,7 @@
                 "id": "sex-block",
                 "questions": [{
                     "id": "sex-question",
-                    "title": "What is {{( [answers['primary-name']] + answers['repeating-name']|default([]) )[group_instance] }}'s sex?",
+                    "title": "What is {{ group_instances[group_instance_id]['repeating-name']|default(group_instances[group_instance_id]['primary-name']) }}'s sex?",
                     "type": "General",
                     "answers": [{
                         "id": "sex-answer",

--- a/tests/app/data_model/test_answer_store.py
+++ b/tests/app/data_model/test_answer_store.py
@@ -33,11 +33,13 @@ class TestAnswer(unittest.TestCase):
             answer_id='4',
             answer_instance=1,
             group_instance=1,
+            group_instance_id='foo-1',
             value=25,
         )
         answer_2 = {
             'answer_id': '4',
             'answer_instance': 1,
+            'group_instance_id': 'foo-1',
             'group_instance': 1,
             'value': 25,
         }
@@ -81,6 +83,7 @@ class TestAnswerStore(unittest.TestCase):  # pylint: disable=too-many-public-met
             answer_id='4',
             answer_instance=1,
             group_instance=1,
+            group_instance_id='group-1',
             value=25,
         )
         self.store.add(answer_1)
@@ -95,6 +98,7 @@ class TestAnswerStore(unittest.TestCase):  # pylint: disable=too-many-public-met
             answer_id='4',
             answer_instance=1,
             group_instance=1,
+            group_instance_id='group-1',
             value=25,
         )
 

--- a/tests/app/forms/test_household_composition.py
+++ b/tests/app/forms/test_household_composition.py
@@ -246,31 +246,37 @@ class TestHouseholdCompositionForm(AppContextTestCase):
 
             expected_answers = [
                 {
+                    'group_instance_id': None,
                     'group_instance': 0,
                     'answer_id': 'first-name',
                     'answer_instance': 0,
                     'value': 'Joe'
                 }, {
+                    'group_instance_id': None,
                     'group_instance': 0,
                     'answer_id': 'middle-names',
                     'answer_instance': 0,
                     'value': ''
                 }, {
+                    'group_instance_id': None,
                     'group_instance': 0,
                     'answer_id': 'last-name',
                     'answer_instance': 0,
                     'value': 'Bloggs'
                 }, {
+                    'group_instance_id': None,
                     'group_instance': 0,
                     'answer_id': 'first-name',
                     'answer_instance': 1,
                     'value': 'Bob'
                 }, {
+                    'group_instance_id': None,
                     'group_instance': 0,
                     'answer_id': 'middle-names',
                     'answer_instance': 1,
                     'value': ''
                 }, {
+                    'group_instance_id': None,
                     'group_instance': 0,
                     'answer_id': 'last-name',
                     'answer_instance': 1,

--- a/tests/app/forms/test_household_relationship_form.py
+++ b/tests/app/forms/test_household_relationship_form.py
@@ -73,7 +73,7 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
 
             relationship_choices = [['a', 'b'], ['c', 'd'], ['e', 'f']]
 
-            form = generate_relationship_form(schema, block_json, relationship_choices, {}, 0)
+            form = generate_relationship_form(schema, block_json, relationship_choices, {}, 0, 'group-0')
 
             self.assertTrue(hasattr(form, answer['id']))
             self.assertEqual(len(form.data[answer['id']]), 3)
@@ -91,7 +91,7 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
                 '{answer_id}-0'.format(answer_id=answer['id']): 'Husband or Wife',
                 '{answer_id}-1'.format(answer_id=answer['id']): 'Brother or Sister',
                 '{answer_id}-2'.format(answer_id=answer['id']): 'Relation - other',
-            }, 0)
+            }, 0, 'group-0')
 
             self.assertTrue(hasattr(form, answer['id']))
 
@@ -107,13 +107,13 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
 
             relationship_choices = [['a', 'b'], ['c', 'd'], ['e', 'f']]
 
-            generated_form = generate_relationship_form(schema, block_json, relationship_choices, None, 0)
+            generated_form = generate_relationship_form(schema, block_json, relationship_choices, None, 0, 'group-0')
 
             form = generate_relationship_form(schema, block_json, relationship_choices, {
                 'csrf_token': generated_form.csrf_token.current_token,
                 '{answer_id}-0'.format(answer_id=answer['id']): '1',
                 '{answer_id}-1'.format(answer_id=answer['id']): '3',
-            }, 0)
+            }, 0, 'group-0')
 
             form.validate()
             mapped_errors = form.map_errors()
@@ -126,20 +126,23 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
 
         field_data = ['Husband or Wife', 'Son or daughter', 'Unrelated']
 
-        actual_answers = serialise_relationship_answers('who-is-related', field_data, 0)
+        actual_answers = serialise_relationship_answers('who-is-related', field_data, 0, 'group-0')
 
         expected_answers = [
             {
+                'group_instance_id': 'group-0',
                 'group_instance': 0,
                 'answer_id': 'who-is-related',
                 'answer_instance': 0,
                 'value': 'Husband or Wife'
             }, {
+                'group_instance_id': 'group-0',
                 'group_instance': 0,
                 'answer_id': 'who-is-related',
                 'answer_instance': 1,
                 'value': 'Son or daughter'
             }, {
+                'group_instance_id': 'group-0',
                 'group_instance': 0,
                 'answer_id': 'who-is-related',
                 'answer_instance': 2,
@@ -154,20 +157,23 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
 
         field_data = ['Husband or Wife', 'Son or daughter', 'Unrelated']
 
-        actual_answers = serialise_relationship_answers('who-is-related', field_data, 1)
+        actual_answers = serialise_relationship_answers('who-is-related', field_data, 1, 'group-1')
 
         expected_answers = [
             {
+                'group_instance_id': 'group-1',
                 'group_instance': 1,
                 'answer_id': 'who-is-related',
                 'answer_instance': 0,
                 'value': 'Husband or Wife'
             }, {
+                'group_instance_id': 'group-1',
                 'group_instance': 1,
                 'answer_id': 'who-is-related',
                 'answer_instance': 1,
                 'value': 'Son or daughter'
             }, {
+                'group_instance_id': 'group-1',
                 'group_instance': 1,
                 'answer_id': 'who-is-related',
                 'answer_instance': 2,

--- a/tests/app/helpers/test_form_helper.py
+++ b/tests/app/helpers/test_form_helper.py
@@ -159,31 +159,27 @@ class TestFormHelper(AppContextTestCase):
 
             answer_store = AnswerStore([
                 {
-                    'group_id': 'who-lives-here-relationship',
                     'group_instance': 0,
+                    'group_instance_id': 'who-lives-here-relationship-0',
                     'answer_id': 'first-name',
-                    'block_id': 'household-composition',
                     'value': 'Joe',
                     'answer_instance': 0,
                 }, {
-                    'group_id': 'who-lives-here-relationship',
                     'group_instance': 0,
+                    'group_instance_id': 'who-lives-here-relationship-0',
                     'answer_id': 'last-name',
-                    'block_id': 'household-composition',
                     'value': 'Bloggs',
                     'answer_instance': 0,
                 }, {
-                    'group_id': 'who-lives-here-relationship',
-                    'group_instance': 1,
+                    'group_instance': 0,
+                    'group_instance_id': 'who-lives-here-relationship-0',
                     'answer_id': 'first-name',
-                    'block_id': 'household-composition',
                     'value': 'Jane',
                     'answer_instance': 1,
                 }, {
-                    'group_id': 'who-lives-here-relationship',
-                    'group_instance': 1,
+                    'group_instance': 0,
+                    'group_instance_id': 'who-lives-here-relationship-0',
                     'answer_id': 'last-name',
-                    'block_id': 'household-composition',
                     'value': 'Bloggs',
                     'answer_instance': 1,
                 }
@@ -209,22 +205,26 @@ class TestFormHelper(AppContextTestCase):
             answer_store = AnswerStore([
                 {
                     'answer_id': 'first-name',
-                    'block_id': 'household-composition',
+                    'group_instance': 0,
+                    'group_instance_id': 'who-lives-here-relationship-0',
                     'value': 'Joe',
                     'answer_instance': 0,
                 }, {
                     'answer_id': 'last-name',
-                    'block_id': 'household-composition',
+                    'group_instance': 0,
+                    'group_instance_id': 'who-lives-here-relationship-0',
                     'value': 'Bloggs',
                     'answer_instance': 0,
                 }, {
                     'answer_id': 'first-name',
-                    'block_id': 'household-composition',
+                    'group_instance': 0,
+                    'group_instance_id': 'who-lives-here-relationship-0',
                     'value': 'Jane',
                     'answer_instance': 1,
                 }, {
                     'answer_id': 'last-name',
-                    'block_id': 'household-composition',
+                    'group_instance': 0,
+                    'group_instance_id': 'who-lives-here-relationship-0',
                     'value': 'Bloggs',
                     'answer_instance': 1,
                 }
@@ -358,12 +358,14 @@ class TestGetMappedAnswers(unittest.TestCase):
         answer_1 = Answer(
             answer_id='answer2',
             answer_instance=1,
+            group_instance_id='group-1',
             group_instance=1,
             value=25,
         )
         answer_2 = Answer(
             answer_id='answer1',
             answer_instance=1,
+            group_instance_id='group-1',
             group_instance=1,
             value=65,
         )
@@ -375,7 +377,7 @@ class TestGetMappedAnswers(unittest.TestCase):
             'answer1_1': 65
         }
 
-        self.assertEqual(get_mapped_answers(schema, self.store, block_id='block1', group_instance=1), expected_answers)
+        self.assertEqual(get_mapped_answers(schema, self.store, block_id='block1', group_instance_id='group-1'), expected_answers)
 
     def test_returns_ordered_map(self):
 
@@ -403,6 +405,7 @@ class TestGetMappedAnswers(unittest.TestCase):
 
         answer = Answer(
             answer_id='answer1',
+            group_instance_id='group-1',
             group_instance=1,
             value=25,
         )
@@ -416,7 +419,7 @@ class TestGetMappedAnswers(unittest.TestCase):
 
         self.assertEqual(len(self.store.answers), 100)
 
-        mapped = get_mapped_answers(schema, self.store, block_id='block1', group_instance=1)
+        mapped = get_mapped_answers(schema, self.store, block_id='block1', group_instance_id='group-1')
 
         for key, _ in mapped.items():
             pos = key.find('_')

--- a/tests/app/helpers/test_schema_helpers.py
+++ b/tests/app/helpers/test_schema_helpers.py
@@ -1,0 +1,81 @@
+from app.data_model.answer_store import Answer, AnswerStore
+from app.helpers.schema_helpers import get_group_instance_id
+from app.questionnaire.location import Location
+from app.questionnaire.questionnaire_schema import QuestionnaireSchema
+from tests.app.app_context_test_case import AppContextTestCase
+
+
+class TestFormHelper(AppContextTestCase):
+
+    def test_get_group_instance_id(self):
+        questionnaire = {
+            'sections': [{
+                'id': 'section1',
+                'groups': [
+                    {
+                        'id': 'group1',
+                        'blocks': [
+                            {
+                                'id': 'block1',
+                                'questions': [{
+                                    'id': 'question1',
+                                    'answers': [
+                                        {
+                                            'id': 'answer1',
+                                            'type': 'TextArea'
+                                        }
+                                    ]
+                                }]
+                            }
+                        ]
+                    },
+                    {
+                        'id': 'group2',
+                        'blocks': [
+                            {
+                                'id': 'block2',
+                                'questions': [{
+                                    'id': 'question2',
+                                    'answers': [
+                                        {
+                                            'id': 'answer2',
+                                            'type': 'TextArea'
+                                        }
+                                    ]
+                                }]
+                            }
+                        ],
+                        'routing_rules': [{
+                            'repeat': {
+                                'type': 'group',
+                                'group_ids': ['group1']
+                            }
+                        }]
+                    }
+                ]
+            }]
+        }
+        schema = QuestionnaireSchema(questionnaire)
+
+        answer_1 = Answer(
+            answer_id='answer1',
+            group_instance_id='group1-aaa',
+            group_instance=0,
+            value=25,
+        )
+        answer_2 = Answer(
+            answer_id='answer1',
+            group_instance_id='group1-bbb',
+            group_instance=1,
+            value=65,
+        )
+
+        store = AnswerStore(None)
+        store.add(answer_1)
+        store.add(answer_2)
+
+        location = Location('group2', 0, 'block2')
+        self.assertEqual(get_group_instance_id(schema, store, location), 'group1-aaa')
+
+        location = Location('group2', 1, 'block2')
+        self.assertEqual(get_group_instance_id(schema, store, location), 'group1-bbb')

--- a/tests/app/questionnaire/test_navigation.py
+++ b/tests/app/questionnaire/test_navigation.py
@@ -370,6 +370,7 @@ class TestNavigation(AppContextTestCase):
         answer_1 = Answer(
             value=2,
             group_instance=0,
+            group_instance_id='group-1-0',
             answer_id='extra-cover-answer',
             answer_instance=0
 
@@ -377,24 +378,28 @@ class TestNavigation(AppContextTestCase):
         answer_2 = Answer(
             value='1',
             group_instance=0,
+            group_instance_id='group-1-0',
             answer_id='extra-cover-items-answer',
             answer_instance=0
         )
         answer_3 = Answer(
             value='Yes',
             group_instance=0,
+            group_instance_id='group-1-0',
             answer_id='extra-cover-items-radio-answer',
             answer_instance=0
         )
         answer_4 = Answer(
             value='2',
             group_instance=1,
+            group_instance_id='group-1-1',
             answer_id='extra-cover-items-answer',
             answer_instance=0
         )
         answer_5 = Answer(
             value='Yes',
             group_instance=1,
+            group_instance_id='group-1-1',
             answer_id='extra-cover-items-radio-answer',
             answer_instance=0
         )
@@ -631,6 +636,7 @@ class TestNavigation(AppContextTestCase):
         answer_1 = Answer(
             value='Contents',
             group_instance=0,
+            group_instance_id='group-0',
             answer_instance=0,
             answer_id='insurance-type-answer'
         )
@@ -645,6 +651,7 @@ class TestNavigation(AppContextTestCase):
         change_answer = Answer(
             value='Buildings',
             group_instance=0,
+            group_instance_id='group-0',
             answer_instance=0,
             answer_id='insurance-type-answer'
         )

--- a/tests/app/questionnaire/test_path_finder.py
+++ b/tests/app/questionnaire/test_path_finder.py
@@ -637,12 +637,14 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
 
         answer_2 = Answer(
             group_instance=0,
+            group_instance_id='group-0',
             answer_id='conditional-answer',
             value='Age and Shoe Size'
         )
 
         answer_3 = Answer(
             group_instance=1,
+            group_instance_id='group-1',
             answer_id='conditional-answer',
             value='Shoe Size Only'
         )
@@ -674,12 +676,12 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         answer_store = AnswerStore()
 
         # Set up some first names
-        answer_store.add(Answer(answer_id='first-name', value='aaa', group_instance=0))
-        answer_store.add(Answer(answer_id='first-name', value='bbb', group_instance=1))
-        answer_store.add(Answer(answer_id='first-name', value='ccc', group_instance=2))
+        answer_store.add(Answer(answer_id='first-name', value='aaa', group_instance=0, group_instance_id='group-1-0'))
+        answer_store.add(Answer(answer_id='first-name', value='bbb', group_instance=1, group_instance_id='group-1-1'))
+        answer_store.add(Answer(answer_id='first-name', value='ccc', group_instance=2, group_instance_id='group-1-2'))
 
         # Set up the independent answer
-        answer_store.add(Answer(answer_id='an-independent-answer', value=independent_answer, group_instance=0))
+        answer_store.add(Answer(answer_id='an-independent-answer', value=independent_answer, group_instance=0, group_instance_id='group-1-0'))
 
         path_finder = PathFinder(schema, answer_store=answer_store, metadata={}, completed_blocks=[])
 
@@ -712,12 +714,12 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         answer_store = AnswerStore()
 
         # Set up some first names
-        answer_store.add(Answer(answer_id='first-name', value='aaa', group_instance=0))
-        answer_store.add(Answer(answer_id='first-name', value='bbb', group_instance=1))
-        answer_store.add(Answer(answer_id='first-name', value='ccc', group_instance=2))
+        answer_store.add(Answer(answer_id='first-name', value='aaa', group_instance=0, group_instance_id='group-1-0'))
+        answer_store.add(Answer(answer_id='first-name', value='bbb', group_instance=1, group_instance_id='group-1-1'))
+        answer_store.add(Answer(answer_id='first-name', value='ccc', group_instance=2, group_instance_id='group-1-2'))
 
         # Set up the independent answer
-        answer_store.add(Answer(answer_id='an-independent-answer', value=independent_answer, group_instance=0))
+        answer_store.add(Answer(answer_id='an-independent-answer', value=independent_answer, group_instance=0, group_instance_id='group-1-0'))
 
         # When
         with patch('app.questionnaire.path_finder.evaluate_skip_conditions', return_value=False):
@@ -760,17 +762,17 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
 
                 # Set up some first names
 
-                answer_store.add(Answer(answer_id='first-name', value='aaa', group_instance=0))
-                answer_store.add(Answer(answer_id='first-name', value='bbb', group_instance=1))
-                answer_store.add(Answer(answer_id='first-name', value='ccc', group_instance=2))
-                answer_store.add(Answer(answer_id='first-name', value='ddd', group_instance=3))
+                answer_store.add(Answer(answer_id='first-name', value='aaa', group_instance=0, group_instance_id='group-1-0'))
+                answer_store.add(Answer(answer_id='first-name', value='bbb', group_instance=1, group_instance_id='group-1-1'))
+                answer_store.add(Answer(answer_id='first-name', value='ccc', group_instance=2, group_instance_id='group-1-2'))
+                answer_store.add(Answer(answer_id='first-name', value='ddd', group_instance=3, group_instance_id='group-1-3'))
 
                 # Now set a date of birth for the two group instances
 
                 answer_store.add(Answer(answer_id='date-of-birth-answer', value='01-01-1980',
-                                        group_instance=first_group_instance))
+                                        group_instance=first_group_instance, group_instance_id='group-1-{}'.format(first_group_instance)))
                 answer_store.add(Answer(answer_id='date-of-birth-answer', value='01-01-1980',
-                                        group_instance=second_group_instance))
+                                        group_instance=second_group_instance, group_instance_id='group-1-{}'.format(second_group_instance)))
 
                 path_finder = PathFinder(schema, answer_store=answer_store, metadata={}, completed_blocks=[])
 
@@ -795,6 +797,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         for i in range(50):
             answers.add(Answer(
                 group_instance=i,
+                group_instance_id='group-1-{}'.format(i),
                 answer_id='conditional-answer',
                 value='Shoe Size Only'
             ))

--- a/tests/app/submitter/test_convert_payload_0_0_2.py
+++ b/tests/app/submitter/test_convert_payload_0_0_2.py
@@ -75,27 +75,19 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
 
             # Then
             self.assertEqual(len(answer_object['data']), 4)
-            self.assertEqual(answer_object['data'][0]['group_id'], 'personal details')
             self.assertEqual(answer_object['data'][0]['group_instance'], 0)
-            self.assertEqual(answer_object['data'][0]['block_id'], 'about you')
             self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
             self.assertEqual(answer_object['data'][0]['value'], 'Joe Bloggs')
 
-            self.assertEqual(answer_object['data'][1]['group_id'], 'personal details')
             self.assertEqual(answer_object['data'][1]['group_instance'], 0)
-            self.assertEqual(answer_object['data'][1]['block_id'], 'about you')
             self.assertEqual(answer_object['data'][1]['answer_instance'], 1)
             self.assertEqual(answer_object['data'][1]['value'], 'Fred Bloggs')
 
-            self.assertEqual(answer_object['data'][2]['group_id'], 'household')
             self.assertEqual(answer_object['data'][2]['group_instance'], 0)
-            self.assertEqual(answer_object['data'][2]['block_id'], 'where you live')
             self.assertEqual(answer_object['data'][2]['answer_instance'], 0)
             self.assertEqual(answer_object['data'][2]['value'], '62 Somewhere')
 
-            self.assertEqual(answer_object['data'][3]['group_id'], 'household')
             self.assertEqual(answer_object['data'][3]['group_instance'], 1)
-            self.assertEqual(answer_object['data'][3]['block_id'], 'where you live')
             self.assertEqual(answer_object['data'][3]['answer_instance'], 0)
             self.assertEqual(answer_object['data'][3]['value'], '63 Somewhere')
 
@@ -136,9 +128,7 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
 
             # Then
             self.assertEqual(len(answer_object['data']), 1)
-            self.assertEqual(answer_object['data'][0]['group_id'], 'favourite-food')
             self.assertEqual(answer_object['data'][0]['group_instance'], 0)
-            self.assertEqual(answer_object['data'][0]['block_id'], 'crisps')
             self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
             self.assertEqual(answer_object['data'][0]['value'], ['Ready salted', 'Sweet chilli'])
 
@@ -175,8 +165,6 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             # Then
             self.assertEqual(len(answer_object['data']), 1)
             self.assertEqual(answer_object['data'][0]['value'], 'Coffee')
-            self.assertEqual(answer_object['data'][0]['group_id'], 'radio-group')
-            self.assertEqual(answer_object['data'][0]['block_id'], 'radio-block')
             self.assertEqual(answer_object['data'][0]['group_instance'], 0)
             self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
 
@@ -203,8 +191,6 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             # Then
             self.assertEqual(len(answer_object['data']), 1)
             self.assertEqual(answer_object['data'][0]['value'], 1.755)
-            self.assertEqual(answer_object['data'][0]['group_id'], 'number-group')
-            self.assertEqual(answer_object['data'][0]['block_id'], 'number-block')
             self.assertEqual(answer_object['data'][0]['group_instance'], 0)
             self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
 
@@ -231,8 +217,6 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             # Then
             self.assertEqual(len(answer_object['data']), 1)
             self.assertEqual(answer_object['data'][0]['value'], 99)
-            self.assertEqual(answer_object['data'][0]['group_id'], 'percentage-group')
-            self.assertEqual(answer_object['data'][0]['block_id'], 'percentage-block')
             self.assertEqual(answer_object['data'][0]['group_instance'], 0)
             self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
 
@@ -259,8 +243,6 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             # Then
             self.assertEqual(len(answer_object['data']), 1)
             self.assertEqual(answer_object['data'][0]['value'], 'This is an example text!')
-            self.assertEqual(answer_object['data'][0]['group_id'], 'textarea-group')
-            self.assertEqual(answer_object['data'][0]['block_id'], 'textarea-block')
             self.assertEqual(answer_object['data'][0]['group_instance'], 0)
             self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
 
@@ -287,8 +269,6 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             # Then
             self.assertEqual(len(answer_object['data']), 1)
             self.assertEqual(answer_object['data'][0]['value'], 100)
-            self.assertEqual(answer_object['data'][0]['group_id'], 'currency-group')
-            self.assertEqual(answer_object['data'][0]['block_id'], 'currency-block')
             self.assertEqual(answer_object['data'][0]['group_instance'], 0)
             self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
 
@@ -329,8 +309,6 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             # Then
             self.assertEqual(len(answer_object['data']), 1)
             self.assertEqual(answer_object['data'][0]['value'], 'Rugby is better!')
-            self.assertEqual(answer_object['data'][0]['group_id'], 'dropdown-group')
-            self.assertEqual(answer_object['data'][0]['block_id'], 'dropdown-block')
             self.assertEqual(answer_object['data'][0]['group_instance'], 0)
             self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
 
@@ -367,14 +345,10 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             # Then
             self.assertEqual(len(answer_object['data']), 2)
             self.assertEqual(answer_object['data'][0]['value'], '01-01-1990')
-            self.assertEqual(answer_object['data'][0]['group_id'], 'date-group')
-            self.assertEqual(answer_object['data'][0]['block_id'], 'date-block')
             self.assertEqual(answer_object['data'][0]['group_instance'], 0)
             self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
 
             self.assertEqual(answer_object['data'][1]['value'], '01-1990')
-            self.assertEqual(answer_object['data'][1]['group_id'], 'date-group')
-            self.assertEqual(answer_object['data'][1]['block_id'], 'date-block')
             self.assertEqual(answer_object['data'][1]['group_instance'], 0)
             self.assertEqual(answer_object['data'][1]['answer_instance'], 0)
 
@@ -401,8 +375,6 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             # Then
             self.assertEqual(len(answer_object['data']), 1)
             self.assertEqual(answer_object['data'][0]['value'], 10)
-            self.assertEqual(answer_object['data'][0]['group_id'], 'unit-group')
-            self.assertEqual(answer_object['data'][0]['block_id'], 'unit-block')
             self.assertEqual(answer_object['data'][0]['group_instance'], 0)
             self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
 
@@ -449,19 +421,14 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             # Then
             self.assertEqual(len(answer_object['data']), 3)
             self.assertEqual(answer_object['data'][0]['value'], 'Unrelated')
-            self.assertEqual(answer_object['data'][0]['group_id'], 'relationship-group')
-            self.assertEqual(answer_object['data'][0]['block_id'], 'relationship-block')
+
             self.assertEqual(answer_object['data'][0]['group_instance'], 0)
             self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
 
             self.assertEqual(answer_object['data'][1]['value'], 'Partner')
-            self.assertEqual(answer_object['data'][1]['group_id'], 'relationship-group')
-            self.assertEqual(answer_object['data'][1]['block_id'], 'relationship-block')
             self.assertEqual(answer_object['data'][1]['group_instance'], 0)
             self.assertEqual(answer_object['data'][1]['answer_instance'], 1)
 
             self.assertEqual(answer_object['data'][2]['value'], 'Husband or wife')
-            self.assertEqual(answer_object['data'][2]['group_id'], 'relationship-group')
-            self.assertEqual(answer_object['data'][2]['block_id'], 'relationship-block')
             self.assertEqual(answer_object['data'][2]['group_instance'], 0)
             self.assertEqual(answer_object['data'][2]['answer_instance'], 2)

--- a/tests/app/templating/summary/test_question.py
+++ b/tests/app/templating/summary/test_question.py
@@ -428,11 +428,13 @@ class TestQuestion(TestCase):
             answer_id='answer',
             value='Value 2',
             group_instance=1,
+            group_instance_id='group-1',
         ))
         self.answer_store.add(Answer(
             answer_id='answer',
             value='Value 3',
             group_instance=2,
+            group_instance_id='group-2',
         ))
         answer_schema = {'id': 'answer', 'title': '', 'type': '', 'label': ''}
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'RepeatingAnswer',

--- a/tests/app/templating/test_schema_context.py
+++ b/tests/app/templating/test_schema_context.py
@@ -5,6 +5,7 @@ from app.templating.schema_context import build_schema_context, _build_answers, 
 from app.utilities.schema import _load_schema_file
 from app.questionnaire.questionnaire_schema import QuestionnaireSchema, DEFAULT_LANGUAGE_CODE
 
+
 def get_metadata_sample():
     """Returns a metadata sample"""
     return {
@@ -21,6 +22,7 @@ def get_metadata_sample():
         'form_type': 'schema_context'
     }
 
+
 def get_test_schema():
     test_json = _load_schema_file('test_schema_context.json', DEFAULT_LANGUAGE_CODE)
     schema = QuestionnaireSchema(test_json, DEFAULT_LANGUAGE_CODE)
@@ -28,6 +30,7 @@ def get_test_schema():
     schema.is_repeating_answer_type = MagicMock(return_value=False)
     schema.answer_is_in_repeating_group = MagicMock(return_value=False)
     return schema
+
 
 class TestBuildSchemaContext(TestCase):  # pylint: disable=too-many-public-methods
 

--- a/tests/integration/census/test_census_communal_submission_data.py
+++ b/tests/integration/census/test_census_communal_submission_data.py
@@ -1,10 +1,13 @@
+from mock import patch
+
 from tests.integration.integration_test_case import IntegrationTestCase
 
 
 class TestCensusCommunalSubmissionData(IntegrationTestCase):
 
     def test_census_communal_data_matches_census_communal(self):
-        self.complete_survey('census', 'communal')
+        with patch('app.helpers.schema_helpers.uuid4', side_effect=range(100)):
+            self.complete_survey('census', 'communal')
 
         # Only verifying 'data'
         actual_downstream_data = self.dumpSubmission()['submission']['data']
@@ -19,31 +22,36 @@ class TestCensusCommunalSubmissionData(IntegrationTestCase):
                 'value': 'Hotel',
                 'answer_id': 'establishment-type-answer',
                 'answer_instance': 0,
-                'group_instance': 0
+                'group_instance': 0,
+                'group_instance_id': 'communal-establishment-3',
             },
             {
                 'value': '',
                 'answer_id': 'establishment-type-answer-other',
                 'answer_instance': 0,
-                'group_instance': 0
+                'group_instance': 0,
+                'group_instance_id': 'communal-establishment-3',
             },
             {
                 'value': 20,
                 'answer_id': 'bed-spaces-answer',
                 'answer_instance': 0,
-                'group_instance': 0
+                'group_instance': 0,
+                'group_instance_id': 'communal-establishment-3',
             },
             {
                 'value': 'Yes',
                 'answer_id': 'usual-residents-answer',
                 'answer_instance': 0,
-                'group_instance': 0
+                'group_instance': 0,
+                'group_instance_id': 'communal-establishment-3',
             },
             {
                 'value': 99,
                 'answer_id': 'usual-residents-number-answer',
                 'answer_instance': 0,
-                'group_instance': 0
+                'group_instance': 0,
+                'group_instance_id': 'communal-establishment-3',
             },
             {
                 'value': [
@@ -54,49 +62,57 @@ class TestCensusCommunalSubmissionData(IntegrationTestCase):
                 ],
                 'answer_id': 'describe-residents-answer',
                 'answer_instance': 0,
-                'group_instance': 0
+                'group_instance': 0,
+                'group_instance_id': 'communal-establishment-3',
             },
             {
                 'value': 'Sports visitors',
                 'answer_id': 'describe-residents-answer-other',
                 'answer_instance': 0,
-                'group_instance': 0
+                'group_instance': 0,
+                'group_instance_id': 'communal-establishment-3',
             },
             {
                 'value': 'Online',
                 'answer_id': 'completion-preference-individual-answer',
                 'answer_instance': 0,
-                'group_instance': 0
+                'group_instance': 0,
+                'group_instance_id': 'communal-establishment-3',
             },
             {
                 'value': 'Online',
                 'answer_id': 'completion-preference-establishment-answer',
                 'answer_instance': 0,
-                'group_instance': 0
+                'group_instance': 0,
+                'group_instance_id': 'communal-establishment-3',
             },
             {
                 'value': 'Yes',
                 'answer_id': 'further-contact-answer',
                 'answer_instance': 0,
-                'group_instance': 0
+                'group_instance': 0,
+                'group_instance_id': 'communal-establishment-3',
             },
             {
                 'value': '0123456789',
                 'answer_id': 'contact-details-answer-phone',
                 'answer_instance': 0,
-                'group_instance': 0
+                'group_instance': 0,
+                'group_instance_id': 'communal-establishment-3',
             },
             {
                 'value': 'danny.boje@gmail.com',
                 'answer_id': 'contact-details-answer-email',
                 'answer_instance': 0,
-                'group_instance': 0
+                'group_instance': 0,
+                'group_instance_id': 'communal-establishment-3',
             },
             {
                 'value': 'Danny',
                 'answer_id': 'contact-details-answer-name',
                 'answer_instance': 0,
-                'group_instance': 0
+                'group_instance': 0,
+                'group_instance_id': 'communal-establishment-3',
             }
         ]
 

--- a/tests/integration/census/test_census_household_submission_data.py
+++ b/tests/integration/census/test_census_household_submission_data.py
@@ -1,10 +1,13 @@
+from mock import patch
+
 from tests.integration.integration_test_case import IntegrationTestCase
 
 
 # pylint: disable=too-many-lines
 class TestCensusHouseholdSubmissionData(IntegrationTestCase):
     def test_census_household_data_matches_census_individual(self):
-        self.complete_survey('census', 'household')
+        with patch('app.helpers.schema_helpers.uuid4', side_effect=range(100)):
+            self.complete_survey('census', 'household')
 
         # Only verifying 'data'
         actual_downstream_data = self.dumpSubmission()['submission']['data']
@@ -16,639 +19,523 @@ class TestCensusHouseholdSubmissionData(IntegrationTestCase):
     @staticmethod
     def get_expected_submission_data():
         expected_downstream_data = [
-            {
-                'answer_id': 'address-line-1',
-                'answer_instance': 0,
-                'group_instance': 0,
-                'value': '44 hill side'
-            },
-            {
-                'answer_id': 'address-line-2',
-                'answer_instance': 0,
-                'group_instance': 0,
-                'value': 'cimla'
-            },
-            {
-                'answer_id': 'county',
-                'answer_instance': 0,
-                'group_instance': 0,
-                'value': 'west glamorgan'
-            },
-            {
-                'answer_id': 'country',
-                'answer_instance': 0,
-                'group_instance': 0,
-                'value': 'wales'
-            },
-            {
-                'answer_id': 'postcode',
-                'answer_instance': 0,
-                'group_instance': 0,
-                'value': 'cf336gn'
-            },
-            {
-                'answer_id': 'address-line-3',
-                'answer_instance': 0,
-                'group_instance': 0,
-                'value': ''
-            },
-            {
-                'answer_id': 'town-city',
-                'answer_instance': 0,
-                'group_instance': 0,
-                'value': 'neath'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'permanent-or-family-home-answer',
-                'answer_instance': 0,
-                'value': 'Yes'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'middle-names',
-                'answer_instance': 0,
-                'value': 'K'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'first-name',
-                'answer_instance': 0,
-                'value': 'Danny'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'last-name',
-                'answer_instance': 0,
-                'value': 'Boje'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'middle-names',
-                'answer_instance': 1,
-                'value': 'K'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'first-name',
-                'answer_instance': 1,
-                'value': 'Anjali'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'last-name',
-                'answer_instance': 1,
-                'value': 'Yo'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'everyone-at-address-confirmation-answer',
-                'answer_instance': 0,
-                'value': 'Yes'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'overnight-visitors-answer',
-                'answer_instance': 0,
-                'value': 2
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'household-relationships-answer',
-                'answer_instance': 0,
-                'value': 'Husband or wife'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'type-of-accommodation-answer',
-                'answer_instance': 0,
-                'value': 'Whole house or bungalow'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'type-of-house-answer',
-                'answer_instance': 0,
-                'value': 'Detached'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'self-contained-accommodation-answer',
-                'answer_instance': 0,
-                'value': 'No'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'number-of-bedrooms-answer',
-                'answer_instance': 0,
-                'value': 2
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'central-heating-answer',
-                'answer_instance': 0,
-                'value': [
-                    'Gas',
-                    'Electric (include storage heaters)',
-                    'Oil',
-                    'Solid fuel (for example wood, coal)',
-                    'Renewable (for example solar panels)',
-                    'Other central heating',
-                    'No central heating'
-                ]
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'own-or-rent-answer',
-                'answer_instance': 0,
-                'value': 'Owns outright'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'number-of-vehicles-answer',
-                'answer_instance': 0,
-                'value': 2
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'over-16-answer',
-                'answer_instance': 0,
-                'value': 'Yes'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'private-response-answer',
-                'answer_instance': 0,
-                'value': 'No, I do not want to request a personal form'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'sex-answer',
-                'answer_instance': 0,
-                'value': 'Male'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'date-of-birth-answer',
-                'answer_instance': 0,
-                'value': '1988-05-12'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'marital-status-answer',
-                'answer_instance': 0,
-                'value': 'In a registered same-sex civil partnership'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'another-address-answer',
-                'answer_instance': 0,
-                'value': 'Yes, an address within the UK'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'another-address-answer-other',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'other-address-answer-building',
-                'answer_instance': 0,
-                'value': '12'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'other-address-answer-street',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'other-address-answer-city',
-                'answer_instance': 0,
-                'value': 'Newport'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'other-address-answer-county',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'other-address-answer-postcode',
-                'answer_instance': 0,
-                'value': 'NP10 8XG'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'address-type-answer',
-                'answer_instance': 0,
-                'value': 'Other'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'address-type-answer-other',
-                'answer_instance': 0,
-                'value': 'Friends Home'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'in-education-answer',
-                'answer_instance': 0,
-                'value': 'Yes'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'term-time-location-answer',
-                'answer_instance': 0,
-                'value': 'Yes'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'country-of-birth-england-answer-other',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'country-of-birth-england-answer',
-                'answer_instance': 0,
-                'value': 'England'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'country-of-birth-wales-answer-other',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'carer-answer',
-                'answer_instance': 0,
-                'value': 'Yes, 1 -19 hours a week'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'national-identity-england-answer',
-                'answer_instance': 0,
-                'value': [
-                    'English',
-                    'Welsh',
-                    'Scottish',
-                    'Northern Irish',
-                    'British',
-                    'Other'
-                ]
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'national-identity-wales-answer',
-                'answer_instance': 0,
-                'value': []
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'national-identity-wales-answer-other',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'national-identity-england-answer-other',
-                'answer_instance': 0,
-                'value': 'Ind'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'ethnic-group-england-answer',
-                'answer_instance': 0,
-                'value': 'Other ethnic group'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'other-ethnic-group-answer',
-                'answer_instance': 0,
-                'value': 'Other'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'other-ethnic-group-answer-other',
-                'answer_instance': 0,
-                'value': 'Telugu'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'language-england-answer-other',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'language-england-answer',
-                'answer_instance': 0,
-                'value': 'English'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'language-welsh-answer-other',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'religion-answer',
-                'answer_instance': 0,
-                'value': [
-                    'No religion',
-                    'Buddhism',
-                    'Hinduism',
-                    'Judaism',
-                    'Islam',
-                    'Sikhism',
-                    'Other'
-                ]
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'religion-answer-other',
-                'answer_instance': 0,
-                'value': 'Ind'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'past-usual-address-answer',
-                'answer_instance': 0,
-                'value': 'This address'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'past-usual-address-answer-other',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'passports-answer',
-                'answer_instance': 0,
-                'value': [
-                    'United Kingdom'
-                ]
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'disability-answer',
-                'answer_instance': 0,
-                'value': 'Yes, limited a lot'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'qualifications-welsh-answer',
-                'answer_instance': 0,
-                'value': []
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'qualifications-england-answer',
-                'answer_instance': 0,
-                'value': [
-                    'Masters Degree',
-                    'Postgraduate Certificate / Diploma'
-                ]
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'employment-type-answer',
-                'answer_instance': 0,
-                'value': [
-                    'none of the above'
-                ]
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'jobseeker-answer',
-                'answer_instance': 0,
-                'value': 'Yes'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'job-availability-answer',
-                'answer_instance': 0,
-                'value': 'Yes'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'job-pending-answer',
-                'answer_instance': 0,
-                'value': 'Yes'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'occupation-answer',
-                'answer_instance': 0,
-                'value': [
-                    'a student',
-                    'long-term sick or disabled'
-                ]
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'ever-worked-answer',
-                'answer_instance': 0,
-                'value': 'Yes'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'main-job-answer',
-                'answer_instance': 0,
-                'value': 'an employee'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'hours-worked-answer',
-                'answer_instance': 0,
-                'value': '31 - 48'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'work-travel-answer',
-                'answer_instance': 0,
-                'value': 'Train'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'job-title-answer',
-                'answer_instance': 0,
-                'value': 'Software Engineer'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'job-description-answer',
-                'answer_instance': 0,
-                'value': 'Development'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'employers-business-answer',
-                'answer_instance': 0,
-                'value': 'Civil Servant'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'main-job-type-answer',
-                'answer_instance': 0,
-                'value': 'Employed by an organisation or business'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'business-name-answer',
-                'answer_instance': 0,
-                'value': 'ONS'
-            },
-            {
-                'group_instance': 1,
-                'answer_id': 'over-16-answer',
-                'answer_instance': 0,
-                'value': 'Yes'
-            },
-            {
-                'group_instance': 1,
-                'answer_id': 'private-response-answer',
-                'answer_instance': 0,
-                'value': 'Yes, I want to request a personal form'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'visitor-first-name',
-                'answer_instance': 0,
-                'value': 'Diya'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'visitor-last-name',
-                'answer_instance': 0,
-                'value': 'K'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'visitor-sex-answer',
-                'answer_instance': 0,
-                'value': 'Female'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'visitor-date-of-birth-answer',
-                'answer_instance': 0,
-                'value': '2016-11-04'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'visitor-uk-resident-answer-other',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'visitor-uk-resident-answer',
-                'answer_instance': 0,
-                'value': 'Yes, usually lives in the United Kingdom'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'visitor-address-answer-postcode',
-                'answer_instance': 0,
-                'value': '530003'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'visitor-address-answer-street',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'visitor-address-answer-building',
-                'answer_instance': 0,
-                'value': '309'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'visitor-address-answer-city',
-                'answer_instance': 0,
-                'value': 'Vizag'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'visitor-address-answer-county',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 1,
-                'answer_id': 'visitor-first-name',
-                'answer_instance': 0,
-                'value': 'Niki'
-            },
-            {
-                'group_instance': 1,
-                'answer_id': 'visitor-last-name',
-                'answer_instance': 0,
-                'value': 'K'
-            },
-            {
-                'group_instance': 1,
-                'answer_id': 'visitor-sex-answer',
-                'answer_instance': 0,
-                'value': 'Male'
-            },
-            {
-                'group_instance': 1,
-                'answer_id': 'visitor-date-of-birth-answer',
-                'answer_instance': 0,
-                'value': '1985-10-17'
-            },
-            {
-                'group_instance': 1,
-                'answer_id': 'visitor-uk-resident-answer-other',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 1,
-                'answer_id': 'visitor-uk-resident-answer',
-                'answer_instance': 0,
-                'value': 'Yes, usually lives in the United Kingdom'
-            },
-            {
-                'group_instance': 1,
-                'answer_id': 'visitor-address-answer-postcode',
-                'answer_instance': 0,
-                'value': '12345'
-            },
-            {
-                'group_instance': 1,
-                'answer_id': 'visitor-address-answer-street',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 1,
-                'answer_id': 'visitor-address-answer-building',
-                'answer_instance': 0,
-                'value': '1009'
-            },
-            {
-                'group_instance': 1,
-                'answer_id': 'visitor-address-answer-city',
-                'answer_instance': 0,
-                'value': 'Detroit'
-            },
-            {
-                'group_instance': 1,
-                'answer_id': 'visitor-address-answer-county',
-                'answer_instance': 0,
-                'value': ''
-            }
+            {'answer_id': 'town-city',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'what-is-your-address-group-7',
+             'value': 'neath'},
+            {'answer_id': 'address-line-2',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'what-is-your-address-group-7',
+             'value': 'cimla'},
+            {'answer_id': 'postcode',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'what-is-your-address-group-7',
+             'value': 'cf336gn'},
+            {'answer_id': 'county',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'what-is-your-address-group-7',
+             'value': 'west glamorgan'},
+            {'answer_id': 'country',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'what-is-your-address-group-7',
+             'value': 'wales'},
+            {'answer_id': 'address-line-3',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'what-is-your-address-group-7',
+             'value': ''},
+            {'answer_id': 'address-line-1',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'what-is-your-address-group-7',
+             'value': '44 hill side'},
+            {'answer_id': 'permanent-or-family-home-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'who-lives-here-13',
+             'value': 'Yes'},
+            {'answer_id': 'first-name',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Danny'},
+            {'answer_id': 'last-name',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Boje'},
+            {'answer_id': 'middle-names',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'K'},
+            {'answer_id': 'first-name',
+             'answer_instance': 1,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Anjali'},
+            {'answer_id': 'last-name',
+             'answer_instance': 1,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Yo'},
+            {'answer_id': 'middle-names',
+             'answer_instance': 1,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'K'},
+            {'answer_id': 'everyone-at-address-confirmation-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'who-lives-here-13',
+             'value': 'Yes'},
+            {'answer_id': 'overnight-visitors-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'who-lives-here-13',
+             'value': 2},
+            {'answer_id': 'household-relationships-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'who-lives-here-relationship-17',
+             'value': 'Husband or wife'},
+            {'answer_id': 'type-of-accommodation-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-and-accommodation-25',
+             'value': 'Whole house or bungalow'},
+            {'answer_id': 'type-of-house-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-and-accommodation-25',
+             'value': 'Detached'},
+            {'answer_id': 'self-contained-accommodation-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-and-accommodation-25',
+             'value': 'No'},
+            {'answer_id': 'number-of-bedrooms-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-and-accommodation-25',
+             'value': 2},
+            {'answer_id': 'central-heating-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-and-accommodation-25',
+             'value': ['Gas',
+                       'Electric (include storage heaters)',
+                       'Oil',
+                       'Solid fuel (for example wood, coal)',
+                       'Renewable (for example solar panels)',
+                       'Other central heating',
+                       'No central heating']},
+            {'answer_id': 'own-or-rent-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-and-accommodation-25',
+             'value': 'Owns outright'},
+            {'answer_id': 'number-of-vehicles-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-and-accommodation-25',
+             'value': 2},
+            {'answer_id': 'over-16-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'Yes'},
+            {'answer_id': 'private-response-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'No, I do not want to request a personal form'},
+            {'answer_id': 'sex-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'Male'},
+            {'answer_id': 'date-of-birth-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': '1988-05-12'},
+            {'answer_id': 'marital-status-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'In a registered same-sex civil partnership'},
+            {'answer_id': 'another-address-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'Yes, an address within the UK'},
+            {'answer_id': 'another-address-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': ''},
+            {'answer_id': 'other-address-answer-street',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': ''},
+            {'answer_id': 'other-address-answer-building',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': '12'},
+            {'answer_id': 'other-address-answer-county',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': ''},
+            {'answer_id': 'other-address-answer-city',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'Newport'},
+            {'answer_id': 'other-address-answer-postcode',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'NP10 8XG'},
+            {'answer_id': 'address-type-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'Friends Home'},
+            {'answer_id': 'address-type-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'Other'},
+            {'answer_id': 'in-education-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'Yes'},
+            {'answer_id': 'term-time-location-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'Yes'},
+            {'answer_id': 'country-of-birth-england-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': ''},
+            {'answer_id': 'country-of-birth-wales-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': ''},
+            {'answer_id': 'country-of-birth-england-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'England'},
+            {'answer_id': 'carer-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'Yes, 1 -19 hours a week'},
+            {'answer_id': 'national-identity-england-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': ['English',
+                       'Welsh',
+                       'Scottish',
+                       'Northern Irish',
+                       'British',
+                       'Other']},
+            {'answer_id': 'national-identity-wales-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': []},
+            {'answer_id': 'national-identity-england-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'Ind'},
+            {'answer_id': 'national-identity-wales-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': ''},
+            {'answer_id': 'ethnic-group-england-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'Other ethnic group'},
+            {'answer_id': 'other-ethnic-group-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'Telugu'},
+            {'answer_id': 'other-ethnic-group-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'Other'},
+            {'answer_id': 'language-welsh-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': ''},
+            {'answer_id': 'language-england-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': ''},
+            {'answer_id': 'language-england-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'English'},
+            {'answer_id': 'religion-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': ['No religion',
+                       'Buddhism',
+                       'Hinduism',
+                       'Judaism',
+                       'Islam',
+                       'Sikhism',
+                       'Other']},
+            {'answer_id': 'religion-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'Ind'},
+            {'answer_id': 'past-usual-address-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': ''},
+            {'answer_id': 'past-usual-address-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'This address'},
+            {'answer_id': 'passports-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': ['United Kingdom']},
+            {'answer_id': 'disability-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'Yes, limited a lot'},
+            {'answer_id': 'qualifications-welsh-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': []},
+            {'answer_id': 'qualifications-england-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': ['Masters Degree', 'Postgraduate Certificate / Diploma']},
+            {'answer_id': 'employment-type-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': ['none of the above']},
+            {'answer_id': 'jobseeker-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'Yes'},
+            {'answer_id': 'job-availability-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'Yes'},
+            {'answer_id': 'job-pending-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'Yes'},
+            {'answer_id': 'occupation-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': ['a student', 'long-term sick or disabled']},
+            {'answer_id': 'ever-worked-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'Yes'},
+            {'answer_id': 'main-job-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'an employee'},
+            {'answer_id': 'hours-worked-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': '31 - 48'},
+            {'answer_id': 'work-travel-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'Train'},
+            {'answer_id': 'job-title-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'Software Engineer'},
+            {'answer_id': 'job-description-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'Development'},
+            {'answer_id': 'main-job-type-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'Employed by an organisation or business'},
+            {'answer_id': 'business-name-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'ONS'},
+            {'answer_id': 'employers-business-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-35',
+             'value': 'Civil Servant'},
+            {'answer_id': 'over-16-answer',
+             'answer_instance': 0,
+             'group_instance': 1,
+             'group_instance_id': 'household-member-45',
+             'value': 'Yes'},
+            {'answer_id': 'private-response-answer',
+             'answer_instance': 0,
+             'group_instance': 1,
+             'group_instance_id': 'household-member-45',
+             'value': 'Yes, I want to request a personal form'},
+            {'answer_id': 'visitor-first-name',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'visitors-51',
+             'value': 'Diya'},
+            {'answer_id': 'visitor-last-name',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'visitors-51',
+             'value': 'K'},
+            {'answer_id': 'visitor-sex-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'visitors-51',
+             'value': 'Female'},
+            {'answer_id': 'visitor-date-of-birth-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'visitors-51',
+             'value': '2016-11-04'},
+            {'answer_id': 'visitor-uk-resident-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'visitors-51',
+             'value': 'Yes, usually lives in the United Kingdom'},
+            {'answer_id': 'visitor-uk-resident-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'visitors-51',
+             'value': ''},
+            {'answer_id': 'visitor-address-answer-street',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'visitors-51',
+             'value': ''},
+            {'answer_id': 'visitor-address-answer-postcode',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'visitors-51',
+             'value': '530003'},
+            {'answer_id': 'visitor-address-answer-city',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'visitors-51',
+             'value': 'Vizag'},
+            {'answer_id': 'visitor-address-answer-building',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'visitors-51',
+             'value': '309'},
+            {'answer_id': 'visitor-address-answer-county',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'visitors-51',
+             'value': ''},
+            {'answer_id': 'visitor-first-name',
+             'answer_instance': 0,
+             'group_instance': 1,
+             'group_instance_id': 'visitors-55',
+             'value': 'Niki'},
+            {'answer_id': 'visitor-last-name',
+             'answer_instance': 0,
+             'group_instance': 1,
+             'group_instance_id': 'visitors-55',
+             'value': 'K'},
+            {'answer_id': 'visitor-sex-answer',
+             'answer_instance': 0,
+             'group_instance': 1,
+             'group_instance_id': 'visitors-55',
+             'value': 'Male'},
+            {'answer_id': 'visitor-date-of-birth-answer',
+             'answer_instance': 0,
+             'group_instance': 1,
+             'group_instance_id': 'visitors-55',
+             'value': '1985-10-17'},
+            {'answer_id': 'visitor-uk-resident-answer',
+             'answer_instance': 0,
+             'group_instance': 1,
+             'group_instance_id': 'visitors-55',
+             'value': 'Yes, usually lives in the United Kingdom'},
+            {'answer_id': 'visitor-uk-resident-answer-other',
+             'answer_instance': 0,
+             'group_instance': 1,
+             'group_instance_id': 'visitors-55',
+             'value': ''},
+            {'answer_id': 'visitor-address-answer-street',
+             'answer_instance': 0,
+             'group_instance': 1,
+             'group_instance_id': 'visitors-55',
+             'value': ''},
+            {'answer_id': 'visitor-address-answer-postcode',
+             'answer_instance': 0,
+             'group_instance': 1,
+             'group_instance_id': 'visitors-55',
+             'value': '12345'},
+            {'answer_id': 'visitor-address-answer-city',
+             'answer_instance': 0,
+             'group_instance': 1,
+             'group_instance_id': 'visitors-55',
+             'value': 'Detroit'},
+            {'answer_id': 'visitor-address-answer-building',
+             'answer_instance': 0,
+             'group_instance': 1,
+             'group_instance_id': 'visitors-55',
+             'value': '1009'},
+            {'answer_id': 'visitor-address-answer-county',
+             'answer_instance': 0,
+             'group_instance': 1,
+             'group_instance_id': 'visitors-55',
+             'value': ''}
         ]
 
         return expected_downstream_data

--- a/tests/integration/census/test_census_individual_submission_data.py
+++ b/tests/integration/census/test_census_individual_submission_data.py
@@ -1,10 +1,13 @@
+from mock import patch
+
 from tests.integration.integration_test_case import IntegrationTestCase
 
 
 class TestCensusIndividualSubmissionData(IntegrationTestCase):
 
     def test_census_individual_data_matches_census_individual(self):
-        self.complete_survey('census', 'individual')
+        with patch('app.helpers.schema_helpers.uuid4', side_effect=range(100)):
+            self.complete_survey('census', 'individual')
 
         # Only verifying 'data'
         actual_downstream_data = self.dumpSubmission()['submission']['data']
@@ -15,368 +18,299 @@ class TestCensusIndividualSubmissionData(IntegrationTestCase):
     @staticmethod
     def get_expected_submission_data():
         expected_downstream_data = [
-            {
-                'group_instance': 0,
-                'value': 'Danny',
-                'answer_instance': 0,
-                'answer_id': 'first-name'
-            },
-            {
-                'group_instance': 0,
-                'value': 'K',
-                'answer_instance': 0,
-                'answer_id': 'middle-names'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Boje',
-                'answer_instance': 0,
-                'answer_id': 'last-name'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Male',
-                'answer_instance': 0,
-                'answer_id': 'sex-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': '1988-05-12',
-                'answer_instance': 0,
-                'answer_id': 'date-of-birth-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'In a registered same-sex civil partnership',
-                'answer_instance': 0,
-                'answer_id': 'marital-status-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Yes, an address within the UK',
-                'answer_instance': 0,
-                'answer_id': 'another-address-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': '',
-                'answer_instance': 0,
-                'answer_id': 'another-address-answer-other'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Newport',
-                'answer_instance': 0,
-                'answer_id': 'other-address-answer-city'
-            },
-            {
-                'group_instance': 0,
-                'value': '',
-                'answer_instance': 0,
-                'answer_id': 'other-address-answer-street'
-            },
-            {
-                'group_instance': 0,
-                'value': '',
-                'answer_instance': 0,
-                'answer_id': 'other-address-answer-county'
-            },
-            {
-                'group_instance': 0,
-                'value': '12',
-                'answer_instance': 0,
-                'answer_id': 'other-address-answer-building'
-            },
-            {
-                'group_instance': 0,
-                'value': 'NP10 8XG',
-                'answer_instance': 0,
-                'answer_id': 'other-address-answer-postcode'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Friends Home',
-                'answer_instance': 0,
-                'answer_id': 'address-type-answer-other'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Other',
-                'answer_instance': 0,
-                'answer_id': 'address-type-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Yes',
-                'answer_instance': 0,
-                'answer_id': 'in-education-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'here, at this address',
-                'answer_instance': 0,
-                'answer_id': 'term-time-location-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': '',
-                'answer_instance': 0,
-                'answer_id': 'country-of-birth-wales-answer-other'
-            },
-            {
-                'group_instance': 0,
-                'value': 'England',
-                'answer_instance': 0,
-                'answer_id': 'country-of-birth-england-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': '',
-                'answer_instance': 0,
-                'answer_id': 'country-of-birth-england-answer-other'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Yes, 1 -19 hours a week',
-                'answer_instance': 0,
-                'answer_id': 'carer-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Ind',
-                'answer_instance': 0,
-                'answer_id': 'national-identity-england-answer-other'
-            },
-            {
-                'group_instance': 0,
-                'value': '',
-                'answer_instance': 0,
-                'answer_id': 'national-identity-wales-answer-other'
-            },
-            {
-                'group_instance': 0,
-                'value': [
-                    'English',
-                    'Welsh',
-                    'Scottish',
-                    'Northern Irish',
-                    'British',
-                    'Other'
-                ],
-                'answer_instance': 0,
-                'answer_id': 'national-identity-england-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': [],
-                'answer_instance': 0,
-                'answer_id': 'national-identity-wales-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Other ethnic group',
-                'answer_instance': 0,
-                'answer_id': 'ethnic-group-england-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Other',
-                'answer_instance': 0,
-                'answer_id': 'other-ethnic-group-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Telugu',
-                'answer_instance': 0,
-                'answer_id': 'other-ethnic-group-answer-other'
-            },
-            {
-                'group_instance': 0,
-                'value': '',
-                'answer_instance': 0,
-                'answer_id': 'language-welsh-answer-other'
-            },
-            {
-                'group_instance': 0,
-                'value': 'English',
-                'answer_instance': 0,
-                'answer_id': 'language-england-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': '',
-                'answer_instance': 0,
-                'answer_id': 'language-england-answer-other'
-            },
-            {
-                'group_instance': 0,
-                'value': [],
-                'answer_instance': 0,
-                'answer_id': 'religion-welsh-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': [
-                    'No religion',
-                    'Christian (Including Church of England, Catholic, Protestant and all other Christian denominations)',
-                    'Buddhist',
-                    'Hindu',
-                    'Jewish',
-                    'Muslim',
-                    'Sikh',
-                    'Other'
-                ],
-                'answer_instance': 0,
-                'answer_id': 'religion-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': '',
-                'answer_instance': 0,
-                'answer_id': 'religion-welsh-answer-other'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Ind',
-                'answer_instance': 0,
-                'answer_id': 'religion-answer-other'
-            },
-            {
-                'group_instance': 0,
-                'value': 'This address',
-                'answer_instance': 0,
-                'answer_id': 'past-usual-address-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': '',
-                'answer_instance': 0,
-                'answer_id': 'past-usual-address-answer-other'
-            },
-            {
-                'group_instance': 0,
-                'value': [
-                    'United Kingdom'
-                ],
-                'answer_instance': 0,
-                'answer_id': 'passports-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Yes, limited a lot',
-                'answer_instance': 0,
-                'answer_id': 'disability-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': [
-                    'Masters Degree',
-                    'Postgraduate Certificate / Diploma'
-                ],
-                'answer_instance': 0,
-                'answer_id': 'qualifications-england-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': [],
-                'answer_instance': 0,
-                'answer_id': 'qualifications-welsh-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'No',
-                'answer_instance': 0,
-                'answer_id': 'volunteering-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': [
-                    'none of the above?'
-                ],
-                'answer_instance': 0,
-                'answer_id': 'employment-type-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Yes',
-                'answer_instance': 0,
-                'answer_id': 'jobseeker-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Yes',
-                'answer_instance': 0,
-                'answer_id': 'job-availability-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Yes',
-                'answer_instance': 0,
-                'answer_id': 'job-pending-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': [
-                    'a student?',
-                    'long-term sick or disabled?'
-                ],
-                'answer_instance': 0,
-                'answer_id': 'occupation-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Yes',
-                'answer_instance': 0,
-                'answer_id': 'ever-worked-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'an employee?',
-                'answer_instance': 0,
-                'answer_id': 'main-job-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Software Engineer',
-                'answer_instance': 0,
-                'answer_id': 'job-title-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Development',
-                'answer_instance': 0,
-                'answer_id': 'job-description-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': '31 - 48',
-                'answer_instance': 0,
-                'answer_id': 'hours-worked-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Train',
-                'answer_instance': 0,
-                'answer_id': 'work-travel-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Civil Servant',
-                'answer_instance': 0,
-                'answer_id': 'employers-business-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Employed by an organisation or business',
-                'answer_instance': 0,
-                'answer_id': 'main-job-type-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'ONS',
-                'answer_instance': 0,
-                'answer_id': 'business-name-answer'
-            }
+            {'answer_id': 'middle-names',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'K'},
+            {'answer_id': 'last-name',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'Boje'},
+            {'answer_id': 'first-name',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'Danny'},
+            {'answer_id': 'sex-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'Male'},
+            {'answer_id': 'date-of-birth-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': '1988-05-12'},
+            {'answer_id': 'marital-status-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'In a registered same-sex civil partnership'},
+            {'answer_id': 'another-address-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': ''},
+            {'answer_id': 'another-address-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'Yes, an address within the UK'},
+            {'answer_id': 'other-address-answer-street',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': ''},
+            {'answer_id': 'other-address-answer-postcode',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'NP10 8XG'},
+            {'answer_id': 'other-address-answer-building',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': '12'},
+            {'answer_id': 'other-address-answer-county',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': ''},
+            {'answer_id': 'other-address-answer-city',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'Newport'},
+            {'answer_id': 'address-type-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'Other'},
+            {'answer_id': 'address-type-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'Friends Home'},
+            {'answer_id': 'in-education-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'Yes'},
+            {'answer_id': 'term-time-location-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'here, at this address'},
+            {'answer_id': 'country-of-birth-england-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': ''},
+            {'answer_id': 'country-of-birth-wales-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': ''},
+            {'answer_id': 'country-of-birth-england-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'England'},
+            {'answer_id': 'carer-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'Yes, 1 -19 hours a week'},
+            {'answer_id': 'national-identity-england-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'Ind'},
+            {'answer_id': 'national-identity-wales-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': ''},
+            {'answer_id': 'national-identity-england-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': ['English',
+                       'Welsh',
+                       'Scottish',
+                       'Northern Irish',
+                       'British',
+                       'Other']},
+            {'answer_id': 'national-identity-wales-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': []},
+            {'answer_id': 'ethnic-group-england-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'Other ethnic group'},
+            {'answer_id': 'other-ethnic-group-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'Telugu'},
+            {'answer_id': 'other-ethnic-group-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'Other'},
+            {'answer_id': 'language-welsh-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': ''},
+            {'answer_id': 'language-england-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': ''},
+            {'answer_id': 'language-england-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'English'},
+            {'answer_id': 'religion-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': ['No religion',
+                       'Christian (Including Church of England, Catholic, Protestant '
+                       'and all other Christian denominations)',
+                       'Buddhist',
+                       'Hindu',
+                       'Jewish',
+                       'Muslim',
+                       'Sikh',
+                       'Other']},
+            {'answer_id': 'religion-welsh-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': ''},
+            {'answer_id': 'religion-welsh-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': []},
+            {'answer_id': 'religion-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'Ind'},
+            {'answer_id': 'past-usual-address-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'This address'},
+            {'answer_id': 'past-usual-address-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': ''},
+            {'answer_id': 'passports-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': ['United Kingdom']},
+            {'answer_id': 'disability-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'Yes, limited a lot'},
+            {'answer_id': 'qualifications-welsh-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': []},
+            {'answer_id': 'qualifications-england-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': ['Masters Degree', 'Postgraduate Certificate / Diploma']},
+            {'answer_id': 'volunteering-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'No'},
+            {'answer_id': 'employment-type-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': ['none of the above?']},
+            {'answer_id': 'jobseeker-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'Yes'},
+            {'answer_id': 'job-availability-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'Yes'},
+            {'answer_id': 'job-pending-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'Yes'},
+            {'answer_id': 'occupation-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': ['a student?', 'long-term sick or disabled?']},
+            {'answer_id': 'ever-worked-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'Yes'},
+            {'answer_id': 'main-job-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'an employee?'},
+            {'answer_id': 'job-title-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'Software Engineer'},
+            {'answer_id': 'job-description-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'Development'},
+            {'answer_id': 'hours-worked-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': '31 - 48'},
+            {'answer_id': 'work-travel-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'Train'},
+            {'answer_id': 'employers-business-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'Civil Servant'},
+            {'answer_id': 'main-job-type-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'Employed by an organisation or business'},
+            {'answer_id': 'business-name-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': 'household-member-3',
+             'value': 'ONS'}
         ]
 
         return expected_downstream_data

--- a/tests/integration/household_composition/test_repeating_relationship.py
+++ b/tests/integration/household_composition/test_repeating_relationship.py
@@ -1,3 +1,5 @@
+from mock import patch
+
 from tests.integration.integration_test_case import IntegrationTestCase
 
 
@@ -25,47 +27,56 @@ class TestRepeatingRelationship(IntegrationTestCase):
 
     def test_multiple_relationship_groups(self):
         # Given
+        uuid_generator = (i for i in range(10))
+
         household_form_data = {
             'household-0-first-name': 'Han',
             'household-1-first-name': 'Leia',
             'household-2-first-name': 'Luke'
         }
-        self.post(household_form_data)
+        with patch('app.helpers.schema_helpers.uuid4', side_effect=uuid_generator):
+            self.post(household_form_data)
 
         # When
         relationship_form_data_1 = {
             'who-is-related-0': 'Husband or wife',
             'who-is-related-1': 'Relation - other'
         }
-        self.post(relationship_form_data_1)
+        with patch('app.helpers.schema_helpers.uuid4', side_effect=uuid_generator):
+            self.post(relationship_form_data_1)
 
         relationship_form_data_2 = {
             'who-is-related-0': 'Brother or sister'
         }
-        self.post(relationship_form_data_2)
+        with patch('app.helpers.schema_helpers.uuid4', side_effect=uuid_generator):
+            self.post(relationship_form_data_2)
 
         # Then
         relationship_answers = [
             answer for answer in self.dumpAnswers()['answers']
             if answer['answer_id'] == 'who-is-related'
         ]
+
         expected_relationship_answers = [
             {
                 'answer_id': 'who-is-related',
                 'answer_instance': 0,
                 'group_instance': 0,
+                'group_instance_id': 'household-relationships-4',
                 'value': 'Husband or wife'
             },
             {
                 'answer_id': 'who-is-related',
                 'answer_instance': 1,
                 'group_instance': 0,
+                'group_instance_id': 'household-relationships-4',
                 'value': 'Relation - other'
             },
             {
                 'answer_id': 'who-is-related',
                 'answer_instance': 0,
                 'group_instance': 1,
+                'group_instance_id': 'household-relationships-8',
                 'value': 'Brother or sister'
             }
         ]

--- a/tests/integration/views/test_dump.py
+++ b/tests/integration/views/test_dump.py
@@ -1,5 +1,6 @@
 import json
 
+from mock import patch
 from werkzeug.datastructures import MultiDict
 
 from tests.integration.integration_test_case import IntegrationTestCase
@@ -53,7 +54,8 @@ class TestDumpAnswers(IntegrationTestCase):
         self.launchSurvey('test', 'radio_mandatory_with_mandatory_other', roles=['dumper'])
 
         # When I submit an answer
-        self.post(post_data={'radio-mandatory-answer': 'Toast'})
+        with patch('app.helpers.schema_helpers.uuid4', side_effect=range(10)):
+            self.post(post_data={'radio-mandatory-answer': 'Toast'})
 
         # And I attempt to dump the answer store
         self.get('/dump/answers')
@@ -69,12 +71,14 @@ class TestDumpAnswers(IntegrationTestCase):
                     'value': '',
                     'answer_instance': 0,
                     'group_instance': 0,
+                    'group_instance_id': 'radio-1',
                     'answer_id': 'other-answer-mandatory',
                 },
                 {
                     'value': 'Toast',
                     'answer_instance': 0,
                     'group_instance': 0,
+                    'group_instance_id': 'radio-1',
                     'answer_id': 'radio-mandatory-answer',
                 }
             ]
@@ -161,7 +165,8 @@ class TestDumpSubmission(IntegrationTestCase):
         self.launchSurvey('test', 'radio_mandatory', roles=['dumper'])
 
         # When I submit an answer
-        self.post(post_data={'radio-mandatory-answer': 'Coffee'})
+        with patch('app.helpers.schema_helpers.uuid4', side_effect=range(10)):
+            self.post(post_data={'radio-mandatory-answer': 'Coffee'})
 
         # And I attempt to dump the submission payload
         self.get('/dump/submission')
@@ -192,6 +197,7 @@ class TestDumpSubmission(IntegrationTestCase):
                         'answer_id': 'radio-mandatory-answer',
                         'answer_instance': 0,
                         'group_instance': 0,
+                        'group_instance_id': 'radio-1',
                         'value': 'Coffee',
                     },
                 ],

--- a/tests/integration/views/test_questionnaire.py
+++ b/tests/integration/views/test_questionnaire.py
@@ -43,12 +43,13 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
             'total-retail-turnover-answer': '1000',
         }
 
-        with self._application.test_request_context():
+        with self._application.test_request_context(), patch('app.helpers.schema_helpers.uuid4', return_value='1'):
             update_questionnaire_store_with_form_data(self.question_store, location, form_data, schema)
 
         self.assertEqual(self.question_store.completed_blocks, [location])
 
         self.assertIn({
+            'group_instance_id': 'rsi-1',
             'group_instance': 0,
             'answer_id': 'total-retail-turnover-answer',
             'answer_instance': 0,
@@ -66,12 +67,13 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
             'answer': None
         }
 
-        with self._application.test_request_context():
+        with self._application.test_request_context(), patch('app.helpers.schema_helpers.uuid4', return_value='1'):
             update_questionnaire_store_with_form_data(self.question_store, location, form_data, schema)
 
         self.assertEqual(self.question_store.completed_blocks, [location])
 
         self.assertIn({
+            'group_instance_id': 'group-1',
             'group_instance': 0,
             'answer_id': 'answer',
             'answer_instance': 0,
@@ -176,16 +178,19 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         answered = [
             Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='first-name',
                 answer_instance=0,
                 value='Joe'
             ), Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='middle-names',
                 answer_instance=0,
                 value=''
             ), Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='last-name',
                 answer_instance=0,
                 value='Bloggs'
@@ -195,16 +200,19 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         unanswered = [
             Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='first-name',
                 answer_instance=1,
                 value=''
             ), Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='middle-names',
                 answer_instance=1,
                 value=''
             ), Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='last-name',
                 answer_instance=1,
                 value=''
@@ -232,16 +240,19 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         answered = [
             Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='first-name',
                 answer_instance=0,
                 value='Joe'
             ), Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='middle-names',
                 answer_instance=0,
                 value=''
             ), Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='last-name',
                 answer_instance=0,
                 value='Bloggs'
@@ -251,31 +262,37 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         partially_answered = [
             Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='first-name',
                 answer_instance=1,
                 value=''
             ), Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='middle-names',
                 answer_instance=1,
                 value=''
             ), Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='last-name',
                 answer_instance=1,
                 value='Last name only'
             ), Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='first-name',
                 answer_instance=2,
                 value='First name only'
             ), Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='middle-names',
                 answer_instance=2,
                 value=''
             ), Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='last-name',
                 answer_instance=2,
                 value=''
@@ -486,21 +503,25 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         answers = [
             Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='first-name',
                 answer_instance=0,
                 value='Joe'
             ), Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='last-name',
                 answer_instance=0,
                 value='Bloggs'
             ), Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='date-of-birth-answer',
                 answer_instance=0,
                 value='2016-03-12'
             ), Answer(
                 group_instance=1,
+                group_instance_id='group-1',
                 answer_id='date-of-birth-answer',
                 answer_instance=0,
                 value='2018-01-01'
@@ -513,8 +534,7 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         answer_form_data = {'date-of-birth-answer': None}
         location = Location('household-member-group', 1, 'date-of-birth')
         with self._application.test_request_context():
-            update_questionnaire_store_with_form_data(
-                self.question_store, location, answer_form_data, schema)
+            update_questionnaire_store_with_form_data(self.question_store, location, answer_form_data, schema)
 
         self.assertIsNone(self.question_store.answer_store.find(answers[3]))
         for answer in answers[:2]:
@@ -528,8 +548,8 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
                              Location('group', 0, 'who-is-answer-block'),
                              Location('group', 0, 'multiple-question-versions-block'),
                              Location('group', 0, 'Summary')]
-        schema_context = _get_schema_context(full_routing_path, 0, {}, AnswerStore(), schema)
         current_location = Location('group', 0, 'single-title-block')
+        schema_context = _get_schema_context(full_routing_path, current_location, {}, AnswerStore(), g.schema)
 
         # When
         with self._application.test_request_context():


### PR DESCRIPTION
### What is the context of this PR?

Adding a repeat type of `group` and the concept of group identifiers (which i've named group_instance_id).

* By default group instances get a group_instance_id based on their group name and a UUID
* Added a new repeating type `group` which repeats over a list of groups specified by their group_ids.  These group instances get the group_instance_id of the group instances they are repeating over
* Added a context objects `group_instances` and `group_instance_id` which allows us to get at the answers from the group instances being repeated over
* There is a new field on answers `group_instance_id`, which will show up in the payload

### How to review
Run `test_routing_repeat_until.json`, enter yes when asked if there are any more people such that you enter at least 3 names.  See that you get asked the sex of each person, look in `/dump/submission` and have a look at the `group_instance_id` of each answer to see that the name and sex answers match up.

See also ONSdigital/eq-schema-validator#71