### PR TITLE
Changed summary section text

### DIFF
--- a/app/templates/summary.html
+++ b/app/templates/summary.html
@@ -16,12 +16,13 @@
 
 {% if content.summary.summary_type == 'Summary' %}
 <div>
-  <h1 class="saturn">{{ _("Your answers") }}</h1>
+  <h1 class="saturn">{{ _("Check your answers and submit") }}</h1>
   <div class="print__message panel panel--simple panel--error u-mb-l">
     <h2 class="saturn">{{ _("Please remember to submit these answers") }}.</h2>
   </div>
-  <div class="print__hidden panel panel--simple panel--warn u-mb-l">
-    <h2 class="neptune">{{ _("Please check your answers carefully before submitting") }}.</h2>
+  <div class="print__hidden panel panel--simple panel--info u-mb-l">
+    <strong>{{ _("Please submit this survey to complete it") }}</strong>
+    <p>{{ _("You can check your answers below") }}</p>
   </div>
 </div>
 {% elif content.summary.summary_type == 'SectionSummary' %}

--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-08-06 09:05+0100\n"
+"POT-Creation-Date: 2018-08-06 12:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -143,7 +143,7 @@ msgid "Summary"
 msgstr ""
 
 #: app/templates/summary.html:19
-msgid "Your answers"
+msgid "Check your answers and submit"
 msgstr ""
 
 #: app/templates/summary.html:21
@@ -151,22 +151,26 @@ msgid "Please remember to submit these answers"
 msgstr ""
 
 #: app/templates/summary.html:24
-msgid "Please check your answers carefully before submitting"
+msgid "Please submit this survey to complete it"
 msgstr ""
 
-#: app/templates/summary.html:32
-msgid "This section is now complete"
+#: app/templates/summary.html:25
+msgid "You can check your answers below"
 msgstr ""
 
 #: app/templates/summary.html:33
+msgid "This section is now complete"
+msgstr ""
+
+#: app/templates/summary.html:34
 msgid "You can review your answers below"
 msgstr ""
 
-#: app/templates/summary.html:40
+#: app/templates/summary.html:41
 msgid "Please review your answers and confirm these are correct"
 msgstr ""
 
-#: app/templates/summary.html:49
+#: app/templates/summary.html:50
 msgid ""
 "You will have the opportunity to view and print a copy of your answers "
 "after submitting this survey"

