### PR TITLE
Introduce AnswerStoreUpdater

### DIFF
--- a/app/data_model/questionnaire_store.py
+++ b/app/data_model/questionnaire_store.py
@@ -53,7 +53,8 @@ class QuestionnaireStore:
            or all group instances within a group and block"""
 
         if 'location' in kwargs:
-            self.completed_blocks.remove(kwargs['location'])
+            if kwargs['location'] in self.completed_blocks:
+                self.completed_blocks.remove(kwargs['location'])
         else:
             self.completed_blocks = [completed_block for completed_block in self.completed_blocks
                                      if completed_block.group_id != kwargs['group_id'] or

--- a/app/questionnaire/answer_store_updater.py
+++ b/app/questionnaire/answer_store_updater.py
@@ -82,8 +82,7 @@ class AnswerStoreUpdater:
                 self._questionnaire_store.remove_completed_blocks(group_id=block['parent_id'], block_id=block['id'])
             else:
                 location = Location(block['parent_id'], group_instance, block['id'])
-                if location in self._questionnaire_store.completed_blocks:
-                    self._questionnaire_store.remove_completed_blocks(location=location)
+                self._questionnaire_store.remove_completed_blocks(location=location)
 
     def _remove_answer_from_questionnaire_store(self, answer_id, group_instance=0):
         self._questionnaire_store.answer_store.remove(answer_ids=[answer_id],

--- a/app/questionnaire/answer_store_updater.py
+++ b/app/questionnaire/answer_store_updater.py
@@ -1,0 +1,97 @@
+from app.data_model.answer_store import Answer
+from app.questionnaire.location import Location
+
+
+class AnswerStoreUpdater:
+    """Component responsible for any actions that need to happen as a result of updating the answer store
+    """
+    def __init__(self, current_location, schema, questionnaire_store):
+        self._current_location = current_location
+        self._schema = schema
+        self._questionnaire_store = questionnaire_store
+
+    def save_form(self, form):
+        if self._should_save_serialised_answers():
+            self._update_questionnaire_store_with_answer_data(form.serialise())
+        else:
+            self._update_questionnaire_store_with_form_data(form.data)
+
+        self._questionnaire_store.add_or_update()
+
+    def _update_questionnaire_store_with_answer_data(self, data):
+        survey_answer_ids = self._schema.get_answer_ids_for_block(self._current_location.block_id)
+
+        valid_answers = (
+            answer for answer in data
+            if answer.answer_id in survey_answer_ids
+        )
+        for answer in valid_answers:
+            self._questionnaire_store.answer_store.add_or_update(answer)
+
+        if self._current_location not in self._questionnaire_store.completed_blocks:
+            self._questionnaire_store.completed_blocks.append(self._current_location)
+
+    def _update_questionnaire_store_with_form_data(self, data):
+        survey_answer_ids = self._schema.get_answer_ids_for_block(self._current_location.block_id)
+
+        for answer_id, answer_value in data.items():
+
+            # If answer is not answered then check for a schema specified default
+            if answer_value is None:
+                answer_value = self._schema.get_answer(answer_id).get('default')
+
+            if answer_id in survey_answer_ids:
+                if answer_value is not None:
+                    answer = Answer(answer_id=answer_id,
+                                    value=answer_value,
+                                    group_instance=self._current_location.group_instance)
+
+                    latest_answer_store_hash = self._questionnaire_store.answer_store.get_hash()
+                    self._questionnaire_store.answer_store.add_or_update(answer)
+                    if (latest_answer_store_hash != self._questionnaire_store.answer_store.get_hash() and
+                            self._schema.dependencies[answer_id]):
+                        self._remove_dependent_answers_from_completed_blocks(answer_id, self._current_location.group_instance)
+                else:
+                    self._remove_answer_from_questionnaire_store(
+                        answer_id,
+                        group_instance=self._current_location.group_instance)
+
+        if self._current_location not in self._questionnaire_store.completed_blocks:
+            self._questionnaire_store.completed_blocks.append(self._current_location)
+
+    def _remove_dependent_answers_from_completed_blocks(self, answer_id, group_instance):
+        """
+        Gets a list of answers ids that are dependent on the answer_id passed in.
+        Then for each dependent answer it will remove it's block from those completed.
+        This will therefore force the respondent to revisit that block.
+        The dependent answers themselves remain untouched.
+        :param answer_id: the answer that has changed
+        :return: None
+        """
+        answer_in_repeating_group = self._schema.answer_is_in_repeating_group(answer_id)
+        dependencies = self._schema.dependencies[answer_id]
+
+        for dependency in dependencies:
+            dependency_in_repeating_group = self._schema.answer_is_in_repeating_group(dependency)
+
+            answer = self._schema.get_answer(dependency)
+            question = self._schema.get_question(answer['parent_id'])
+            block = self._schema.get_block(question['parent_id'])
+
+            if dependency_in_repeating_group and not answer_in_repeating_group:
+                self._questionnaire_store.remove_completed_blocks(group_id=block['parent_id'], block_id=block['id'])
+            else:
+                location = Location(block['parent_id'], group_instance, block['id'])
+                if location in self._questionnaire_store.completed_blocks:
+                    self._questionnaire_store.remove_completed_blocks(location=location)
+
+    def _remove_answer_from_questionnaire_store(self, answer_id, group_instance=0):
+        self._questionnaire_store.answer_store.remove(answer_ids=[answer_id],
+                                                      group_instance=group_instance,
+                                                      answer_instance=0)
+
+    def _should_save_serialised_answers(self):
+        """Returns `True` if the answer store should be updated with answer values provided by a form's
+        serialise() method rather than those processed by the form object
+        """
+        return self._current_location.block_id in ['relationships', 'household-relationships', 'household-composition']

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -450,9 +450,8 @@ def _save_sign_out(routing_path, current_location, form, schema, answer_store, m
         answer_store_updater = AnswerStoreUpdater(this_location, schema, questionnaire_store)
         answer_store_updater.save_form(form)
 
-        if current_location in questionnaire_store.completed_blocks:
-            questionnaire_store.remove_completed_blocks(location=current_location)
-            questionnaire_store.add_or_update()
+        questionnaire_store.remove_completed_blocks(location=current_location)
+        questionnaire_store.add_or_update()
 
         logout_user()
 

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -1,4 +1,3 @@
-from functools import wraps
 import re
 from collections import defaultdict
 from datetime import datetime, timedelta
@@ -225,8 +224,11 @@ def post_household_composition(routing_path, schema, metadata, answer_store, **k
         return response
 
     if form.validate():
-        questionnaire_store = get_questionnaire_store(current_user.user_id, current_user.user_ik)
-        answer_store_updater = AnswerStoreUpdater(current_location, schema, questionnaire_store)
+        answer_store_updater = AnswerStoreUpdater(
+            current_location,
+            schema,
+            get_questionnaire_store(current_user.user_id, current_user.user_ik)
+        )
         answer_store_updater.save_form(form)
 
         metadata = get_metadata(current_user)
@@ -447,7 +449,7 @@ def _save_sign_out(routing_path, current_location, form, schema, answer_store, m
     block = _get_block_json(current_location, schema, answer_store, metadata)
 
     if form.validate():
-        answer_store_updater = AnswerStoreUpdater(this_location, schema, questionnaire_store)
+        answer_store_updater = AnswerStoreUpdater(current_location, schema, questionnaire_store)
         answer_store_updater.save_form(form)
 
         questionnaire_store.remove_completed_blocks(location=current_location)

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -14,7 +14,7 @@ from sdc.crypto.encrypter import encrypt
 from structlog import get_logger
 
 from app.globals import get_session_store, get_completeness
-from app.data_model.answer_store import Answer, AnswerStore
+from app.data_model.answer_store import AnswerStore
 from app.data_model.app_models import SubmittedResponse
 from app.globals import get_answer_store, get_completed_blocks, get_metadata, get_questionnaire_store
 from app.helpers.form_helper import post_form_for_location
@@ -24,6 +24,7 @@ from app.helpers.session_helpers import with_answer_store, with_metadata
 from app.helpers.template_helper import (with_session_timeout, with_metadata_context, with_analytics,
                                          with_questionnaire_url_prefix, with_legal_basis, render_template)
 
+from app.questionnaire.answer_store_updater import AnswerStoreUpdater
 from app.questionnaire.location import Location
 from app.questionnaire.navigation import Navigation
 from app.questionnaire.path_finder import PathFinder
@@ -113,20 +114,6 @@ def add_cache_control(response):
     return response
 
 
-def save_questionnaire_store(func):
-    @wraps(func)
-    def save_questionnaire_store_wrapper(*args, **kwargs):
-        response = func(*args, **kwargs)
-        if not current_user.is_anonymous:
-            questionnaire_store = get_questionnaire_store(current_user.user_id, current_user.user_ik)
-
-            questionnaire_store.add_or_update()
-
-        return response
-
-    return save_questionnaire_store_wrapper
-
-
 @questionnaire_blueprint.route('<group_id>/<int:group_instance>/<block_id>', methods=['GET'])
 @login_required
 @with_answer_store
@@ -159,6 +146,10 @@ def post_block(routing_path, schema, metadata, answer_store, eq_id, form_type, c
                group_instance, block_id):
     current_location = Location(group_id, group_instance, block_id)
     completeness = get_completeness(current_user)
+    metadata = get_metadata(current_user)
+    questionnaire_store = get_questionnaire_store(current_user.user_id, current_user.user_ik)
+    answer_store = questionnaire_store.answer_store
+
     router = Router(schema, routing_path, completeness, current_location)
 
     if not router.can_access_location():
@@ -177,7 +168,9 @@ def post_block(routing_path, schema, metadata, answer_store, eq_id, form_type, c
         return _save_sign_out(routing_path, current_location, form, schema, answer_store, metadata)
 
     if form.validate():
-        _update_questionnaire_store(current_location, form, schema)
+        answer_store_updater = AnswerStoreUpdater(current_location, schema, questionnaire_store)
+        answer_store_updater.save_form(form)
+
         next_location = path_finder.get_next_location(current_location=current_location)
 
         if _is_end_of_questionnaire(block, next_location):
@@ -233,7 +226,8 @@ def post_household_composition(routing_path, schema, metadata, answer_store, **k
 
     if form.validate():
         questionnaire_store = get_questionnaire_store(current_user.user_id, current_user.user_ik)
-        update_questionnaire_store_with_answer_data(questionnaire_store, current_location, form.serialise(), schema)
+        answer_store_updater = AnswerStoreUpdater(current_location, schema, questionnaire_store)
+        answer_store_updater.save_form(form)
 
         metadata = get_metadata(current_user)
         next_location = path_finder.get_next_location(current_location=current_location)
@@ -453,7 +447,8 @@ def _save_sign_out(routing_path, current_location, form, schema, answer_store, m
     block = _get_block_json(current_location, schema, answer_store, metadata)
 
     if form.validate():
-        _update_questionnaire_store(current_location, form, schema)
+        answer_store_updater = AnswerStoreUpdater(this_location, schema, questionnaire_store)
+        answer_store_updater.save_form(form)
 
         if current_location in questionnaire_store.completed_blocks:
             questionnaire_store.remove_completed_blocks(location=current_location)
@@ -526,93 +521,6 @@ def remove_empty_household_members_from_answer_store(answer_store, schema):
 
     for instance_to_remove in to_be_removed:
         answer_store.remove(answer_ids=answer_ids, answer_instance=instance_to_remove)
-
-
-def _update_questionnaire_store(current_location, form, schema):
-    questionnaire_store = get_questionnaire_store(current_user.user_id, current_user.user_ik)
-    if current_location.block_id in ['relationships', 'household-relationships']:
-        update_questionnaire_store_with_answer_data(questionnaire_store, current_location,
-                                                    form.serialise(), schema)
-    else:
-        update_questionnaire_store_with_form_data(questionnaire_store, current_location, form.data, schema)
-
-
-@save_questionnaire_store
-def update_questionnaire_store_with_form_data(questionnaire_store, location, answer_dict, schema):
-
-    survey_answer_ids = schema.get_answer_ids_for_block(location.block_id)
-
-    for answer_id, answer_value in answer_dict.items():
-
-        # If answer is not answered then check for a schema specified default
-        if answer_value is None:
-            answer_value = schema.get_answer(answer_id).get('default')
-
-        if answer_id in survey_answer_ids or location.block_id == 'household-composition':
-            if answer_value is not None:
-                answer = Answer(answer_id=answer_id,
-                                value=answer_value,
-                                group_instance=location.group_instance)
-
-                latest_answer_store_hash = questionnaire_store.answer_store.get_hash()
-                questionnaire_store.answer_store.add_or_update(answer)
-                if latest_answer_store_hash != questionnaire_store.answer_store.get_hash() and schema.dependencies[answer_id]:
-                    _remove_dependent_answers_from_completed_blocks(answer_id, location.group_instance, questionnaire_store, schema)
-            else:
-                _remove_answer_from_questionnaire_store(
-                    answer_id,
-                    questionnaire_store,
-                    group_instance=location.group_instance)
-
-    if location not in questionnaire_store.completed_blocks:
-        questionnaire_store.completed_blocks.append(location)
-
-
-def _remove_dependent_answers_from_completed_blocks(answer_id, group_instance, questionnaire_store, schema):
-    """
-    Gets a list of answers ids that are dependent on the answer_id passed in.
-    Then for each dependent answer it will remove it's block from those completed.
-    This will therefore force the respondent to revisit that block.
-    The dependent answers themselves remain untouched.
-    :param answer_id: the answer that has changed
-    :param questionnaire_store: holds the completed blocks
-    :return: None
-    """
-    answer_in_repeating_group = schema.answer_is_in_repeating_group(answer_id)
-    dependencies = schema.dependencies[answer_id]
-
-    for dependency in dependencies:
-        dependency_in_repeating_group = schema.answer_is_in_repeating_group(dependency)
-
-        answer = schema.get_answer(dependency)
-        question = schema.get_question(answer['parent_id'])
-        block = schema.get_block(question['parent_id'])
-
-        if dependency_in_repeating_group and not answer_in_repeating_group:
-            questionnaire_store.remove_completed_blocks(group_id=block['parent_id'], block_id=block['id'])
-        else:
-            location = Location(block['parent_id'], group_instance, block['id'])
-            if location in questionnaire_store.completed_blocks:
-                questionnaire_store.remove_completed_blocks(location=location)
-
-
-def _remove_answer_from_questionnaire_store(answer_id, questionnaire_store,
-                                            group_instance=0):
-    questionnaire_store.answer_store.remove(answer_ids=[answer_id],
-                                            group_instance=group_instance,
-                                            answer_instance=0)
-
-
-@save_questionnaire_store
-def update_questionnaire_store_with_answer_data(questionnaire_store, location, answers, schema):
-
-    survey_answer_ids = schema.get_answer_ids_for_block(location.block_id)
-
-    for answer in [a for a in answers if a.answer_id in survey_answer_ids]:
-        questionnaire_store.answer_store.add_or_update(answer)
-
-    if location not in questionnaire_store.completed_blocks:
-        questionnaire_store.completed_blocks.append(location)
 
 
 def _check_same_survey(url_eq_id, url_form_type, url_collection_id, session_eq_id, session_form_type, session_collection_id):

--- a/tests/app/questionnaire/test_answer_store_updater.py
+++ b/tests/app/questionnaire/test_answer_store_updater.py
@@ -208,7 +208,7 @@ class TestAnswerStoreUpdaterDependencies(unittest.TestCase):
         self.schema.get_answer_ids_for_block.return_value = [parent_id]
         self.schema.dependencies = {parent_id: [dependent_answer_id]}
         self.schema.get_block.return_value = {'id': dependent_location.block_id, 'parent_id': dependent_location.group_id}
-        
+
         # the dependent answer is in a repeating group, the parent is not
         self.schema.answer_is_in_repeating_group = lambda _answer_id: _answer_id == dependent_answer_id
 

--- a/tests/app/questionnaire/test_answer_store_updater.py
+++ b/tests/app/questionnaire/test_answer_store_updater.py
@@ -1,0 +1,237 @@
+import unittest
+
+import mock
+from app.data_model.answer_store import Answer, AnswerStore
+from app.data_model.questionnaire_store import QuestionnaireStore
+from app.questionnaire.answer_store_updater import AnswerStoreUpdater
+from app.questionnaire.location import Location
+from app.questionnaire.questionnaire_schema import QuestionnaireSchema
+
+
+class TestAnswerStoreUpdater(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.location = Location('group_foo', 0, 'block_bar')
+        self.schema = mock.Mock(spec=QuestionnaireSchema)
+        self.answer_store = mock.Mock(spec=AnswerStore)
+        self.questionnaire_store = mock.Mock(
+            spec=QuestionnaireStore,
+            completed_blocks=[],
+            answer_store=self.answer_store
+        )
+        self.answer_store_updater = AnswerStoreUpdater(self.location, self.schema, self.questionnaire_store)
+
+    def test_save_household_composition(self):
+        self.location.block_id = 'household-composition'
+
+        answers = [
+            Answer(
+                group_instance=0,
+                answer_id='first-name',
+                answer_instance=0,
+                value='Joe'
+            ), Answer(
+                group_instance=0,
+                answer_id='middle-names',
+                answer_instance=0,
+                value=''
+            ), Answer(
+                group_instance=0,
+                answer_id='last-name',
+                answer_instance=0,
+                value='Bloggs'
+            ), Answer(
+                group_instance=0,
+                answer_id='first-name',
+                answer_instance=1,
+                value='Bob'
+            ), Answer(
+                group_instance=0,
+                answer_id='middle-names',
+                answer_instance=1,
+                value=''
+            ), Answer(
+                group_instance=0,
+                answer_id='last-name',
+                answer_instance=1,
+                value='Seymour'
+            )
+        ]
+
+        form = mock.Mock()
+        form.serialise.return_value = answers
+
+        self.schema.get_answer_ids_for_block.return_value = [
+            'first-name',
+            'middle-names',
+            'last-name'
+        ]
+
+        self.answer_store_updater.save_form(form)
+
+        self.assertEqual(self.questionnaire_store.completed_blocks, [self.location])
+
+        self.assertEqual(len(answers), self.answer_store.add_or_update.call_count)
+
+        # answers should be passed straight through as Answer objects
+        answer_calls = map(mock.call, answers)
+        self.answer_store.add_or_update.assert_has_calls(answer_calls, any_order=True)
+
+    def test_save_form_data(self):
+        answer_id = 'answer'
+        answer_value = '1000'
+        self.schema.get_answer_ids_for_block.return_value = [answer_id]
+
+        form = mock.Mock(data={answer_id: answer_value})
+
+        self.answer_store_updater.save_form(form)
+
+        self.assertEqual(self.questionnaire_store.completed_blocks, [self.location])
+
+        self.assertEqual(1, self.answer_store.add_or_update.call_count)
+        created_answer = self.answer_store.add_or_update.call_args[0][0]
+        self.assertEqual(created_answer.__dict__, {
+            'group_instance': 0,
+            'answer_id': answer_id,
+            'answer_instance': 0,
+            'value': answer_value
+        })
+
+    def test_save_form_stores_specific_group(self):
+        answer_id = 'answer'
+        answer_value = '1000'
+        self.location.group_instance = 1
+        self.schema.get_answer_ids_for_block.return_value = [answer_id]
+
+        form = mock.Mock(data={answer_id: answer_value})
+
+        self.answer_store_updater.save_form(form)
+
+        self.assertEqual(self.questionnaire_store.completed_blocks, [self.location])
+
+        self.assertEqual(1, self.answer_store.add_or_update.call_count)
+        created_answer = self.answer_store.add_or_update.call_args[0][0]
+        self.assertEqual(created_answer.__dict__, {
+            'group_instance': self.location.group_instance,
+            'answer_id': answer_id,
+            'answer_instance': 0,
+            'value': answer_value
+        })
+
+    def test_save_form_data_with_default_value(self):
+        answer_id = 'answer'
+        default_value = 0
+        self.schema.get_answer_ids_for_block.return_value = [answer_id]
+        self.schema.get_answer.return_value = {'default': default_value}
+
+        # No answer given so will use schema defined default
+        form_data = {
+            answer_id: None
+        }
+        form = mock.Mock(data=form_data)
+
+        self.answer_store_updater.save_form(form)
+
+        self.assertEqual(self.questionnaire_store.completed_blocks, [self.location])
+
+        self.assertEqual(1, self.answer_store.add_or_update.call_count)
+        created_answer = self.answer_store.add_or_update.call_args[0][0]
+        self.assertEqual(created_answer.__dict__, {
+            'group_instance': 0,
+            'answer_id': answer_id,
+            'answer_instance': 0,
+            'value': default_value
+        })
+
+class TestAnswerStoreUpdaterDependencies(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.schema = mock.Mock(
+            spec=QuestionnaireSchema,
+            get_answer=mock.MagicMock(),
+            get_question=mock.MagicMock(),
+            get_block=mock.MagicMock(),
+            get_group=mock.MagicMock(),
+        )
+        self.answer_store = mock.Mock(spec=AnswerStore)
+        self.questionnaire_store = mock.Mock(
+            spec=QuestionnaireStore,
+            completed_blocks=[],
+            answer_store=self.answer_store,
+        )
+
+    def test_save_form_removes_completed_block_for_dependencies(self):
+        parent_id, dependent_answer_id = 'parent_answer', 'dependent_answer'
+        parent_location = Location('group', 0, 'min-block')
+        dependent_location = Location('group', 0, 'dependent-block')
+
+        self.questionnaire_store.completed_blocks = [parent_location, dependent_location]
+
+        self.schema.get_answer_ids_for_block.return_value = [parent_id]
+        self.schema.dependencies = {parent_id: [dependent_answer_id]}
+        self.schema.get_block.return_value = {'id': dependent_location.block_id, 'parent_id': dependent_location.group_id}
+
+        # rotate the hash every time get_hash() is called to simulate the stored answer changing
+        self.answer_store.get_hash.side_effect = ['first_hash', 'second_hash']
+
+        form = mock.Mock(data={parent_id: '10'})
+
+        answer_store_updater = AnswerStoreUpdater(parent_location, self.schema, self.questionnaire_store)
+        answer_store_updater.save_form(form)
+
+        self.questionnaire_store.remove_completed_blocks.assert_called_with(location=dependent_location)
+
+        self.assertEqual(1, self.answer_store.add_or_update.call_count)
+        created_answer = self.answer_store.add_or_update.call_args[0][0]
+        self.assertEqual(created_answer.__dict__, {
+            'group_instance': 0,
+            'answer_id': parent_id,
+            'answer_instance': 0,
+            'value': '10'
+        })
+
+        self.assertFalse(self.answer_store.remove.called)
+
+    def test_save_form_removes_completed_block_for_dependencies_repeating(self):
+        """
+        Tests that all dependent completed blocks are removed across all repeating groups when
+        parent answer is not in a repeating group
+        """
+        parent_id, dependent_answer_id = 'parent_answer', 'dependent_answer'
+        parent_location = Location('group', 0, 'min-block')
+        dependent_location = Location('group', 0, 'dependent-block')
+
+        self.questionnaire_store.completed_blocks = [parent_location, dependent_location]
+
+        self.schema.get_answer_ids_for_block.return_value = [parent_id]
+        self.schema.dependencies = {parent_id: [dependent_answer_id]}
+        self.schema.get_block.return_value = {'id': dependent_location.block_id, 'parent_id': dependent_location.group_id}
+        
+        # the dependent answer is in a repeating group, the parent is not
+        self.schema.answer_is_in_repeating_group = lambda _answer_id: _answer_id == dependent_answer_id
+
+        # rotate the hash every time get_hash() is called to simulate the stored answer changing
+        self.answer_store.get_hash.side_effect = ['first_hash', 'second_hash']
+
+        form = mock.Mock(data={parent_id: '10'})
+
+        answer_store_updater = AnswerStoreUpdater(parent_location, self.schema, self.questionnaire_store)
+        answer_store_updater.save_form(form)
+
+        self.questionnaire_store.remove_completed_blocks.assert_called_with(
+            group_id=dependent_location.group_id,
+            block_id=dependent_location.block_id
+        )
+
+        self.assertEqual(1, self.answer_store.add_or_update.call_count)
+        created_answer = self.answer_store.add_or_update.call_args[0][0]
+        self.assertEqual(created_answer.__dict__, {
+            'group_instance': 0,
+            'answer_id': parent_id,
+            'answer_instance': 0,
+            'value': '10'
+        })
+
+        self.assertFalse(self.answer_store.remove.called)

--- a/tests/integration/views/test_questionnaire.py
+++ b/tests/integration/views/test_questionnaire.py
@@ -1,5 +1,5 @@
 from flask import g
-from mock import Mock, patch
+from mock import Mock
 import simplejson as json
 
 from app.data_model.answer_store import Answer, AnswerStore
@@ -7,9 +7,11 @@ from app.data_model.questionnaire_store import QuestionnaireStore
 from app.questionnaire.location import Location
 from app.templating.view_context import build_view_context
 from app.utilities.schema import load_schema_from_params
-from app.views.questionnaire import update_questionnaire_store_with_answer_data, \
-    update_questionnaire_store_with_form_data, remove_empty_household_members_from_answer_store, \
-    get_page_title_for_location, _get_schema_context
+from app.views.questionnaire import (
+    remove_empty_household_members_from_answer_store,
+    get_page_title_for_location,
+    _get_schema_context
+)
 
 from tests.integration.integration_test_case import IntegrationTestCase
 
@@ -32,143 +34,6 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
 
     def tearDown(self):
         self._application_context.pop()
-
-    def test_update_questionnaire_store_with_form_data(self):
-
-        schema = load_schema_from_params('test', '0112')
-
-        location = Location('rsi', 0, 'total-retail-turnover')
-
-        form_data = {
-            'total-retail-turnover-answer': '1000',
-        }
-
-        with self._application.test_request_context():
-            update_questionnaire_store_with_form_data(self.question_store, location, form_data, schema)
-
-        self.assertEqual(self.question_store.completed_blocks, [location])
-
-        self.assertIn({
-            'group_instance': 0,
-            'answer_id': 'total-retail-turnover-answer',
-            'answer_instance': 0,
-            'value': '1000'
-        }, self.question_store.answer_store.answers)
-
-    def test_update_questionnaire_store_with_default_value(self):
-
-        schema = load_schema_from_params('test', 'default')
-
-        location = Location('group', 0, 'number-question')
-
-        # No answer given so will use schema defined default
-        form_data = {
-            'answer': None
-        }
-
-        with self._application.test_request_context():
-            update_questionnaire_store_with_form_data(self.question_store, location, form_data, schema)
-
-        self.assertEqual(self.question_store.completed_blocks, [location])
-
-        self.assertIn({
-            'group_instance': 0,
-            'answer_id': 'answer',
-            'answer_instance': 0,
-            'value': 0
-        }, self.question_store.answer_store.answers)
-
-    def test_update_questionnaire_store_with_answer_data(self):
-        schema = load_schema_from_params('census', 'household')
-
-        location = Location('who-lives-here', 0, 'household-composition')
-
-        answers = [
-            Answer(
-                group_instance=0,
-                answer_id='first-name',
-                answer_instance=0,
-                value='Joe'
-            ), Answer(
-                group_instance=0,
-                answer_id='middle-names',
-                answer_instance=0,
-                value=''
-            ), Answer(
-                group_instance=0,
-                answer_id='last-name',
-                answer_instance=0,
-                value='Bloggs'
-            ), Answer(
-                group_instance=0,
-                answer_id='first-name',
-                answer_instance=1,
-                value='Bob'
-            ), Answer(
-                group_instance=0,
-                answer_id='middle-names',
-                answer_instance=1,
-                value=''
-            ), Answer(
-                group_instance=0,
-                answer_id='last-name',
-                answer_instance=1,
-                value='Seymour'
-            )
-        ]
-
-        with self._application.test_request_context():
-            update_questionnaire_store_with_answer_data(self.question_store, location, answers, schema)
-
-        self.assertEqual(self.question_store.completed_blocks, [location])
-
-        for answer in answers:
-            self.assertIn(answer.__dict__, self.question_store.answer_store.answers)
-
-    def test_remove_empty_household_members_from_answer_store(self):
-        schema = load_schema_from_params('census', 'household')
-
-        answers = [
-            Answer(
-                group_instance=0,
-                answer_id='first-name',
-                answer_instance=0,
-                value=''
-            ), Answer(
-                group_instance=0,
-                answer_id='middle-names',
-                answer_instance=0,
-                value=''
-            ), Answer(
-                group_instance=0,
-                answer_id='last-name',
-                answer_instance=0,
-                value=''
-            ), Answer(
-                group_instance=0,
-                answer_id='first-name',
-                answer_instance=1,
-                value=''
-            ), Answer(
-                group_instance=0,
-                answer_id='middle-names',
-                answer_instance=1,
-                value=''
-            ), Answer(
-                group_instance=0,
-                answer_id='last-name',
-                answer_instance=1,
-                value=''
-            )
-        ]
-
-        for answer in answers:
-            self.question_store.answer_store.add_or_update(answer)
-
-        remove_empty_household_members_from_answer_store(self.question_store.answer_store, schema)
-
-        for answer in answers:
-            self.assertIsNone(self.question_store.answer_store.find(answer))
 
     def test_remove_empty_household_members_values_entered_are_stored(self):
         schema = load_schema_from_params('census', 'household')
@@ -379,147 +244,6 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         # Then
         self.assertEqual(page_title, 'How is … related to the people below? - 2017 Census Test')
 
-    def test_updating_questionnaire_store_removes_completed_block_for_min_dependencies(self):
-
-        schema = load_schema_from_params('test', 'dependencies_min_value')
-
-        min_answer_location = Location('group', 0, 'min-block')
-        dependent_location = Location('group', 0, 'dependent-block')
-
-        min_answer_data = {
-            'min-answer': '10',
-        }
-
-        dependent_data = {
-            'dependent-1': '10',
-        }
-
-        with self._application.test_request_context():
-            update_questionnaire_store_with_form_data(self.question_store, min_answer_location, min_answer_data, schema)
-
-        with self._application.test_request_context():
-            update_questionnaire_store_with_form_data(self.question_store, dependent_location, dependent_data, schema)
-
-        self.assertIn(min_answer_location, self.question_store.completed_blocks)
-        self.assertIn(dependent_location, self.question_store.completed_blocks)
-
-        min_answer_data = {
-            'min-answer': '9',
-        }
-
-        with self._application.test_request_context():
-            update_questionnaire_store_with_form_data(self.question_store, min_answer_location, min_answer_data, schema)
-
-        self.assertNotIn(dependent_location, self.question_store.completed_blocks)
-
-    def test_updating_questionnaire_store_removes_completed_block_for_max_dependencies(self):
-
-        schema = load_schema_from_params('test', 'dependencies_max_value')
-
-        max_answer_location = Location('group', 0, 'max-block')
-        dependent_location = Location('group', 0, 'dependent-block')
-
-        max_answer_data = {
-            'max-answer': '10',
-        }
-
-        dependent_data = {
-            'dependent-1': '10',
-        }
-
-        with self._application.test_request_context():
-            update_questionnaire_store_with_form_data(self.question_store, max_answer_location, max_answer_data, schema)
-
-        with self._application.test_request_context():
-            update_questionnaire_store_with_form_data(self.question_store, dependent_location, dependent_data, schema)
-
-        self.assertIn(max_answer_location, self.question_store.completed_blocks)
-        self.assertIn(dependent_location, self.question_store.completed_blocks)
-
-        max_answer_data = {
-            'max-answer': '11',
-        }
-
-        with self._application.test_request_context():
-            update_questionnaire_store_with_form_data(self.question_store, max_answer_location, max_answer_data, schema)
-
-        self.assertNotIn(dependent_location, self.question_store.completed_blocks)
-
-    def test_updating_questionnaire_store_removes_completed_block_for_calculation_dependencies(self):
-
-        schema = load_schema_from_params('test', 'dependencies_calculation')
-
-        calculation_answer_location = Location('group', 0, 'total-block')
-        dependent_location = Location('group', 0, 'breakdown-block')
-
-        calculation_answer_data = {
-            'total-answer': '100',
-        }
-
-        dependent_data = {
-            'breakdown-1': '10',
-            'breakdown-2': '20',
-            'breakdown-3': '30',
-            'breakdown-4': '40'
-        }
-
-        with self._application.test_request_context():
-            update_questionnaire_store_with_form_data(self.question_store, calculation_answer_location, calculation_answer_data, schema)
-
-        with self._application.test_request_context():
-            update_questionnaire_store_with_form_data(self.question_store, dependent_location, dependent_data, schema)
-
-        self.assertIn(calculation_answer_location, self.question_store.completed_blocks)
-        self.assertIn(dependent_location, self.question_store.completed_blocks)
-
-        calculation_answer_data = {
-            'total-answer': '99',
-        }
-
-        with self._application.test_request_context():
-            update_questionnaire_store_with_form_data(self.question_store, calculation_answer_location, calculation_answer_data, schema)
-
-        self.assertNotIn(dependent_location, self.question_store.completed_blocks)
-
-    def test_updating_questionnaire_store_specific_group(self):
-        schema = load_schema_from_params('test', 'repeating_household_routing')
-        answers = [
-            Answer(
-                group_instance=0,
-                answer_id='first-name',
-                answer_instance=0,
-                value='Joe'
-            ), Answer(
-                group_instance=0,
-                answer_id='last-name',
-                answer_instance=0,
-                value='Bloggs'
-            ), Answer(
-                group_instance=0,
-                answer_id='date-of-birth-answer',
-                answer_instance=0,
-                value='2016-03-12'
-            ), Answer(
-                group_instance=1,
-                answer_id='date-of-birth-answer',
-                answer_instance=0,
-                value='2018-01-01'
-            )
-        ]
-
-        for answer in answers:
-            self.question_store.answer_store.add_or_update(answer)
-
-        answer_form_data = {'date-of-birth-answer': None}
-        location = Location('household-member-group', 1, 'date-of-birth')
-        with self._application.test_request_context():
-            update_questionnaire_store_with_form_data(
-                self.question_store, location, answer_form_data, schema)
-
-        self.assertIsNone(self.question_store.answer_store.find(answers[3]))
-        for answer in answers[:2]:
-            self.assertIsNotNone(self.question_store.answer_store.find(answer))
-
     def test_build_view_context_for_question(self):
         # Given
         g.schema = schema = load_schema_from_params('test', 'titles')
@@ -538,24 +262,6 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
 
         # Then
         self.assertEqual(question_view_context['question_titles']['single-title-question'], 'How are you feeling??')
-
-    def test_answer_non_repeating_dependency_repeating_validate_all_of_block_and_group_removed(self):
-        """ load a schema with a non repeating independent answer and a repeating one that depends on it
-        validate that when the independent variable is set a call is made to remove all instances of
-        the dependant variables
-        """
-        # Given
-        schema = load_schema_from_params('test', 'titles_repeating_non_repeating_dependency')
-        colour_answer_location = Location('colour-group', 0, 'favourite-colour')
-        colour_answer = {'fav-colour-answer': 'blue'}
-
-        # When
-        with self._application.test_request_context():
-            with patch('app.data_model.questionnaire_store.QuestionnaireStore.remove_completed_blocks') as patch_remove:
-                update_questionnaire_store_with_form_data(self.question_store, colour_answer_location, colour_answer, schema)
-
-        # Then
-        patch_remove.assert_called_with(group_id='repeating-group', block_id='repeating-block-3')
 
     def test_remove_completed_by_group_and_block(self):
         for i in range(10):


### PR DESCRIPTION
### What is the context of this PR?
Introduced a new component to handle logic around what happens when the answer store gets updated. I'm hoping this:

- Makes the code more understandable
- Better defines the responsibilities of this object
- Provides a component that can be better tested as a single unit
- Allows a few of the schema-specific integration tests to be removed

### How to review 
All tests should pass
Code coverage should not reduce
No changes to functionality

### Checklist

* [] New static content marked up for translation
* [] Newly defined schema content included in eq-translations repo
