### PR TITLE
Change region_code to country_code in lms schema

### DIFF
--- a/data/en/lms_1.json
+++ b/data/en/lms_1.json
@@ -22,7 +22,7 @@
         "ru_name": {
             "validator": "string"
         },
-        "region_code": {
+        "country_code": {
             "validator": "string"
         },
         "display_address": {
@@ -1381,9 +1381,9 @@
                                 ],
                                 "skip_conditions": [{
                                     "when": [{
-                                        "meta": "region_code",
+                                        "meta": "country_code",
                                         "condition": "equals",
-                                        "value": "GB-WLS"
+                                        "value": "W"
                                     }]
                                 }]
                             },
@@ -1443,9 +1443,9 @@
                                 ],
                                 "skip_conditions": [{
                                     "when": [{
-                                        "meta": "region_code",
+                                        "meta": "country_code",
                                         "condition": "not equals",
-                                        "value": "GB-WLS"
+                                        "value": "W"
                                     }]
                                 }]
                             }
@@ -1454,9 +1454,9 @@
                                 "goto": {
                                     "block": "understand-welsh",
                                     "when": [{
-                                        "meta": "region_code",
+                                        "meta": "country_code",
                                         "condition": "equals",
-                                        "value": "GB-WLS"
+                                        "value": "W"
                                     }]
                                 }
                             },


### PR DESCRIPTION
### What is the context of this PR?
https://trello.com/c/CpVU2T8q/2283-lms-test-1-change-regioncode-to-countrycode

We're going to use the country_code supplied instead of the region_code that was previously used for social surveys.

### How to review 
In go launcher, set the country code to W.  Then ensure the steps that used to be affected by region code are skipped with the country code
### Checklist

* [x] New static content marked up for translation
* [x] Newly defined schema content included in eq-translations repo
