### PR TITLE
Update question definitions to support multiple content

### DIFF
--- a/app/templates/partials/answer-guidance.html
+++ b/app/templates/partials/answer-guidance.html
@@ -18,16 +18,14 @@
   "aria-hidden": "true"
 } %}
 
-{% set guidance_content = {
-  "content": answer_guidance.schema_item.content
-} %}
+{% set content_block = answer_guidance.schema_item.content %}
 
 <div class="guidance js-details" {{guidance|xmlattr}}>
   <a class="guidance__link js-details-trigger js-details-label mars"
     {{guidance_link|xmlattr}} {{helpers.track('click', 'Help', 'Guidance click', answer_guidance.id)}}>{{_(answer_guidance.schema_item.show_guidance)}}</a>
   <div class="guidance__main js-details-body" {{guidance_body|xmlattr}}>
     <div class="guidance__content mars">
-      {% include 'partials/guidance.html' %}
+      {% include 'partials/content-block.html' %}
     </div>
   </div>
 </div>

--- a/app/templates/partials/content-block.html
+++ b/app/templates/partials/content-block.html
@@ -1,6 +1,6 @@
 {% import 'macros/helpers.html' as helpers %}
 
-{% for item in guidance_content.content %}
+{% for item in content_block %}
   {%- if item.title -%}
     <strong class="u-mb-s u-d-b">{{item.title}}</strong>
   {% endif %}

--- a/app/templates/partials/question-definition.html
+++ b/app/templates/partials/question-definition.html
@@ -1,16 +1,23 @@
+
 {% for definition in question.definitions %}
-    <div class="definition js-details u-mb-s" data-hide-label="Click to collapse." data-show-label="Click to expand.">
+  {% set content_block = definition.content %}
+  <div id="question-definition-{{question.id}}" class="definition js-details u-mb-s" data-hide-label="{{ _('Click to collapse') }}." data-show-label="{{ _('Click to expand') }}.">
 
-        <a href="#definition" class="definition__link mars js-details-trigger u-no-js-hide" aria-expanded="false" data-definition-title-index="{{loop.index}}" data-js-accordion-event-label="{{ definition.title }}" data-ga-label="definition-pattern-library" data-ga-action="Definition click" data-ga="click"
-            data-ga-category="Help">{{ definition.title }} <span class="u-vh js-details-label">Click to expand.</span></a>
+    <a href="#definition" class="definition__link mars js-details-trigger u-no-js-hide" aria-expanded="false" data-definition-title-index="{{loop.index}}" data-js-accordion-event-label="{{ definition.title }}" data-ga-label="definition-pattern-library" data-ga-action="Definition click" data-ga="click"
+      data-ga-category="Help">{{ definition.title }} <span class="u-vh js-details-label">{{ _("Click to expand") }}.</span></a>
 
-        <h3 class="venus u-no-js-show u-mb-no">{{ definition.title }}</h3>
+    <h3 class="venus u-no-js-show u-mb-no">{{ definition.title }}</h3>
 
-        <div id="definition" class="definition__main js-details-body">
-            <div class="definition__content mars" data-definition-content-index="{{loop.index}}">
-                <p>{{ definition.description }}</p>
-            </div>
-            <button class="btn btn--secondary btn--small definition__content-close-trigger js-details-trigger u-no-js-hide" data-definition-hide-button-index="{{loop.index}}">Hide this</button>
-        </div>
+    <div id="definition" class="definition__main js-details-body">
+      <div class="definition__content mars" data-definition-content-index="{{loop.index}}">
+        <aside>
+          <div>
+            {% include 'partials/content-block.html' %}
+          </div>
+        </aside>
+      </div>
+      <button class="btn btn--secondary btn--small definition__content-close-trigger js-details-trigger u-no-js-hide" data-definition-hide-button-index="{{loop.index}}">{{ _("Hide this") }}</button>
     </div>
+
+  </div>
 {% endfor %}

--- a/app/templates/partials/question.html
+++ b/app/templates/partials/question.html
@@ -40,12 +40,10 @@
 
 {% set question_guidance %}
   {%- if question.guidance -%}
-    {% set guidance_content = {
-      "content": question.guidance.content
-    } %}
+    {% set content_block = question.guidance.content %}
     <aside class="question__guidance">
       <div class="panel panel--simple panel--info" id="question-guidance-{{question.id}}">
-        {% include 'partials/guidance.html' %}
+        {% include 'partials/content-block.html' %}
       </div>
     </aside>
   {% endif %}

--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-07-27 15:02+0100\n"
+"POT-Creation-Date: 2018-08-06 09:05+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.4.0\n"
+"Generated-By: Babel 2.6.0\n"
 
 #: app/jinja_filters.py:63 app/validation/validators.py:297
 #, python-format
@@ -169,8 +169,7 @@ msgstr ""
 #: app/templates/summary.html:49
 msgid ""
 "You will have the opportunity to view and print a copy of your answers "
-"after submitting\n"
-"        this survey"
+"after submitting this survey"
 msgstr ""
 
 #: app/templates/thank-you.html:3
@@ -402,6 +401,19 @@ msgstr ""
 
 #: app/templates/partials/previous-link.html:5
 msgid "Previous"
+msgstr ""
+
+#: app/templates/partials/question-definition.html:4
+msgid "Click to collapse"
+msgstr ""
+
+#: app/templates/partials/question-definition.html:4
+#: app/templates/partials/question-definition.html:7
+msgid "Click to expand"
+msgstr ""
+
+#: app/templates/partials/question-definition.html:19
+msgid "Hide this"
 msgstr ""
 
 #: app/templates/partials/timeout.html:12

