### PR TITLE
Flatten variant_flags in to top level claims object

### DIFF
--- a/app/questionnaire/rules.py
+++ b/app/questionnaire/rules.py
@@ -236,25 +236,9 @@ def get_answer_ids_on_routing_path(schema, path):
     return answer_ids_on_path
 
 
-def get_metadata_value(metadata, keys):
-    if not _contains_in_dict(metadata, keys):
-        return None
-
-    if '.' in keys:
-        key, rest = keys.split('.', 1)
-        return get_metadata_value(metadata[key], rest)
-    return metadata[keys]
+def get_metadata_value(metadata, key):
+    return metadata.get(key)
 
 
 def is_goto_rule(rule):
     return any(key in rule.get('goto', {}) for key in ('when', 'block', 'group'))
-
-
-def _contains_in_dict(metadata, keys):
-    if '.' in keys:
-        key, rest = keys.split('.', 1)
-        if key not in metadata:
-            return False
-        return _contains_in_dict(metadata[key], rest)
-
-    return keys in metadata

--- a/data/en/census_household.json
+++ b/data/en/census_household.json
@@ -20,8 +20,8 @@
         "name": "region_code",
         "validator": "string"
     }, {
-        "name": "variant_flags",
-        "validator": "object"
+        "name": "sexual_identity",
+        "validator": "boolean"
     }],
     "sections": [{
         "id": "address-section",
@@ -1711,7 +1711,7 @@
                             "condition": "equals",
                             "value": "Yes"
                         }, {
-                            "meta": "variant_flags.sexual_identity",
+                            "meta": "sexual_identity",
                             "condition": "equals",
                             "value": true
                         }]
@@ -1814,7 +1814,7 @@
                             "condition": "equals",
                             "value": "Yes"
                         }, {
-                            "meta": "variant_flags.sexual_identity",
+                            "meta": "sexual_identity",
                             "condition": "equals",
                             "value": true
                         }]
@@ -1874,7 +1874,7 @@
                             "condition": "equals",
                             "value": "Yes"
                         }, {
-                            "meta": "variant_flags.sexual_identity",
+                            "meta": "sexual_identity",
                             "condition": "equals",
                             "value": true
                         }]
@@ -1937,7 +1937,7 @@
                             "condition": "equals",
                             "value": "Yes"
                         }, {
-                            "meta": "variant_flags.sexual_identity",
+                            "meta": "sexual_identity",
                             "condition": "equals",
                             "value": true
                         }]
@@ -1994,7 +1994,7 @@
                             "condition": "equals",
                             "value": "Yes"
                         }, {
-                            "meta": "variant_flags.sexual_identity",
+                            "meta": "sexual_identity",
                             "condition": "equals",
                             "value": true
                         }]
@@ -2048,7 +2048,7 @@
                             "condition": "equals",
                             "value": "Yes"
                         }, {
-                            "meta": "variant_flags.sexual_identity",
+                            "meta": "sexual_identity",
                             "condition": "equals",
                             "value": true
                         }]

