### PR TITLE
Fix relationship answers overwriting each other

### DIFF
--- a/app/forms/household_relationship_form.py
+++ b/app/forms/household_relationship_form.py
@@ -56,12 +56,14 @@ def build_relationship_choices(answer_store, group_instance):  # pylint: disable
     return choices
 
 
-def serialise_relationship_answers(answer_id, listfield_data):
+def serialise_relationship_answers(answer_id, listfield_data, group_instance):
     answers = []
+
     for index, listfield_value in enumerate(listfield_data):
         answer = Answer(
             answer_id=answer_id,
             answer_instance=index,
+            group_instance=group_instance,
             value=listfield_value,
         )
         answers.append(answer)
@@ -81,7 +83,7 @@ def deserialise_relationship_answers(answers):
     return relationships
 
 
-def generate_relationship_form(schema, block_json, relationship_choices, data):
+def generate_relationship_form(schema, block_json, relationship_choices, data, group_instance):
 
     answer = schema.get_answers_for_block(block_json['id'])[0]
 
@@ -110,7 +112,7 @@ def generate_relationship_form(schema, block_json, relationship_choices, data):
             """
             list_field = getattr(self, answer['id'])
 
-            return serialise_relationship_answers(answer['id'], list_field.data)
+            return serialise_relationship_answers(answer['id'], list_field.data, group_instance)
 
     choices = [('', 'Select relationship')] + build_choices(answer['options'])
 

--- a/app/helpers/form_helper.py
+++ b/app/helpers/form_helper.py
@@ -42,7 +42,7 @@ def get_form_for_location(schema, block_json, location, answer_store, metadata, 
 
         relationship_choices = build_relationship_choices(answer_store, location.group_instance)
 
-        form = generate_relationship_form(schema, block_json, relationship_choices, data)
+        form = generate_relationship_form(schema, block_json, relationship_choices, data, location.group_instance)
 
         return form
 
@@ -76,7 +76,7 @@ def post_form_for_location(schema, block_json, location, answer_store, metadata,
 
     if location.block_id in ['relationships', 'household-relationships']:
         relationship_choices = build_relationship_choices(answer_store, location.group_instance)
-        form = generate_relationship_form(schema, block_json, relationship_choices, request_form)
+        form = generate_relationship_form(schema, block_json, relationship_choices, request_form, location.group_instance)
 
         return form
 

--- a/tests/app/forms/test_household_relationship_form.py
+++ b/tests/app/forms/test_household_relationship_form.py
@@ -73,7 +73,7 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
 
             relationship_choices = [['a', 'b'], ['c', 'd'], ['e', 'f']]
 
-            form = generate_relationship_form(schema, block_json, relationship_choices, {})
+            form = generate_relationship_form(schema, block_json, relationship_choices, {}, 0)
 
             self.assertTrue(hasattr(form, answer['id']))
             self.assertEqual(len(form.data[answer['id']]), 3)
@@ -91,7 +91,7 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
                 '{answer_id}-0'.format(answer_id=answer['id']): 'Husband or Wife',
                 '{answer_id}-1'.format(answer_id=answer['id']): 'Brother or Sister',
                 '{answer_id}-2'.format(answer_id=answer['id']): 'Relation - other',
-            })
+            }, 0)
 
             self.assertTrue(hasattr(form, answer['id']))
 
@@ -107,13 +107,13 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
 
             relationship_choices = [['a', 'b'], ['c', 'd'], ['e', 'f']]
 
-            generated_form = generate_relationship_form(schema, block_json, relationship_choices, None)
+            generated_form = generate_relationship_form(schema, block_json, relationship_choices, None, 0)
 
             form = generate_relationship_form(schema, block_json, relationship_choices, {
                 'csrf_token': generated_form.csrf_token.current_token,
                 '{answer_id}-0'.format(answer_id=answer['id']): '1',
                 '{answer_id}-1'.format(answer_id=answer['id']): '3',
-            })
+            }, 0)
 
             form.validate()
             mapped_errors = form.map_errors()
@@ -126,7 +126,7 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
 
         field_data = ['Husband or Wife', 'Son or daughter', 'Unrelated']
 
-        actual_answers = serialise_relationship_answers('who-is-related', field_data)
+        actual_answers = serialise_relationship_answers('who-is-related', field_data, 0)
 
         expected_answers = [
             {
@@ -141,6 +141,34 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
                 'value': 'Son or daughter'
             }, {
                 'group_instance': 0,
+                'answer_id': 'who-is-related',
+                'answer_instance': 2,
+                'value': 'Unrelated'
+            }
+        ]
+
+        for answer in actual_answers:
+            self.assertIn(answer.__dict__, expected_answers)
+
+    def test_serialise_relationship_answers_second_group(self):
+
+        field_data = ['Husband or Wife', 'Son or daughter', 'Unrelated']
+
+        actual_answers = serialise_relationship_answers('who-is-related', field_data, 1)
+
+        expected_answers = [
+            {
+                'group_instance': 1,
+                'answer_id': 'who-is-related',
+                'answer_instance': 0,
+                'value': 'Husband or Wife'
+            }, {
+                'group_instance': 1,
+                'answer_id': 'who-is-related',
+                'answer_instance': 1,
+                'value': 'Son or daughter'
+            }, {
+                'group_instance': 1,
                 'answer_id': 'who-is-related',
                 'answer_instance': 2,
                 'value': 'Unrelated'


### PR DESCRIPTION
### What is the context of this PR?
This fixes a bug where each page relationships page would overwrite the answers provided on the first page.

### How to review 
- Test a schema that asks for household relationships.
- Enter at least 3 household members. 
- Specify a different value for the first relationship on each of the pages
- Return to the first page, the value should not have been overridden by the one on the second page
- Verify that the answer store has an answer value for each of the relationships. The answer_instance refers to which relationship on a given page. The group_instance refers to the page the relationship value was on.

### Checklist

* [] New static content marked up for translation
* [] Newly defined schema content included in eq-translations repo
