### PR TITLE
Schemas to make use of question definitions

### DIFF
--- a/data/en/1_0005.json
+++ b/data/en/1_0005.json
@@ -409,7 +409,14 @@
                         "q_code": "90w",
                         "type": "Radio"
                     }],
-                    "description": "<p>This is your own interpretation of whether there has been a significant change in {{metadata['trad_as_or_ru_name']}}\u2019s figures compared with the previous month.</p><p>Also consider whether there has been a significant change from the same month in the previous year. </p>",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a ‘significant change’ is dependent on your own interpretation of whether there has been a significant change in {{metadata['trad_as_or_ru_name']}}\u2019s figures compared with the previous month."
+                        }, {
+                            "description": "Also consider whether there has been a significant change from the same month in the previous year."
+                        }]
+                    }],
                     "guidance": {
                         "content": [{
                             "title": "Include:",
@@ -778,7 +785,14 @@
                         "q_code": "90f",
                         "type": "Radio"
                     }],
-                    "description": "<p>This is your own interpretation of whether there has been a significant change in  {{metadata['trad_as_or_ru_name']}}\u2019s figures compared with the previous month.</p><p>Also consider whether there has been a significant change from the same month in the previous year.</p>",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a ‘significant change’ is dependent on your own interpretation of whether there has been a significant change in {{metadata['trad_as_or_ru_name']}}\u2019s figures compared with the previous month."
+                        }, {
+                            "description": "Also consider whether there has been a significant change from the same month in the previous year."
+                        }]
+                    }],
                     "guidance": {
                         "content": [{
                             "title": "Include:",
@@ -1139,7 +1153,14 @@
                     "id": "calendar-monthly-pay-significant-changes-paid-employees-question",
                     "title": "Did any significant changes occur to the <em>total pay or number</em> of <em>calendar monthly</em> paid employees?",
                     "type": "General",
-                    "description": "<p>This is your own interpretation of whether there has been a significant change in  {{metadata['trad_as_or_ru_name']}}\u2019s figures compared with the previous month.</p><p>Also consider whether there has been a significant change from the same month in the previous year.</p>",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a ‘significant change’ is dependent on your own interpretation of whether there has been a significant change in {{metadata['trad_as_or_ru_name']}}\u2019s figures compared with the previous month."
+                        }, {
+                            "description": "Also consider whether there has been a significant change from the same month in the previous year."
+                        }]
+                    }],
                     "guidance": {
                         "content": [{
                             "title": "Include:",
@@ -1497,7 +1518,14 @@
                     "id": "four-weekly-pay-significant-changes-paid-employees-question",
                     "title": "Did any significant changes occur to the <em>total pay or number</em> of <em>four weekly</em> paid employees?",
                     "type": "General",
-                    "description": "<p>This is your own interpretation of whether there has been a significant change in  {{metadata['trad_as_or_ru_name']}}\u2019s figures compared with the previous month.</p><p>Also consider whether there has been a significant change from the same month in the previous year.</p>",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a ‘significant change’ is dependent on your own interpretation of whether there has been a significant change in {{metadata['trad_as_or_ru_name']}}\u2019s figures compared with the previous month."
+                        }, {
+                            "description": "Also consider whether there has been a significant change from the same month in the previous year."
+                        }]
+                    }],
                     "guidance": {
                         "content": [{
                             "title": "Include:",
@@ -1862,7 +1890,14 @@
                     "id": "five-weekly-pay-significant-changes-paid-employees-question",
                     "title": "Did any significant changes occur to the <em>total pay or number</em> of <em>five weekly</em> paid employees?",
                     "type": "General",
-                    "description": "<p>This is your own interpretation of whether there has been a significant change in  {{metadata['trad_as_or_ru_name']}}\u2019s figures compared with the previous month.</p><p>Also consider whether there has been a significant change from the same month in the previous year.</p>",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a ‘significant change’ is dependent on your own interpretation of whether there has been a significant change in {{metadata['trad_as_or_ru_name']}}\u2019s figures compared with the previous month."
+                        }, {
+                            "description": "Also consider whether there has been a significant change from the same month in the previous year."
+                        }]
+                    }],
                     "guidance": {
                         "content": [{
                             "title": "Include:",

--- a/data/en/1_0102.json
+++ b/data/en/1_0102.json
@@ -292,7 +292,14 @@
                         "q_code": "146a",
                         "type": "Radio"
                     }],
-                    "description": "Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "id": "significant-change-question",
                     "title": "Did any significant changes occur to the total retail turnover for {{metadata['trad_as_or_ru_name']}}?",
                     "type": "General"

--- a/data/en/1_0112.json
+++ b/data/en/1_0112.json
@@ -300,7 +300,14 @@
                         "q_code": "146a",
                         "type": "Radio"
                     }],