--- a/data/en/census_individual.json
+++ b/data/en/census_individual.json
@@ -17,8 +17,8 @@
         "name": "region_code",
         "validator": "string"
     }, {
-        "name": "variant_flags",
-        "validator": "object"
+        "name": "sexual_identity",
+        "validator": "boolean"
     }],
     "sections": [{
         "id": "default-section",
@@ -955,7 +955,7 @@
                     "goto": {
                         "block": "sexual-identity",
                         "when": [{
-                            "meta": "variant_flags.sexual_identity",
+                            "meta": "sexual_identity",
                             "condition": "equals",
                             "value": true
                         }]
@@ -1073,7 +1073,7 @@
                     "goto": {
                         "block": "sexual-identity",
                         "when": [{
-                            "meta": "variant_flags.sexual_identity",
+                            "meta": "sexual_identity",
                             "condition": "equals",
                             "value": true
                         }]
@@ -1139,7 +1139,7 @@
                     "goto": {
                         "block": "sexual-identity",
                         "when": [{
-                            "meta": "variant_flags.sexual_identity",
+                            "meta": "sexual_identity",
                             "condition": "equals",
                             "value": true
                         }]
@@ -1208,7 +1208,7 @@
                     "goto": {
                         "block": "sexual-identity",
                         "when": [{
-                            "meta": "variant_flags.sexual_identity",
+                            "meta": "sexual_identity",
                             "condition": "equals",
                             "value": true
                         }]
@@ -1271,7 +1271,7 @@
                     "goto": {
                         "block": "sexual-identity",
                         "when": [{
-                            "meta": "variant_flags.sexual_identity",
+                            "meta": "sexual_identity",
                             "condition": "equals",
                             "value": true
                         }]
@@ -1331,7 +1331,7 @@
                     "goto": {
                         "block": "sexual-identity",
                         "when": [{
-                            "meta": "variant_flags.sexual_identity",
+                            "meta": "sexual_identity",
                             "condition": "equals",
                             "value": true
                         }]

--- a/data/en/test_metadata_routing.json
+++ b/data/en/test_metadata_routing.json
@@ -14,8 +14,8 @@
         "name": "period_id",
         "validator": "string"
     }, {
-        "name": "variant_flags",
-        "validator": "object"
+        "name": "flag_1",
+        "validator": "boolean"
     }],
     "sections": [{
         "id": "default-section",
@@ -41,7 +41,7 @@
                     "goto": {
                         "block": "block3",
                         "when": [{
-                            "meta": "variant_flags.flag_1",
+                            "meta": "flag_1",
                             "condition": "equals",
                             "value": true
                         }]

--- a/data/en/test_metadata_validation.json
+++ b/data/en/test_metadata_validation.json
@@ -1,0 +1,80 @@
+{
+    "data_version": "0.0.1",
+    "description": "Test Metadata validations",
+    "legal_basis": "Voluntary",
+    "metadata": [{
+            "name": "ref_p_start_date",
+            "validator": "date"
+        },
+        {
+            "name": "user_id",
+            "validator": "string"
+        },
+        {
+            "name": "period_id",
+            "validator": "string"
+        },
+        {
+            "name": "trad_as",
+            "validator": "string"
+        },
+        {
+            "name": "trad_as_or_ru_name",
+            "validator": "string"
+        },
+        {
+            "name": "ru_name",
+            "validator": "string"
+        },
+        {
+            "name": "flag",
+            "validator": "boolean"
+        },
+        {
+            "name": "case_id",
+            "validator": "uuid"
+        }
+    ],
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "sections": [{
+        "groups": [{
+            "blocks": [{
+                    "id": "introduction",
+                    "primary_content": [{
+                        "content": [{
+                                "title": "(String) trad_as: {{ metadata['trad_as'] }}"
+                            },
+                            {
+                                "title": "(Computed String) trad_as_or_ru_name: {{ metadata['trad_as_or_ru_name'] }}"
+                            },
+                            {
+                                "title": "(Date) ref_p_start_date: {{ metadata['ref_p_start_date'] }}"
+                            },
+                            {
+                                "title": "(Boolean) flag: {{ metadata['flag'] }}"
+                            },
+                            {
+                                "title": "(UUID) case_id: {{ metadata['case_id'] }}"
+                            }
+                        ],
+                        "id": "preview",
+                        "title": "Here's the metadata you passed in, with the validation type in brackets",
+                        "type": "Preview"
+                    }],
+                    "type": "Introduction"
+                },
+                {
+                    "type": "Summary",
+                    "id": "summary"
+                }
+            ],
+            "id": "metadata-information",
+            "title": "Metadata display section"
+        }],
+        "id": "introduction-section"
+    }],
+    "survey_id": "145",
+    "theme": "default",
+    "title": "Test Metadata"
+}

--- a/data/en/test_schema_context.json
+++ b/data/en/test_schema_context.json
@@ -40,9 +40,6 @@
     }, {
         "name": "region_code",
         "validator": "string"
-    }, {
-        "name": "variant_flags",
-        "validator": "object"
     }],
     "sections": [{
         "id": "default-section",
@@ -72,8 +69,6 @@
                         "title": "return_by: {{ metadata['return_by'] }}"
                     }, {
                         "title": "region_code: {{ metadata['region_code'] }}"
-                    }, {
-                        "title": "variant_flags: {{ metadata['variant_flags'] }}"
                     }]
                 }]
             }],

--- a/tests/app/questionnaire/test_path_finder.py
+++ b/tests/app/questionnaire/test_path_finder.py
@@ -816,9 +816,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         expected_next_location = expected_path[1]
 
         metadata = {
-            'variant_flags': {
-                'flag_1': True
-            }
+            'flag_1': True,
         }
 
         path_finder = PathFinder(schema, AnswerStore(), metadata=metadata, completed_blocks=[])
@@ -837,10 +835,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
 
         expected_next_location = expected_path[1]
 
-        metadata = {
-            'variant_flags': {
-            }
-        }
+        metadata = {}
 
         path_finder = PathFinder(schema, AnswerStore(), metadata=metadata, completed_blocks=[])
 

--- a/tests/app/storage/test_metadata_parser.py
+++ b/tests/app/storage/test_metadata_parser.py
@@ -1,0 +1,70 @@
+from unittest import TestCase
+from datetime import datetime
+
+import pytest
+
+from app.storage.metadata_parser import boolean_parser, uuid_4_parser, iso_8601_date_parser
+
+
+class TestMetaDataValidators(TestCase):
+
+    def simple_mapping_assertion(self, method, value, expected, exc_type=Exception):
+        """Given a method which should be called, assert that expected is
+           returned. A special case is when expected=='err', expect an error
+           to be raised."""
+        if expected == 'err':
+            with pytest.raises(exc_type):
+                method(value)
+        else:
+            self.assertEqual(method(value), expected)
+
+
+    def test_boolean_validator(self):
+        """ Asserts that only boolean True/False are accepted"""
+        variations = (
+            ('False', 'err'),
+            ('True', 'err'),
+            (0, 'err'),
+            (1, 'err'),
+            (True, True),
+            (False, False),
+            ({}, 'err'),
+            (tuple(), 'err'),
+        )
+        for (claim_value, expected) in variations:
+            self.simple_mapping_assertion(boolean_parser, claim_value, expected, TypeError)
+
+
+    def test_uuid_4_parser(self):
+        """ Asserts that only boolean True/False are accepted"""
+        variations = (
+            ('False', 'err'),
+            (0, 'err'),
+            (1, 'err'),
+            (True, 'err'),
+            (False, 'err'),
+            ({}, 'err'),
+            (tuple(), 'err'),
+            ('3e0a497f-ee63-4b12-b0b9-234eca1850fa', '3e0a497f-ee63-4b12-b0b9-234eca1850fa'),
+            ('8b8d701d-1f76-430a-895f-53c9030f7ca2', '8b8d701d-1f76-430a-895f-53c9030f7ca2'),
+        )
+        for (claim_value, expected) in variations:
+            self.simple_mapping_assertion(uuid_4_parser, claim_value, expected)
+
+
+    def test_iso_8601_date_parser(self):
+        """ Asserts that only boolean True/False are accepted"""
+        variations = (
+            ('False', 'err'),
+            (0, 'err'),
+            (1, 'err'),
+            (True, 'err'),
+            (False, 'err'),
+            ({}, 'err'),
+            (tuple(), 'err'),
+            ('3e0a497f-ee63-4b12-b0b9-234eca1850fa', 'err'),
+            ('1970-01-15', datetime(1970, 1, 15)),
+            ('1998-09-21', datetime(1998, 9, 21)),
+        )
+        for (claim_value, expected) in variations:
+            self.simple_mapping_assertion(iso_8601_date_parser, claim_value, expected)

--- a/tests/functional/jwt_helper.js
+++ b/tests/functional/jwt_helper.js
@@ -26,10 +26,6 @@ module.exports = function generateToken(schema, userId, collectionId, periodId =
     kid: '709eb42cfee5570058ce0711f730bfbb7d4c8ade'
   };
 
-  let variantFlags = {
-    'sexual_identity': sexualIdentity
-  };
-
   // Payload
   let oPayload = {
     tx_id: uuid(),
@@ -51,7 +47,7 @@ module.exports = function generateToken(schema, userId, collectionId, periodId =
     return_by: '2017-03-01',
     region_code: regionCode,
     language_code: languageCode,
-    variant_flags: variantFlags
+    sexual_identity: sexualIdentity
   };
 
   // Sign JWT, password=616161

--- a/tests/integration/census/test_census_household_submission_data.py
+++ b/tests/integration/census/test_census_household_submission_data.py
@@ -654,8 +654,7 @@ class TestCensusHouseholdSubmissionData(IntegrationTestCase):
         return expected_downstream_data
 
     def complete_survey(self, eq_id, form_type_id):
-        variant_flags = {'sexual_identity': 'false'}
-        self.launchSurvey(eq_id, form_type_id, region_code='GB-ENG', variant_flags=variant_flags, roles=['dumper'])
+        self.launchSurvey(eq_id, form_type_id, region_code='GB-ENG', sexual_identity=False, roles=['dumper'])
 
         self.post(action='start_questionnaire')
 

--- a/tests/integration/census/test_census_individual_submission_data.py
+++ b/tests/integration/census/test_census_individual_submission_data.py
@@ -382,8 +382,7 @@ class TestCensusIndividualSubmissionData(IntegrationTestCase):
         return expected_downstream_data
 
     def complete_survey(self, eq_id, form_type_id):
-        variant_flags = {'sexual_identity': 'false'}
-        self.launchSurvey(eq_id, form_type_id, region_code='GB-ENG', variant_flags=variant_flags, roles=['dumper'])
+        self.launchSurvey(eq_id, form_type_id, region_code='GB-ENG', sexual_identity=False, roles=['dumper'])
 
         # We are in the questionnaire
         self.assertInPage('What is your name?')

--- a/tests/integration/create_token.py
+++ b/tests/integration/create_token.py
@@ -17,7 +17,6 @@ PAYLOAD = {
     'return_by': '2016-05-06',
     'trad_as': 'Integration Tests',
     'employment_date': '1983-06-02',
-    'variant_flags': None,
     'region_code': 'GB-ENG',
     'language_code': 'en',
     'roles': [],

--- a/tests/integration/questionnaire/test_questionnaire_csrf.py
+++ b/tests/integration/questionnaire/test_questionnaire_csrf.py
@@ -58,7 +58,7 @@ class TestQuestionnaireCsrf(IntegrationTestCase):
 
     def test_given_valid_answers_on_household_composition_when_answer_with_invalid_csrf_token_then_answers_not_saved(self):
         # Given
-        self.launchSurvey('census', 'household', roles=['dumper'])
+        self.launchSurvey('census', 'household', sexual_identity=False, roles=['dumper'])
         post_data = {'first_name': 'Joe'}
 
         # When

--- a/tests/integration/questionnaire/test_questionnaire_previous_link.py
+++ b/tests/integration/questionnaire/test_questionnaire_previous_link.py
@@ -35,7 +35,7 @@ class TestQuestionnairePreviousLink(IntegrationTestCase):
     def test_previous_link_on_relationship(self):
 
         # Given the census questionnaire.
-        self.launchSurvey('census', 'household')
+        self.launchSurvey('census', 'household', sexual_identity=False)
         self.post(action='start_questionnaire')
 
         # When we complete the who lives here section and the other questions needed to build the path.

--- a/tests/integration/session/test_metadata.py
+++ b/tests/integration/session/test_metadata.py
@@ -1,0 +1,60 @@
+from tests.integration.integration_test_case import IntegrationTestCase
+
+def get_metadata_for_metadata_survey():
+    return {
+        'ref_p_start_date': '2010-10-15',
+        'trad_as': 'Essential Enterprises',
+        'flag': True,
+        'case_id': '1574ae2c-653a-4cf6-b792-798e60ddb21c',
+    }
+
+class TestMetadataValidation(IntegrationTestCase):
+
+    def test_all_metadata_correct(self):
+        # Given
+        metadata = get_metadata_for_metadata_survey()
+
+        # When
+        self.launchSurvey('test', 'metadata_validation', **metadata)
+
+        # Then
+        self.assertStatusOK()
+        # Assert that all the metadata is formatted in the page
+        for name, value in metadata.items():
+            self.assertInPage(value, 'No value for `{}`, expected `{}`'.format(name, value))
+
+    def test_invalid_uuid_in_survey(self):
+        # Given
+        metadata = get_metadata_for_metadata_survey()
+        metadata['case_id'] = 'not-a-uuid'
+
+        # When
+        self.launchSurvey('test', 'metadata_validation', **metadata)
+
+        # Then
+        # This is forbidden because it should fail to validate the metadata
+        self.assertStatusForbidden()
+
+    def test_invalid_date_in_survey(self):
+        # Given
+        metadata = get_metadata_for_metadata_survey()
+        metadata['ref_p_start_date'] = 'not-a-date'
+
+        # When
+        self.launchSurvey('test', 'metadata_validation', **metadata)
+
+        # Then
+        # This is forbidden because it should fail to validate the metadata
+        self.assertStatusForbidden()
+
+    def test_invalid_boolean_in_survey(self):
+        # Given
+        metadata = get_metadata_for_metadata_survey()
+        metadata['flag'] = 'not-a-bool'
+
+        # When
+        self.launchSurvey('test', 'metadata_validation', **metadata)
+
+        # Then
+        # This is forbidden because it should fail to validate the metadata
+        self.assertStatusForbidden()

--- a/tests/integration/views/test_thank_you.py
+++ b/tests/integration/views/test_thank_you.py
@@ -45,7 +45,6 @@ class TestThankYou(IntegrationTestCase):
             'ref_p_end_date': '2016-04-30',
             'return_by': '2016-05-06',
             'employment_date': '1983-06-02',
-            'variant_flags': None,
             'region_code': 'GB-ENG',
             'language_code': 'en',
             'roles': []
@@ -91,7 +90,6 @@ class TestThankYou(IntegrationTestCase):
             'ref_p_end_date': '2016-04-30',
             'return_by': '2016-05-06',
             'employment_date': '1983-06-02',
-            'variant_flags': None,
             'region_code': 'GB-ENG',
             'language_code': 'en',
             'trad_as': '',

--- a/tests/integration/views/test_view_submission.py
+++ b/tests/integration/views/test_view_submission.py
@@ -161,7 +161,6 @@ class TestViewSubmission(IntegrationTestCase):
             'ref_p_end_date': '2016-04-30',
             'return_by': '2016-05-06',
             'employment_date': '1983-06-02',
-            'variant_flags': None,
             'region_code': 'GB-ENG',
             'language_code': 'en',
             'roles': []
@@ -218,7 +217,6 @@ class TestViewSubmission(IntegrationTestCase):
             'ref_p_end_date': '2016-04-30',
             'return_by': '2016-05-06',
             'employment_date': '1983-06-02',
-            'variant_flags': None,
             'region_code': 'GB-ENG',
             'language_code': 'en',
             'roles': [],


### PR DESCRIPTION
### What is the context of this PR?
Related to https://github.com/ONSdigital/ons-schema-definitions/pull/32#discussion_r207161581
Required changes to schema validation in https://github.com/ONSdigital/eq-schema-validator/pull/73

`variant_flags` was a special case and it was decided that it could be flattened in to the top level object. The knock on effects of this are:
1. Nothing uses the `object` validator for metadata. The actual content of objects was never validated and it seemed to have the potential to cause corner cases, so it's been removed.
2. The `variant_flags` did sometimes contain boolean values, however there was no way to validate these at the top level of the schema.

Some surveys now use `sexual_identity` in the claims rather than `varient_flags.sexual_identity`. there wasn't really any other place where functionality was being enabled/disabled from the metadata.

### How to review 
Nothing should break. Run some surveys from the launcher.
