### PR TITLE
Change case of 'what' to 'What' in significant changes definition pattern

### DIFF
--- a/data/en/1_0005.json
+++ b/data/en/1_0005.json
@@ -412,7 +412,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a ‘significant change’ is dependent on your own interpretation of whether there has been a significant change in {{metadata['trad_as_or_ru_name']}}\u2019s figures compared with the previous month."
+                            "description": "What constitutes a ‘significant change’ is dependent on your own interpretation of whether there has been a significant change in {{metadata['trad_as_or_ru_name']}}\u2019s figures compared with the previous month."
                         }, {
                             "description": "Also consider whether there has been a significant change from the same month in the previous year."
                         }]
@@ -788,7 +788,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a ‘significant change’ is dependent on your own interpretation of whether there has been a significant change in {{metadata['trad_as_or_ru_name']}}\u2019s figures compared with the previous month."
+                            "description": "What constitutes a ‘significant change’ is dependent on your own interpretation of whether there has been a significant change in {{metadata['trad_as_or_ru_name']}}\u2019s figures compared with the previous month."
                         }, {
                             "description": "Also consider whether there has been a significant change from the same month in the previous year."
                         }]
@@ -1156,7 +1156,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a ‘significant change’ is dependent on your own interpretation of whether there has been a significant change in {{metadata['trad_as_or_ru_name']}}\u2019s figures compared with the previous month."
+                            "description": "What constitutes a ‘significant change’ is dependent on your own interpretation of whether there has been a significant change in {{metadata['trad_as_or_ru_name']}}\u2019s figures compared with the previous month."
                         }, {
                             "description": "Also consider whether there has been a significant change from the same month in the previous year."
                         }]
@@ -1521,7 +1521,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a ‘significant change’ is dependent on your own interpretation of whether there has been a significant change in {{metadata['trad_as_or_ru_name']}}\u2019s figures compared with the previous month."
+                            "description": "What constitutes a ‘significant change’ is dependent on your own interpretation of whether there has been a significant change in {{metadata['trad_as_or_ru_name']}}\u2019s figures compared with the previous month."
                         }, {
                             "description": "Also consider whether there has been a significant change from the same month in the previous year."
                         }]
@@ -1893,7 +1893,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a ‘significant change’ is dependent on your own interpretation of whether there has been a significant change in {{metadata['trad_as_or_ru_name']}}\u2019s figures compared with the previous month."
+                            "description": "What constitutes a ‘significant change’ is dependent on your own interpretation of whether there has been a significant change in {{metadata['trad_as_or_ru_name']}}\u2019s figures compared with the previous month."
                         }, {
                             "description": "Also consider whether there has been a significant change from the same month in the previous year."
                         }]

--- a/data/en/1_0102.json
+++ b/data/en/1_0102.json
@@ -295,7 +295,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/1_0112.json
+++ b/data/en/1_0112.json
@@ -303,7 +303,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/1_0203.json
+++ b/data/en/1_0203.json
@@ -483,7 +483,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/1_0205.json
+++ b/data/en/1_0205.json
@@ -515,7 +515,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/1_0213.json
+++ b/data/en/1_0213.json
@@ -484,7 +484,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/1_0215.json
+++ b/data/en/1_0215.json
@@ -538,7 +538,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/mbs_0106.json
+++ b/data/en/mbs_0106.json
@@ -226,7 +226,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/mbs_0111.json
+++ b/data/en/mbs_0111.json
@@ -228,7 +228,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/mbs_0117.json
+++ b/data/en/mbs_0117.json
@@ -251,7 +251,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/mbs_0123.json
+++ b/data/en/mbs_0123.json
@@ -248,7 +248,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/mbs_0158.json
+++ b/data/en/mbs_0158.json
@@ -392,7 +392,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/mbs_0161.json
+++ b/data/en/mbs_0161.json
@@ -390,7 +390,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/mbs_0167.json
+++ b/data/en/mbs_0167.json
@@ -427,7 +427,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/mbs_0173.json
+++ b/data/en/mbs_0173.json
@@ -407,7 +407,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/mbs_0201.json
+++ b/data/en/mbs_0201.json
@@ -311,7 +311,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/mbs_0202.json
+++ b/data/en/mbs_0202.json
@@ -311,7 +311,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/mbs_0203.json
+++ b/data/en/mbs_0203.json
@@ -166,7 +166,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/mbs_0204.json
+++ b/data/en/mbs_0204.json
@@ -166,7 +166,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/mbs_0205.json
+++ b/data/en/mbs_0205.json
@@ -276,7 +276,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/mbs_0216.json
+++ b/data/en/mbs_0216.json
@@ -276,7 +276,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/mbs_0251.json
+++ b/data/en/mbs_0251.json
@@ -482,7 +482,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/mbs_0253.json
+++ b/data/en/mbs_0253.json
@@ -332,7 +332,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/mbs_0255.json
+++ b/data/en/mbs_0255.json
@@ -440,7 +440,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/mbs_0817.json
+++ b/data/en/mbs_0817.json
@@ -226,7 +226,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/mbs_0823.json
+++ b/data/en/mbs_0823.json
@@ -226,7 +226,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/mbs_0867.json
+++ b/data/en/mbs_0867.json
@@ -388,7 +388,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/mbs_0873.json
+++ b/data/en/mbs_0873.json
@@ -388,7 +388,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/mci_transformation.json
+++ b/data/en/mci_transformation.json
@@ -552,7 +552,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]

--- a/data/en/rsi_transformation.json
+++ b/data/en/rsi_transformation.json
@@ -370,7 +370,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "what constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]


### PR DESCRIPTION
Quick PR to change the case sensitivity of definition's description for significant changes that was introduced in #1713 
Design and Jimi stated lowercase so 😶 

### How to review

Make sure the definition's description starts with an uppercase. (`what` -> `What`)
```What constitutes a ‘significant change’ is dependent on your own interpretation in relation to ESSENTIAL ENTERPRISE LTD.’s figures from the previous reporting period and the same reporting period last year.```