### PR TITLE
Add repeating over multiple groups

### DIFF
--- a/app/data_model/answer_store.py
+++ b/app/data_model/answer_store.py
@@ -3,14 +3,18 @@ import re
 from datetime import datetime
 from jinja2 import escape
 import simplejson as json
+from structlog import get_logger
+
+logger = get_logger()
 
 
 class Answer:
-    def __init__(self, answer_id, value, group_instance=0, answer_instance=0):
+    def __init__(self, answer_id, value, group_instance_id=None, group_instance=0, answer_instance=0):
         if answer_id is None or value is None:
             raise ValueError("Both 'answer_id' and 'value' must be set for Answer")
 
         self.answer_id = answer_id
+        self.group_instance_id = group_instance_id
         self.group_instance = group_instance
         self.answer_instance = answer_instance
         self.value = value
@@ -18,12 +22,13 @@ class Answer:
     def matches(self, answer):
         """
         Check to see if two answers match.
-        Two answers are considered to match if they share the same block_id, answer, answer_instance, group_id and group_instance.
+        Two answers are considered to match if they share the same answer_id, answer_instance and group_instance_id.
 
         :param answer: An answer to compare
         :return: True if both answers match, otherwise False.
         """
         return self.answer_id == answer.answer_id and \
+            self.group_instance_id == answer.group_instance_id and \
             self.group_instance == answer.group_instance and \
             self.answer_instance == answer.answer_instance
 
@@ -38,6 +43,7 @@ class Answer:
         return self.matches(Answer(
             answer_dict['answer_id'],
             answer_dict['value'],
+            answer_dict['group_instance_id'],
             answer_dict['group_instance'],
             answer_dict['answer_instance'],
         ))
@@ -155,14 +161,14 @@ class AnswerStore:
             escaped.append(answer)
         return self.__class__(existing_answers=escaped)
 
-    def filter(self, answer_ids, group_instance=None, answer_instance=None,
-               limit=None):
+    def filter(self, answer_ids=None, group_instance=None, group_instance_id=None, answer_instance=None, limit=None):
         """
         Find all answers in the answer store for a given set of filter parameter matches.
         If no filter parameters are passed it returns a copy of the instance.
 
         :param answer_ids: The answer ids to filter results by
         :param answer_instance: The answer instance to filter results by
+        :param group_instance_id: The group instance ID to filter results by
         :param group_instance: The group instance to filter results by
         :param limit: True | False Limit the number of answers returned
         :return: Return a new AnswerStore object with filtered answers for chaining
@@ -172,6 +178,7 @@ class AnswerStore:
         filter_vars = {
             'answer_id': answer_ids,
             'answer_instance': answer_instance,
+            'group_instance_id': group_instance_id,
             'group_instance': group_instance,
         }
 
@@ -201,7 +208,7 @@ class AnswerStore:
         :param answer_instance: The answer instance to filter results to remove
         :param group_instance: The group instance to filter results to remove
         """
-        for answer in self.filter(answer_ids, group_instance, answer_instance):
+        for answer in self.filter(answer_ids, group_instance=group_instance, answer_instance=answer_instance):
             self.answers.remove(answer)
 
     def get_hash(self):
@@ -213,21 +220,18 @@ class AnswerStore:
         return hash(json.dumps(self.answers, sort_keys=True))
 
     def upgrade(self, current_version, schema):
+        """
+            Upgrade the answer_store to the latest version
 
-        # Upgrade from version 0 to version 1
-        if current_version == 0:
-            # Update Date formats
-            for answer in self.answers:
-                answer_schema = schema.get_answer(answer['answer_id'])
+            :param current_version: The current version integer of the answer store
+            :param schema: The new schema
+        """
+        desired_version = len(UPGRADE_TRANSFORMS)
 
-                if answer_schema:
-                    if answer_schema['type'] == 'Date':
-                        answer['value'] = datetime.strptime(answer['value'], '%d/%m/%Y').strftime('%Y-%m-%d')
-                        continue
-
-                    if answer_schema['type'] == 'MonthYearDate':
-                        answer['value'] = datetime.strptime(answer['value'], '%m/%Y').strftime('%Y-%m')
-                        continue
+        for version in range(current_version, desired_version):
+            transform = UPGRADE_TRANSFORMS[version]
+            logger.info('Upgrading answer store version', current_version=current_version, new_version=version, transform=transform.__name__)
+            transform(self, schema)
 
 
 def number_else_string(text):
@@ -242,3 +246,47 @@ def natural_order(key):
     :return:
     """
     return [number_else_string(c) for c in re.split(r'(\d+)', key)]
+
+
+def upgrade_0_to_1_update_date_formats(answer_store, schema):
+    """ Updates the date format """
+    for answer in answer_store.answers:
+        answer_schema = schema.get_answer(answer['answer_id'])
+
+        if answer_schema:
+            if answer_schema['type'] == 'Date':
+                answer['value'] = datetime.strptime(answer['value'], '%d/%m/%Y').strftime('%Y-%m-%d')
+                continue
+
+            if answer_schema['type'] == 'MonthYearDate':
+                answer['value'] = datetime.strptime(answer['value'], '%m/%Y').strftime('%Y-%m')
+                continue
+
+
+def upgrade_1_to_2_add_group_instance_id(answer_store, schema):
+    """ Answers should have a `group_instance_id` ready for more complex group repeat rules. """
+    from app.questionnaire.location import Location
+    from app.helpers.schema_helpers import get_group_instance_id
+
+    for answer in answer_store.answers:
+        # Happily, parent_id's are patched on to the schema for each nested level, so we can
+        # retrieve the block_id and group_id for the answer we're processing here.
+        answer_schema = schema.get_answer(answer['answer_id'])
+        question = schema.get_question(answer_schema['parent_id'])
+        block_id = question['parent_id']
+        block = schema.get_block(question['parent_id'])
+        group_id = block['parent_id']
+
+        location = Location(
+            group_id=group_id,
+            group_instance=answer['group_instance'],
+            block_id=block_id,
+        )
+        # `get_group_instance_id` handles providing a consistent group_instance_id
+        answer['group_instance_id'] = get_group_instance_id(schema, answer_store, location, answer['answer_instance'])
+
+
+UPGRADE_TRANSFORMS = (
+    upgrade_0_to_1_update_date_formats,
+    upgrade_1_to_2_add_group_instance_id,
+)

--- a/app/data_model/questionnaire_store.py
+++ b/app/data_model/questionnaire_store.py
@@ -6,7 +6,7 @@ from app.questionnaire.location import Location
 
 
 class QuestionnaireStore:
-    LATEST_VERSION = 1
+    LATEST_VERSION = 2
 
     def __init__(self, storage, version=None):
         self._storage = storage
@@ -43,6 +43,16 @@ class QuestionnaireStore:
         This should be removed after deployment of collection_metadata changes.
         """
         self._metadata[key] = value
+
+    def ensure_latest_version(self, schema):
+        """ If the code has been updated, the data being loaded may need
+        transforming to match the latest code. """
+        new_version = self.get_latest_version_number()
+        if self.version < new_version:
+            self.answer_store.upgrade(self.version, schema)
+            self.version = new_version
+
+        return self
 
     def _deserialise(self, data):
         json_data = json.loads(data, use_decimal=True)

--- a/app/forms/household_relationship_form.py
+++ b/app/forms/household_relationship_form.py
@@ -56,7 +56,7 @@ def build_relationship_choices(answer_store, group_instance):  # pylint: disable
     return choices
 
 
-def serialise_relationship_answers(answer_id, listfield_data, group_instance):
+def serialise_relationship_answers(answer_id, listfield_data, group_instance, group_instance_id):
     answers = []
 
     for index, listfield_value in enumerate(listfield_data):
@@ -64,6 +64,7 @@ def serialise_relationship_answers(answer_id, listfield_data, group_instance):
             answer_id=answer_id,
             answer_instance=index,
             group_instance=group_instance,
+            group_instance_id=group_instance_id,
             value=listfield_value,
         )
         answers.append(answer)
@@ -83,7 +84,7 @@ def deserialise_relationship_answers(answers):
     return relationships
 
 
-def generate_relationship_form(schema, block_json, relationship_choices, data, group_instance):
+def generate_relationship_form(schema, block_json, relationship_choices, data, group_instance, group_instance_id):
 
     answer = schema.get_answers_for_block(block_json['id'])[0]
 
