### PR TITLE
Remove CVE ignore now that database has been corrected

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
     - pyenv global $(cat .python-version)
     - pip install -U pip pipenv wheel
     - pipenv install --dev --deploy
-    - pipenv check -i '36333 ' -i '36351 '
+    - pipenv check -i '36333 '
 cache:
     - yarn
     - pip


### PR DESCRIPTION
### What is the context of this PR?
I added an ignore to the list of CVE-ignores for `pipenv check`, however that should be remove now because the database has been updated here: https://github.com/pyupio/safety-db/issues/2272#issuecomment-409580901

### How to review 
If `pipenv check` passes in travis, then we're all good. I tested that here: https://travis-ci.org/ONSdigital/eq-survey-runner
