### PR TITLE
Remove needless description in mts intro

### DIFF
--- a/data/en/mts_1.json
+++ b/data/en/mts_1.json
@@ -98,20 +98,16 @@
                                 {
                                     "question": "Significant changes to turnover",
                                     "content": [{
-                                            "description": "Significant changes to turnover"
-                                        },
-                                        {
-                                            "description": "Include:",
-                                            "list": [
-                                                "change in level of business activity",
-                                                "maintenance/shutdowns",
-                                                "special/calendar events",
-                                                "weather",
-                                                "price effects",
-                                                "currency effects (increase/decrease in currency value)"
-                                            ]
-                                        }
-                                    ]
+                                        "description": "Include:",
+                                        "list": [
+                                            "change in level of business activity",
+                                            "maintenance/shutdowns",
+                                            "special/calendar events",
+                                            "weather",
+                                            "price effects",
+                                            "currency effects (increase/decrease in currency value)"
+                                        ]
+                                    }]
                                 }
                             ]
                         },


### PR DESCRIPTION
### What is the context of this PR?
https://trello.com/c/k90u0zIB/2204-mts-wholesale-motor-trade-prototyping
There was an description in the mts form that was a duplicate of the title.  This shouldn't be there.

### How to review 
Look at MTS intro page, it should match the first page of the prototype in the trello card

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
