### PR TITLE
Hide personal data from page titles

### DIFF
--- a/app/helpers/template_helper.py
+++ b/app/helpers/template_helper.py
@@ -40,7 +40,7 @@ def with_metadata_context(func):
         metadata = get_metadata(current_user)
         metadata_context = build_metadata_context(metadata)
 
-        return func(*args, metadata=metadata_context, **kwargs)
+        return func(*args, metadata_context=metadata_context, **kwargs)
 
     return metadata_context_wrapper
 

--- a/tests/functional/spec/features/conditional_question_title/conditional_question_title.spec.js
+++ b/tests/functional/spec/features/conditional_question_title/conditional_question_title.spec.js
@@ -35,7 +35,7 @@ describe('Feature: Conditional question title', function() {
         .getTitle().should.eventually.contain('Who are you answering on behalf of? - Multiple Question Title Test')
         .click(SingleTitlePage.chad())
         .click(SingleTitlePage.submit())
-        .getTitle().should.eventually.contain('What is chad’s gender? - Multiple Question Title Test')
+        .getTitle().should.eventually.contain('What is … gender? - Multiple Question Title Test')
         .click(ConditionalTitlePage.genderMale())
         .setValue(ConditionalTitlePage.age(), '25')
         .click(ConditionalTitlePage.sureYes())

--- a/tests/integration/views/test_questionnaire.py
+++ b/tests/integration/views/test_questionnaire.py
@@ -332,7 +332,7 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         schema = load_schema_from_params('test', 'final_confirmation')
 
         # When
-        page_title = get_page_title_for_location(schema, Location('final-confirmation', 0, 'introduction'), {})
+        page_title = get_page_title_for_location(schema, Location('final-confirmation', 0, 'introduction'), {}, AnswerStore())
 
         # Then
         self.assertEqual(page_title, 'Final confirmation to submit')
@@ -342,7 +342,7 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         schema = load_schema_from_params('test', 'interstitial_page')
 
         # When
-        page_title = get_page_title_for_location(schema, Location('favourite-foods', 0, 'breakfast-interstitial'), {})
+        page_title = get_page_title_for_location(schema, Location('favourite-foods', 0, 'breakfast-interstitial'), {}, AnswerStore())
 
         # Then
         self.assertEqual(page_title, 'Favourite food - Interstitial Pages')
@@ -352,19 +352,18 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         schema = load_schema_from_params('test', 'final_confirmation')
 
         # When
-        page_title = get_page_title_for_location(schema, Location('final-confirmation', 0, 'breakfast'), {})
+        page_title = get_page_title_for_location(schema, Location('final-confirmation', 0, 'breakfast'), {}, AnswerStore())
 
         # Then
         self.assertEqual(page_title, 'What is your favourite breakfast food - Final confirmation to submit')
 
     def test_given_questionnaire_page_when_get_page_title_with_titles_object(self):
-        context = {'question_titles': {'single-title-question': 'How are you feeling??'}}
 
         # Given
         schema = load_schema_from_params('test', 'titles')
 
         # When
-        page_title = get_page_title_for_location(schema, Location('group', 0, 'single-title-block'), context)
+        page_title = get_page_title_for_location(schema, Location('group', 0, 'single-title-block'), {}, AnswerStore())
 
         # Then
         self.assertEqual(page_title, 'How are you feeling?? - Multiple Question Title Test')
@@ -374,7 +373,7 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         schema = load_schema_from_params('census', 'household')
 
         # When
-        page_title = get_page_title_for_location(schema, Location('who-lives-here-relationship', 0, 'household-relationships'), {})
+        page_title = get_page_title_for_location(schema, Location('who-lives-here-relationship', 0, 'household-relationships'), {}, AnswerStore())
 
         # Then
         self.assertEqual(page_title, 'How is … related to the people below? - 2017 Census Test')


### PR DESCRIPTION
Closes #1723

This is because page titles are sent to analytics services, such as google analytics.

### What is the context of this PR?
No page title's should contain answers, or metadata anymore, but should show `…` instead. This should not affect the page content though,

### How to review 
Run a survey which uses titles containing templating, e.g. `test_titles_conditional_within_repeating_block.json`. You should see something like this in the tab title:

![screenshot from 2018-08-07 17-13-41](https://user-images.githubusercontent.com/471170/43788466-5e9dc310-9a65-11e8-91c5-e9374bb2f768.png)

But the page content should still show:

![screenshot from 2018-08-07 17-13-28](https://user-images.githubusercontent.com/471170/43788488-6be9b3e4-9a65-11e8-9ba7-968457d062ee.png)

Net code removal :fist_oncoming: 