-                    "description": "Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "id": "significant-change-question",
                     "title": "Did any significant changes occur to the total retail turnover for {{metadata['trad_as_or_ru_name']}}?",
                     "type": "General"

--- a/data/en/1_0203.json
+++ b/data/en/1_0203.json
@@ -480,7 +480,14 @@
                         "q_code": "146a",
                         "type": "Radio"
                     }],
-                    "description": "Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "id": "significant-change-question",
                     "title": "Did any significant changes occur to the total retail turnover for {{metadata['trad_as_or_ru_name']}}?",
                     "type": "General"

--- a/data/en/1_0205.json
+++ b/data/en/1_0205.json
@@ -512,7 +512,14 @@
                         "q_code": "146a",
                         "type": "Radio"
                     }],
-                    "description": "Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "id": "significant-change-question",
                     "title": "Did any significant changes occur to the total retail turnover for {{metadata['trad_as_or_ru_name']}}?",
                     "type": "General"

--- a/data/en/1_0213.json
+++ b/data/en/1_0213.json
@@ -481,7 +481,14 @@
                         "q_code": "146a",
                         "type": "Radio"
                     }],
-                    "description": "Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "id": "significant-change-question",
                     "title": "Did any significant changes occur to the total retail turnover for {{metadata['trad_as_or_ru_name']}}?",
                     "type": "General"

--- a/data/en/1_0215.json
+++ b/data/en/1_0215.json
@@ -535,7 +535,14 @@
                         "q_code": "146a",
                         "type": "Radio"
                     }],
-                    "description": "Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "id": "significant-change-question",
                     "title": "Did any significant changes occur to the total retail turnover for {{metadata['trad_as_or_ru_name']}}?",
                     "type": "General"

