### PR TITLE
Add started_at to final payload

### DIFF
--- a/app/submitter/converter.py
+++ b/app/submitter/converter.py
@@ -36,6 +36,7 @@ def convert_answers(metadata, schema, answer_store, routing_path, flushed=False)
           'instrument_id': 'yui789',
           'period': '2016-02-01'
         },
+        'started_at': '2016-03-06T15:28:05Z',
         'submitted_at': '2016-03-07T15:28:05Z',
         'metadata': {
           'user_id': '789473423',
@@ -57,6 +58,8 @@ def convert_answers(metadata, schema, answer_store, routing_path, flushed=False)
         'collection': _build_collection(metadata),
         'metadata': _build_metadata(metadata),
     }
+    if 'started_at' in metadata and metadata['started_at']:
+        payload['started_at'] = metadata['started_at']
     if 'case_id' in metadata and metadata['case_id']:
         payload['case_id'] = metadata['case_id']
     if 'case_ref' in metadata and metadata['case_ref']:
@@ -69,7 +72,7 @@ def convert_answers(metadata, schema, answer_store, routing_path, flushed=False)
     else:
         raise DataVersionError(schema.json['data_version'])
 
-    logger.debug('converted answer ready for submission')
+    logger.info('converted answer ready for submission')
     return payload
 
 

--- a/tests/app/submitter/test_converter.py
+++ b/tests/app/submitter/test_converter.py
@@ -1,3 +1,4 @@
+import copy
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -44,6 +45,7 @@ class TestConverter(AppContextTestCase):  # pylint: disable=too-many-public-meth
             'ru_ref': '432423423423',
             'ru_name': 'Apple',
             'return_by': '2016-07-07',
+            'started_at': '2018-07-04T14:49:33.448608+00:00',
             'case_id': '1234567890',
             'case_ref': '1000000000000001'
         }, self.schema_metadata)
@@ -102,6 +104,32 @@ class TestConverter(AppContextTestCase):  # pylint: disable=too-many-public-meth
             answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), {}, flushed=True)
 
             self.assertTrue(answer_object['flushed'])
+
+    def test_started_at_should_be_set_in_payload_if_present_in_metadata(self):
+        with self._app.test_request_context():
+
+            questionnaire = {
+                'survey_id': '021',
+                'data_version': '0.0.2'
+            }
+
+            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(), {})
+
+            self.assertEqual(answer_object['started_at'], self.metadata['started_at'])
+
+    def test_started_at_should_not_be_set_in_payload_if_absent_in_metadata(self):
+        with self._app.test_request_context():
+
+            questionnaire = {
+                'survey_id': '021',
+                'data_version': '0.0.2'
+            }
+            metadata_copy = copy.copy(self.metadata)
+            del metadata_copy['started_at']
+
+            answer_object = convert_answers(metadata_copy, QuestionnaireSchema(questionnaire), AnswerStore(), {})
+
+            self.assertFalse('started_at' in answer_object)
 
     def test_submitted_at_should_be_set_in_payload(self):
         with self._app.test_request_context():

--- a/tests/integration/mci/test_mci_submission_data.py
+++ b/tests/integration/mci/test_mci_submission_data.py
@@ -68,6 +68,7 @@ class TestMciSubmissionData(IntegrationTestCase):
                 'survey_id': '023',
                 'flushed': False,
                 'tx_id': actual['submission']['tx_id'],
+                'started_at': actual['submission']['started_at'],
                 'submitted_at': actual['submission']['submitted_at'],
                 'collection': {
                     'period': '201604',

--- a/tests/integration/qbs/test_qbs_submission_data.py
+++ b/tests/integration/qbs/test_qbs_submission_data.py
@@ -41,6 +41,7 @@ class TestQbsSubmissionData(IntegrationTestCase):
         expected = {
             'submission': {
                 'origin': 'uk.gov.ons.edc.eq',
+                'started_at': actual['submission']['started_at'],
                 'submitted_at': actual['submission']['submitted_at'],
                 'collection': {
                     'exercise_sid': '789',

--- a/tests/integration/rsi/test_rsi_submission_data.py
+++ b/tests/integration/rsi/test_rsi_submission_data.py
@@ -48,6 +48,7 @@ class TestRsiSubmissionData(IntegrationTestCase):
         expected = {
             'submission': {
                 'version': '0.0.1',
+                'started_at': actual['submission']['started_at'],
                 'submitted_at': actual['submission']['submitted_at'],
                 'tx_id': actual['submission']['tx_id'],
                 'type': 'uk.gov.ons.edc.eq:surveyresponse',
@@ -136,6 +137,7 @@ class TestRsiSubmissionData(IntegrationTestCase):
         expected = {
             'submission': {
                 'type': 'uk.gov.ons.edc.eq:surveyresponse',
+                'started_at': actual['submission']['started_at'],
                 'submitted_at': actual['submission']['submitted_at'],
                 'version': '0.0.1',
                 'survey_id': '023',

--- a/tests/integration/views/test_dump.py
+++ b/tests/integration/views/test_dump.py
@@ -181,6 +181,7 @@ class TestDumpSubmission(IntegrationTestCase):
                 'origin': 'uk.gov.ons.edc.eq',
                 'type': 'uk.gov.ons.edc.eq:surveyresponse',
                 'tx_id': actual['submission']['tx_id'],
+                'started_at': actual['submission']['started_at'],
                 'submitted_at': actual['submission']['submitted_at'],
                 'collection': {
                     'period': '201604',


### PR DESCRIPTION
### What is the context of this PR?
https://trello.com/c/HGU9OpOe/2173-add-dates-to-metadata-for-downstream-systems

Needed to add the started at time to a survey as the downstream systems needed it.  It gets added to the metadata and written in the same place as 'submitted_at' in the final payload

### How to review 
Submit any survey and check that started_at appears in the payload at the top level of the json

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
