### PR TITLE
Session store was being reloaded from the database after creation

### DIFF
--- a/app/data_model/session_store.py
+++ b/app/data_model/session_store.py
@@ -42,6 +42,8 @@ class SessionStore:
 
             data_access.put(self._eq_session)
 
+        return self
+
     def delete(self):
         """
         deletes user session from database

--- a/app/globals.py
+++ b/app/globals.py
@@ -42,7 +42,7 @@ def create_session_store(eq_session_id, user_id, user_ik, session_data):
 
     # pylint: disable=W0212
     pepper = current_app.eq['secret_store'].get_secret_by_name('EQ_SERVER_SIDE_STORAGE_ENCRYPTION_USER_PEPPER')
-    g._session_store = SessionStore(user_ik, pepper).create(eq_session_id, user_id, session_data).save()  # pylint: disable=assignment-from-no-return
+    g._session_store = SessionStore(user_ik, pepper).create(eq_session_id, user_id, session_data).save()
 
 
 def get_metadata(user):


### PR DESCRIPTION
### What is the context of this PR?
This change populates `g._session_store` when the session is created - it looks that this was always the intended behaviour.

There's no easy way to test this, since the moto library does not simulate eventual consistency (I checked through the code)

The problem would be that in some cases the document would be written, but might not be available for 'a bit' of time, if syncing between multiple instances is occurring.

### How to review 
The session should not be read from the database immediately after creation.