@@ -112,7 +113,7 @@ def generate_relationship_form(schema, block_json, relationship_choices, data, g
             """
             list_field = getattr(self, answer['id'])
 
-            return serialise_relationship_answers(answer['id'], list_field.data, group_instance)
+            return serialise_relationship_answers(answer['id'], list_field.data, group_instance, group_instance_id)
 
     choices = [('', 'Select relationship')] + build_choices(answer['options'])
 

--- a/app/helpers/schema_helpers.py
+++ b/app/helpers/schema_helpers.py
@@ -1,4 +1,5 @@
 from functools import wraps
+from uuid import uuid4
 
 from app.globals import get_session_store
 from app.utilities.schema import load_schema_from_session_data
@@ -24,3 +25,71 @@ def with_schema(function):
         schema = load_schema_from_session_data(session_data)
         return function(schema, *args, **kwargs)
     return wrapped_function
+
+
+def get_group_instance_id(schema, answer_store, location, answer_instance=0):
+    """Return a group instance_id if required, or None if not"""
+    if not schema.location_requires_group_instance(location):
+        return None
+
+    dependent_drivers = schema.get_group_dependencies(location.group_id)
+    if dependent_drivers:
+        return _get_dependent_group_instance(schema, dependent_drivers, answer_store, location.group_instance)
+
+    existing_answers = []
+    if location.group_id in schema.get_group_dependencies_group_drivers():
+        group_answer_ids = schema.get_answer_ids_for_group(location.group_id)
+        existing_answers = answer_store.filter(answer_ids=group_answer_ids, group_instance=location.group_instance)
+
+    if location.block_id in schema.get_group_dependencies_block_drivers():
+        block_answer_ids = schema.get_answer_ids_for_block(location.block_id)
+        existing_answers = answer_store.filter(answer_ids=block_answer_ids, answer_instance=answer_instance)
+
+    # If there are existing answers with a group_instance_id
+    if existing_answers and [x for x in existing_answers if x.get('group_instance_id')]:
+        return existing_answers[0]['group_instance_id']
+
+    return str(uuid4())
+
+
+def _get_dependent_group_instance(schema, dependent_drivers, answer_store, group_instance):
+    group_instance_ids = []
+    for driver_id in dependent_drivers:
+        if driver_id in schema.get_group_dependencies_group_drivers():
+            driver_answer_ids = schema.get_answer_ids_for_group(driver_id)
+            group_instance_ids.extend(_get_group_instance_ids_for_group(answer_store, driver_answer_ids))
+        if driver_id in schema.get_group_dependencies_block_drivers():
+            driver_answer_ids = schema.get_answer_ids_for_block(driver_id)
+            group_instance_ids.extend(_get_group_instance_ids_for_block(answer_store, driver_answer_ids))
+
+    return group_instance_ids[group_instance]
+
+
+def _get_group_instance_ids_for_group(answer_store, group_answer_ids):
+    group_instance_ids = []
+
+    group_instances = 0
+    for answer in list(answer_store.filter(answer_ids=group_answer_ids)):
+        group_instances = max(group_instances, answer['group_instance'])
+
+    for i in range(group_instances + 1):
+        answers = list(answer_store.filter(answer_ids=group_answer_ids, group_instance=i))
+        if answers:
+            group_instance_ids.append(answers[0]['group_instance_id'])
+
+    return group_instance_ids
+
+
+def _get_group_instance_ids_for_block(answer_store, block_answer_ids):
+    group_instance_ids = []
+
+    answer_instances = 0
+    for answer in list(answer_store.filter(answer_ids=block_answer_ids)):
+        answer_instances = max(answer_instances, answer['answer_instance'])
+
+    for i in range(answer_instances + 1):
+        answers = list(answer_store.filter(answer_ids=block_answer_ids, answer_instance=i))
+        if answers:
+            group_instance_ids.append(answers[0]['group_instance_id'])
+
+    return group_instance_ids

--- a/app/questionnaire/answer_dependencies.py
+++ b/app/questionnaire/answer_dependencies.py
@@ -37,7 +37,7 @@ class AnswerDependencies:
             self.answer_dependencies[key] |= dependencies
 
 
-def get_dependencies(schema):
+def get_answer_dependencies(schema):
     """gets the all the answer dependencies for a schema by walking questions and answers
     """
     dependencies = _get_answer_level_dependencies(schema)

--- a/app/questionnaire/group_dependencies.py
+++ b/app/questionnaire/group_dependencies.py
@@ -1,0 +1,109 @@
+from collections import defaultdict
+
+
+class GroupDependencies:
+    """represents the dependencies for a group or groups
+    held internally as a dict(string,list)
+
+    group_drivers - list of groups driving a group dependency
+    block_drivers - list of blocks with answers driving a group dependency
+
+    To add a dependency either call add with a single dependency
+    or update with another dependency object
+
+    To access dependencies for a question id simply index
+    i.e  a['group_id']
+    indexing is read only
+    """
+
+    def __init__(self):
+        self._group_dependencies = defaultdict(list)
+        self._group_dependencies['group_drivers'] = []
+        self._group_dependencies['block_drivers'] = []
+
+    def __len__(self):
+        """
+        returns length of group dependencies, needed for index access
+        -2 refers to the group and block drivers
+        """
+
+        return len(self._group_dependencies) - 2
+
+    def __getitem__(self, group_id):
+        """allows the support of indexing e.g a[group_id]"""
+        return self._group_dependencies[group_id]
+
+    @property
+    def group_dependencies(self):
+        return self._group_dependencies
+
+    def add(self, dependent_id, dependency_driver_id, group_or_block):
+        """ Adds a dependency to a specific group_id without duplicating """
+        if dependency_driver_id not in self._group_dependencies[dependent_id]:
+            self._group_dependencies[dependent_id].append(dependency_driver_id)
+        if group_or_block == 'block' and dependency_driver_id not in self._group_dependencies['block_drivers']:
+            self._group_dependencies['block_drivers'].append(dependency_driver_id)
+        if group_or_block == 'group' and dependency_driver_id not in self._group_dependencies['group_drivers']:
+            self._group_dependencies['group_drivers'].append(dependency_driver_id)
+
+    def update(self, dependencies):
+        for dependency in dependencies.group_dependencies:
+            if dependency not in ['group_drivers', 'block_drivers']:
+                for driver_id in dependencies[dependency]:
+                    group_or_block = 'group' if driver_id in dependencies['group_drivers'] else 'block'
+                    self.add(dependency, driver_id, group_or_block)
+
+
+def get_group_dependencies(schema):
+    """
+    gets the all the answer dependencies for a schema by walking through repeats
+    """
+    dependencies = GroupDependencies()
+
+    for group in schema.groups:
+        if group.get('routing_rules') and not _group_has_relationship_type(schema, group['blocks']):
+            for routing_rule in group['routing_rules']:
+                if _routing_rule_has_repeat(routing_rule):
+                    if 'group_ids' in routing_rule['repeat']:
+                        dependencies.update(
+                            _get_dependency_drivers_from_group_ids(group['id'],
+                                                                   routing_rule['repeat']['group_ids']))
+                    else:
+                        dependencies.update(
+                            _get_dependency_driver_from_answer_id(schema,
+                                                                  group['id'],
+                                                                  routing_rule['repeat']['answer_id']))
+
+    return dependencies
+
+
+def _get_dependency_drivers_from_group_ids(dependent_group_id, group_ids):
+    dependencies = GroupDependencies()
+    for group_id in group_ids:
+        dependencies.add(dependent_group_id, group_id, 'group')
+
+    return dependencies
+
+
+def _get_dependency_driver_from_answer_id(schema, dependent_group_id, answer_id):
+    dependencies = GroupDependencies()
+    question_id = schema.get_answer(answer_id)['parent_id']
+    block_id = schema.get_question(question_id)['parent_id']
+    dependencies.add(dependent_group_id, block_id, 'block')
+
+    return dependencies
+
+
+def _group_has_relationship_type(schema, blocks):
+    for block in blocks:
+        if schema.block_has_question_type(block['id'], 'Relationship'):
+            return True
+
+    return False
+
+
+def _routing_rule_has_repeat(routing_rule):
+    dependent_routing_types = ['group', 'answer_count', 'answer_count_minus_one']
+    if routing_rule.get('repeat') and routing_rule['repeat'].get('type') in dependent_routing_types:
+        return True
+    return False

--- a/app/questionnaire/navigation.py
+++ b/app/questionnaire/navigation.py
@@ -82,7 +82,7 @@ class Navigation:
     def _build_repeating_navigation(self, repeating_rule, section, current_group_id, current_group_instance):
         groups = section['groups']
         answer_ids_on_path = get_answer_ids_on_routing_path(self.schema, self.routing_path)
-        no_of_repeats = evaluate_repeat(repeating_rule, self.answer_store, answer_ids_on_path)
+        no_of_repeats = evaluate_repeat(self.schema, repeating_rule, self.answer_store, answer_ids_on_path)
 
         repeating_nav = []
         if repeating_rule['type'] == 'answer_count':

--- a/app/questionnaire/questionnaire_schema.py
+++ b/app/questionnaire/questionnaire_schema.py
@@ -4,7 +4,8 @@ from collections import OrderedDict
 from flask_babel import force_locale
 
 from app.validation.error_messages import error_messages
-from app.questionnaire.answer_dependencies import get_dependencies
+from app.questionnaire.answer_dependencies import get_answer_dependencies
+from app.questionnaire.group_dependencies import get_group_dependencies
 
 
 DEFAULT_LANGUAGE_CODE = 'en'
@@ -37,8 +38,12 @@ class QuestionnaireSchema:  # pylint: disable=too-many-public-methods
         return self._answers_by_id.values()
 
     @property
-    def dependencies(self):
+    def answer_dependencies(self):
         return self._answer_dependencies
+
+    @property
+    def group_dependencies(self):
+        return self._group_dependencies.group_dependencies
 
     def get_section(self, section_id):
         return self._sections_by_id.get(section_id)
@@ -135,6 +140,27 @@ class QuestionnaireSchema:  # pylint: disable=too-many-public-methods
                 options_with_children.update(answer_options_with_children)
         return options_with_children
 
+    def get_group_dependencies(self, group_id):
+        return self.group_dependencies.get(group_id)
+
+    def get_group_dependencies_group_drivers(self):
+        return self.group_dependencies['group_drivers']
+
+    def get_group_dependencies_block_drivers(self):
+        return self.group_dependencies['block_drivers']
+
+    def location_requires_group_instance(self, location):
+        return bool(self.group_dependencies.get(location.group_id) or
+                    location.group_id in self.get_group_dependencies_group_drivers() or
+                    location.block_id in self.get_group_dependencies_block_drivers())
+
+    def block_has_question_type(self, block_id, question_type):
+        block = self.get_block(block_id)
+        for question in block.get('questions', []):
+            if question['type'] == question_type:
+                return True
+        return False
+
     @staticmethod
     def get_repeat_rule(group):
         if 'routing_rules' in group:
@@ -200,7 +226,8 @@ class QuestionnaireSchema:  # pylint: disable=too-many-public-methods
         self._questions_by_id = get_nested_schema_objects(self._blocks_by_id, 'questions')
         self._answers_by_id = get_nested_schema_objects(self._questions_by_id, 'answers')
         self.error_messages = self._get_error_messages()
-        self._answer_dependencies = get_dependencies(self)
+        self._answer_dependencies = get_answer_dependencies(self)
+        self._group_dependencies = get_group_dependencies(self)
 
     def _get_sections_by_id(self):
         return OrderedDict(

--- a/app/submitter/convert_payload_0_0_2.py
+++ b/app/submitter/convert_payload_0_0_2.py
@@ -1,3 +1,4 @@
+
 def convert_answers_to_payload_0_0_2(answer_store, schema, routing_path):
     """
     Convert answers into the data format below

--- a/app/templating/schema_context.py
+++ b/app/templating/schema_context.py
@@ -1,20 +1,25 @@
+from collections import defaultdict
+
 from jinja2 import escape
 
 
-def build_schema_context(metadata, schema, answer_store, answer_ids_on_path, group_instance=0):
+def build_schema_context(metadata, schema, answer_store, answer_ids_on_path, group_instance=0, group_instance_id=None):
     """
     Build questionnaire schema context containing exercise and answers
     :param metadata: user metadata
     :param schema: Survey schema
     :param answer_store: all the answers for the given questionnaire
     :param answer_ids_on_path: a list of the answer ids on the routing path
-    :param group_instance: The group instance Id passed into the url route
+    :param group_instance: The group instance passed into the url route
+    :param group_instance_id: The group instance Id passed into the url route
     :return: questionnaire schema context
     """
     return {
         'metadata': build_schema_metadata(metadata, schema),
         'answers': _build_answers(answer_store, schema, answer_ids_on_path),
+        'group_instances': _build_group_instances(answer_store, answer_ids_on_path),
         'group_instance': group_instance,
+        'group_instance_id': group_instance_id,
     }
 
 
@@ -42,6 +47,18 @@ def _build_answers(answer_store, schema, answer_ids_on_path):
         answers[answer_id] = value
 
     return answers
+
+
+def _build_group_instances(answer_store, answer_ids_on_path):
+    groups = defaultdict(dict)
+
+    for answer_id in answer_ids_on_path:
+        matching_answers = answer_store.filter(answer_ids=[answer_id], limit=True)
+
+        for answer in matching_answers:
+            groups[answer.get('group_instance_id')][answer_id] = answer['value']
+
+    return groups
 
 
 def build_schema_metadata(metadata, schema):

--- a/data/en/test_routing_repeat_until.json
+++ b/data/en/test_routing_repeat_until.json
@@ -125,9 +125,11 @@
             "title": "Household Member Details",
             "routing_rules": [{
                 "repeat": {
-                    "type": "answer_count",
-                    "answer_id": "repeating-name",
-                    "offset": 1
+                    "type": "group",
+                    "group_ids": [
+                        "primary-group",
+                        "repeating-group"
+                    ]
                 }
             }],
             "blocks": [{
@@ -135,7 +137,7 @@
                 "id": "sex-block",
                 "questions": [{
                     "id": "sex-question",
-                    "title": "What is {{( [answers['primary-name']] + answers['repeating-name']|default([]) )[group_instance] }}'s sex?",
+                    "title": "What is {{ group_instances[group_instance_id]['repeating-name']|default(group_instances[group_instance_id]['primary-name']) }}'s sex?",
                     "type": "General",
                     "answers": [{
                         "id": "sex-answer",

--- a/tests/app/forms/test_household_composition.py
+++ b/tests/app/forms/test_household_composition.py
@@ -246,31 +246,37 @@ class TestHouseholdCompositionForm(AppContextTestCase):
 
             expected_answers = [
                 {
+                    'group_instance_id': None,
                     'group_instance': 0,
                     'answer_id': 'first-name',
                     'answer_instance': 0,
                     'value': 'Joe'
                 }, {
+                    'group_instance_id': None,
                     'group_instance': 0,
                     'answer_id': 'middle-names',
                     'answer_instance': 0,
                     'value': ''
                 }, {
+                    'group_instance_id': None,
                     'group_instance': 0,
                     'answer_id': 'last-name',
                     'answer_instance': 0,
                     'value': 'Bloggs'
                 }, {
+                    'group_instance_id': None,
                     'group_instance': 0,
                     'answer_id': 'first-name',
                     'answer_instance': 1,
                     'value': 'Bob'
                 }, {
+                    'group_instance_id': None,
                     'group_instance': 0,
                     'answer_id': 'middle-names',
                     'answer_instance': 1,
                     'value': ''
                 }, {
+                    'group_instance_id': None,
                     'group_instance': 0,
                     'answer_id': 'last-name',
                     'answer_instance': 1,

--- a/tests/app/forms/test_household_relationship_form.py
+++ b/tests/app/forms/test_household_relationship_form.py
@@ -73,7 +73,7 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
 
             relationship_choices = [['a', 'b'], ['c', 'd'], ['e', 'f']]
 
-            form = generate_relationship_form(schema, block_json, relationship_choices, {}, 0)
+            form = generate_relationship_form(schema, block_json, relationship_choices, {}, 0, 'group-0')
 
             self.assertTrue(hasattr(form, answer['id']))
             self.assertEqual(len(form.data[answer['id']]), 3)
@@ -91,7 +91,7 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
                 '{answer_id}-0'.format(answer_id=answer['id']): 'Husband or Wife',
                 '{answer_id}-1'.format(answer_id=answer['id']): 'Brother or Sister',
                 '{answer_id}-2'.format(answer_id=answer['id']): 'Relation - other',
-            }, 0)
+            }, 0, 'group-0')
 
             self.assertTrue(hasattr(form, answer['id']))
 
@@ -107,13 +107,13 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
 
             relationship_choices = [['a', 'b'], ['c', 'd'], ['e', 'f']]
 
-            generated_form = generate_relationship_form(schema, block_json, relationship_choices, None, 0)
+            generated_form = generate_relationship_form(schema, block_json, relationship_choices, None, 0, 'group-0')
 
             form = generate_relationship_form(schema, block_json, relationship_choices, {
                 'csrf_token': generated_form.csrf_token.current_token,
                 '{answer_id}-0'.format(answer_id=answer['id']): '1',
                 '{answer_id}-1'.format(answer_id=answer['id']): '3',
-            }, 0)
+            }, 0, 'group-0')
 
             form.validate()
             mapped_errors = form.map_errors()
@@ -126,20 +126,23 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
 
         field_data = ['Husband or Wife', 'Son or daughter', 'Unrelated']
 
-        actual_answers = serialise_relationship_answers('who-is-related', field_data, 0)
+        actual_answers = serialise_relationship_answers('who-is-related', field_data, 0, 'group-0')
 
         expected_answers = [
             {
+                'group_instance_id': 'group-0',
                 'group_instance': 0,
                 'answer_id': 'who-is-related',
                 'answer_instance': 0,
                 'value': 'Husband or Wife'
             }, {
+                'group_instance_id': 'group-0',
                 'group_instance': 0,
                 'answer_id': 'who-is-related',
                 'answer_instance': 1,
                 'value': 'Son or daughter'
             }, {
+                'group_instance_id': 'group-0',
                 'group_instance': 0,
                 'answer_id': 'who-is-related',
                 'answer_instance': 2,
@@ -154,20 +157,23 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
 
         field_data = ['Husband or Wife', 'Son or daughter', 'Unrelated']
 
-        actual_answers = serialise_relationship_answers('who-is-related', field_data, 1)
+        actual_answers = serialise_relationship_answers('who-is-related', field_data, 1, 'group-1')
 
         expected_answers = [
             {
+                'group_instance_id': 'group-1',
                 'group_instance': 1,
                 'answer_id': 'who-is-related',
                 'answer_instance': 0,
                 'value': 'Husband or Wife'
             }, {
+                'group_instance_id': 'group-1',
                 'group_instance': 1,
                 'answer_id': 'who-is-related',
                 'answer_instance': 1,
                 'value': 'Son or daughter'
             }, {
+                'group_instance_id': 'group-1',
                 'group_instance': 1,
                 'answer_id': 'who-is-related',
                 'answer_instance': 2,

--- a/tests/app/helpers/test_form_helper.py
+++ b/tests/app/helpers/test_form_helper.py
@@ -159,31 +159,27 @@ class TestFormHelper(AppContextTestCase):
 
             answer_store = AnswerStore([
                 {
-                    'group_id': 'who-lives-here-relationship',
                     'group_instance': 0,
+                    'group_instance_id': 'who-lives-here-relationship-0',
                     'answer_id': 'first-name',
-                    'block_id': 'household-composition',
                     'value': 'Joe',
                     'answer_instance': 0,
                 }, {
-                    'group_id': 'who-lives-here-relationship',
                     'group_instance': 0,
+                    'group_instance_id': 'who-lives-here-relationship-0',
                     'answer_id': 'last-name',
-                    'block_id': 'household-composition',
                     'value': 'Bloggs',
                     'answer_instance': 0,
                 }, {
-                    'group_id': 'who-lives-here-relationship',
-                    'group_instance': 1,
+                    'group_instance': 0,
+                    'group_instance_id': 'who-lives-here-relationship-0',
                     'answer_id': 'first-name',
-                    'block_id': 'household-composition',
                     'value': 'Jane',
                     'answer_instance': 1,
                 }, {
-                    'group_id': 'who-lives-here-relationship',
-                    'group_instance': 1,
+                    'group_instance': 0,
+                    'group_instance_id': 'who-lives-here-relationship-0',
                     'answer_id': 'last-name',
-                    'block_id': 'household-composition',
                     'value': 'Bloggs',
                     'answer_instance': 1,
                 }
@@ -209,22 +205,26 @@ class TestFormHelper(AppContextTestCase):
             answer_store = AnswerStore([
                 {
                     'answer_id': 'first-name',
-                    'block_id': 'household-composition',
+                    'group_instance': 0,
+                    'group_instance_id': 'who-lives-here-relationship-0',
                     'value': 'Joe',
                     'answer_instance': 0,
                 }, {
                     'answer_id': 'last-name',
-                    'block_id': 'household-composition',
+                    'group_instance': 0,
+                    'group_instance_id': 'who-lives-here-relationship-0',
                     'value': 'Bloggs',
                     'answer_instance': 0,
                 }, {
                     'answer_id': 'first-name',
-                    'block_id': 'household-composition',
+                    'group_instance': 0,
+                    'group_instance_id': 'who-lives-here-relationship-0',
                     'value': 'Jane',
                     'answer_instance': 1,
                 }, {
                     'answer_id': 'last-name',
-                    'block_id': 'household-composition',
+                    'group_instance': 0,
+                    'group_instance_id': 'who-lives-here-relationship-0',
                     'value': 'Bloggs',
                     'answer_instance': 1,
                 }
@@ -358,12 +358,14 @@ class TestGetMappedAnswers(unittest.TestCase):
         answer_1 = Answer(
             answer_id='answer2',
             answer_instance=1,
+            group_instance_id='group-1',
             group_instance=1,
             value=25,
         )
         answer_2 = Answer(
             answer_id='answer1',
             answer_instance=1,
+            group_instance_id='group-1',
             group_instance=1,
             value=65,
         )
@@ -375,7 +377,7 @@ class TestGetMappedAnswers(unittest.TestCase):
             'answer1_1': 65
         }
 
-        self.assertEqual(get_mapped_answers(schema, self.store, block_id='block1', group_instance=1), expected_answers)
+        self.assertEqual(get_mapped_answers(schema, self.store, block_id='block1', group_instance=1, group_instance_id='group-1'), expected_answers)
 
     def test_returns_ordered_map(self):
 
@@ -403,6 +405,7 @@ class TestGetMappedAnswers(unittest.TestCase):
 
         answer = Answer(
             answer_id='answer1',
+            group_instance_id='group-1',
             group_instance=1,
             value=25,
         )
@@ -416,7 +419,7 @@ class TestGetMappedAnswers(unittest.TestCase):
 
         self.assertEqual(len(self.store.answers), 100)
 
-        mapped = get_mapped_answers(schema, self.store, block_id='block1', group_instance=1)
+        mapped = get_mapped_answers(schema, self.store, block_id='block1', group_instance=1, group_instance_id='group-1')
 
         for key, _ in mapped.items():
             pos = key.find('_')

--- a/tests/app/helpers/test_schema_helpers.py
+++ b/tests/app/helpers/test_schema_helpers.py
@@ -1,0 +1,83 @@
+from app.data_model.answer_store import Answer, AnswerStore
+from app.helpers.schema_helpers import get_group_instance_id
+from app.questionnaire.location import Location
+from app.questionnaire.questionnaire_schema import QuestionnaireSchema
+from tests.app.app_context_test_case import AppContextTestCase
+
+
+class TestFormHelper(AppContextTestCase):
+
+    def test_get_group_instance_id(self):
+        questionnaire = {
+            'sections': [{
+                'id': 'section1',
+                'groups': [
+                    {
+                        'id': 'group1',
+                        'blocks': [
+                            {
+                                'id': 'block1',
+                                'questions': [{
+                                    'id': 'question1',
+                                    'type': 'Question',
+                                    'answers': [
+                                        {
+                                            'id': 'answer1',
+                                            'type': 'TextArea'
+                                        }
+                                    ]
+                                }]
+                            }
+                        ]
+                    },
+                    {
+                        'id': 'group2',
+                        'blocks': [
+                            {
+                                'id': 'block2',
+                                'questions': [{
+                                    'id': 'question2',
+                                    'type': 'Question',
+                                    'answers': [
+                                        {
+                                            'id': 'answer2',
+                                            'type': 'TextArea'
+                                        }
+                                    ]
+                                }]
+                            }
+                        ],
+                        'routing_rules': [{
+                            'repeat': {
+                                'type': 'group',
+                                'group_ids': ['group1']
+                            }
+                        }]
+                    }
+                ]
+            }]
+        }
+        schema = QuestionnaireSchema(questionnaire)
+
+        answer_1 = Answer(
+            answer_id='answer1',
+            group_instance_id='group1-aaa',
+            group_instance=0,
+            value=25,
+        )
+        answer_2 = Answer(
+            answer_id='answer1',
+            group_instance_id='group1-bbb',
+            group_instance=1,
+            value=65,
+        )
+
+        store = AnswerStore(None)
+        store.add(answer_1)
+        store.add(answer_2)
+
+        location = Location('group2', 0, 'block2')
+        self.assertEqual(get_group_instance_id(schema, store, location), 'group1-aaa')
+
+        location = Location('group2', 1, 'block2')
+        self.assertEqual(get_group_instance_id(schema, store, location), 'group1-bbb')

--- a/tests/app/questionnaire/test_answer_dependencies.py
+++ b/tests/app/questionnaire/test_answer_dependencies.py
@@ -1,6 +1,6 @@
 import unittest
 from app.questionnaire.answer_dependencies import AnswerDependencies
-from app.questionnaire.answer_dependencies import get_dependencies
+from app.questionnaire.answer_dependencies import get_answer_dependencies
 from app.questionnaire.questionnaire_schema import QuestionnaireSchema
 
 
@@ -109,7 +109,7 @@ class TestGetDependencies(unittest.TestCase):
 
         schema = QuestionnaireSchema(survey_json)   # schema uses a dependencies builder, using an external one to make tests obvious
 
-        dependencies = get_dependencies(schema)
+        dependencies = get_answer_dependencies(schema)
 
         self.assertEqual(len(dependencies), 2)
         self.assertEqual(dependencies['dependency1'], {'set-minimum'})
@@ -167,7 +167,7 @@ class TestGetDependencies(unittest.TestCase):
 
         schema = QuestionnaireSchema(survey_json)
 
-        dependencies = get_dependencies(schema)
+        dependencies = get_answer_dependencies(schema)
 
         self.assertEqual(len(dependencies), 2)
         self.assertEqual(dependencies['dependency1'], {'set-minimum'})
@@ -239,7 +239,7 @@ class TestGetDependencies(unittest.TestCase):
         }
         schema = QuestionnaireSchema(survey_json)
 
-        dependencies = get_dependencies(schema)
+        dependencies = get_answer_dependencies(schema)
 
         self.assertEqual(len(dependencies), 1)
         self.assertEqual(dependencies['total-answer'], {'breakdown-1', 'breakdown-2', 'breakdown-3', 'breakdown-4'})
@@ -307,7 +307,7 @@ class TestGetDependencies(unittest.TestCase):
 
         schema = QuestionnaireSchema(survey_json)
 
-        dependencies = get_dependencies(schema)
+        dependencies = get_answer_dependencies(schema)
 
         self.assertEqual(len(dependencies), 3)
         self.assertEqual(dependencies['behalf-of-answer1'], {'gender-answer'})

--- a/tests/app/questionnaire/test_group_dependencies.py
+++ b/tests/app/questionnaire/test_group_dependencies.py
@@ -1,0 +1,323 @@
+import unittest
+from app.questionnaire.group_dependencies import GroupDependencies
+from app.questionnaire.group_dependencies import get_group_dependencies
+from app.questionnaire.questionnaire_schema import QuestionnaireSchema
+
+
+class TestGroupDependencies(unittest.TestCase):
+    def test_adding_of_dependencies(self):
+        sut = GroupDependencies()
+
+        sut.add('dependent_id', 'dependency_driver_id', 'group')
+        sut.add('dependent_id2', 'dependency_driver_id2', 'group')
+        sut.add('dependent_id3', 'dependency_driver_id3', 'block')
+
+        self.assertEqual(len(sut), 3)
+        self.assertEqual(sut['dependent_id2'], ['dependency_driver_id2'])
+        self.assertEqual(sut['group_drivers'], ['dependency_driver_id', 'dependency_driver_id2'])
+        self.assertEqual(sut['block_drivers'], ['dependency_driver_id3'])
+
+    def test_duplicate_dependencies_do_not_duplicate(self):
+        sut = GroupDependencies()
+
+        sut.add('dependent_id', 'dependency_driver_id', 'group')
+        sut.add('dependent_id', 'dependency_driver_id', 'group')
+        sut.add('dependent_id2', 'dependency_driver_id2', 'block')
+        sut.add('dependent_id2', 'dependency_driver_id2', 'block')
+
+        self.assertEqual(sut['dependent_id'], ['dependency_driver_id'])
+        self.assertEqual(sut['dependent_id2'], ['dependency_driver_id2'])
+        self.assertEqual(sut['group_drivers'], ['dependency_driver_id'])
+        self.assertEqual(sut['block_drivers'], ['dependency_driver_id2'])
+
+    def test_multiple_adds_are_added_to_correct_group(self):
+        sut = GroupDependencies()
+
+        sut.add('dependent_id1', 'dependency_driver_id1', 'group')
+        sut.add('dependent_id2', 'dependency_driver_id2.1', 'group')
+        sut.add('dependent_id2', 'dependency_driver_id2.2', 'group')
+        sut.add('dependent_id3', 'dependency_driver_id3.1', 'block')
+        sut.add('dependent_id3', 'dependency_driver_id3.2', 'block')
+        sut.add('dependent_id3', 'dependency_driver_id3.3', 'block')
+
+        self.assertEqual(sut['dependent_id1'], ['dependency_driver_id1'])
+        self.assertEqual(sut['dependent_id2'], ['dependency_driver_id2.1', 'dependency_driver_id2.2'])
+        self.assertEqual(sut['dependent_id3'],
+                         ['dependency_driver_id3.1', 'dependency_driver_id3.2', 'dependency_driver_id3.3'])
+        self.assertEqual(sut['group_drivers'],
+                         ['dependency_driver_id1', 'dependency_driver_id2.1', 'dependency_driver_id2.2'])
+        self.assertEqual(sut['block_drivers'],
+                         ['dependency_driver_id3.1', 'dependency_driver_id3.2', 'dependency_driver_id3.3'])
+
+    def test_dependencies_can_be_added_with_update_without_duplicates(self):
+        sut_a = GroupDependencies()
+        sut_a.add('dependent_id1', 'dependency_driver_id1', 'group')
+        sut_a.add('dependent_id2', 'dependency_driver_id2.1', 'group')
+        sut_a.add('dependent_id2', 'dependency_driver_id2.2', 'group')
+        sut_a.add('dependent_id3', 'dependency_driver_id3.1', 'block')
+
+        sut_b = GroupDependencies()
+        sut_a.add('dependent_id2', 'dependency_driver_id2.1', 'group')
+        sut_b.add('dependent_id3', 'dependency_driver_id3.1', 'block')
+        sut_b.add('dependent_id3', 'dependency_driver_id3.2', 'block')
+        sut_b.add('dependent_id3', 'dependency_driver_id3.3', 'block')
+
+        sut_a.update(sut_b)
+
+        self.assertEqual(sut_a['dependent_id1'], ['dependency_driver_id1'])
+        self.assertEqual(sut_a['dependent_id2'], ['dependency_driver_id2.1', 'dependency_driver_id2.2'])
+        self.assertEqual(sut_a['dependent_id3'],
+                         ['dependency_driver_id3.1', 'dependency_driver_id3.2', 'dependency_driver_id3.3'])
+        self.assertEqual(sut_a['group_drivers'],
+                         ['dependency_driver_id1', 'dependency_driver_id2.1', 'dependency_driver_id2.2'])
+        self.assertEqual(sut_a['block_drivers'],
+                         ['dependency_driver_id3.1', 'dependency_driver_id3.2', 'dependency_driver_id3.3'])
+
+
+class TestGetDependencies(unittest.TestCase):
+
+    def test_repeat_with_group_ids_added_to_dependencies(self):
+        survey_json = {
+            'sections': [{
+                'id': 'default-section',
+                'groups': [
+                    {
+                        'id': 'dependent-group',
+                        'routing_rules': [{
+                            'repeat': {
+                                'type': 'group',
+                                'group_ids': [
+                                    'primary-group',
+                                    'repeating-group'
+                                ]
+                            }
+                        }],
+                        'blocks': [{
+                            'type': 'Question',
+                            'id': 'dependent-block',
+                            'questions': [{
+                                'id': 'dependent-question',
+                                'type': 'General',
+                                'answers': [{
+                                    'id': 'dependent-answer',
+                                    'type': 'TextField'
+                                }]
+                            }]
+                        }]
+                    }]
+            }]
+        }
+
+        schema = QuestionnaireSchema(survey_json)
+        dependencies = get_group_dependencies(schema)
+
+        self.assertEqual(len(dependencies), 1)
+        self.assertEqual(dependencies['dependent-group'], ['primary-group', 'repeating-group'])
+        self.assertEqual(dependencies['group_drivers'], ['primary-group', 'repeating-group'])
+        self.assertEqual(dependencies['block_drivers'], [])
+
+    def test_repeat_with_answer_count_added_to_dependencies(self):
+        survey_json = {
+            'sections': [{
+                'id': 'default-section',
+                'groups': [
+                    {
+                        'id': 'driving-group',
+                        'blocks': [{
+                            'type': 'Question',
+                            'id': 'driving-block',
+                            'questions': [{
+                                'id': 'driving-question',
+                                'type': 'General',
+                                'answers': [{
+                                    'id': 'driving-answer',
+                                    'type': 'TextField'
+                                }]
+                            }]
+                        }]
+                    },
+                    {
+                        'id': 'dependent-group',
+                        'routing_rules': [{
+                            'repeat': {
+                                'type': 'answer_count',
+                                'answer_id': 'driving-answer'
+                            }
+                        }],
+                        'blocks': [{
+                            'type': 'Question',
+                            'id': 'dependent-block',
+                            'questions': [{
+                                'id': 'dependent-question',
+                                'type': 'General',
+                                'answers': [{
+                                    'id': 'dependent-answer',
+                                    'type': 'TextField'
+                                }]
+                            }]
+                        }]
+                    }]
+            }]
+        }
+
+        schema = QuestionnaireSchema(survey_json)
+        dependencies = get_group_dependencies(schema)
+
+        self.assertEqual(len(dependencies), 1)
+        self.assertEqual(dependencies['dependent-group'], ['driving-block'])
+        self.assertEqual(dependencies['group_drivers'], [])
+        self.assertEqual(dependencies['block_drivers'], ['driving-block'])
+
+    def test_repeat_with_answer_count_minus_one_added_to_dependencies(self):
+        survey_json = {
+            'sections': [{
+                'id': 'default-section',
+                'groups': [
+                    {
+                        'id': 'driving-group',
+                        'blocks': [{
+                            'type': 'Question',
+                            'id': 'driving-block',
+                            'questions': [{
+                                'id': 'driving-question',
+                                'type': 'General',
+                                'answers': [{
+                                    'id': 'driving-answer',
+                                    'type': 'TextField'
+                                }]
+                            }]
+                        }]
+                    },
+                    {
+                        'id': 'dependent-group',
+                        'routing_rules': [{
+                            'repeat': {
+                                'type': 'answer_count_minus_one',
+                                'answer_id': 'driving-answer'
+                            }
+                        }],
+                        'blocks': [{
+                            'type': 'Question',
+                            'id': 'dependent-block',
+                            'questions': [{
+                                'id': 'dependent-question',
+                                'type': 'General',
+                                'answers': [{
+                                    'id': 'dependent-answer',
+                                    'type': 'TextField'
+                                }]
+                            }]
+                        }]
+                    }]
+            }]
+        }
+
+        schema = QuestionnaireSchema(survey_json)
+        dependencies = get_group_dependencies(schema)
+
+        self.assertEqual(len(dependencies), 1)
+        self.assertEqual(dependencies['dependent-group'], ['driving-block'])
+        self.assertEqual(dependencies['group_drivers'], [])
+        self.assertEqual(dependencies['block_drivers'], ['driving-block'])
+
+    def test_repeat_with_relationship_block_not_added_to_dependencies(self):
+        survey_json = {
+            'sections': [{
+                'id': 'default-section',
+                'groups': [
+                    {
+                        'id': 'driving-group',
+                        'blocks': [{
+                            'type': 'Question',
+                            'id': 'driving-block',
+                            'questions': [{
+                                'id': 'driving-question',
+                                'type': 'General',
+                                'answers': [{
+                                    'id': 'driving-answer',
+                                    'type': 'TextField'
+                                }]
+                            }]
+                        }]
+                    },
+                    {
+                        'id': 'dependent-group',
+                        'routing_rules': [{
+                            'repeat': {
+                                'type': 'answer_count',
+                                'answer_id': 'driving-answer'
+                            }
+                        }],
+                        'blocks': [{
+                            'type': 'Question',
+                            'id': 'dependent-block',
+                            'questions': [{
+                                'id': 'dependent-question',
+                                'type': 'Relationship',
+                                'answers': [{
+                                    'id': 'dependent-answer',
+                                    'type': 'TextField'
+                                }]
+                            }]
+                        }]
+                    }]
+            }]
+        }
+
+        schema = QuestionnaireSchema(survey_json)
+        dependencies = get_group_dependencies(schema)
+
+        self.assertEqual(len(dependencies), 0)
+        self.assertEqual(dependencies['group_drivers'], [])
+        self.assertEqual(dependencies['block_drivers'], [])
+
+    def test_repeat_with_answer_value_not_added_to_dependencies(self):
+        survey_json = {
+            'sections': [{
+                'id': 'default-section',
+                'groups': [
+                    {
+                        'id': 'driving-group',
+                        'blocks': [{
+                            'type': 'Question',
+                            'id': 'driving-block',
+                            'questions': [{
+                                'id': 'driving-question',
+                                'type': 'General',
+                                'answers': [{
+                                    'id': 'driving-answer',
+                                    'type': 'Number'
+                                }]
+                            }]
+                        }]
+                    },
+                    {
+                        'id': 'dependent-group',
+                        'routing_rules': [{
+                            'repeat': {
+                                'type': 'answer_value',
+                                'answer_id': 'driving-answer'
+                            }
+                        }],
+                        'blocks': [{
+                            'type': 'Question',
+                            'id': 'dependent-block',
+                            'questions': [{
+                                'id': 'dependent-question',
+                                'type': 'General',
+                                'answers': [{
+                                    'id': 'dependent-answer',
+                                    'type': 'TextField'
+                                }]
+                            }]
+                        }]
+                    }]
+            }]
+        }
+
+        schema = QuestionnaireSchema(survey_json)
+        dependencies = get_group_dependencies(schema)
+
+        self.assertEqual(len(dependencies), 0)
+        self.assertEqual(dependencies['group_drivers'], [])
+        self.assertEqual(dependencies['block_drivers'], [])

--- a/tests/app/questionnaire/test_navigation.py
+++ b/tests/app/questionnaire/test_navigation.py
@@ -370,6 +370,7 @@ class TestNavigation(AppContextTestCase):
         answer_1 = Answer(
             value=2,
             group_instance=0,
+            group_instance_id='group-1-0',
             answer_id='extra-cover-answer',
             answer_instance=0
 
@@ -377,24 +378,28 @@ class TestNavigation(AppContextTestCase):
         answer_2 = Answer(
             value='1',
             group_instance=0,
+            group_instance_id='group-1-0',
             answer_id='extra-cover-items-answer',
             answer_instance=0
         )
         answer_3 = Answer(
             value='Yes',
             group_instance=0,
+            group_instance_id='group-1-0',
             answer_id='extra-cover-items-radio-answer',
             answer_instance=0
         )
         answer_4 = Answer(
             value='2',
             group_instance=1,
+            group_instance_id='group-1-1',
             answer_id='extra-cover-items-answer',
             answer_instance=0
         )
         answer_5 = Answer(
             value='Yes',
             group_instance=1,
+            group_instance_id='group-1-1',
             answer_id='extra-cover-items-radio-answer',
             answer_instance=0
         )
@@ -631,6 +636,7 @@ class TestNavigation(AppContextTestCase):
         answer_1 = Answer(
             value='Contents',
             group_instance=0,
+            group_instance_id='group-0',
             answer_instance=0,
             answer_id='insurance-type-answer'
         )
@@ -645,6 +651,7 @@ class TestNavigation(AppContextTestCase):
         change_answer = Answer(
             value='Buildings',
             group_instance=0,
+            group_instance_id='group-0',
             answer_instance=0,
             answer_id='insurance-type-answer'
         )

--- a/tests/app/questionnaire/test_path_finder.py
+++ b/tests/app/questionnaire/test_path_finder.py
@@ -637,12 +637,14 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
 
         answer_2 = Answer(
             group_instance=0,
+            group_instance_id='group-0',
             answer_id='conditional-answer',
             value='Age and Shoe Size'
         )
 
         answer_3 = Answer(
             group_instance=1,
+            group_instance_id='group-1',
             answer_id='conditional-answer',
             value='Shoe Size Only'
         )
@@ -674,12 +676,12 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         answer_store = AnswerStore()
 
         # Set up some first names
-        answer_store.add(Answer(answer_id='first-name', value='aaa', group_instance=0))
-        answer_store.add(Answer(answer_id='first-name', value='bbb', group_instance=1))
-        answer_store.add(Answer(answer_id='first-name', value='ccc', group_instance=2))
+        answer_store.add(Answer(answer_id='first-name', value='aaa', group_instance=0, group_instance_id='group-1-0'))
+        answer_store.add(Answer(answer_id='first-name', value='bbb', group_instance=1, group_instance_id='group-1-1'))
+        answer_store.add(Answer(answer_id='first-name', value='ccc', group_instance=2, group_instance_id='group-1-2'))
 
         # Set up the independent answer
-        answer_store.add(Answer(answer_id='an-independent-answer', value=independent_answer, group_instance=0))
+        answer_store.add(Answer(answer_id='an-independent-answer', value=independent_answer, group_instance=0, group_instance_id='group-1-0'))
 
         path_finder = PathFinder(schema, answer_store=answer_store, metadata={}, completed_blocks=[])
 
@@ -712,12 +714,12 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         answer_store = AnswerStore()
 
         # Set up some first names
-        answer_store.add(Answer(answer_id='first-name', value='aaa', group_instance=0))
-        answer_store.add(Answer(answer_id='first-name', value='bbb', group_instance=1))
-        answer_store.add(Answer(answer_id='first-name', value='ccc', group_instance=2))
+        answer_store.add(Answer(answer_id='first-name', value='aaa', group_instance=0, group_instance_id='group-1-0'))
+        answer_store.add(Answer(answer_id='first-name', value='bbb', group_instance=1, group_instance_id='group-1-1'))
+        answer_store.add(Answer(answer_id='first-name', value='ccc', group_instance=2, group_instance_id='group-1-2'))
 
         # Set up the independent answer
-        answer_store.add(Answer(answer_id='an-independent-answer', value=independent_answer, group_instance=0))
+        answer_store.add(Answer(answer_id='an-independent-answer', value=independent_answer, group_instance=0, group_instance_id='group-1-0'))
 
         # When
         with patch('app.questionnaire.path_finder.evaluate_skip_conditions', return_value=False):
@@ -760,17 +762,17 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
 
                 # Set up some first names
 
-                answer_store.add(Answer(answer_id='first-name', value='aaa', group_instance=0))
-                answer_store.add(Answer(answer_id='first-name', value='bbb', group_instance=1))
-                answer_store.add(Answer(answer_id='first-name', value='ccc', group_instance=2))
-                answer_store.add(Answer(answer_id='first-name', value='ddd', group_instance=3))
+                answer_store.add(Answer(answer_id='first-name', value='aaa', group_instance=0, group_instance_id='group-1-0'))
+                answer_store.add(Answer(answer_id='first-name', value='bbb', group_instance=1, group_instance_id='group-1-1'))
+                answer_store.add(Answer(answer_id='first-name', value='ccc', group_instance=2, group_instance_id='group-1-2'))
+                answer_store.add(Answer(answer_id='first-name', value='ddd', group_instance=3, group_instance_id='group-1-3'))
 
                 # Now set a date of birth for the two group instances
 
                 answer_store.add(Answer(answer_id='date-of-birth-answer', value='01-01-1980',
-                                        group_instance=first_group_instance))
+                                        group_instance=first_group_instance, group_instance_id='group-1-{}'.format(first_group_instance)))
                 answer_store.add(Answer(answer_id='date-of-birth-answer', value='01-01-1980',
-                                        group_instance=second_group_instance))
+                                        group_instance=second_group_instance, group_instance_id='group-1-{}'.format(second_group_instance)))
 
                 path_finder = PathFinder(schema, answer_store=answer_store, metadata={}, completed_blocks=[])
 
@@ -795,6 +797,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         for i in range(50):
             answers.add(Answer(
                 group_instance=i,
+                group_instance_id='group-1-{}'.format(i),
                 answer_id='conditional-answer',
                 value='Shoe Size Only'
             ))

--- a/tests/app/questionnaire/test_questionnaire_schema.py
+++ b/tests/app/questionnaire/test_questionnaire_schema.py
@@ -330,7 +330,7 @@ class TestQuestionnaireSchema(AppContextTestCase):
 
     def test_title_when_dependencies_are_added_to_dependencies(self):
         schema = load_schema_from_params('test', 'titles')
-        dependencies = schema.dependencies['behalf-of-answer']
+        dependencies = schema.answer_dependencies['behalf-of-answer']
 
         self.assertIn('gender-answer', dependencies)
         self.assertIn('age-answer', dependencies)

--- a/tests/app/submitter/test_convert_payload_0_0_2.py
+++ b/tests/app/submitter/test_convert_payload_0_0_2.py
@@ -75,27 +75,19 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
 
             # Then
             self.assertEqual(len(answer_object['data']), 4)
-            self.assertEqual(answer_object['data'][0]['group_id'], 'personal details')
             self.assertEqual(answer_object['data'][0]['group_instance'], 0)
-            self.assertEqual(answer_object['data'][0]['block_id'], 'about you')
             self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
             self.assertEqual(answer_object['data'][0]['value'], 'Joe Bloggs')
 
-            self.assertEqual(answer_object['data'][1]['group_id'], 'personal details')
             self.assertEqual(answer_object['data'][1]['group_instance'], 0)
-            self.assertEqual(answer_object['data'][1]['block_id'], 'about you')
             self.assertEqual(answer_object['data'][1]['answer_instance'], 1)
             self.assertEqual(answer_object['data'][1]['value'], 'Fred Bloggs')
 
-            self.assertEqual(answer_object['data'][2]['group_id'], 'household')
             self.assertEqual(answer_object['data'][2]['group_instance'], 0)
-            self.assertEqual(answer_object['data'][2]['block_id'], 'where you live')
             self.assertEqual(answer_object['data'][2]['answer_instance'], 0)
             self.assertEqual(answer_object['data'][2]['value'], '62 Somewhere')
 
-            self.assertEqual(answer_object['data'][3]['group_id'], 'household')
             self.assertEqual(answer_object['data'][3]['group_instance'], 1)
-            self.assertEqual(answer_object['data'][3]['block_id'], 'where you live')
             self.assertEqual(answer_object['data'][3]['answer_instance'], 0)
             self.assertEqual(answer_object['data'][3]['value'], '63 Somewhere')
 
@@ -136,9 +128,7 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
 
             # Then
             self.assertEqual(len(answer_object['data']), 1)
-            self.assertEqual(answer_object['data'][0]['group_id'], 'favourite-food')
             self.assertEqual(answer_object['data'][0]['group_instance'], 0)
-            self.assertEqual(answer_object['data'][0]['block_id'], 'crisps')
             self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
             self.assertEqual(answer_object['data'][0]['value'], ['Ready salted', 'Sweet chilli'])
 
@@ -175,8 +165,6 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             # Then
             self.assertEqual(len(answer_object['data']), 1)
             self.assertEqual(answer_object['data'][0]['value'], 'Coffee')
-            self.assertEqual(answer_object['data'][0]['group_id'], 'radio-group')
-            self.assertEqual(answer_object['data'][0]['block_id'], 'radio-block')
             self.assertEqual(answer_object['data'][0]['group_instance'], 0)
             self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
 
@@ -203,8 +191,6 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             # Then
             self.assertEqual(len(answer_object['data']), 1)
             self.assertEqual(answer_object['data'][0]['value'], 1.755)
-            self.assertEqual(answer_object['data'][0]['group_id'], 'number-group')
-            self.assertEqual(answer_object['data'][0]['block_id'], 'number-block')
             self.assertEqual(answer_object['data'][0]['group_instance'], 0)
             self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
 
@@ -231,8 +217,6 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             # Then
             self.assertEqual(len(answer_object['data']), 1)
             self.assertEqual(answer_object['data'][0]['value'], 99)
-            self.assertEqual(answer_object['data'][0]['group_id'], 'percentage-group')
-            self.assertEqual(answer_object['data'][0]['block_id'], 'percentage-block')
             self.assertEqual(answer_object['data'][0]['group_instance'], 0)
             self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
 
@@ -259,8 +243,6 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             # Then
             self.assertEqual(len(answer_object['data']), 1)
             self.assertEqual(answer_object['data'][0]['value'], 'This is an example text!')
-            self.assertEqual(answer_object['data'][0]['group_id'], 'textarea-group')
-            self.assertEqual(answer_object['data'][0]['block_id'], 'textarea-block')
             self.assertEqual(answer_object['data'][0]['group_instance'], 0)
             self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
 
@@ -287,8 +269,6 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             # Then
             self.assertEqual(len(answer_object['data']), 1)
             self.assertEqual(answer_object['data'][0]['value'], 100)
-            self.assertEqual(answer_object['data'][0]['group_id'], 'currency-group')
-            self.assertEqual(answer_object['data'][0]['block_id'], 'currency-block')
             self.assertEqual(answer_object['data'][0]['group_instance'], 0)
             self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
 
@@ -329,8 +309,6 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             # Then
             self.assertEqual(len(answer_object['data']), 1)
             self.assertEqual(answer_object['data'][0]['value'], 'Rugby is better!')
-            self.assertEqual(answer_object['data'][0]['group_id'], 'dropdown-group')
-            self.assertEqual(answer_object['data'][0]['block_id'], 'dropdown-block')
             self.assertEqual(answer_object['data'][0]['group_instance'], 0)
             self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
 
@@ -367,14 +345,10 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             # Then
             self.assertEqual(len(answer_object['data']), 2)
             self.assertEqual(answer_object['data'][0]['value'], '01-01-1990')
-            self.assertEqual(answer_object['data'][0]['group_id'], 'date-group')
-            self.assertEqual(answer_object['data'][0]['block_id'], 'date-block')
             self.assertEqual(answer_object['data'][0]['group_instance'], 0)
             self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
 
             self.assertEqual(answer_object['data'][1]['value'], '01-1990')
-            self.assertEqual(answer_object['data'][1]['group_id'], 'date-group')
-            self.assertEqual(answer_object['data'][1]['block_id'], 'date-block')
             self.assertEqual(answer_object['data'][1]['group_instance'], 0)
             self.assertEqual(answer_object['data'][1]['answer_instance'], 0)
 
@@ -401,8 +375,6 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             # Then
             self.assertEqual(len(answer_object['data']), 1)
             self.assertEqual(answer_object['data'][0]['value'], 10)
-            self.assertEqual(answer_object['data'][0]['group_id'], 'unit-group')
-            self.assertEqual(answer_object['data'][0]['block_id'], 'unit-block')
             self.assertEqual(answer_object['data'][0]['group_instance'], 0)
             self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
 
@@ -449,19 +421,14 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             # Then
             self.assertEqual(len(answer_object['data']), 3)
             self.assertEqual(answer_object['data'][0]['value'], 'Unrelated')
-            self.assertEqual(answer_object['data'][0]['group_id'], 'relationship-group')
-            self.assertEqual(answer_object['data'][0]['block_id'], 'relationship-block')
+
             self.assertEqual(answer_object['data'][0]['group_instance'], 0)
             self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
 
             self.assertEqual(answer_object['data'][1]['value'], 'Partner')
-            self.assertEqual(answer_object['data'][1]['group_id'], 'relationship-group')
-            self.assertEqual(answer_object['data'][1]['block_id'], 'relationship-block')
             self.assertEqual(answer_object['data'][1]['group_instance'], 0)
             self.assertEqual(answer_object['data'][1]['answer_instance'], 1)
 
             self.assertEqual(answer_object['data'][2]['value'], 'Husband or wife')
-            self.assertEqual(answer_object['data'][2]['group_id'], 'relationship-group')
-            self.assertEqual(answer_object['data'][2]['block_id'], 'relationship-block')
             self.assertEqual(answer_object['data'][2]['group_instance'], 0)
             self.assertEqual(answer_object['data'][2]['answer_instance'], 2)

--- a/tests/app/templating/summary/test_question.py
+++ b/tests/app/templating/summary/test_question.py
@@ -428,11 +428,13 @@ class TestQuestion(TestCase):
             answer_id='answer',
             value='Value 2',
             group_instance=1,
+            group_instance_id='group-1',
         ))
         self.answer_store.add(Answer(
             answer_id='answer',
             value='Value 3',
             group_instance=2,
+            group_instance_id='group-2',
         ))
         answer_schema = {'id': 'answer', 'title': '', 'type': '', 'label': ''}
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'RepeatingAnswer',

--- a/tests/app/templating/test_schema_context.py
+++ b/tests/app/templating/test_schema_context.py
@@ -5,6 +5,7 @@ from app.templating.schema_context import build_schema_context, _build_answers, 
 from app.utilities.schema import _load_schema_file
 from app.questionnaire.questionnaire_schema import QuestionnaireSchema, DEFAULT_LANGUAGE_CODE
 
+
 def get_metadata_sample():
     """Returns a metadata sample"""
     return {
@@ -21,6 +22,7 @@ def get_metadata_sample():
         'form_type': 'schema_context'
     }
 
+
 def get_test_schema():
     test_json = _load_schema_file('test_schema_context.json', DEFAULT_LANGUAGE_CODE)
     schema = QuestionnaireSchema(test_json, DEFAULT_LANGUAGE_CODE)
@@ -28,6 +30,7 @@ def get_test_schema():
     schema.is_repeating_answer_type = MagicMock(return_value=False)
     schema.answer_is_in_repeating_group = MagicMock(return_value=False)
     return schema
+
 
 class TestBuildSchemaContext(TestCase):  # pylint: disable=too-many-public-methods
 

--- a/tests/app/templating/test_summary_context.py
+++ b/tests/app/templating/test_summary_context.py
@@ -142,19 +142,19 @@ class TestCalculatedSummaryContext(TestStandardSummaryContext):
         super().setUp()
         self.schema = load_schema_from_params('test', 'calculated_summary')
         answers = [
-            {'value': 1, 'answer_id': 'first-number-answer', 'group_instance': 0, 'answer_instance': 0},
-            {'value': 2, 'answer_id': 'second-number-answer', 'group_instance': 0, 'answer_instance': 0},
-            {'value': 3, 'answer_id': 'second-number-answer-unit-total', 'group_instance': 0, 'answer_instance': 0},
-            {'value': 4, 'answer_id': 'second-number-answer-also-in-total', 'group_instance': 0, 'answer_instance': 0},
-            {'value': 5, 'answer_id': 'third-number-answer', 'group_instance': 0, 'answer_instance': 0},
-            {'value': 6, 'answer_id': 'third-number-answer-unit-total', 'group_instance': 0, 'answer_instance': 0},
-            {'value': 'No', 'answer_id': 'skip-fourth-block-answer', 'group_instance': 0, 'answer_instance': 0},
-            {'value': 7, 'answer_id': 'fourth-number-answer', 'group_instance': 0, 'answer_instance': 0},
-            {'value': 8, 'answer_id': 'fourth-number-answer-also-in-total', 'group_instance': 0, 'answer_instance': 0},
-            {'value': 9, 'answer_id': 'fifth-percent-answer', 'group_instance': 0, 'answer_instance': 0},
-            {'value': 10, 'answer_id': 'fifth-number-answer', 'group_instance': 0, 'answer_instance': 0},
-            {'value': 11, 'answer_id': 'sixth-percent-answer', 'group_instance': 0, 'answer_instance': 0},
-            {'value': 12, 'answer_id': 'sixth-number-answer', 'group_instance': 0, 'answer_instance': 0},
+            {'value': 1, 'answer_id': 'first-number-answer', 'group_instance': 0, 'group_instance_id': None, 'answer_instance': 0},
+            {'value': 2, 'answer_id': 'second-number-answer', 'group_instance': 0, 'group_instance_id': None, 'answer_instance': 0},
+            {'value': 3, 'answer_id': 'second-number-answer-unit-total', 'group_instance': 0, 'group_instance_id': None, 'answer_instance': 0},
+            {'value': 4, 'answer_id': 'second-number-answer-also-in-total', 'group_instance': 0, 'group_instance_id': None, 'answer_instance': 0},
+            {'value': 5, 'answer_id': 'third-number-answer', 'group_instance': 0, 'group_instance_id': None, 'answer_instance': 0},
+            {'value': 6, 'answer_id': 'third-number-answer-unit-total', 'group_instance': 0, 'group_instance_id': None, 'answer_instance': 0},
+            {'value': 'No', 'answer_id': 'skip-fourth-block-answer', 'group_instance': 0, 'group_instance_id': None, 'answer_instance': 0},
+            {'value': 7, 'answer_id': 'fourth-number-answer', 'group_instance': 0, 'group_instance_id': None, 'answer_instance': 0},
+            {'value': 8, 'answer_id': 'fourth-number-answer-also-in-total', 'group_instance': 0, 'group_instance_id': None, 'answer_instance': 0},
+            {'value': 9, 'answer_id': 'fifth-percent-answer', 'group_instance': 0, 'group_instance_id': None, 'answer_instance': 0},
+            {'value': 10, 'answer_id': 'fifth-number-answer', 'group_instance': 0, 'group_instance_id': None, 'answer_instance': 0},
+            {'value': 11, 'answer_id': 'sixth-percent-answer', 'group_instance': 0, 'group_instance_id': None, 'answer_instance': 0},
+            {'value': 12, 'answer_id': 'sixth-number-answer', 'group_instance': 0, 'group_instance_id': None, 'answer_instance': 0},
         ]
         self.answer_store = AnswerStore(answers)
         self.schema_context = {

--- a/tests/integration/census/test_census_communal_submission_data.py
+++ b/tests/integration/census/test_census_communal_submission_data.py
@@ -1,10 +1,13 @@
+from mock import patch
+
 from tests.integration.integration_test_case import IntegrationTestCase
 
 
 class TestCensusCommunalSubmissionData(IntegrationTestCase):
 
     def test_census_communal_data_matches_census_communal(self):
-        self.complete_survey('census', 'communal')
+        with patch('app.helpers.schema_helpers.uuid4', side_effect=range(100)):
+            self.complete_survey('census', 'communal')
 
         # Only verifying 'data'
         actual_downstream_data = self.dumpSubmission()['submission']['data']
@@ -19,31 +22,36 @@ class TestCensusCommunalSubmissionData(IntegrationTestCase):
                 'value': 'Hotel',
                 'answer_id': 'establishment-type-answer',
                 'answer_instance': 0,
-                'group_instance': 0
+                'group_instance': 0,
+                'group_instance_id': None,
             },
             {
                 'value': '',
                 'answer_id': 'establishment-type-answer-other',
                 'answer_instance': 0,
-                'group_instance': 0
+                'group_instance': 0,
+                'group_instance_id': None,
             },
             {
                 'value': 20,
                 'answer_id': 'bed-spaces-answer',
                 'answer_instance': 0,
-                'group_instance': 0
+                'group_instance': 0,
+                'group_instance_id': None,
             },
             {
                 'value': 'Yes',
                 'answer_id': 'usual-residents-answer',
                 'answer_instance': 0,
-                'group_instance': 0
+                'group_instance': 0,
+                'group_instance_id': None,
             },
             {
                 'value': 99,
                 'answer_id': 'usual-residents-number-answer',
                 'answer_instance': 0,
-                'group_instance': 0
+                'group_instance': 0,
+                'group_instance_id': None,
             },
             {
                 'value': [
@@ -54,49 +62,57 @@ class TestCensusCommunalSubmissionData(IntegrationTestCase):
                 ],
                 'answer_id': 'describe-residents-answer',
                 'answer_instance': 0,
-                'group_instance': 0
+                'group_instance': 0,
+                'group_instance_id': None,
             },
             {
                 'value': 'Sports visitors',
                 'answer_id': 'describe-residents-answer-other',
                 'answer_instance': 0,
-                'group_instance': 0
+                'group_instance': 0,
+                'group_instance_id': None,
             },
             {
                 'value': 'Online',
                 'answer_id': 'completion-preference-individual-answer',
                 'answer_instance': 0,
-                'group_instance': 0
+                'group_instance': 0,
+                'group_instance_id': None,
             },
             {
                 'value': 'Online',
                 'answer_id': 'completion-preference-establishment-answer',
                 'answer_instance': 0,
-                'group_instance': 0
+                'group_instance': 0,
+                'group_instance_id': None,
             },
             {
                 'value': 'Yes',
                 'answer_id': 'further-contact-answer',
                 'answer_instance': 0,
-                'group_instance': 0
+                'group_instance': 0,
+                'group_instance_id': None,
             },
             {
                 'value': '0123456789',
                 'answer_id': 'contact-details-answer-phone',
                 'answer_instance': 0,
-                'group_instance': 0
+                'group_instance': 0,
+                'group_instance_id': None,
             },
             {
                 'value': 'danny.boje@gmail.com',
                 'answer_id': 'contact-details-answer-email',
                 'answer_instance': 0,
-                'group_instance': 0
+                'group_instance': 0,
+                'group_instance_id': None,
             },
             {
                 'value': 'Danny',
                 'answer_id': 'contact-details-answer-name',
                 'answer_instance': 0,
-                'group_instance': 0
+                'group_instance': 0,
+                'group_instance_id': None,
             }
         ]
 

--- a/tests/integration/census/test_census_household_submission_data.py
+++ b/tests/integration/census/test_census_household_submission_data.py
@@ -1,654 +1,542 @@
+from mock import patch
+
 from tests.integration.integration_test_case import IntegrationTestCase
 
 
 # pylint: disable=too-many-lines
 class TestCensusHouseholdSubmissionData(IntegrationTestCase):
     def test_census_household_data_matches_census_individual(self):
-        self.complete_survey('census', 'household')
+        with patch('app.helpers.schema_helpers.uuid4', side_effect=range(100)):
+            self.complete_survey('census', 'household')
 
         # Only verifying 'data'
         actual_downstream_data = self.dumpSubmission()['submission']['data']
 
         expected_downstream_data = self.get_expected_submission_data()
-
         self.assertCountEqual(actual_downstream_data, expected_downstream_data)
 
     @staticmethod
     def get_expected_submission_data():
         expected_downstream_data = [
-            {
-                'answer_id': 'address-line-1',
-                'answer_instance': 0,
-                'group_instance': 0,
-                'value': '44 hill side'
-            },
-            {
-                'answer_id': 'address-line-2',
-                'answer_instance': 0,
-                'group_instance': 0,
-                'value': 'cimla'
-            },
-            {
-                'answer_id': 'county',
-                'answer_instance': 0,
-                'group_instance': 0,
-                'value': 'west glamorgan'
-            },
-            {
-                'answer_id': 'country',
-                'answer_instance': 0,
-                'group_instance': 0,
-                'value': 'wales'
-            },
-            {
-                'answer_id': 'postcode',
-                'answer_instance': 0,
-                'group_instance': 0,
-                'value': 'cf336gn'
-            },
-            {
-                'answer_id': 'address-line-3',
-                'answer_instance': 0,
-                'group_instance': 0,
-                'value': ''
-            },
-            {
-                'answer_id': 'town-city',
-                'answer_instance': 0,
-                'group_instance': 0,
-                'value': 'neath'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'permanent-or-family-home-answer',
-                'answer_instance': 0,
-                'value': 'Yes'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'middle-names',
-                'answer_instance': 0,
-                'value': 'K'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'first-name',
-                'answer_instance': 0,
-                'value': 'Danny'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'last-name',
-                'answer_instance': 0,
-                'value': 'Boje'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'middle-names',
-                'answer_instance': 1,
-                'value': 'K'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'first-name',
-                'answer_instance': 1,
-                'value': 'Anjali'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'last-name',
-                'answer_instance': 1,
-                'value': 'Yo'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'everyone-at-address-confirmation-answer',
-                'answer_instance': 0,
-                'value': 'Yes'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'overnight-visitors-answer',
-                'answer_instance': 0,
-                'value': 2
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'household-relationships-answer',
-                'answer_instance': 0,
-                'value': 'Husband or wife'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'type-of-accommodation-answer',
-                'answer_instance': 0,
-                'value': 'Whole house or bungalow'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'type-of-house-answer',
-                'answer_instance': 0,
-                'value': 'Detached'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'self-contained-accommodation-answer',
-                'answer_instance': 0,
-                'value': 'No'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'number-of-bedrooms-answer',
-                'answer_instance': 0,
-                'value': 2
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'central-heating-answer',
-                'answer_instance': 0,
-                'value': [
-                    'Gas',
-                    'Electric (include storage heaters)',
-                    'Oil',
-                    'Solid fuel (for example wood, coal)',
-                    'Renewable (for example solar panels)',
-                    'Other central heating',
-                    'No central heating'
-                ]
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'own-or-rent-answer',
-                'answer_instance': 0,
-                'value': 'Owns outright'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'number-of-vehicles-answer',
-                'answer_instance': 0,
-                'value': 2
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'over-16-answer',
-                'answer_instance': 0,
-                'value': 'Yes'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'private-response-answer',
-                'answer_instance': 0,
-                'value': 'No, I do not want to request a personal form'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'sex-answer',
-                'answer_instance': 0,
-                'value': 'Male'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'date-of-birth-answer',
-                'answer_instance': 0,
-                'value': '1988-05-12'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'marital-status-answer',
-                'answer_instance': 0,
-                'value': 'In a registered same-sex civil partnership'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'another-address-answer',
-                'answer_instance': 0,
-                'value': 'Yes, an address within the UK'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'another-address-answer-other',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'other-address-answer-building',
-                'answer_instance': 0,
-                'value': '12'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'other-address-answer-street',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'other-address-answer-city',
-                'answer_instance': 0,
-                'value': 'Newport'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'other-address-answer-county',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'other-address-answer-postcode',
-                'answer_instance': 0,
-                'value': 'NP10 8XG'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'address-type-answer',
-                'answer_instance': 0,
-                'value': 'Other'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'address-type-answer-other',
-                'answer_instance': 0,
-                'value': 'Friends Home'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'in-education-answer',
-                'answer_instance': 0,
-                'value': 'Yes'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'term-time-location-answer',
-                'answer_instance': 0,
-                'value': 'Yes'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'country-of-birth-england-answer-other',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'country-of-birth-england-answer',
-                'answer_instance': 0,
-                'value': 'England'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'country-of-birth-wales-answer-other',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'carer-answer',
-                'answer_instance': 0,
-                'value': 'Yes, 1 -19 hours a week'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'national-identity-england-answer',
-                'answer_instance': 0,
-                'value': [
-                    'English',
-                    'Welsh',
-                    'Scottish',
-                    'Northern Irish',
-                    'British',
-                    'Other'
-                ]
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'national-identity-wales-answer',
-                'answer_instance': 0,
-                'value': []
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'national-identity-wales-answer-other',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'national-identity-england-answer-other',
-                'answer_instance': 0,
-                'value': 'Ind'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'ethnic-group-england-answer',
-                'answer_instance': 0,
-                'value': 'Other ethnic group'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'other-ethnic-group-answer',
-                'answer_instance': 0,
-                'value': 'Other'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'other-ethnic-group-answer-other',
-                'answer_instance': 0,
-                'value': 'Telugu'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'language-england-answer-other',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'language-england-answer',
-                'answer_instance': 0,
-                'value': 'English'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'language-welsh-answer-other',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'religion-answer',
-                'answer_instance': 0,
-                'value': [
-                    'No religion',
-                    'Buddhism',
-                    'Hinduism',
-                    'Judaism',
-                    'Islam',
-                    'Sikhism',
-                    'Other'
-                ]
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'religion-answer-other',
-                'answer_instance': 0,
-                'value': 'Ind'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'past-usual-address-answer',
-                'answer_instance': 0,
-                'value': 'This address'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'past-usual-address-answer-other',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'passports-answer',
-                'answer_instance': 0,
-                'value': [
-                    'United Kingdom'
-                ]
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'disability-answer',
-                'answer_instance': 0,
-                'value': 'Yes, limited a lot'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'qualifications-welsh-answer',
-                'answer_instance': 0,
-                'value': []
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'qualifications-england-answer',
-                'answer_instance': 0,
-                'value': [
-                    'Masters Degree',
-                    'Postgraduate Certificate / Diploma'
-                ]
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'employment-type-answer',
-                'answer_instance': 0,
-                'value': [
-                    'none of the above'
-                ]
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'jobseeker-answer',
-                'answer_instance': 0,
-                'value': 'Yes'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'job-availability-answer',
-                'answer_instance': 0,
-                'value': 'Yes'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'job-pending-answer',
-                'answer_instance': 0,
-                'value': 'Yes'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'occupation-answer',
-                'answer_instance': 0,
-                'value': [
-                    'a student',
-                    'long-term sick or disabled'
-                ]
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'ever-worked-answer',
-                'answer_instance': 0,
-                'value': 'Yes'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'main-job-answer',
-                'answer_instance': 0,
-                'value': 'an employee'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'hours-worked-answer',
-                'answer_instance': 0,
-                'value': '31 - 48'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'work-travel-answer',
-                'answer_instance': 0,
-                'value': 'Train'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'job-title-answer',
-                'answer_instance': 0,
-                'value': 'Software Engineer'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'job-description-answer',
-                'answer_instance': 0,
-                'value': 'Development'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'employers-business-answer',
-                'answer_instance': 0,
-                'value': 'Civil Servant'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'main-job-type-answer',
-                'answer_instance': 0,
-                'value': 'Employed by an organisation or business'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'business-name-answer',
-                'answer_instance': 0,
-                'value': 'ONS'
-            },
-            {
-                'group_instance': 1,
-                'answer_id': 'over-16-answer',
-                'answer_instance': 0,
-                'value': 'Yes'
-            },
-            {
-                'group_instance': 1,
-                'answer_id': 'private-response-answer',
-                'answer_instance': 0,
-                'value': 'Yes, I want to request a personal form'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'visitor-first-name',
-                'answer_instance': 0,
-                'value': 'Diya'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'visitor-last-name',
-                'answer_instance': 0,
-                'value': 'K'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'visitor-sex-answer',
-                'answer_instance': 0,
-                'value': 'Female'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'visitor-date-of-birth-answer',
-                'answer_instance': 0,
-                'value': '2016-11-04'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'visitor-uk-resident-answer-other',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'visitor-uk-resident-answer',
-                'answer_instance': 0,
-                'value': 'Yes, usually lives in the United Kingdom'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'visitor-address-answer-postcode',
-                'answer_instance': 0,
-                'value': '530003'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'visitor-address-answer-street',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'visitor-address-answer-building',
-                'answer_instance': 0,
-                'value': '309'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'visitor-address-answer-city',
-                'answer_instance': 0,
-                'value': 'Vizag'
-            },
-            {
-                'group_instance': 0,
-                'answer_id': 'visitor-address-answer-county',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 1,
-                'answer_id': 'visitor-first-name',
-                'answer_instance': 0,
-                'value': 'Niki'
-            },
-            {
-                'group_instance': 1,
-                'answer_id': 'visitor-last-name',
-                'answer_instance': 0,
-                'value': 'K'
-            },
-            {
-                'group_instance': 1,
-                'answer_id': 'visitor-sex-answer',
-                'answer_instance': 0,
-                'value': 'Male'
-            },
-            {
-                'group_instance': 1,
-                'answer_id': 'visitor-date-of-birth-answer',
-                'answer_instance': 0,
-                'value': '1985-10-17'
-            },
-            {
-                'group_instance': 1,
-                'answer_id': 'visitor-uk-resident-answer-other',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 1,
-                'answer_id': 'visitor-uk-resident-answer',
-                'answer_instance': 0,
-                'value': 'Yes, usually lives in the United Kingdom'
-            },
-            {
-                'group_instance': 1,
-                'answer_id': 'visitor-address-answer-postcode',
-                'answer_instance': 0,
-                'value': '12345'
-            },
-            {
-                'group_instance': 1,
-                'answer_id': 'visitor-address-answer-street',
-                'answer_instance': 0,
-                'value': ''
-            },
-            {
-                'group_instance': 1,
-                'answer_id': 'visitor-address-answer-building',
-                'answer_instance': 0,
-                'value': '1009'
-            },
-            {
-                'group_instance': 1,
-                'answer_id': 'visitor-address-answer-city',
-                'answer_instance': 0,
-                'value': 'Detroit'
-            },
-            {
-                'group_instance': 1,
-                'answer_id': 'visitor-address-answer-county',
-                'answer_instance': 0,
-                'value': ''
-            }
+            {'value': 'west glamorgan',
+             'answer_id': 'county',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': 'wales',
+             'answer_id': 'country',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': '44 hill side',
+             'answer_id': 'address-line-1',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': '',
+             'answer_id': 'address-line-3',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': 'cimla',
+             'answer_id': 'address-line-2',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': 'neath',
+             'answer_id': 'town-city',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': 'cf336gn',
+             'answer_id': 'postcode',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': 'Yes',
+             'answer_id': 'permanent-or-family-home-answer',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': 'K',
+             'answer_id': 'middle-names',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'Boje',
+             'answer_id': 'last-name',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'Danny',
+             'answer_id': 'first-name',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'K',
+             'answer_id': 'middle-names',
+             'answer_instance': 1,
+             'group_instance_id': '3',
+             'group_instance': 0},
+            {'value': 'Yo',
+             'answer_id': 'last-name',
+             'answer_instance': 1,
+             'group_instance_id': '3',
+             'group_instance': 0},
+            {'value': 'Anjali',
+             'answer_id': 'first-name',
+             'answer_instance': 1,
+             'group_instance_id': '3',
+             'group_instance': 0},
+            {'value': 'Yes',
+             'answer_id': 'everyone-at-address-confirmation-answer',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': 2,
+             'answer_id': 'overnight-visitors-answer',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': 'Husband or wife',
+             'answer_id': 'household-relationships-answer',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': 'Whole house or bungalow',
+             'answer_id': 'type-of-accommodation-answer',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': 'Detached',
+             'answer_id': 'type-of-house-answer',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': 'No',
+             'answer_id': 'self-contained-accommodation-answer',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': 2,
+             'answer_id': 'number-of-bedrooms-answer',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': ['Gas',
+                       'Electric (include storage heaters)',
+                       'Oil',
+                       'Solid fuel (for example wood, coal)',
+                       'Renewable (for example solar panels)',
+                       'Other central heating',
+                       'No central heating'],
+             'answer_id': 'central-heating-answer',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': 'Owns outright',
+             'answer_id': 'own-or-rent-answer',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': 2,
+             'answer_id': 'number-of-vehicles-answer',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': 'Yes',
+             'answer_id': 'over-16-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'No, I do not want to request a personal form',
+             'answer_id': 'private-response-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'Male',
+             'answer_id': 'sex-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': '1988-05-12',
+             'answer_id': 'date-of-birth-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'In a registered same-sex civil partnership',
+             'answer_id': 'marital-status-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': '',
+             'answer_id': 'another-address-answer-other',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'Yes, an address within the UK',
+             'answer_id': 'another-address-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': '',
+             'answer_id': 'other-address-answer-street',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'NP10 8XG',
+             'answer_id': 'other-address-answer-postcode',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': '',
+             'answer_id': 'other-address-answer-county',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'Newport',
+             'answer_id': 'other-address-answer-city',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': '12',
+             'answer_id': 'other-address-answer-building',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'Other',
+             'answer_id': 'address-type-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'Friends Home',
+             'answer_id': 'address-type-answer-other',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'Yes',
+             'answer_id': 'in-education-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'Yes',
+             'answer_id': 'term-time-location-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': '',
+             'answer_id': 'country-of-birth-wales-answer-other',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'England',
+             'answer_id': 'country-of-birth-england-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': '',
+             'answer_id': 'country-of-birth-england-answer-other',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'Yes, 1 -19 hours a week',
+             'answer_id': 'carer-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': [],
+             'answer_id': 'national-identity-wales-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': '',
+             'answer_id': 'national-identity-wales-answer-other',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'Ind',
+             'answer_id': 'national-identity-england-answer-other',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': ['English',
+                       'Welsh',
+                       'Scottish',
+                       'Northern Irish',
+                       'British',
+                       'Other'],
+             'answer_id': 'national-identity-england-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'Other ethnic group',
+             'answer_id': 'ethnic-group-england-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'Other',
+             'answer_id': 'other-ethnic-group-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'Telugu',
+             'answer_id': 'other-ethnic-group-answer-other',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': '',
+             'answer_id': 'language-england-answer-other',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'English',
+             'answer_id': 'language-england-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': '',
+             'answer_id': 'language-welsh-answer-other',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'Ind',
+             'answer_id': 'religion-answer-other',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': ['No religion',
+                       'Buddhism',
+                       'Hinduism',
+                       'Judaism',
+                       'Islam',
+                       'Sikhism',
+                       'Other'],
+             'answer_id': 'religion-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'This address',
+             'answer_id': 'past-usual-address-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': '',
+             'answer_id': 'past-usual-address-answer-other',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': ['United Kingdom'],
+             'answer_id': 'passports-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'Yes, limited a lot',
+             'answer_id': 'disability-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': ['Masters Degree',
+                       'Postgraduate Certificate / Diploma'],
+             'answer_id': 'qualifications-england-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': [],
+             'answer_id': 'qualifications-welsh-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': ['none of the above'],
+             'answer_id': 'employment-type-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'Yes',
+             'answer_id': 'jobseeker-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'Yes',
+             'answer_id': 'job-availability-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'Yes',
+             'answer_id': 'job-pending-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': ['a student',
+                       'long-term sick or disabled'],
+             'answer_id': 'occupation-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'Yes',
+             'answer_id': 'ever-worked-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'an employee',
+             'answer_id': 'main-job-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': '31 - 48',
+             'answer_id': 'hours-worked-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'Train',
+             'answer_id': 'work-travel-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'Software Engineer',
+             'answer_id': 'job-title-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'Development',
+             'answer_id': 'job-description-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'Employed by an organisation or business',
+             'answer_id': 'main-job-type-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'ONS',
+             'answer_id': 'business-name-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'Civil Servant',
+             'answer_id': 'employers-business-answer',
+             'answer_instance': 0,
+             'group_instance_id': '2',
+             'group_instance': 0},
+            {'value': 'Yes',
+             'answer_id': 'over-16-answer',
+             'answer_instance': 0,
+             'group_instance_id': '3',
+             'group_instance': 1},
+            {'value': 'Yes, I want to request a personal form',
+             'answer_id': 'private-response-answer',
+             'answer_instance': 0,
+             'group_instance_id': '3',
+             'group_instance': 1},
+            {'value': 'K',
+             'answer_id': 'visitor-last-name',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': 'Diya',
+             'answer_id': 'visitor-first-name',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': 'Female',
+             'answer_id': 'visitor-sex-answer',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': '2016-11-04',
+             'answer_id': 'visitor-date-of-birth-answer',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': 'Yes, usually lives in the United Kingdom',
+             'answer_id': 'visitor-uk-resident-answer',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': '',
+             'answer_id': 'visitor-uk-resident-answer-other',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': 'Vizag',
+             'answer_id': 'visitor-address-answer-city',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': '',
+             'answer_id': 'visitor-address-answer-county',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': '',
+             'answer_id': 'visitor-address-answer-street',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': '530003',
+             'answer_id': 'visitor-address-answer-postcode',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': '309',
+             'answer_id': 'visitor-address-answer-building',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 0},
+            {'value': 'K',
+             'answer_id': 'visitor-last-name',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 1},
+            {'value': 'Niki',
+             'answer_id': 'visitor-first-name',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 1},
+            {'value': 'Male',
+             'answer_id': 'visitor-sex-answer',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 1},
+            {'value': '1985-10-17',
+             'answer_id': 'visitor-date-of-birth-answer',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 1},
+            {'value': 'Yes, usually lives in the United Kingdom',
+             'answer_id': 'visitor-uk-resident-answer',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 1},
+            {'value': '',
+             'answer_id': 'visitor-uk-resident-answer-other',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 1},
+            {'value': 'Detroit',
+             'answer_id': 'visitor-address-answer-city',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 1},
+            {'value': '',
+             'answer_id': 'visitor-address-answer-county',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 1},
+            {'value': '',
+             'answer_id': 'visitor-address-answer-street',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 1},
+            {'value': '12345',
+             'answer_id': 'visitor-address-answer-postcode',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 1},
+            {'value': '1009',
+             'answer_id': 'visitor-address-answer-building',
+             'answer_instance': 0,
+             'group_instance_id': None,
+             'group_instance': 1}
         ]
 
         return expected_downstream_data