--- a/data/en/test_question_definition.json
+++ b/data/en/test_question_definition.json
@@ -30,11 +30,25 @@
                     "id": "question",
                     "title": "Do you connect a LiFePO4 battery to your <em>photovoltaic system</em> to store surplus energy?",
                     "type": "General",
-                    "description": "",
                     "definitions": [{
-                        "title": "What is a photovoltaic system?",
-                        "description": "A typical photovoltaic system employs solar panels, each comprising a number of solar cells, which generate electrical power. PV installations may be ground-mounted, rooftop mounted or wall mounted. The mount may be fixed, or use a solar tracker to follow the sun across the sky."
-                    }],
+                            "title": "What is a photovoltaic system?",
+                            "content": [{
+                                "description": "A typical photovoltaic system employs solar panels, each comprising a number of solar cells, which generate electrical power. PV installations may be ground-mounted, rooftop mounted or wall mounted. The mount may be fixed, or use a solar tracker to follow the sun across the sky."
+                            }]
+                        },
+                        {
+                            "title": "Why use LiFePO4 batteries?",
+                            "content": [{
+                                "title": "3 Benefits of LifePO4 batteries."
+                            }, {
+                                "list": [
+                                    "LifePO4 batteries have a life span 10 times longer than that of traditional lead acid batteries. This dramatically reduces the need for battery changes.",
+                                    "Lithium iron phosphate batteries operate with much lower resistance and consequently recharge at a faster rate.",
+                                    "LifeP04 lightweight batteries are lighter than lead acid batteries, usually weighing about 1/4 less."
+                                ]
+                            }]
+                        }
+                    ],
                     "answers": [{
                         "type": "Radio",
                         "id": "radio-mandatory-answer",
@@ -43,8 +57,10 @@
                             "label": "Yes, I do connect a battery",
                             "value": "yes"
                         }, {
+
                             "label": "No, I don't connect a battery",
                             "value": "no"
+
                         }]
                     }]
                 }],

--- a/tests/functional/pages/surveys/question_definitions/definition-block.page.js
+++ b/tests/functional/pages/surveys/question_definitions/definition-block.page.js
@@ -13,6 +13,12 @@ class DefinitionBlockPage extends QuestionPage {
 
   definitionButton1() { return '[data-definition-hide-button-index="1"]'; }
 
+  definitionTitle2() { return '[data-definition-title-index="2"]'; }
+
+  definitionContent2() { return '[data-definition-content-index="2"]'; }
+
+  definitionButton2() { return '[data-definition-hide-button-index="2"]'; }
+
   yes() {
     return '#radio-mandatory-answer-0';
   }

--- a/tests/functional/spec/question_definitions.spec.js
+++ b/tests/functional/spec/question_definitions.spec.js
@@ -61,5 +61,21 @@ describe('Component: Definition', function() {
 
     });
 
+
+    it('When I click the second definition\'s title link then the description and "Hide this" button for the second definition should be visible', function() {
+
+      return browser
+        .isVisible(DefinitionPage.definitionContent2()).should.eventually.be.false
+        .isVisible(DefinitionPage.definitionButton2()).should.eventually.be.false
+
+        // When
+        .click(DefinitionPage.definitionTitle2())
+
+        // Then
+        .waitForVisible(DefinitionPage.definitionContent2(), 300)
+        .waitForVisible(DefinitionPage.definitionButton2(), 300);
+
+    });
+
   });
 });

--- a/tests/integration/questionnaire/test_questionnaire_question_definition.py
+++ b/tests/integration/questionnaire/test_questionnaire_question_definition.py
@@ -4,15 +4,23 @@ from tests.integration.integration_test_case import IntegrationTestCase
 class TestQuestionnaireQuestionDefinition(IntegrationTestCase):
 
     def test_question_definition(self):
-        # Given I launch a questionnaire with a definition
+        # Given I launch a questionnaire with definitions
         self.launchSurvey('test', 'question_definition')
 
-        # When I start the survey I am presented with the definition title and description correctly
+        # When I start the survey I am presented with the definitions title and content correctly
         self.assertInPage('Do you connect a LiFePO4 battery to your photovoltaic system to store surplus energy?')
+
         self.assertInPage('What is a photovoltaic system?')
         self.assertInPage('A typical photovoltaic system employs solar panels, each comprising a number of solar cells, '
                           'which generate electrical power. PV installations may be ground-mounted, rooftop mounted or wall mounted. '
                           'The mount may be fixed, or use a solar tracker to follow the sun across the sky.')
+
+        self.assertInPage('Why use LiFePO4 batteries?')
+        self.assertInPage('3 Benefits of LifePO4 batteries.')
+        self.assertInPage('LifePO4 batteries have a life span 10 times longer than that of traditional lead acid batteries. '
+                          'This dramatically reduces the need for battery changes.')
+        self.assertInPage('Lithium iron phosphate batteries operate with much lower resistance and consequently recharge at a faster rate.')
+        self.assertInPage('LifeP04 lightweight batteries are lighter than lead acid batteries, usually weighing about 1/4 less.')
 
         # When we continue we go to the summary page
         self.post(action='save_continue')


### PR DESCRIPTION
### What is the context of this PR?
Modified definitions structure to allow content so we can display bullet points etc. Needed for: trello.com/c/rC82gUmp/2180-move-significant-changes-to-use-definition-pattern

### How to review 
- Make sure app works as expected.
- Definitions to now allow multiple contents ie multiple descriptions, lists etc.

### Checklist

* [x] New static content marked up for translation
* [x] Newly defined schema content included in eq-translations repo

Related PRs:
1. https://github.com/ONSdigital/eq-schema-validator/pull/72
2. https://github.com/ONSdigital/eq-translations/pull/20