--- a/data/en/1_0005.json
+++ b/data/en/1_0005.json
@@ -2086,7 +2086,7 @@
         }]
     }, {
         "id": "summary-section",
-        "title": "Summary",
+        "title": "Check your answers and submit",
         "groups": [{
             "blocks": [{
                 "type": "Summary",

--- a/tests/integration/mci/test_empty_comments.py
+++ b/tests/integration/mci/test_empty_comments.py
@@ -43,8 +43,8 @@ class TestEmptyComments(IntegrationTestCase):
 
         # We are on the review answers page
         self.assertInPage('>Monthly Business Survey - Retail Sales Index</')
-        self.assertInPage('>Your answers<')
-        self.assertInPage('Please check your answers carefully before submitting')
+        self.assertInPage('>Check your answers and submit<')
+        self.assertInPage('You can check your answers below')
         self.assertInPage('>Submit answers<')
 
         # We submit our answers

--- a/tests/integration/mci/test_empty_submission.py
+++ b/tests/integration/mci/test_empty_submission.py
@@ -63,8 +63,8 @@ class TestEmptySubmission(IntegrationTestCase):
         self.assertInUrl(mci_test_urls.MCI_0205_SUMMARY)
 
         # We are on the review answers page
-        self.assertInPage('>Your answers<')
-        self.assertInPage('Please check your answers carefully before submitting')
+        self.assertInPage('>Check your answers and submit<')
+        self.assertInPage('You can check your answers below')
         self.assertInPage('>Submit answers<')
 
         # We submit our answers

--- a/tests/integration/mci/test_happy_path.py
+++ b/tests/integration/mci/test_happy_path.py
@@ -42,8 +42,8 @@ class HappyPathHelperMixin():
 
         # We are on the review answers page
         self.assertInPage('>Monthly Business Survey - Retail Sales Index</')
-        self.assertInPage('>Your answers<')
-        self.assertInPage('Please check your answers carefully before submitting.')
+        self.assertInPage('>Check your answers and submit<')
+        self.assertInPage('You can check your answers below')
         self.assertInPage('>Submit answers<')
 
         # Submit answers

--- a/tests/integration/mci/test_invalid_dates_numbers.py
+++ b/tests/integration/mci/test_invalid_dates_numbers.py
@@ -52,8 +52,8 @@ class TestInvalidDateNumber(IntegrationTestCase):
         self.assertInUrl(mci_test_urls.MCI_0205_SUMMARY)
 
         # We are on the review answers page
-        self.assertInPage('>Your answers<')
-        self.assertInPage('Please check your answers carefully before submitting')
+        self.assertInPage('>Check your answers and submit<')
+        self.assertInPage('You can check your answers below')
         self.assertInPage('>Submit answers<')
 
         # We submit our answers

--- a/tests/integration/mci/test_mci_submission_data.py
+++ b/tests/integration/mci/test_mci_submission_data.py
@@ -44,8 +44,8 @@ class TestMciSubmissionData(IntegrationTestCase):
         # There are no validation errors (we're on the summary screen)
         self.assertInUrl('summary')
         self.assertInPage('>Monthly Business Survey - Retail Sales Index</')
-        self.assertInPage('>Your answers<')
-        self.assertInPage('Please check your answers carefully before submitting')
+        self.assertInPage('>Check your answers and submit<')
+        self.assertInPage('You can check your answers below')
         self.assertInPage('>Submit answers<')
 
         actual = self.dumpSubmission()

--- a/tests/integration/qbs/test_qbs_submission_data.py
+++ b/tests/integration/qbs/test_qbs_submission_data.py
@@ -31,8 +31,8 @@ class TestQbsSubmissionData(IntegrationTestCase):
         # There are no validation errors (we're on the summary screen)
         self.assertInUrl('summary')
         self.assertInPage('>Quarterly Business Survey</')
-        self.assertInPage('>Your answers<')
-        self.assertInPage('Please check your answers carefully before submitting')
+        self.assertInPage('>Check your answers and submit<')
+        self.assertInPage('You can check your answers below')
         self.assertInPage('>Submit answers<')
 
         # And the JSON response contains the data I submitted

--- a/tests/integration/questionnaire/test_questionnaire_is_skipping_question.py
+++ b/tests/integration/questionnaire/test_questionnaire_is_skipping_question.py
@@ -58,7 +58,7 @@ class TestQuestionnaireChangeAnswer(IntegrationTestCase):
         self.assertInPage('Were you forced to complete section 2?')
         self.post(action='save_continue')
 
-        self.assertInPage('Please check your answers carefully before submitting.')
+        self.assertInPage('You can check your answers below')
         self.assertInPage('Were you forced to complete section 1?')
         self.assertInPage('Were you forced to complete section 2?')
         self.assertInPage('Submit answers')

--- a/tests/integration/rsi/test_rsi_submission_data.py
+++ b/tests/integration/rsi/test_rsi_submission_data.py
@@ -38,8 +38,8 @@ class TestRsiSubmissionData(IntegrationTestCase):
         # There are no validation errors (we're on the summary screen)
         self.assertInUrl('summary')
         self.assertInPage('>Monthly Business Survey - Retail Sales Index</')
-        self.assertInPage('>Your answers<')
-        self.assertInPage('Please check your answers carefully before submitting')
+        self.assertInPage('>Check your answers and submit<')
+        self.assertInPage('You can check your answers below')
         self.assertInPage('>Submit answers<')
 
         # And the JSON response contains the data I submitted
@@ -127,8 +127,8 @@ class TestRsiSubmissionData(IntegrationTestCase):
         # There are no validation errors (we're on the summary screen)
         self.assertInUrl('summary')
         self.assertInPage('>Monthly Business Survey - Retail Sales Index</')
-        self.assertInPage('>Your answers<')
-        self.assertInPage('Please check your answers carefully before submitting')
+        self.assertInPage('>Check your answers and submit<')
+        self.assertInPage('You can check your answers below')
         self.assertInPage('>Submit answers<')
 
         # And the JSON response contains the data I submitted

--- a/tests/integration/star_wars/test_conditional_display.py
+++ b/tests/integration/star_wars/test_conditional_display.py
@@ -43,7 +43,7 @@ class TestConditionalDisplay(StarWarsTestCase):
 
         # We are on the summary page
         self.assertInPage('>Star Wars</')
-        self.assertInPage('>Your answers<')
+        self.assertInPage('>Check your answers and submit<')
         self.assertInPage('What is the name of Jar Jar Binks')
 
     def test_conditional_display_questions_non_present(self):
@@ -81,5 +81,5 @@ class TestConditionalDisplay(StarWarsTestCase):
 
         # We are on the review answers page
         self.assertInPage('>Star Wars</')
-        self.assertInPage('>Your answers<')
+        self.assertInPage('>Check your answers and submit<')
         self.assertNotInPage('What is the name of Jar Jar Binks')

--- a/tests/integration/star_wars/test_confirmation_page.py
+++ b/tests/integration/star_wars/test_confirmation_page.py
@@ -57,4 +57,4 @@ class TestConfirmationPage(IntegrationTestCase):
 
     def rogue_one_check_confirmation_page(self):
         self.assertInPage('Summary')
-        self.assertInPage('Please check your answers carefully before submitting')
+        self.assertInPage('You can check your answers below')

--- a/tests/integration/star_wars/test_empty_submission_fails.py
+++ b/tests/integration/star_wars/test_empty_submission_fails.py
@@ -42,7 +42,7 @@ class TestEmptySubmissionFails(StarWarsTestCase):
 
         # We are on the review answers page
         self.assertInPage('>Star Wars</')
-        self.assertInPage('>Your answers<')
+        self.assertInPage('>Check your answers and submit<')
         self.assertRegexPage('(?s)How old is Chewy?.*?234')
         self.assertRegexPage('(?s)How many Octillions do Nasa reckon it would cost to build a death star?.*?£40')
         self.assertRegexPage('(?s)How hot is a lightsaber in degrees C?.*?1,370')
@@ -57,7 +57,7 @@ class TestEmptySubmissionFails(StarWarsTestCase):
         self.assertRegexPage('(?s)What was the total number of Ewoks?.*?')
         self.assertRegexPage("(?s)Why doesn't Chewbacca receive a medal at the end of A New Hope?.*?"
                              'Wookiees don’t place value in material rewards and refused the medal initially')
-        self.assertInPage('>Please check your answers carefully before submitting.<')
+        self.assertInPage('>You can check your answers below<')
         self.assertInPage('>Submit answers<')
 
         # Submit answers

--- a/tests/integration/star_wars/test_light_side_path.py
+++ b/tests/integration/star_wars/test_light_side_path.py
@@ -37,7 +37,7 @@ class TestLightSidePath(StarWarsTestCase):
 
         # We are on the review answers page
         self.assertInPage('>Star Wars</')
-        self.assertInPage('>Your answers<')
+        self.assertInPage('>Check your answers and submit<')
         self.assertRegexPage('(?s)How old is Chewy?.*?234')
         self.assertRegexPage('(?s)How many Octillions do Nasa reckon it would cost to build a death star?.*?£40')
         self.assertRegexPage('(?s)How hot is a lightsaber in degrees C?.*?1,370')
@@ -51,7 +51,7 @@ class TestLightSidePath(StarWarsTestCase):
         self.assertRegexPage('(?s)What was the total number of Ewoks?.*?')
         self.assertRegexPage("(?s)Why doesn't Chewbacca receive a medal at the end of A New Hope?.*?"
                              'Wookiees don’t place value in material rewards and refused the medal initially')
-        self.assertInPage('Please check your answers carefully before submitting')
+        self.assertInPage('You can check your answers below')
         self.assertInPage('>Submit answers<')
 
         # Post answers

--- a/tests/integration/star_wars/test_navigation.py
+++ b/tests/integration/star_wars/test_navigation.py
@@ -47,7 +47,7 @@ class TestNavigation(StarWarsTestCase):
 
         # We are on the review answers page
         self.assertInPage('>Star Wars</')
-        self.assertInPage('>Your answers<')
+        self.assertInPage('>Check your answers and submit<')
         self.assertRegexPage('(?s)How old is Chewy?.*?234')
         self.assertRegexPage('(?s)How many Octillions do Nasa reckon it would cost to build a death star?.*?£40')
         self.assertRegexPage('(?s)How hot is a lightsaber in degrees C?.*?1,370')
@@ -60,7 +60,7 @@ class TestNavigation(StarWarsTestCase):
         self.assertRegexPage('(?s)What was the total number of Ewoks?.*?')
         self.assertRegexPage("(?s)Why doesn't Chewbacca receive a medal at the end of A New Hope?.*?"
                              'Wookiees don’t place value in material rewards and refused the medal initially')  # NOQA
-        self.assertInPage('>Please check your answers carefully before submitting.<')
+        self.assertInPage('>You can check your answers below<')
         self.assertInPage('>Submit answers<')
 
         # Submit answers

--- a/tests/integration/views/test_view_submission.py
+++ b/tests/integration/views/test_view_submission.py
@@ -38,7 +38,7 @@ class TestViewSubmission(IntegrationTestCase):
         self.assertInUrl('summary')
 
         # check we're on the review answers page
-        self.assertInPage('Please check your answers carefully before submitting.')
+        self.assertInPage('You can check your answers below')
 
         # Submit answers
         self.post(action=None)


### PR DESCRIPTION
### What is the context of this PR?
Text change for https://trello.com/c/kjjICyej/2192-change-all-summary-section-titles-to-check-your-answers-and-submit

### How to review 
Run `1_0005.json`, complete the survey as far as the final summary, the changes should make it look like: https://sketch.cloud/s/3Kk9r/all/pagewidth998px/checkanswersandsubmit/play (Other than the accordians which are in another card). Those changes are:
1. The right hand nav should now read "Check your answers and submit".
2. The "check your answers" panel below the title should now be blue.
3. There are a couple of minor text changes to match the designs.