--- a/data/en/mbs_0106.json
+++ b/data/en/mbs_0106.json
@@ -223,7 +223,14 @@
                 "questions": [{
                     "title": "Did any significant changes occur to the total turnover for {{metadata['trad_as_or_ru_name']}}?",
                     "id": "changes-in-total-turnover-question",
-                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "answers": [{
                         "options": [{
                             "value": "Yes",

--- a/data/en/mbs_0111.json
+++ b/data/en/mbs_0111.json
@@ -225,7 +225,14 @@
                 "questions": [{
                     "title": "Did any significant changes occur to the total turnover for {{metadata['trad_as_or_ru_name']}}?",
                     "id": "changes-in-turnover-question",
-                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "answers": [{
                         "options": [{
                             "value": "Yes",

--- a/data/en/mbs_0117.json
+++ b/data/en/mbs_0117.json
@@ -248,7 +248,14 @@
                 "questions": [{
                     "title": "Did any significant changes occur to the turnover for {{metadata['trad_as_or_ru_name']}}?",
                     "id": "changes-in-turnover-question",
-                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "answers": [{
                         "options": [{
                             "value": "Yes",

--- a/data/en/mbs_0123.json
+++ b/data/en/mbs_0123.json
@@ -245,7 +245,14 @@
                 "questions": [{
                     "title": "Did any significant changes occur to the figures provided for {{metadata['trad_as_or_ru_name']}}?",
                     "id": "changes-question",
-                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "answers": [{
                         "options": [{
                             "value": "Yes",

--- a/data/en/mbs_0158.json
+++ b/data/en/mbs_0158.json
@@ -389,7 +389,14 @@
                     "type": "General",
                     "title": "Did any significant changes occur to the total turnover for {{metadata['trad_as_or_ru_name']}}?",
                     "id": "changes-in-turnover-question",
-                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "answers": [{
                         "id": "changes-in-turnover-answer",
                         "type": "Radio",

--- a/data/en/mbs_0161.json
+++ b/data/en/mbs_0161.json
@@ -387,7 +387,14 @@
                 "questions": [{
                     "title": "Did any significant changes occur to the total turnover for {{metadata['trad_as_or_ru_name']}}?",
                     "id": "changes-in-turnover-question",
-                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "answers": [{
                         "options": [{
                             "value": "Yes",

--- a/data/en/mbs_0167.json
+++ b/data/en/mbs_0167.json
@@ -424,7 +424,14 @@
                 "questions": [{
                     "title": "Did any significant changes occur to the turnover for {{metadata['trad_as_or_ru_name']}}?",
                     "id": "changes-in-turnover-question",
-                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "answers": [{
                         "options": [{
                             "value": "Yes",

--- a/data/en/mbs_0173.json
+++ b/data/en/mbs_0173.json
@@ -404,7 +404,14 @@
                 "questions": [{
                     "title": "Did any significant changes occur to the figures provided for {{metadata['trad_as_or_ru_name']}}?",
                     "id": "changes-question",
-                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "answers": [{
                         "options": [{
                             "value": "Yes",

--- a/data/en/mbs_0201.json
+++ b/data/en/mbs_0201.json
@@ -308,7 +308,14 @@
                 "questions": [{
                     "title": "Did any significant changes occur to the total turnover for {{metadata['trad_as_or_ru_name']}}?",
                     "id": "changes-in-turnover-question",
-                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "answers": [{
                         "options": [{
                             "value": "Yes",

--- a/data/en/mbs_0202.json
+++ b/data/en/mbs_0202.json
@@ -308,7 +308,14 @@
                 "questions": [{
                     "title": "Did any significant changes occur to the total turnover for {{metadata['trad_as_or_ru_name']}}?",
                     "id": "changes-in-turnover-question",
-                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "answers": [{
                         "options": [{
                             "value": "Yes",

--- a/data/en/mbs_0203.json
+++ b/data/en/mbs_0203.json
@@ -163,7 +163,14 @@
                     "type": "General",
                     "id": "significant-change-question",
                     "title": "Did any significant changes occur to the figures provided for {{metadata['trad_as_or_ru_name']}}?",
-                    "description": "Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "answers": [{
                         "id": "significant-change-established-answer",
                         "label": "",

--- a/data/en/mbs_0204.json
+++ b/data/en/mbs_0204.json
@@ -163,7 +163,14 @@
                     "type": "General",
                     "id": "significant-change-question",
                     "title": "Did any significant changes occur to the figures provided for {{metadata['trad_as_or_ru_name']}}?",
-                    "description": "Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "answers": [{
                         "id": "significant-change-established-answer",
                         "label": "",

--- a/data/en/mbs_0205.json
+++ b/data/en/mbs_0205.json
@@ -273,7 +273,14 @@
                 "questions": [{
                     "title": "Did any significant changes occur to the turnover for {{metadata['trad_as_or_ru_name']}}?",
                     "id": "changes-in-turnover-question",
-                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "answers": [{
                         "options": [{
                             "value": "Yes",

--- a/data/en/mbs_0216.json
+++ b/data/en/mbs_0216.json
@@ -273,7 +273,14 @@
                 "questions": [{
                     "title": "Did any significant changes occur to the turnover for {{metadata['trad_as_or_ru_name']}}?",
                     "id": "changes-in-turnover-question",
-                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "answers": [{
                         "options": [{
                             "value": "Yes",

--- a/data/en/mbs_0251.json
+++ b/data/en/mbs_0251.json
@@ -479,7 +479,14 @@
                 "questions": [{
                     "title": "Did any significant changes occur to the total turnover for {{ metadata['trad_as_or_ru_name'] }}?",
                     "id": "changes-in-turnover-question",
-                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ metadata['trad_as_or_ru_name'] }}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "answers": [{
                         "options": [{
                             "value": "Yes",

--- a/data/en/mbs_0253.json
+++ b/data/en/mbs_0253.json
@@ -329,7 +329,14 @@
                     "type": "General",
                     "id": "significant-change-question",
                     "title": "Did any significant changes occur to the figures provided for {{metadata['trad_as_or_ru_name']}}?",
-                    "description": "Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "answers": [{
                         "id": "significant-change-established-answer",
                         "label": "",

--- a/data/en/mbs_0255.json
+++ b/data/en/mbs_0255.json
@@ -437,7 +437,14 @@
                 "questions": [{
                     "title": "Did any significant changes occur to the turnover for {{metadata['trad_as_or_ru_name']}}?",
                     "id": "changes-in-turnover-question",
-                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "answers": [{
                         "options": [{
                             "value": "Yes",

--- a/data/en/mbs_0817.json
+++ b/data/en/mbs_0817.json
@@ -223,7 +223,14 @@
                 "questions": [{
                     "title": "Did any significant changes occur to the turnover for {{metadata['trad_as_or_ru_name']}}?",
                     "id": "changes-in-turnover-question",
-                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "answers": [{
                         "options": [{
                             "value": "Yes",

--- a/data/en/mbs_0823.json
+++ b/data/en/mbs_0823.json
@@ -223,7 +223,14 @@
                 "questions": [{
                     "title": "Did any significant changes occur to the total turnover for {{metadata['trad_as_or_ru_name']}}?",
                     "id": "changes-in-turnover-question",
-                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "answers": [{
                         "options": [{
                             "value": "Yes",

--- a/data/en/mbs_0867.json
+++ b/data/en/mbs_0867.json
@@ -385,7 +385,14 @@
                 "questions": [{
                     "title": "Did any significant changes occur to the turnover for {{metadata['trad_as_or_ru_name']}}?",
                     "id": "changes-in-turnover-question",
-                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "answers": [{
                         "options": [{
                             "value": "Yes",

--- a/data/en/mbs_0873.json
+++ b/data/en/mbs_0873.json
@@ -385,7 +385,14 @@
                 "questions": [{
                     "title": "Did any significant changes occur to the total turnover for {{metadata['trad_as_or_ru_name']}}?",
                     "id": "changes-in-turnover-question",
-                    "description": "<p>Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "answers": [{
                         "options": [{
                             "value": "Yes",

--- a/data/en/mci_transformation.json
+++ b/data/en/mci_transformation.json
@@ -549,7 +549,14 @@
                     "id": "significant-change-question",
                     "title": "Did any significant changes occur to the <em>retail sales</em> for {{metadata['trad_as_or_ru_name']}}?",
                     "type": "General",
-                    "description": "Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "guidance": {
                         "content": [{
                             "title": "Include",

--- a/data/en/rsi_transformation.json
+++ b/data/en/rsi_transformation.json
@@ -367,7 +367,14 @@
                         "q_code": "146a",
                         "type": "Radio"
                     }],
-                    "description": "Please note: what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year.<br><br>This information will help us to validate your data and should reduce the need to query any figures with you.",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
                     "id": "significant-change-question",
                     "title": "Did any significant changes occur to the retail sales for {{metadata['trad_as_or_ru_name']}}?",
                     "type": "General"


### PR DESCRIPTION
### What is the context of this PR?
Moved significant changes description into question definitions.
https://trello.com/c/rC82gUmp/2180-move-significant-changes-to-use-definition-pattern

These changes are dependant on: https://github.com/ONSdigital/eq-survey-runner/pull/1712. Review that first.


### How to review 
Make sure the content matches the slides on Trello.

Can also rebase against the other branch to test it live.
`git fetch origin update-definitions-to-support-markup && git rebase -i origin/update-definitions-to-support-markup`

### Checklist

* [x] New static content marked up for translation
* [x] Newly defined schema content included in eq-translations repo
