### PR TITLE
Calculate reference dates

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -24,6 +24,7 @@ httmock = "*"
 "flake8-tuple" = "*"
 moto = "*"
 google-compute-engine = "*"
+freezegun = "*"
 
 [packages]
 colorama = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f135c1215573eae2667bc9730596c422122443033838854907ee3ab71c5f00e3"
+            "sha256": "ee89e0fd6ba7a5e5868bb042858abd73296f91b09a34e87fb90ccb46c8e18f66"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -39,25 +39,25 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:c848ae99e09f2899c5f81b8fdad90b2ef1fb7a760b13f2b1e51a345f4fd11d2b",
-                "sha256:e225d9fa3f313049547bf510a54d5f0af82f70d53fe0c0f891a0a9f8d4474681"
+                "sha256:ab9c7261fc30a99e3c3009ab599209001af311c94b8f6cb3b35ccd5369db07f8",
+                "sha256:c8381411249716aaa9f64f98be4a96818004ebf80daa7673a3db07d021c46594"
             ],
             "index": "pypi",
-            "version": "==1.7.67"
+            "version": "==1.7.83"
         },
         "botocore": {
             "hashes": [
-                "sha256:e578f2618d0076950bcbd6ac938471310b08c292277b49092b938c59788012a6",
-                "sha256:e9eea23c566c30c69879941c4183294b7d45d8d8ff7946669364d8bb48ed0c90"
+                "sha256:aeb54fd5f9a01399593e77612e7cdcf53e90a7d623378225685e599b989792d6",
+                "sha256:ce14556d139fa0641ca7f1973ed68d19ba70691490f3840bd2c6d906e4a99fc8"
             ],
-            "version": "==1.10.67"
+            "version": "==1.10.83"
         },
         "certifi": {
             "hashes": [
-                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
-                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
+                "sha256:4c1d68a1408dd090d2f3a869aa94c3947cc1d967821d1ed303208c9f41f0f2f4",
+                "sha256:b6e8b28b2b7e771a41ecdd12d4d43262ecab52adebbafa42c77d6b57fb6ad3a4"
             ],
-            "version": "==2018.4.16"
+            "version": "==2018.8.13"
         },
         "cffi": {
             "hashes": [
@@ -221,33 +221,33 @@
         },
         "gevent": {
             "hashes": [
-                "sha256:201b14bb62f72073369f86f21f824bfc079477b864590d43574d625266d358ec",
-                "sha256:298fff6b452e879ffd8de2cf17b453469bef4f34fecc1c3d2252358d01000d42",
-                "sha256:2e9c15461ead5714fa70fb0179927410fcaeb39125ead575472a45d13973de32",
-                "sha256:32a231c52a5e8c0a5e62ffa2d25f14cfa5fe6bc8856093f5babe3f1e32d471d3",
-                "sha256:425edae7557599f16bf428b84d58f5aa5623c7ed9c2c2ef4a915046799992069",
-                "sha256:42deb83ae2a1944f318e9a9ce4d8715ebcbfb62ca348787d43304ff25818c2c0",
-                "sha256:55fa0607b72710372d37b35e9af85755a0c8bd0e3e82d70970a349feb2b426f6",
-                "sha256:5fcf30b6172c6ae4f89dbe6051971a71bb04080d0eda9a0c31862054346d1ddd",
-                "sha256:6eb85cce56bf530664f7661c4bf2fe5d9d4de231c1cd2860c7563c517a6f56dc",
-                "sha256:77abcc8a9e04d33325b79d2130e1faf32a02069e63131c184802bb79fb5711d1",
-                "sha256:7f15861f3cc92f49663ca88c4774d26d8044783a65fbc28071a2bd1c7bf36ff0",
-                "sha256:82e0eb07ab596908295d49f27e84799bff73638e13699496048d13051c8421a1",
-                "sha256:856ed81267a802eeaf925d7bf1a676c721f90c162c05ae906ab9c4646086c1a3",
-                "sha256:8a8bcb9bbf7af0527ef77d86fa094b647d0e8cd377c5e31c1ad1a3d456b4a10b",
-                "sha256:8bbf3f2ab60e39be4363923d2b5996bff65d4163fe560280b71bb8ca18df2055",
-                "sha256:916457841e4f335ccd228ac274801f1773973d27be3c53ed3ee1209f7629950e",
-                "sha256:a46b85bb42aeeab11f140587b8482d0f04d4b3db6f20f6668624bb0a822a28b0",
-                "sha256:a52f5cef4073d9e8d58c8c44d4795cbc2e298d374125745637d8f078f8970b6b",
-                "sha256:a7969bfff628318e9a0ce56ad322eed39d1047d7006a0b41dc2e8783349ecece",
-                "sha256:aa04c207f6abb5d34de148e08b4d461544e808534000c4e5429eda08aa1204d6",
-                "sha256:bd34e943810df73d7bf346262dae09281d045edebd086205e9ff2db377bae060",
-                "sha256:d0a4d114890b6d619e81140550c45d3611588c00f2baa1d6af9362907687ca1d",
-                "sha256:e2e3a6a2a147330d24e6e2b2f144c196841a707a41ee61253565d400ed7df62f"
+                "sha256:03d03ea4f33e535b0a99b6be2696fde9c7417022b8ee67fb15b78f47672a0b86",
+                "sha256:13a0e74432ede9efdad5fd9aed73bd30bcfc73ddcbffe719849210f4546db833",
+                "sha256:23d623b41a431e04a9410b046520778517f5304dfbb9bfd3b1bbcc722eeaeea5",
+                "sha256:2f82d8b4d09285ca4aef34ae5c093ccf966da90e7db3bd34764ffb014c8bfa68",
+                "sha256:3223eb697d819d73dedc9a55b3dfa0cc1931e6459df4f0bf83c7c27ca256a3bd",
+                "sha256:3c00ade4ae707dd6a17d6d56ebac689dc56719b83389f9aeb6a10b1e01326177",
+                "sha256:652bdd59afb330ad95550bda6864b87876e977aa4e48b9216235d932368e1987",
+                "sha256:7b413c391e8ad6607b7f7540d698a94349abd64e4935184c595f7cdcc69904c6",
+                "sha256:7feaf556fe2dc94340b603a3bfb00fbb526aaafcb8d804960939244ace4a262f",
+                "sha256:810ae07c1baee83cb3d54f7dca236803554659dc00ef662ac962e4e4fd3e79bb",
+                "sha256:86fa642228b8fc6a8fa268efab20440bb26599d28814e8dcd99af5dc92da10d7",
+                "sha256:a9a0a61f8dc652b3dd5dc8b9f5f9ace5d2f91f5e81f368e9ef180c8eec968234",
+                "sha256:ac3d258521b1056acb922b3aa77031a64888bb8cda1f7f6f370692cf3e224761",
+                "sha256:af7b0d16541dea42f1eceac4a02815ea3ebd8fe1eb6fc714c81ab1842ec259d4",
+                "sha256:bafef5a426473b52648c25d0ff9027aa8806982b57f8bc03abcc5f4669bfe19f",
+                "sha256:bc31cdec2e584106c026a4fd24f800cb575ea8ebfcce7974b630b65d61cf36df",
+                "sha256:cc42af305cb7bf1766b0084011520a81e56315dcc5b7662c209ef71a00764634",
+                "sha256:e01223b43b2e9d92733ab9953038c7a99b9c3cdb32dc865b9ce94f03a2199f96",
+                "sha256:e57f9d267b45ef9e3eb0e234307faaffa5a79cdb1477afa1befbf04de0cd8cbe",
+                "sha256:e9e2942704f7fe75064ef0bc17ba46b097a57ec0e70eca1d790d5a3edb691628",
+                "sha256:f2ca6fc669def8e622b4a10809f6f6a4b6a822a1cc1175b89ad8eb34235aaa2e",
+                "sha256:f456a6321f0955e802e305946ce7e7d672a7da313417ea4b4add6809630d3b0e",
+                "sha256:ff8e09696a8c9100b1c88066ee44b50fbbea367ae91d830910561c902d1e7f3c"
             ],
             "index": "pypi",
             "markers": "platform_python_implementation =='CPython'",
-            "version": "==1.3.5"
+            "version": "==1.3.6"
         },
         "greenlet": {
             "hashes": [
@@ -331,11 +331,11 @@
         },
         "marshmallow": {
             "hashes": [
-                "sha256:171f409d48b44786b7df2793cbd7f1a9062f0fe2c14d547da536b5010f671ade",
-                "sha256:c231784b5a5d2b26e50c90f3038004a3552ec27658cde6e0a5a7279d0c5a8e26"
+                "sha256:0f3776aa5b5405f6000c9304841abe6d4d708bb08207fc89a5ecd86622ec9e54",
+                "sha256:57a107cfd58e9ed52dd355c65444e983d064fdcf63214a487d7305a2d24680db"
             ],
             "index": "pypi",
-            "version": "==2.15.3"
+            "version": "==2.15.4"
         },
         "newrelic": {
             "hashes": [
@@ -475,9 +475,9 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:72325e67fb85f6e9ad304c603d83626d1df684fdf0c7ab1f0352e71feeab69d8"
+                "sha256:ef6569ad403520ee13e180e1bfd6ed71a0254192a934ec1dbd3dbf48f4aa9524"
             ],
-            "version": "==1.2.10"
+            "version": "==1.2.11"
         },
         "structlog": {
             "hashes": [
@@ -500,7 +500,7 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version != '3.1.*' and python_version >= '2.6' and python_version < '4' and python_version != '3.0.*' and python_version != '3.2.*' and python_version != '3.3.*'",
+            "markers": "python_version < '4' and python_version != '3.2.*' and python_version >= '2.6' and python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.0.*'",
             "version": "==1.23"
         },
         "werkzeug": {
@@ -528,10 +528,10 @@
         },
         "astroid": {
             "hashes": [
-                "sha256:a48b57ede295c3188ef5c84273bc2a8eadc46e4cbb001eae0d49fb5d1fabbb19",
-                "sha256:d066cdeec5faeb51a4be5010da612680653d844b57afd86a5c8315f2f801b4cc"
+                "sha256:292fa429e69d60e4161e7612cb7cc8fa3609e2e309f80c224d93a76d5e7b58be",
+                "sha256:c7013d119ec95eb626f7a2011f0b63d0c9a095df9ad06d8507b37084eada1a8d"
             ],
-            "version": "==2.0.2"
+            "version": "==2.0.4"
         },
         "atomicwrites": {
             "hashes": [
@@ -552,7 +552,6 @@
                 "sha256:72791618feb22eaff2e628462b0d58f398ce8c1bacfa989b7679817ab1fad60c",
                 "sha256:9e7ba8dd08fd2939376c21423376206bff01d0deaea7d7721c6b35921fed1943"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version < '4' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.6'",
             "version": "==0.95"
         },
         "backports.ssl-match-hostname": {
@@ -564,12 +563,12 @@
         },
         "beautifulsoup4": {
             "hashes": [
-                "sha256:272081ad78c5495ba67083a0e50920163701fa6fe67fbb5eefeb21b5dd88c40b",
-                "sha256:5a3d659840960a4107047b6328d6d4cdaaee69939bf11adc07466a1856c99a80",
-                "sha256:bd43a3b26d2886acd63070c43da821b60dea603eb6d45bab0294aac6129adbfa"
+                "sha256:194ec62a25438adcb3fdb06378b26559eda1ea8a747367d34c33cef9c7f48d57",
+                "sha256:90f8e61121d6ae58362ce3bed8cd997efb00c914eae0ff3d363c32f9a9822d10",
+                "sha256:f0abd31228055d698bb392a826528ea08ebb9959e6bea17c606fd9c9009db938"
             ],
             "index": "pypi",
-            "version": "==4.6.1"
+            "version": "==4.6.3"
         },
         "blinker": {
             "hashes": [
@@ -587,25 +586,25 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:c848ae99e09f2899c5f81b8fdad90b2ef1fb7a760b13f2b1e51a345f4fd11d2b",
-                "sha256:e225d9fa3f313049547bf510a54d5f0af82f70d53fe0c0f891a0a9f8d4474681"
+                "sha256:ab9c7261fc30a99e3c3009ab599209001af311c94b8f6cb3b35ccd5369db07f8",
+                "sha256:c8381411249716aaa9f64f98be4a96818004ebf80daa7673a3db07d021c46594"
             ],
             "index": "pypi",
-            "version": "==1.7.67"
+            "version": "==1.7.83"
         },
         "botocore": {
             "hashes": [
-                "sha256:e578f2618d0076950bcbd6ac938471310b08c292277b49092b938c59788012a6",
-                "sha256:e9eea23c566c30c69879941c4183294b7d45d8d8ff7946669364d8bb48ed0c90"
+                "sha256:aeb54fd5f9a01399593e77612e7cdcf53e90a7d623378225685e599b989792d6",
+                "sha256:ce14556d139fa0641ca7f1973ed68d19ba70691490f3840bd2c6d906e4a99fc8"
             ],
-            "version": "==1.10.67"
+            "version": "==1.10.83"
         },
         "certifi": {
             "hashes": [
-                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
-                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
+                "sha256:4c1d68a1408dd090d2f3a869aa94c3947cc1d967821d1ed303208c9f41f0f2f4",
+                "sha256:b6e8b28b2b7e771a41ecdd12d4d43262ecab52adebbafa42c77d6b57fb6ad3a4"
             ],
-            "version": "==2018.4.16"
+            "version": "==2018.8.13"
         },
         "cffi": {
             "hashes": [
@@ -699,7 +698,7 @@
                 "sha256:e05cb4d9aad6233d67e0541caa7e511fa4047ed7750ec2510d466e806e0255d6",
                 "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version < '4' and python_version != '3.0.*' and python_version >= '2.6'",
+            "markers": "python_version < '4' and python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version >= '2.6'",
             "version": "==4.5.1"
         },
         "cryptography": {
@@ -728,11 +727,10 @@
         },
         "docker": {
             "hashes": [
-                "sha256:52cf5b1c3c394f9abf897638bfc3336d6b63a0f65969d0d4d2da6d3b1d8032b6",
-                "sha256:ad077b49660b711d20f50f344f70cfae014d635ef094bf21b0d7df5f0aeedf99"
+                "sha256:6c4da20ef40e8d3eaf650f1488d91452b9a1128045481d7169fd34665ffa90ee",
+                "sha256:bc693be5a84b3b9e5aaf156068c5c0a445ee5138c638c3fbc857133bf67ebe07"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version < '4' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.6'",
-            "version": "==3.4.1"
+            "version": "==3.5.0"
         },
         "docker-pycreds": {
             "hashes": [
@@ -748,6 +746,13 @@
                 "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6"
             ],
             "version": "==0.14"
+        },
+        "ecdsa": {
+            "hashes": [
+                "sha256:40d002cf360d0e035cf2cb985e1308d41aaa087cbfc135b2dc2d844296ea546c",
+                "sha256:64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa"
+            ],
+            "version": "==0.13"
         },
         "flake8": {
             "hashes": [
@@ -816,6 +821,20 @@
             "index": "pypi",
             "version": "==0.10.1"
         },
+        "freezegun": {
+            "hashes": [
+                "sha256:703caac155dcaad61f78de4cb0666dca778d854dfb90b3699930adee0559a622",
+                "sha256:94c59d69bb99c9ec3ca5a3adb41930d3ea09d2a9756c23a02d89fa75646e78dd"
+            ],
+            "index": "pypi",
+            "version": "==0.3.10"
+        },
+        "future": {
+            "hashes": [
+                "sha256:e39ced1ab767b5936646cedba8bcce582398233d6a627067d4c6a454c90cfedb"
+            ],
+            "version": "==0.16.0"
+        },
         "google-compute-engine": {
             "hashes": [
                 "sha256:14947a0cfc20e1d64d1184bbd137b9f3b66d7c94efcbe1b73e21c090e7002af4"
@@ -843,7 +862,7 @@
                 "sha256:b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8",
                 "sha256:ec9ef8f4a9bc6f71eec99e1806bfa2de401650d996c59330782b89a5555c1497"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7'",
+            "markers": "python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version >= '2.7'",
             "version": "==4.3.4"
         },
         "itsdangerous": {
@@ -951,11 +970,11 @@
         },
         "moto": {
             "hashes": [
-                "sha256:45d14aca2b06b0083d5e82cfd770ebca0ba77b5070aec6928670240939a78681",
-                "sha256:ee71b515ba34d64c5f625950fc995594040f793a4a106614ff108ae02c1a2896"
+                "sha256:7c86d1c3bd6362954afaded735354c11afd22037eb6736152f057a1bff0c8868",
+                "sha256:b8556c1e0cebf931a698bf7198bb3eaf2287c8c9bb4f3455ea5d2015ad8f1708"
             ],
             "index": "pypi",
-            "version": "==1.3.3"
+            "version": "==1.3.4"
         },
         "pathlib2": {
             "hashes": [
@@ -985,7 +1004,7 @@
                 "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1",
                 "sha256:95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.2.*' and python_version != '3.3.*'",
+            "markers": "python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version >= '2.7'",
             "version": "==0.7.1"
         },
         "py": {
@@ -993,7 +1012,7 @@
                 "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
                 "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.2.*' and python_version != '3.3.*'",
+            "markers": "python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version >= '2.7'",
             "version": "==1.5.4"
         },
         "pyaml": {
@@ -1016,6 +1035,41 @@
             ],
             "version": "==2.18"
         },
+        "pycryptodome": {
+            "hashes": [
+                "sha256:0f027d5da3f3c4c0167f3ccf4a1f56674248120656099df35098dfaf3edff0fb",
+                "sha256:1e970715407a862b6b4c61f1a8c60734c0fa39f45d36dda46dbd0baf2d8caec2",
+                "sha256:2652a86850d7873249c64365a61e1052934f1504f11b57dbe76c1a4dc9b5d593",
+                "sha256:26953969934e09d49b2e370229ef262dd480b46130660086b22fea29df335dea",
+                "sha256:31d2f9fa32fd651694dbae298682c1afa2337fa6454b32b241164c2ffe96e1c1",
+                "sha256:53cd63d379224ea52d8ba2012fe8acf9eb682aa819c3a9a02397fe3e6b4315a4",
+                "sha256:637bfc8bfb68d477619c54b56d912117abca05306a222ccf03dfc09ab6b4e5a4",
+                "sha256:6b8a3753e31b058d48bdd26c50c049a04f35f0f05c0d866c63fc90fc9b8dc5d7",
+                "sha256:7bd1c4671b3a2c8d647731e9c34115efa928ff12d0ef1bef68f0f7af984bc239",
+                "sha256:7cb057b700d688bb37082b0086d061462dde18c1fbbe355615db87f3bf97ffa4",
+                "sha256:7d7e07e885cee42b222ab190ea292f144aaf6e915ea3d1bf9e2f812fc2ad9f18",
+                "sha256:80c55dd2246a17b4af18bd615711b90c8df4b780451692f627a38a636d0792ae",
+                "sha256:864249afa1d801c7a2abb3fbed0e9e8ce4844a8f68daff8028a40634f69f0135",
+                "sha256:927ce443c5183ee7738ce113ecf656842fafbad1d6f4ab726dc12abc8adabfad",
+                "sha256:9dd8fb9d76fde52c01dcc6d24dc384ddb60ff6fb96216a58017dacc5580600e3",
+                "sha256:abd859f70a9cad653644b0415adfe6223f708093296747970ec56a8f5537bfb3",
+                "sha256:b3cb4af317d9b84f6df50f0cfa6840ba69556af637a83fd971537823e13d601a",
+                "sha256:b4c5d98eb9608bf29b66504dba96494a9fac75b3c0c57dfb557f6e812989a3fe",
+                "sha256:bc130342d9b6267efaa97ea305b9a46f59c097e95263a6d65abc7890331535e7",
+                "sha256:c26f706a8b8e1e44076126bfe0319b7eb9038350d5b6ff55c86b2edb434b3e52",
+                "sha256:c58539996e2acdb6c5554851cd1b333af889a6aadeb9865127e4bbc17d01ff53",
+                "sha256:c899042914a780abfc01250d22f5674f60195b8149f161a6481b6f6b7aa81dee",
+                "sha256:d0468c5c9944859c862d81621985d407097c08c0e18bb537883b9268c6e34bd1",
+                "sha256:dfa339c6ef6a1f36642db0dd0d442207aa2a071caa122d744222f2a2832c530f",
+                "sha256:e23b2e13580a4e2d35f7acba674b2b1d1fca9b20a5c0d8ffb98b8fe58c2e7107",
+                "sha256:e4406a5141d6d5d19ee515ff6c69baf9a7a10006a8490e7447cbc8dcf61f9903",
+                "sha256:ef50df5404b50109a13e46f4421ffe64a650104e2216e282a49662712b024dae",
+                "sha256:f459395378709b7aa32bb6e59d55d72d48631840ed6c1c919f63036bd548f375",
+                "sha256:fa99a0bcadef482300f5308bb9c0041d4f084b085dff0c908350de382df9f87d",
+                "sha256:fbd0def77da8edd5293e5e3b534763861e1c3f4f645ef3602f718fd709536a77"
+            ],
+            "version": "==3.6.6"
+        },
         "pyflakes": {
             "hashes": [
                 "sha256:08bd6a50edf8cffa9fa09a463063c425ecaaf10d1eb0335a7e8b1401aef89e6f",
@@ -1025,11 +1079,11 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:0edfec21270725c5aa8e8d8d06ef5666f766e0e748ed2f1ab23624727303b935",
-                "sha256:4cadcaa4f1fb19123d4baa758d9fbe6286c5b3aa513af6ea42a2d51d405db205"
+                "sha256:1d6d3622c94b4887115fe5204982eee66fdd8a951cf98635ee5caee6ec98c3ec",
+                "sha256:31142f764d2a7cd41df5196f9933b12b7ee55e73ef12204b648ad7e556c119fb"
             ],
             "index": "pypi",
-            "version": "==2.1.0"
+            "version": "==2.1.1"
         },
         "pylint-mccabe": {
             "hashes": [
@@ -1048,11 +1102,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:8214ab8446104a1d0c17fbd218ec6aac743236c6ffbe23abc038e40213c60b88",
-                "sha256:e2b2c6e1560b8f9dc8dd600b0923183fbd68ba3d9bdecde04467be6dd296a384"
+                "sha256:3459a123ad5532852d36f6f4501dfe1acf4af1dd9541834a164666aa40395b02",
+                "sha256:96bfd45dbe863b447a3054145cd78a9d7f31475d2bce6111b133c0cc4f305118"
             ],
             "index": "pypi",
-            "version": "==3.7.0"
+            "version": "==3.7.2"
         },
         "pytest-cov": {
             "hashes": [
@@ -1069,6 +1123,13 @@
             ],
             "markers": "python_version >= '2.7'",
             "version": "==2.7.3"
+        },
+        "python-jose": {
+            "hashes": [
+                "sha256:391f860dbe274223d73dd87de25e4117bf09e8fe5f93a417663b1f2d7b591165",
+                "sha256:3b35cdb0e55a88581ff6d3f12de753aa459e940b50fe7ca5aa25149bc94cb37b"
+            ],
+            "version": "==2.0.2"
         },
         "pytz": {
             "hashes": [
@@ -1107,7 +1168,6 @@
                 "sha256:c6082710f4abfb60793899ca5f21e7ceb25aabf321560cc0726f8b59006811c9",
                 "sha256:f23a29dca18b815d9d64a516b4a0abb1fbdccff6141d988ad8100facb81cf7b3"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version < '4' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.6'",
             "version": "==0.9.0"
         },
         "s3transfer": {
@@ -1119,20 +1179,20 @@
         },
         "scandir": {
             "hashes": [
-                "sha256:24f32112c483ac6c4a40b62f1282e61ecca7977153b66a0d26a9583a716dcb64",
-                "sha256:6c80092f8fe3e62c3da3110067589c6661c722b0889906d2974e5150f1314523",
-                "sha256:7729b8444c5f5187649ff58501e7c2ad22b84d7dc28f738f64c5b615913fec22",
-                "sha256:8e3ca5925cc13787aeafbf08f055a8066c091fc20bfa8783235b916cf047afbe",
-                "sha256:96dfc553f50946deb6d1cd762bac5cf122832c4aa253c885ca357ef53dd8d072",
-                "sha256:b2d55be869c4f716084a19b1e16932f0769711316ba62de941320bf2be84763d",
-                "sha256:b55a091b91f9e6c9c7129889b2f58df329530172a99172de9e784545342a45e6",
-                "sha256:b6cb611a18a828146a178362a36a2c6557c51c596ded4314cb516dd8c947b4ce",
-                "sha256:d985e36eb3effebb20434e6cd7495440b4ba676a22f3ec61e9fff9f3e2995238",
-                "sha256:f39dd5affde2860fb28176d2233f318ccca97c55019407ee8172b3fba0b211db",
-                "sha256:f91418e82edb5a43b020fa15e30a41d730b71c5957536749366bf63cc05427b1"
+                "sha256:04b8adb105f2ed313a7c2ef0f1cf7aff4871aa7a1883fa4d8c44b5551ab052d6",
+                "sha256:1444134990356c81d12f30e4b311379acfbbcd03e0bab591de2696a3b126d58e",
+                "sha256:1b5c314e39f596875e5a95dd81af03730b338c277c54a454226978d5ba95dbb6",
+                "sha256:346619f72eb0ddc4cf355ceffd225fa52506c92a2ff05318cfabd02a144e7c4e",
+                "sha256:44975e209c4827fc18a3486f257154d34ec6eaec0f90fef0cca1caa482db7064",
+                "sha256:61859fd7e40b8c71e609c202db5b0c1dbec0d5c7f1449dec2245575bdc866792",
+                "sha256:a5e232a0bf188362fa00123cc0bb842d363a292de7126126df5527b6a369586a",
+                "sha256:c14701409f311e7a9b7ec8e337f0815baf7ac95776cc78b419a1e6d49889a383",
+                "sha256:c7708f29d843fc2764310732e41f0ce27feadde453261859ec0fca7865dfc41b",
+                "sha256:c9009c527929f6e25604aec39b0a43c3f831d2947d89d6caaab22f057b7055c8",
+                "sha256:f5c71e29b4e2af7ccdc03a020c626ede51da471173b4a6ad1e904f2b2e04b4bd"
             ],
             "markers": "python_version < '3.5'",
-            "version": "==1.7"
+            "version": "==1.9.0"
         },
         "six": {
             "hashes": [
@@ -1167,6 +1227,7 @@
                 "sha256:edb04bdd45bfd76c8292c4d9654568efaedf76fe78eb246dde69bdb13b2dad87",
                 "sha256:f19f2a4f547505fe9072e15f6f4ae714af51b5a681a97f187971f50c283193b6"
             ],
+            "markers": "python_version < '3.7' and implementation_name == 'cpython'",
             "version": "==1.1.0"
         },
         "typing": {
@@ -1175,6 +1236,7 @@
                 "sha256:b2c689d54e1144bbcfd191b0832980a21c2dbcf7b5ff7a66248a60c90e951eb8",
                 "sha256:d400a9344254803a2368533e4533a4200d21eb7b6b729c173bc38201a74db3f2"
             ],
+            "markers": "python_version < '3.5'",
             "version": "==3.6.4"
         },
         "urllib3": {
@@ -1182,15 +1244,15 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version != '3.1.*' and python_version >= '2.6' and python_version < '4' and python_version != '3.0.*' and python_version != '3.2.*' and python_version != '3.3.*'",
+            "markers": "python_version < '4' and python_version != '3.2.*' and python_version >= '2.6' and python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.0.*'",
             "version": "==1.23"
         },
         "websocket-client": {
             "hashes": [
-                "sha256:18f1170e6a1b5463986739d9fd45c4308b0d025c1b2f9b88788d8f69e8a5eb4a",
-                "sha256:db70953ae4a064698b27ae56dcad84d0ee68b7b43cb40940f537738f38f510c1"
+                "sha256:030bbfbf29ac9e315ffb207ed5ed42b6981b5038ea00d1e13b02b872cc95e8f6",
+                "sha256:a35bac3d9647c62c1ba3e8a7340385d92981f5486b033557d592138fd4b21b90"
             ],
-            "version": "==0.48.0"
+            "version": "==0.51.0"
         },
         "werkzeug": {
             "hashes": [

--- a/app/submitter/converter.py
+++ b/app/submitter/converter.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime
 from structlog import get_logger
 from app.submitter.convert_payload_0_0_1 import convert_answers_to_payload_0_0_1
 from app.submitter.convert_payload_0_0_2 import convert_answers_to_payload_0_0_2
@@ -47,7 +47,7 @@ def convert_answers(metadata, collection_metadata, schema, answer_store, routing
       }
     """
     survey_id = schema.json['survey_id']
-    submitted_at = datetime.now(timezone.utc)
+    submitted_at = datetime.utcnow()
     payload = {
         'tx_id': metadata['tx_id'],
         'type': 'uk.gov.ons.edc.eq:surveyresponse',
@@ -128,7 +128,7 @@ def convert_feedback(message, name, email, url, metadata, survey_id):
         'data': {}
       }
     """
-    submitted_at = datetime.now(timezone.utc)
+    submitted_at = datetime.utcnow()
     payload = {
         'tx_id': metadata['tx_id'],
         'type': 'uk.gov.ons.edc.eq:feedback',

--- a/app/templating/schema_context.py
+++ b/app/templating/schema_context.py
@@ -3,10 +3,11 @@ from collections import defaultdict
 from jinja2 import escape
 
 
-def build_schema_context(metadata, schema, answer_store, answer_ids_on_path, group_instance=0, group_instance_id=None):
+def build_schema_context(metadata, collection_metadata, schema, answer_store, answer_ids_on_path, group_instance=0, group_instance_id=None):
     """
     Build questionnaire schema context containing exercise and answers
     :param metadata: user metadata
+    :param collection_metadata: metadata for the collection of the questionnaire
     :param schema: Survey schema
     :param answer_store: all the answers for the given questionnaire
     :param answer_ids_on_path: a list of the answer ids on the routing path
@@ -16,6 +17,7 @@ def build_schema_context(metadata, schema, answer_store, answer_ids_on_path, gro
     """
     return {
         'metadata': build_schema_metadata(metadata, schema),
+        'collection_metadata': collection_metadata,
         'answers': _build_answers(answer_store, schema, answer_ids_on_path),
         'group_instances': _build_group_instances(answer_store, answer_ids_on_path),
         'group_instance': group_instance,

--- a/app/templating/template_renderer.py
+++ b/app/templating/template_renderer.py
@@ -26,6 +26,9 @@ class TemplateRenderer:
         env.globals['get_current_date'] = filters.get_current_date
         env.globals['min_value'] = filters.min_value
         env.globals['max_value'] = filters.max_value
+        env.filters['format_date_custom'] = filters.format_date_custom
+        env.globals['format_date_range_no_repeated_month_year'] = filters.format_date_range_no_repeated_month_year
+        env.globals['calculate_offset_from_weekday_in_last_whole_week'] = filters.calculate_offset_from_weekday_in_last_whole_week
         self.environment = env
 
     def render(self, renderable, **context):

--- a/data/en/test_date_reference_ranges.json
+++ b/data/en/test_date_reference_ranges.json
@@ -1,0 +1,97 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "survey_id": "023",
+    "title": "Date formats",
+    "description": "A test schema for different date formats",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "metadata": [{
+        "name": "user_id",
+        "validator": "string"
+    }, {
+        "name": "period_id",
+        "validator": "string"
+    }, {
+        "name": "ru_name",
+        "validator": "string"
+    }],
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "blocks": [{
+                "type": "Question",
+                "id": "manual-range-block",
+                "description": "",
+                "questions": [{
+                    "answers": [{
+                        "id": "manual-range-radio",
+                        "mandatory": true,
+                        "options": [{
+                            "label": "Yes",
+                            "value": "Yes"
+                        }, {
+                            "label": "No",
+                            "value": "No"
+                        }],
+                        "type": "Radio"
+                    }],
+                    "description": "",
+                    "id": "manual-range-question",
+                    "title": "Did you have a paid job, either as an employee or self-employed, in the week {{ calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}) | format_date_custom( 'EEEE d MMMM YYYY' ) }} to {{ calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU') | format_date_custom( 'EEEE d MMMM YYYY' ) }}",
+                    "type": "General"
+                }]
+            }, {
+                "type": "Question",
+                "id": "date-separate-block",
+                "description": "",
+                "questions": [{
+                    "answers": [{
+                        "id": "date-separate-radio",
+                        "mandatory": true,
+                        "options": [{
+                            "label": "Yes",
+                            "value": "Yes"
+                        }, {
+                            "label": "No",
+                            "value": "No"
+                        }],
+                        "type": "Radio"
+                    }],
+                    "description": "",
+                    "id": "date-separate-question",
+                    "title": "If you had been offered a job in the week starting {{ calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}) | format_date_custom( 'EEEE d MMMM' ) }} would you be able to start before {{ calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {'weeks':2}) | format_date_custom( 'EEEE d MMMM' ) }}",
+                    "type": "General"
+                }]
+            }, {
+                "type": "Question",
+                "id": "date-range-block",
+                "description": "",
+                "questions": [{
+                    "answers": [{
+                        "id": "date-range-radio",
+                        "mandatory": true,
+                        "options": [{
+                            "label": "Yes",
+                            "value": "Yes"
+                        }, {
+                            "label": "No",
+                            "value": "No"
+                        }],
+                        "type": "Radio"
+                    }],
+                    "description": "",
+                    "id": "date-range-question",
+                    "title": "In the 4 weeks between {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {'weeks': -3}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU')) }} did you look for any paid work?",
+                    "type": "General"
+                }]
+            }, {
+                "type": "Summary",
+                "id": "summary"
+            }],
+            "id": "dates",
+            "title": "Date Examples"
+        }]
+    }]
+}

--- a/tests/app/submitter/test_converter.py
+++ b/tests/app/submitter/test_converter.py
@@ -1,6 +1,6 @@
 import copy
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 import dateutil.parser
 
@@ -125,28 +125,6 @@ class TestConverter(AppContextTestCase):  # pylint: disable=too-many-public-meth
 
             self.assertEqual(answer_object['started_at'], self.collection_metadata['started_at'])
 
-    def test_started_at_comes_from_metadata_if_necessary(self):
-        """
-        This tests functionality that should be removed after collection_metadata changes are released
-        """
-        questionnaire = {
-            'survey_id': '021',
-            'data_version': '0.0.2'
-        }
-
-        # Remove started at from collection metadata and add it to metadata
-        collection_metadata = self.collection_metadata.copy()
-        metadata = self.metadata.copy()
-        metadata['started_at'] = collection_metadata['started_at']
-        del collection_metadata['started_at']
-
-        answer_object = convert_answers(
-            metadata, collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(), {}
-        )
-
-        self.assertEqual(answer_object['started_at'], metadata['started_at'])
-
-
     def test_started_at_should_not_be_set_in_payload_if_absent_in_metadata(self):
         with self._app.test_request_context():
 
@@ -175,7 +153,7 @@ class TestConverter(AppContextTestCase):  # pylint: disable=too-many-public-meth
 
             answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), {})
 
-            self.assertLess(datetime.now(timezone.utc) - dateutil.parser.parse(answer_object['submitted_at']),
+            self.assertLess(datetime.utcnow() - dateutil.parser.parse(answer_object['submitted_at']),
                             timedelta(seconds=5))
 
     def test_case_id_should_be_set_in_payload(self):

--- a/tests/app/templating/test_schema_context.py
+++ b/tests/app/templating/test_schema_context.py
@@ -38,19 +38,22 @@ class TestBuildSchemaContext(TestCase):  # pylint: disable=too-many-public-metho
         self.answer_store = AnswerStore()
         self.metadata = get_metadata_sample()
         self.schema = get_test_schema()
+        self.collection_metadata = {'test': 'test'}
 
     def test_build_schema_context(self):
         # Given
         with patch('app.templating.schema_context.build_schema_metadata', return_value='schema_metadata'), \
                 patch('app.templating.schema_context._build_answers', return_value='answer_context'):
             # When
-            schema_context = build_schema_context(self.metadata, self.schema, self.answer_store, [])
+            schema_context = build_schema_context(self.metadata, self.collection_metadata, self.schema, self.answer_store, [])
 
         # Then
         self.assertIn('metadata', schema_context)
         self.assertEqual(schema_context['metadata'], 'schema_metadata')
         self.assertIn('answers', schema_context)
         self.assertEqual(schema_context['answers'], 'answer_context')
+        self.assertIn('collection_metadata', schema_context)
+        self.assertEqual(schema_context['collection_metadata'], self.collection_metadata)
 
 
 class TestBuildAnswersContext(TestCase):

--- a/tests/functional/pages/features/date_reference_ranges/date-range-block.page.js
+++ b/tests/functional/pages/features/date_reference_ranges/date-range-block.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class DateRangeBlockPage extends QuestionPage {
+
+  constructor() {
+    super('date-range-block');
+  }
+
+  yes() {
+    return '#date-range-radio-0';
+  }
+
+  yesLabel() { return '#label-date-range-radio-0'; }
+
+  no() {
+    return '#date-range-radio-1';
+  }
+
+  noLabel() { return '#label-date-range-radio-1'; }
+
+}
+module.exports = new DateRangeBlockPage();

--- a/tests/functional/pages/features/date_reference_ranges/date-separate-block.page.js
+++ b/tests/functional/pages/features/date_reference_ranges/date-separate-block.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class DateSeparateBlockPage extends QuestionPage {
+
+  constructor() {
+    super('date-separate-block');
+  }
+
+  yes() {
+    return '#date-separate-radio-0';
+  }
+
+  yesLabel() { return '#label-date-separate-radio-0'; }
+
+  no() {
+    return '#date-separate-radio-1';
+  }
+
+  noLabel() { return '#label-date-separate-radio-1'; }
+
+}
+module.exports = new DateSeparateBlockPage();

--- a/tests/functional/pages/features/date_reference_ranges/introduction.page.js
+++ b/tests/functional/pages/features/date_reference_ranges/introduction.page.js
@@ -1,0 +1,11 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class IntroductionPage extends QuestionPage {
+
+  constructor() {
+    super('introduction');
+  }
+
+}
+module.exports = new IntroductionPage();

--- a/tests/functional/pages/features/date_reference_ranges/manual-range-block.page.js
+++ b/tests/functional/pages/features/date_reference_ranges/manual-range-block.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class ManualRangeBlockPage extends QuestionPage {
+
+  constructor() {
+    super('manual-range-block');
+  }
+
+  yes() {
+    return '#manual-range-radio-0';
+  }
+
+  yesLabel() { return '#label-manual-range-radio-0'; }
+
+  no() {
+    return '#manual-range-radio-1';
+  }
+
+  noLabel() { return '#label-manual-range-radio-1'; }
+
+}
+module.exports = new ManualRangeBlockPage();

--- a/tests/functional/pages/features/date_reference_ranges/summary.page.js
+++ b/tests/functional/pages/features/date_reference_ranges/summary.page.js
@@ -1,0 +1,25 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  manualRangeRadio() { return '#manual-range-radio-answer'; }
+
+  manualRangeRadioEdit() { return '[data-qa="manual-range-radio-edit"]'; }
+
+  dateSeparateRadio() { return '#date-separate-radio-answer'; }
+
+  dateSeparateRadioEdit() { return '[data-qa="date-separate-radio-edit"]'; }
+
+  dateRangeRadio() { return '#date-range-radio-answer'; }
+
+  dateRangeRadioEdit() { return '[data-qa="date-range-radio-edit"]'; }
+
+  datesTitle() { return '#dates'; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/spec/date_reference_ranges.spec.js
+++ b/tests/functional/spec/date_reference_ranges.spec.js
@@ -1,0 +1,41 @@
+const helpers = require('../helpers');
+
+const ManualRangeBlockPage = require('../pages/features/date_reference_ranges/manual-range-block.page.js');
+const DateSeparateBlockPage = require('../pages/features/date_reference_ranges/date-separate-block.page.js');
+const DateRangeBlockPage = require('../pages/features/date_reference_ranges/date-range-block.page.js');
+const SummaryPage = require('../pages/features/date_reference_ranges/summary.page.js');
+
+describe('Reference Date Range Checks', function() {
+  // We have no way to mock out started_at, the unit and integration tests cover the date values
+  // this test is only to validate the general questionnaire functionality and to make sure
+  // the date format is correct.
+  it('Given we start the survey, when we click the button, the dates should be in the correct format...', function() {
+    return helpers.openQuestionnaire('test_date_reference_ranges.json').then(() => {
+        return browser
+          // Should show a date range in the right format
+
+          // Matches `in the week Friday 24 August 2018 to`. The day of the month can be 1 or two characters
+          .getText(SummaryPage.questionText()).should.eventually.match(new RegExp('in the week [a-zA-Z]+ \\d(?:\\d)? [a-zA-Z]+ \\d{4} to'))
+          // Matches `to Saturday 25 August 2018 to`. The day of the month can be 1 or two characters
+          .getText(SummaryPage.questionText()).should.eventually.match(new RegExp('to [a-zA-Z]+ \\d(?:\\d)? [a-zA-Z]+ \\d{4}$'))
+
+          .click(ManualRangeBlockPage.yes())
+          .click(ManualRangeBlockPage.submit())
+
+          // Matches `week starting Saturday 25 August 2018 would`. The day of the month can be 1 or two characters
+          .getText(DateSeparateBlockPage.questionText()).should.eventually.match(new RegExp('week starting [a-zA-Z]+ \\d(?:\\d)? [a-zA-Z]+ would'))
+          // Matches `before Saturday 25 August 2018`. The day of the month can be 1 or two characters
+          .getText(DateSeparateBlockPage.questionText()).should.eventually.match(new RegExp('before [a-zA-Z]+ \\d(?:\\d)? [a-zA-Z]*$'))
+
+          .click(DateSeparateBlockPage.yes())
+          .click(DateSeparateBlockPage.submit())
+
+          // Matches `between Friday 24 August 2018 to Saturday 25 September 2019`. The day of the month can be 1 or two characters
+          // In this case, the month and the year can be ommitted if they are both the same in the range.
+          .getText(DateRangeBlockPage.questionText()).should.eventually.match(new RegExp('between \\d(?:\\d)?(?:[a-zA-Z ]+)?(?:[\\d ]{4})? to \\d(?:\\d)? \\w+ \\d{4} did'))
+
+
+        });
+    });
+});
+

--- a/tests/integration/introduction/test_introduction.py
+++ b/tests/integration/introduction/test_introduction.py
@@ -57,21 +57,3 @@ class TestIntroduction(IntegrationTestCase):
         started_at_datetime = datetime.strptime(actual['started_at'], '%Y-%m-%dT%H:%M:%S.%f')
 
         self.assertIsNotNone(started_at_datetime)
-
-    def test_started_at_retrieved_from_metadata_if_available(self):
-        """
-        This tests functionality to load started_at from metadata which
-        should only occur during deployment of collection_metadata
-        This should be removed after collection_metadata changes are deployed.
-        """
-        # Given survey with a start survey button and started_at set in metadata
-        now = datetime.utcnow().isoformat()
-        self.launchSurvey('1', '0112', roles=['dumper'], started_at=now)
-
-        self.post(action='start_questionnaire')
-
-        # When start survey button is pressed,
-        # Then started_at should be set from metadata
-        actual = self.dumpSubmission()['submission']
-
-        self.assertEqual(actual['started_at'], now)

--- a/tests/integration/mci/test_date_reference_ranges.py
+++ b/tests/integration/mci/test_date_reference_ranges.py
@@ -1,0 +1,38 @@
+from freezegun import freeze_time
+from tests.integration.integration_test_case import IntegrationTestCase
+
+@freeze_time('2018-10-08')
+class TestHappyPath(IntegrationTestCase):
+
+    def test_date_range(self):
+        self.launchSurvey('test',
+                          'date_reference_ranges',
+                          )
+
+        self.post(action='start_questionnaire')
+
+        # We are in the Questionnaire
+        self.assertInPage('Did you have a paid job, either as an employee or self-employed, in the week')
+        self.assertInPage('Monday 1 October 2018')
+        self.assertInPage('Sunday 7 October 2018')
+
+        self.post({
+            'manual-range-radio': 'Yes'
+        })
+
+        # We're on the second question
+
+        self.assertInPage('If you had been offered a job in the week starting')
+        self.assertInPage('Monday 1 October')
+        self.assertInPage('Monday 15 October')
+
+
+        self.post({
+            'date-separate-radio': 'Yes'
+        })
+
+        # We're on the third question
+
+        self.assertInPage('In the 4 weeks between')
+        self.assertInPage('10 September')
+        self.assertInPage('7 October 2018')

--- a/tests/integration/views/test_questionnaire.py
+++ b/tests/integration/views/test_questionnaire.py
@@ -548,7 +548,7 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
                              Location('group', 0, 'multiple-question-versions-block'),
                              Location('group', 0, 'Summary')]
         current_location = Location('group', 0, 'single-title-block')
-        schema_context = _get_schema_context(full_routing_path, current_location, {}, AnswerStore(), g.schema)
+        schema_context = _get_schema_context(full_routing_path, current_location, {}, {}, AnswerStore(), g.schema)
 
         # When
         with self._application.test_request_context():


### PR DESCRIPTION
This is currently blocked on #1731 (Which may cause significant changes)

### What is the context of this PR?
We need to add a few reference date ranges, which all amount to dates which are a constant offset from the previous Sunday (not including today if it is Sunday).

There is additional functionality in the formatting of these date ranges. If the range spans a single month and year, then the first month / year should not be shown. e.g. `Thursday 16 to Friday 17 August 2018` rather than `Thursday 16 August 2018 to Friday 17 August 2018`. I've assumed this change is required going from the examples, but let me know if that's incorrect.

### How to review 

* The test schema contains a few examples as per the examples we were given. If testing manually with go-launcher, remove `started_at` from metadata to default to `utcnow()`.
* Ensure these examples match the expected ranges from trello.

### Notable changes
Look over the following code in particular:

* `started_at` changed from `now(timezone.utc)` to `utcnow()`. Due to discrepancies between these, I think we should standardise `utcnow()`.
* `metadata_parser.py` there is a special case here for validating started_at for the first question when it isn't present. This also defaults to `utcnow()` . See more detailed comment in trello.
* I've added a dependency on `freezegun` in order to pin `started_at` after the first question has been answered in integration tests. I can't see a way to inject any metadata for the second question, but if anyone knows of a way to do this nicely I'd love to remove this.

I'll need to setup signed commits before this is merged.