--- a/tests/integration/census/test_census_individual_submission_data.py
+++ b/tests/integration/census/test_census_individual_submission_data.py
@@ -1,10 +1,13 @@
+from mock import patch
+
 from tests.integration.integration_test_case import IntegrationTestCase
 
 
 class TestCensusIndividualSubmissionData(IntegrationTestCase):
 
     def test_census_individual_data_matches_census_individual(self):
-        self.complete_survey('census', 'individual')
+        with patch('app.helpers.schema_helpers.uuid4', side_effect=range(100)):
+            self.complete_survey('census', 'individual')
 
         # Only verifying 'data'
         actual_downstream_data = self.dumpSubmission()['submission']['data']
@@ -15,368 +18,299 @@ class TestCensusIndividualSubmissionData(IntegrationTestCase):
     @staticmethod
     def get_expected_submission_data():
         expected_downstream_data = [
-            {
-                'group_instance': 0,
-                'value': 'Danny',
-                'answer_instance': 0,
-                'answer_id': 'first-name'
-            },
-            {
-                'group_instance': 0,
-                'value': 'K',
-                'answer_instance': 0,
-                'answer_id': 'middle-names'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Boje',
-                'answer_instance': 0,
-                'answer_id': 'last-name'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Male',
-                'answer_instance': 0,
-                'answer_id': 'sex-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': '1988-05-12',
-                'answer_instance': 0,
-                'answer_id': 'date-of-birth-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'In a registered same-sex civil partnership',
-                'answer_instance': 0,
-                'answer_id': 'marital-status-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Yes, an address within the UK',
-                'answer_instance': 0,
-                'answer_id': 'another-address-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': '',
-                'answer_instance': 0,
-                'answer_id': 'another-address-answer-other'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Newport',
-                'answer_instance': 0,
-                'answer_id': 'other-address-answer-city'
-            },
-            {
-                'group_instance': 0,
-                'value': '',
-                'answer_instance': 0,
-                'answer_id': 'other-address-answer-street'
-            },
-            {
-                'group_instance': 0,
-                'value': '',
-                'answer_instance': 0,
-                'answer_id': 'other-address-answer-county'
-            },
-            {
-                'group_instance': 0,
-                'value': '12',
-                'answer_instance': 0,
-                'answer_id': 'other-address-answer-building'
-            },
-            {
-                'group_instance': 0,
-                'value': 'NP10 8XG',
-                'answer_instance': 0,
-                'answer_id': 'other-address-answer-postcode'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Friends Home',
-                'answer_instance': 0,
-                'answer_id': 'address-type-answer-other'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Other',
-                'answer_instance': 0,
-                'answer_id': 'address-type-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Yes',
-                'answer_instance': 0,
-                'answer_id': 'in-education-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'here, at this address',
-                'answer_instance': 0,
-                'answer_id': 'term-time-location-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': '',
-                'answer_instance': 0,
-                'answer_id': 'country-of-birth-wales-answer-other'
-            },
-            {
-                'group_instance': 0,
-                'value': 'England',
-                'answer_instance': 0,
-                'answer_id': 'country-of-birth-england-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': '',
-                'answer_instance': 0,
-                'answer_id': 'country-of-birth-england-answer-other'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Yes, 1 -19 hours a week',
-                'answer_instance': 0,
-                'answer_id': 'carer-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Ind',
-                'answer_instance': 0,
-                'answer_id': 'national-identity-england-answer-other'
-            },
-            {
-                'group_instance': 0,
-                'value': '',
-                'answer_instance': 0,
-                'answer_id': 'national-identity-wales-answer-other'
-            },
-            {
-                'group_instance': 0,
-                'value': [
-                    'English',
-                    'Welsh',
-                    'Scottish',
-                    'Northern Irish',
-                    'British',
-                    'Other'
-                ],
-                'answer_instance': 0,
-                'answer_id': 'national-identity-england-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': [],
-                'answer_instance': 0,
-                'answer_id': 'national-identity-wales-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Other ethnic group',
-                'answer_instance': 0,
-                'answer_id': 'ethnic-group-england-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Other',
-                'answer_instance': 0,
-                'answer_id': 'other-ethnic-group-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Telugu',
-                'answer_instance': 0,
-                'answer_id': 'other-ethnic-group-answer-other'
-            },
-            {
-                'group_instance': 0,
-                'value': '',
-                'answer_instance': 0,
-                'answer_id': 'language-welsh-answer-other'
-            },
-            {
-                'group_instance': 0,
-                'value': 'English',
-                'answer_instance': 0,
-                'answer_id': 'language-england-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': '',
-                'answer_instance': 0,
-                'answer_id': 'language-england-answer-other'
-            },
-            {
-                'group_instance': 0,
-                'value': [],
-                'answer_instance': 0,
-                'answer_id': 'religion-welsh-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': [
-                    'No religion',
-                    'Christian (Including Church of England, Catholic, Protestant and all other Christian denominations)',
-                    'Buddhist',
-                    'Hindu',
-                    'Jewish',
-                    'Muslim',
-                    'Sikh',
-                    'Other'
-                ],
-                'answer_instance': 0,
-                'answer_id': 'religion-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': '',
-                'answer_instance': 0,
-                'answer_id': 'religion-welsh-answer-other'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Ind',
-                'answer_instance': 0,
-                'answer_id': 'religion-answer-other'
-            },
-            {
-                'group_instance': 0,
-                'value': 'This address',
-                'answer_instance': 0,
-                'answer_id': 'past-usual-address-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': '',
-                'answer_instance': 0,
-                'answer_id': 'past-usual-address-answer-other'
-            },
-            {
-                'group_instance': 0,
-                'value': [
-                    'United Kingdom'
-                ],
-                'answer_instance': 0,
-                'answer_id': 'passports-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Yes, limited a lot',
-                'answer_instance': 0,
-                'answer_id': 'disability-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': [
-                    'Masters Degree',
-                    'Postgraduate Certificate / Diploma'
-                ],
-                'answer_instance': 0,
-                'answer_id': 'qualifications-england-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': [],
-                'answer_instance': 0,
-                'answer_id': 'qualifications-welsh-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'No',
-                'answer_instance': 0,
-                'answer_id': 'volunteering-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': [
-                    'none of the above?'
-                ],
-                'answer_instance': 0,
-                'answer_id': 'employment-type-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Yes',
-                'answer_instance': 0,
-                'answer_id': 'jobseeker-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Yes',
-                'answer_instance': 0,
-                'answer_id': 'job-availability-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Yes',
-                'answer_instance': 0,
-                'answer_id': 'job-pending-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': [
-                    'a student?',
-                    'long-term sick or disabled?'
-                ],
-                'answer_instance': 0,
-                'answer_id': 'occupation-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Yes',
-                'answer_instance': 0,
-                'answer_id': 'ever-worked-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'an employee?',
-                'answer_instance': 0,
-                'answer_id': 'main-job-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Software Engineer',
-                'answer_instance': 0,
-                'answer_id': 'job-title-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Development',
-                'answer_instance': 0,
-                'answer_id': 'job-description-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': '31 - 48',
-                'answer_instance': 0,
-                'answer_id': 'hours-worked-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Train',
-                'answer_instance': 0,
-                'answer_id': 'work-travel-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Civil Servant',
-                'answer_instance': 0,
-                'answer_id': 'employers-business-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'Employed by an organisation or business',
-                'answer_instance': 0,
-                'answer_id': 'main-job-type-answer'
-            },
-            {
-                'group_instance': 0,
-                'value': 'ONS',
-                'answer_instance': 0,
-                'answer_id': 'business-name-answer'
-            }
+            {'answer_id': 'middle-names',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'K'},
+            {'answer_id': 'last-name',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Boje'},
+            {'answer_id': 'first-name',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Danny'},
+            {'answer_id': 'sex-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Male'},
+            {'answer_id': 'date-of-birth-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': '1988-05-12'},
+            {'answer_id': 'marital-status-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'In a registered same-sex civil partnership'},
+            {'answer_id': 'another-address-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': ''},
+            {'answer_id': 'another-address-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Yes, an address within the UK'},
+            {'answer_id': 'other-address-answer-street',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': ''},
+            {'answer_id': 'other-address-answer-postcode',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'NP10 8XG'},
+            {'answer_id': 'other-address-answer-building',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': '12'},
+            {'answer_id': 'other-address-answer-county',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': ''},
+            {'answer_id': 'other-address-answer-city',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Newport'},
+            {'answer_id': 'address-type-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Other'},
+            {'answer_id': 'address-type-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Friends Home'},
+            {'answer_id': 'in-education-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Yes'},
+            {'answer_id': 'term-time-location-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'here, at this address'},
+            {'answer_id': 'country-of-birth-england-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': ''},
+            {'answer_id': 'country-of-birth-wales-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': ''},
+            {'answer_id': 'country-of-birth-england-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'England'},
+            {'answer_id': 'carer-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Yes, 1 -19 hours a week'},
+            {'answer_id': 'national-identity-england-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Ind'},
+            {'answer_id': 'national-identity-wales-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': ''},
+            {'answer_id': 'national-identity-england-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': ['English',
+                       'Welsh',
+                       'Scottish',
+                       'Northern Irish',
+                       'British',
+                       'Other']},
+            {'answer_id': 'national-identity-wales-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': []},
+            {'answer_id': 'ethnic-group-england-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Other ethnic group'},
+            {'answer_id': 'other-ethnic-group-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Telugu'},
+            {'answer_id': 'other-ethnic-group-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Other'},
+            {'answer_id': 'language-welsh-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': ''},
+            {'answer_id': 'language-england-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': ''},
+            {'answer_id': 'language-england-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'English'},
+            {'answer_id': 'religion-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': ['No religion',
+                       'Christian (Including Church of England, Catholic, Protestant '
+                       'and all other Christian denominations)',
+                       'Buddhist',
+                       'Hindu',
+                       'Jewish',
+                       'Muslim',
+                       'Sikh',
+                       'Other']},
+            {'answer_id': 'religion-welsh-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': ''},
+            {'answer_id': 'religion-welsh-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': []},
+            {'answer_id': 'religion-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Ind'},
+            {'answer_id': 'past-usual-address-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'This address'},
+            {'answer_id': 'past-usual-address-answer-other',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': ''},
+            {'answer_id': 'passports-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': ['United Kingdom']},
+            {'answer_id': 'disability-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Yes, limited a lot'},
+            {'answer_id': 'qualifications-welsh-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': []},
+            {'answer_id': 'qualifications-england-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': ['Masters Degree', 'Postgraduate Certificate / Diploma']},
+            {'answer_id': 'volunteering-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'No'},
+            {'answer_id': 'employment-type-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': ['none of the above?']},
+            {'answer_id': 'jobseeker-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Yes'},
+            {'answer_id': 'job-availability-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Yes'},
+            {'answer_id': 'job-pending-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Yes'},
+            {'answer_id': 'occupation-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': ['a student?', 'long-term sick or disabled?']},
+            {'answer_id': 'ever-worked-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Yes'},
+            {'answer_id': 'main-job-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'an employee?'},
+            {'answer_id': 'job-title-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Software Engineer'},
+            {'answer_id': 'job-description-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Development'},
+            {'answer_id': 'hours-worked-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': '31 - 48'},
+            {'answer_id': 'work-travel-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Train'},
+            {'answer_id': 'employers-business-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Civil Servant'},
+            {'answer_id': 'main-job-type-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'Employed by an organisation or business'},
+            {'answer_id': 'business-name-answer',
+             'answer_instance': 0,
+             'group_instance': 0,
+             'group_instance_id': None,
+             'value': 'ONS'}
         ]
 
         return expected_downstream_data

--- a/tests/integration/household_composition/test_repeating_relationship.py
+++ b/tests/integration/household_composition/test_repeating_relationship.py
@@ -25,6 +25,7 @@ class TestRepeatingRelationship(IntegrationTestCase):
 
     def test_multiple_relationship_groups(self):
         # Given
+
         household_form_data = {
             'household-0-first-name': 'Han',
             'household-1-first-name': 'Leia',
@@ -49,23 +50,27 @@ class TestRepeatingRelationship(IntegrationTestCase):
             answer for answer in self.dumpAnswers()['answers']
             if answer['answer_id'] == 'who-is-related'
         ]
+
         expected_relationship_answers = [
             {
                 'answer_id': 'who-is-related',
                 'answer_instance': 0,
                 'group_instance': 0,
+                'group_instance_id': None,
                 'value': 'Husband or wife'
             },
             {
                 'answer_id': 'who-is-related',
                 'answer_instance': 1,
                 'group_instance': 0,
+                'group_instance_id': None,
                 'value': 'Relation - other'
             },
             {
                 'answer_id': 'who-is-related',
                 'answer_instance': 0,
                 'group_instance': 1,
+                'group_instance_id': None,
                 'value': 'Brother or sister'
             }
         ]

--- a/tests/integration/session/test_questionnaire_store_upgrade.py
+++ b/tests/integration/session/test_questionnaire_store_upgrade.py
@@ -1,5 +1,25 @@
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
+
+import simplejson as json
+
 from tests.integration.integration_test_case import IntegrationTestCase
+from tests.integration.create_token import PAYLOAD
+
+def get_mocked_questionnaire_store(data, version):
+    """Returns a mocked version of the questionnaire storage, which allows
+        injection of answers and older/invalid versions of the store.
+    """
+
+    # Add the default metadata
+    metadata = dict(PAYLOAD)
+    metadata.update(data['METADATA'])
+    metadata['roles'] = ['dumper']  # Always give the dumper role
+    data['METADATA'] = metadata
+
+    json_data = json.dumps(data)
+    mocked_store = MagicMock()
+    mocked_store.get_user_data = MagicMock(return_value=(json_data, version))
+    return patch('app.storage.encrypted_questionnaire_storage.EncryptedQuestionnaireStorage', return_value=mocked_store)
 
 class TestLogin(IntegrationTestCase):
 
@@ -16,3 +36,77 @@ class TestLogin(IntegrationTestCase):
             self.post(action='start_questionnaire')
 
         upgrade.assert_called_once()
+
+
+    def test_questionnaire_store_answer_store_group_instance_id_added(self):
+        """ Simulates loading version 1 of an answer_store and seeing that it gets upgraded to version 2 """
+
+        # Given
+        existing_answers = [
+            {
+                'answer_id': 'primary-name',
+                'answer_instance': 0,
+                'group_instance': 0,
+                'value': 'Han'
+            },
+            {
+                'answer_id': 'primary-anyone-else',
+                'answer_instance': 0,
+                'group_instance': 0,
+                'value': 'Yes'
+            },
+            {
+                'answer_id': 'repeating-name',
+                'answer_instance': 0,
+                'group_instance': 0,
+                'value': 'Luke'
+            },
+            {
+                'answer_id': 'repeating-anyone-else',
+                'answer_instance': 0,
+                'group_instance': 0,
+                'value': 'Yes'
+            },
+            {
+                'answer_id': 'repeating-name',
+                'answer_instance': 0,
+                'group_instance': 1,
+                'value': 'Leia'
+            },
+            {
+                'answer_id': 'repeating-anyone-else',
+                'answer_instance': 0,
+                'group_instance': 1,
+                'value': 'No'
+            }
+        ]
+
+        store_data = {
+            'METADATA': {
+                'eq_id': 'test',
+                'form_type': 'routing_repeat_until',
+                'tx_id': '0f6485e2-b9f1-439d-b90f-bd8a377a7d0b',
+            },
+            'ANSWERS': existing_answers,
+            'COMPLETED_BLOCKS': [],
+        }
+
+        # When
+        self.launchSurvey('test', 'routing_repeat_until', roles=['dumper'])
+
+        with get_mocked_questionnaire_store(store_data, 1):
+            dumped = self.dumpAnswers()
+
+        answers = dumped['answers']
+
+        # Then
+        for i in answers:
+            self.assertIn('group_instance_id', i)
+
+        # This survey works out as having pairs of answers which should have
+        # the same `group_instance_id`
+        for i in range(0, 6, 2):
+            self.assertEqual(
+                answers[i]['group_instance_id'],
+                answers[i+1]['group_instance_id']
+            )

--- a/tests/integration/views/test_dump.py
+++ b/tests/integration/views/test_dump.py
@@ -1,5 +1,6 @@
 import json
 
+from mock import patch
 from werkzeug.datastructures import MultiDict
 
 from tests.integration.integration_test_case import IntegrationTestCase
@@ -53,7 +54,8 @@ class TestDumpAnswers(IntegrationTestCase):
         self.launchSurvey('test', 'radio_mandatory_with_mandatory_other', roles=['dumper'])
 
         # When I submit an answer
-        self.post(post_data={'radio-mandatory-answer': 'Toast'})
+        with patch('app.helpers.schema_helpers.uuid4', side_effect=range(10)):
+            self.post(post_data={'radio-mandatory-answer': 'Toast'})
 
         # And I attempt to dump the answer store
         self.get('/dump/answers')
@@ -69,12 +71,14 @@ class TestDumpAnswers(IntegrationTestCase):
                     'value': '',
                     'answer_instance': 0,
                     'group_instance': 0,
+                    'group_instance_id': None,
                     'answer_id': 'other-answer-mandatory',
                 },
                 {
                     'value': 'Toast',
                     'answer_instance': 0,
                     'group_instance': 0,
+                    'group_instance_id': None,
                     'answer_id': 'radio-mandatory-answer',
                 }
             ]
@@ -162,7 +166,8 @@ class TestDumpSubmission(IntegrationTestCase):
         self.launchSurvey('test', 'radio_mandatory', roles=['dumper'])
 
         # When I submit an answer
-        self.post(post_data={'radio-mandatory-answer': 'Coffee'})
+        with patch('app.helpers.schema_helpers.uuid4', side_effect=range(10)):
+            self.post(post_data={'radio-mandatory-answer': 'Coffee'})
 
         # And I attempt to dump the submission payload
         self.get('/dump/submission')
@@ -195,6 +200,7 @@ class TestDumpSubmission(IntegrationTestCase):
                         'answer_id': 'radio-mandatory-answer',
                         'answer_instance': 0,
                         'group_instance': 0,
+                        'group_instance_id': None,
                         'value': 'Coffee',
                     },
                 ],

--- a/tests/integration/views/test_questionnaire.py
+++ b/tests/integration/views/test_questionnaire.py
@@ -49,6 +49,7 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         self.assertEqual(self.question_store.completed_blocks, [location])
 
         self.assertIn({
+            'group_instance_id': None,
             'group_instance': 0,
             'answer_id': 'total-retail-turnover-answer',
             'answer_instance': 0,
@@ -72,6 +73,7 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         self.assertEqual(self.question_store.completed_blocks, [location])
 
         self.assertIn({
+            'group_instance_id': None,
             'group_instance': 0,
             'answer_id': 'answer',
             'answer_instance': 0,
@@ -176,16 +178,19 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         answered = [
             Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='first-name',
                 answer_instance=0,
                 value='Joe'
             ), Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='middle-names',
                 answer_instance=0,
                 value=''
             ), Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='last-name',
                 answer_instance=0,
                 value='Bloggs'
@@ -195,16 +200,19 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         unanswered = [
             Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='first-name',
                 answer_instance=1,
                 value=''
             ), Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='middle-names',
                 answer_instance=1,
                 value=''
             ), Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='last-name',
                 answer_instance=1,
                 value=''
@@ -232,16 +240,19 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         answered = [
             Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='first-name',
                 answer_instance=0,
                 value='Joe'
             ), Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='middle-names',
                 answer_instance=0,
                 value=''
             ), Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='last-name',
                 answer_instance=0,
                 value='Bloggs'
@@ -251,31 +262,37 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         partially_answered = [
             Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='first-name',
                 answer_instance=1,
                 value=''
             ), Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='middle-names',
                 answer_instance=1,
                 value=''
             ), Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='last-name',
                 answer_instance=1,
                 value='Last name only'
             ), Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='first-name',
                 answer_instance=2,
                 value='First name only'
             ), Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='middle-names',
                 answer_instance=2,
                 value=''
             ), Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='last-name',
                 answer_instance=2,
                 value=''
@@ -485,21 +502,25 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         answers = [
             Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='first-name',
                 answer_instance=0,
                 value='Joe'
             ), Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='last-name',
                 answer_instance=0,
                 value='Bloggs'
             ), Answer(
                 group_instance=0,
+                group_instance_id='group-0',
                 answer_id='date-of-birth-answer',
                 answer_instance=0,
                 value='2016-03-12'
             ), Answer(
                 group_instance=1,
+                group_instance_id='group-1',
                 answer_id='date-of-birth-answer',
                 answer_instance=0,
                 value='2018-01-01'
@@ -512,8 +533,7 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         answer_form_data = {'date-of-birth-answer': None}
         location = Location('household-member-group', 1, 'date-of-birth')
         with self._application.test_request_context():
-            update_questionnaire_store_with_form_data(
-                self.question_store, location, answer_form_data, schema)
+            update_questionnaire_store_with_form_data(self.question_store, location, answer_form_data, schema)
 
         self.assertIsNone(self.question_store.answer_store.find(answers[3]))
         for answer in answers[:2]:
@@ -527,8 +547,8 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
                              Location('group', 0, 'who-is-answer-block'),
                              Location('group', 0, 'multiple-question-versions-block'),
                              Location('group', 0, 'Summary')]
-        schema_context = _get_schema_context(full_routing_path, 0, {}, AnswerStore(), schema)
         current_location = Location('group', 0, 'single-title-block')
+        schema_context = _get_schema_context(full_routing_path, current_location, {}, AnswerStore(), g.schema)
 
         # When
         with self._application.test_request_context():


### PR DESCRIPTION
### What is the context of this PR?
For the most part, this is the same as #1700, however it's been modified to add an upgrade for the answer store and testing of that. 

### How to review 
For the answer_store upgrade:
1. In docker-compose, run a survey which contains repeating groups from the master branch. Complete some answers so that you have multiple `group_instance` values.
2. Dump those answers and keep them somewhere for later comparison (e.g. keep the tab open!)
3. Then stop docker-compose, check this branch out and re-start docker-compose
4. Dump the answers again - they should have been upgraded to have `group_instance_id` added.

I've not changed anything relating to the addition of the group iteration from the previous PR, so the testing from that should still be valid, however check the original PR for testing that.