### PR TITLE
Use labels instead of questions within the total playback summary type

### DIFF
--- a/app/templates/partials/summary/display-answer-label.html
+++ b/app/templates/partials/summary/display-answer-label.html
@@ -1,0 +1,1 @@
+<div class="summary__label mars" id="{{ answer.id }}-label" data-qa="{{ answer.id }}-label">{{ answer.label|striptags }}</div>

--- a/app/templates/partials/summary/question-multiple-answers.html
+++ b/app/templates/partials/summary/question-multiple-answers.html
@@ -9,7 +9,7 @@
     {% set is_textarea = answer_is_type(answer, 'textarea') %}
     <div class="grid">
         <div class="grid__col col-12@xs {{ 'col-10@m' if is_textarea else 'col-6@m' }}">
-            <div class="summary__label mars">{{ answer.label|striptags }}</div>
+            {%- include theme(['partials/summary/display-answer-label.html']) -%}
         </div>
 
         {%- include theme(['partials/summary/display-answer.html']) -%}

--- a/app/templates/partials/summary/question-single-answer.html
+++ b/app/templates/partials/summary/question-single-answer.html
@@ -4,7 +4,11 @@
         {% set is_textarea = answer_is_type(answer, 'textarea') %}
 
         <div class="grid__col col-12@xs mars {{ 'col-10@m' if is_textarea else 'col-6@m' }}">
-            {%- include theme(['partials/summary/display-question.html']) -%}
+            {% if content.summary.summary_type == 'CalculatedSummary' and answer.label %}
+                {%- include theme(['partials/summary/display-answer-label.html']) -%}
+            {% else %}
+                {%- include theme(['partials/summary/display-question.html']) -%}
+            {% endif %}
         </div>
 
         {%- include theme(['partials/summary/display-answer.html']) -%}

--- a/data/en/test_calculated_summary.json
+++ b/data/en/test_calculated_summary.json
@@ -59,7 +59,7 @@
                         "type": "General",
                         "answers": [{
                                 "id": "second-number-answer",
-                                "label": "Second answer in currency total",
+                                "label": "Second answer in currency label",
                                 "mandatory": true,
                                 "type": "Currency",
                                 "currency": "GBP",

--- a/tests/functional/pages/calculated-summary.page.js
+++ b/tests/functional/pages/calculated-summary.page.js
@@ -1,0 +1,17 @@
+const QuestionPage = require('./surveys/question.page');
+
+class CalculatedSummaryPage extends QuestionPage {
+
+  constructor(pageName) {
+    super(pageName);
+  }
+
+  calculatedSummaryTitle() { return '[data-qa="calculated-summary-title"]'; }
+
+  calculatedSummaryQuestion() { return '#calculated-summary-question'; }
+
+  calculatedSummaryAnswer() { return '#calculated-summary-answer-answer'; }
+
+}
+
+module.exports = CalculatedSummaryPage;

--- a/tests/functional/pages/features/calculated_summary/currency-total-playback.page.js
+++ b/tests/functional/pages/features/calculated_summary/currency-total-playback.page.js
@@ -1,7 +1,7 @@
 // >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
-const QuestionPage = require('../../surveys/question.page');
+const CalculatedSummaryPage = require('../../calculated-summary.page');
 
-class CurrencyTotalPlaybackPage extends QuestionPage {
+class CurrencyTotalPlaybackPage extends CalculatedSummaryPage {
 
   constructor() {
     super('currency-total-playback');
@@ -11,53 +11,37 @@ class CurrencyTotalPlaybackPage extends QuestionPage {
 
   firstNumberAnswerEdit() { return '[data-qa="first-number-answer-edit"]'; }
 
+  firstNumberAnswerLabel() { return '#first-number-answer-label'; } 
+
   secondNumberAnswer() { return '#second-number-answer-answer'; }
 
   secondNumberAnswerEdit() { return '[data-qa="second-number-answer-edit"]'; }
 
-  secondNumberAnswerUnitTotal() { return '#second-number-answer-unit-total-answer'; }
-
-  secondNumberAnswerUnitTotalEdit() { return '[data-qa="second-number-answer-unit-total-edit"]'; }
+  secondNumberAnswerLabel() { return '#second-number-answer-label'; } 
 
   secondNumberAnswerAlsoInTotal() { return '#second-number-answer-also-in-total-answer'; }
 
   secondNumberAnswerAlsoInTotalEdit() { return '[data-qa="second-number-answer-also-in-total-edit"]'; }
 
+  secondNumberAnswerAlsoInTotalLabel() { return '#second-number-answer-also-in-total-label'; } 
+
   thirdNumberAnswer() { return '#third-number-answer-answer'; }
 
   thirdNumberAnswerEdit() { return '[data-qa="third-number-answer-edit"]'; }
 
-  thirdNumberAnswerUnitTotal() { return '#third-number-answer-unit-total-answer'; }
-
-  thirdNumberAnswerUnitTotalEdit() { return '[data-qa="third-number-answer-unit-total-edit"]'; }
+  thirdNumberAnswerLabel() { return '#third-number-answer-label'; } 
 
   fourthNumberAnswer() { return '#fourth-number-answer-answer'; }
 
   fourthNumberAnswerEdit() { return '[data-qa="fourth-number-answer-edit"]'; }
 
+  fourthNumberAnswerLabel() { return '#fourth-number-answer-label'; } 
+
   fourthNumberAnswerAlsoInTotal() { return '#fourth-number-answer-also-in-total-answer'; }
 
   fourthNumberAnswerAlsoInTotalEdit() { return '[data-qa="fourth-number-answer-also-in-total-edit"]'; }
 
-  fifthNumberAnswer() { return '#fifth-number-answer-answer'; }
-
-  fifthNumberAnswerEdit() { return '[data-qa="fifth-number-answer-edit"]'; }
-
-  sixthPercentAnswer() { return '#sixth-percent-answer-answer'; }
-
-  sixthPercentAnswerEdit() { return '[data-qa="sixth-percent-answer-edit"]'; }
-
-  sixthNumberAnswer() { return '#sixth-number-answer-answer'; }
-
-  sixthNumberAnswerEdit() { return '[data-qa="sixth-number-answer-edit"]'; }
-
-  calculatedSummaryTitle() { return '[data-qa="calculated-summary-title"]'; }
-
-  calculatedSummaryQuestion() { return '#calculated-summary-question'; }
-
-  calculatedSummaryAnswer() { return '#calculated-summary-answer-answer'; }
-
-  groupTitle() { return '#group'; }
+  fourthNumberAnswerAlsoInTotalLabel() { return '#fourth-number-answer-also-in-total-label'; } 
 
 }
 module.exports = new CurrencyTotalPlaybackPage();

--- a/tests/functional/pages/features/calculated_summary/number-total-playback.page.js
+++ b/tests/functional/pages/features/calculated_summary/number-total-playback.page.js
@@ -1,7 +1,7 @@
 // >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
-const QuestionPage = require('../../surveys/question.page');
+const CalculatedSummaryPage = require('../../calculated-summary.page');
 
-class NumberTotalPlaybackPage extends QuestionPage {
+class NumberTotalPlaybackPage extends CalculatedSummaryPage {
 
   constructor() {
     super('number-total-playback');
@@ -11,17 +11,13 @@ class NumberTotalPlaybackPage extends QuestionPage {
 
   fifthNumberAnswerEdit() { return '[data-qa="fifth-number-answer-edit"]'; }
 
+  fifthNumberAnswerLabel() { return '#fifth-number-answer-label'; } 
+
   sixthNumberAnswer() { return '#sixth-number-answer-answer'; }
 
   sixthNumberAnswerEdit() { return '[data-qa="sixth-number-answer-edit"]'; }
 
-  calculatedSummaryTitle() { return '[data-qa="calculated-summary-title"]'; }
-
-  calculatedSummaryQuestion() { return '#calculated-summary-question'; }
-
-  calculatedSummaryAnswer() { return '#calculated-summary-answer-answer'; }
-
-  groupTitle() { return '#group'; }
+  sixthNumberAnswerLabel() { return '#sixth-number-answer-label'; } 
 
 }
 module.exports = new NumberTotalPlaybackPage();

--- a/tests/functional/pages/features/calculated_summary/percentage-total-playback.page.js
+++ b/tests/functional/pages/features/calculated_summary/percentage-total-playback.page.js
@@ -1,27 +1,23 @@
 // >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
-const QuestionPage = require('../../surveys/question.page');
+const CalculatedSummaryPage = require('../../calculated-summary.page');
 
-class CurrencyTotalPlaybackPage extends QuestionPage {
+class PercentageTotalPlaybackPage extends CalculatedSummaryPage {
 
   constructor() {
-    super('currency-total-playback');
+    super('percentage-total-playback');
   }
 
   fifthPercentAnswer() { return '#fifth-percent-answer-answer'; }
 
   fifthPercentAnswerEdit() { return '[data-qa="fifth-percent-answer-edit"]'; }
 
+  fifthPercentAnswerLabel() { return '#fifth-percent-answer-label'; } 
+
   sixthPercentAnswer() { return '#sixth-percent-answer-answer'; }
 
   sixthPercentAnswerEdit() { return '[data-qa="sixth-percent-answer-edit"]'; }
 
-  calculatedSummaryTitle() { return '[data-qa="calculated-summary-title"]'; }
-
-  calculatedSummaryQuestion() { return '#calculated-summary-question'; }
-
-  calculatedSummaryAnswer() { return '#calculated-summary-answer-answer'; }
-
-  groupTitle() { return '#group'; }
+  sixthPercentAnswerLabel() { return '#sixth-percent-answer-label'; } 
 
 }
-module.exports = new CurrencyTotalPlaybackPage();
+module.exports = new PercentageTotalPlaybackPage();

--- a/tests/functional/pages/features/calculated_summary/sixth-number-block.page.js
+++ b/tests/functional/pages/features/calculated_summary/sixth-number-block.page.js
@@ -1,7 +1,6 @@
 // >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
 const QuestionPage = require('../../surveys/question.page');
 
-
 class SixthNumberBlockPage extends QuestionPage {
 
   constructor() {

--- a/tests/functional/pages/features/calculated_summary/unit-total-playback.page.js
+++ b/tests/functional/pages/features/calculated_summary/unit-total-playback.page.js
@@ -1,27 +1,23 @@
 // >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
-const QuestionPage = require('../../surveys/question.page');
+const CalculatedSummaryPage = require('../../calculated-summary.page');
 
-class CurrencyTotalPlaybackPage extends QuestionPage {
+class UnitTotalPlaybackPage extends CalculatedSummaryPage {
 
   constructor() {
-    super('currency-total-playback');
+    super('unit-total-playback');
   }
 
   secondNumberAnswerUnitTotal() { return '#second-number-answer-unit-total-answer'; }
 
   secondNumberAnswerUnitTotalEdit() { return '[data-qa="second-number-answer-unit-total-edit"]'; }
 
+  secondNumberAnswerUnitTotalLabel() { return '#second-number-answer-unit-total-label'; } 
+
   thirdNumberAnswerUnitTotal() { return '#third-number-answer-unit-total-answer'; }
 
   thirdNumberAnswerUnitTotalEdit() { return '[data-qa="third-number-answer-unit-total-edit"]'; }
 
-  calculatedSummaryTitle() { return '[data-qa="calculated-summary-title"]'; }
-
-  calculatedSummaryQuestion() { return '#calculated-summary-question'; }
-
-  calculatedSummaryAnswer() { return '#calculated-summary-answer-answer'; }
-
-  groupTitle() { return '#group'; }
+  thirdNumberAnswerUnitTotalLabel() { return '#third-number-answer-unit-total-label'; } 
 
 }
-module.exports = new CurrencyTotalPlaybackPage();
+module.exports = new UnitTotalPlaybackPage();

--- a/tests/functional/spec/features/calculated_summary.spec.js
+++ b/tests/functional/spec/features/calculated_summary.spec.js
@@ -13,7 +13,7 @@ const NumberTotalPlaybackPage = require('../../pages/features/calculated_summary
 const SummaryPage = require('../../pages/summary.page.js');
 const ThankYouPage = require('../../pages/thank-you.page.js');
 
-describe('@watch Feature: Calculated Summary', function() {
+describe('Feature: Calculated Summary', function() {
 
   describe('Given I have a Calculated Summary', function() {
 
@@ -56,18 +56,24 @@ describe('@watch Feature: Calculated Summary', function() {
       .getText(CurrencyTotalPlaybackPage.calculatedSummaryAnswer()).should.eventually.contain('£20.71')
 
       // Answers included in calculation should be shown
+      .getText(CurrencyTotalPlaybackPage.firstNumberAnswerLabel()).should.eventually.contain('First answer label')
       .getText(CurrencyTotalPlaybackPage.firstNumberAnswer()).should.eventually.contain('£1.23')
+      .getText(CurrencyTotalPlaybackPage.secondNumberAnswerLabel()).should.eventually.contain('Second answer in currency label')
       .getText(CurrencyTotalPlaybackPage.secondNumberAnswer()).should.eventually.contain('£4.56')
+      .getText(CurrencyTotalPlaybackPage.secondNumberAnswerAlsoInTotalLabel()).should.eventually.contain('Second answer label also in currency total (optional)')
       .getText(CurrencyTotalPlaybackPage.secondNumberAnswerAlsoInTotal()).should.eventually.contain('£0.12')
+      .getText(CurrencyTotalPlaybackPage.thirdNumberAnswerLabel()).should.eventually.contain('Third answer label')
       .getText(CurrencyTotalPlaybackPage.thirdNumberAnswer()).should.eventually.contain('£3.45')
+      .getText(CurrencyTotalPlaybackPage.fourthNumberAnswerLabel()).should.eventually.contain('Fourth answer label (optional)')
       .getText(CurrencyTotalPlaybackPage.fourthNumberAnswer()).should.eventually.contain('£9.01')
+      .getText(CurrencyTotalPlaybackPage.fourthNumberAnswerAlsoInTotalLabel()).should.eventually.contain('Fourth answer label also in total (optional)')
       .getText(CurrencyTotalPlaybackPage.fourthNumberAnswerAlsoInTotal()).should.eventually.contain('£2.34')
 
       // Answers not included in calculation should not be shown
-      .elements(CurrencyTotalPlaybackPage.secondNumberAnswerUnitTotal()).then(result => result.value).should.eventually.be.empty
-      .elements(CurrencyTotalPlaybackPage.thirdNumberAnswerUnitTotal()).then(result => result.value).should.eventually.be.empty
-      .elements(CurrencyTotalPlaybackPage.fifthNumberAnswer()).then(result => result.value).should.eventually.be.empty
-      .elements(CurrencyTotalPlaybackPage.sixthNumberAnswer()).then(result => result.value).should.eventually.be.empty;
+      .elements(UnitTotalPlaybackPage.secondNumberAnswerUnitTotal()).then(result => result.value).should.eventually.be.empty
+      .elements(UnitTotalPlaybackPage.thirdNumberAnswerUnitTotal()).then(result => result.value).should.eventually.be.empty
+      .elements(NumberTotalPlaybackPage.fifthNumberAnswer()).then(result => result.value).should.eventually.be.empty
+      .elements(NumberTotalPlaybackPage.sixthNumberAnswer()).then(result => result.value).should.eventually.be.empty;
     });
 
     it('Given change an answer, When i get to the currency summary, Then I should see the new total', function() {
@@ -110,7 +116,9 @@ describe('@watch Feature: Calculated Summary', function() {
         .getText(UnitTotalPlaybackPage.calculatedSummaryAnswer()).should.eventually.contain('1,467 cm')
 
         // Answers included in calculation should be shown
+        .getText(UnitTotalPlaybackPage.secondNumberAnswerUnitTotalLabel()).should.eventually.contain('Second answer label in unit total')
         .getText(UnitTotalPlaybackPage.secondNumberAnswerUnitTotal()).should.eventually.contain('789 cm')
+        .getText(UnitTotalPlaybackPage.thirdNumberAnswerUnitTotalLabel()).should.eventually.contain('Third answer label in unit total')
         .getText(UnitTotalPlaybackPage.thirdNumberAnswerUnitTotal()).should.eventually.contain('678 cm');
     });
 
@@ -123,7 +131,9 @@ describe('@watch Feature: Calculated Summary', function() {
         .getText(UnitTotalPlaybackPage.calculatedSummaryAnswer()).should.eventually.contain('79%')
 
         // Answers included in calculation should be shown
+        .getText(PercentageTotalPlaybackPage.fifthPercentAnswerLabel()).should.eventually.contain('Fifth answer label percentage tota')
         .getText(PercentageTotalPlaybackPage.fifthPercentAnswer()).should.eventually.contain('56%')
+        .getText(PercentageTotalPlaybackPage.sixthPercentAnswerLabel()).should.eventually.contain('Sixth answer label percentage tota')
         .getText(PercentageTotalPlaybackPage.sixthPercentAnswer()).should.eventually.contain('23%');
     });
 
@@ -136,7 +146,9 @@ describe('@watch Feature: Calculated Summary', function() {
         .getText(UnitTotalPlaybackPage.calculatedSummaryAnswer()).should.eventually.contain('124.58')
 
         // Answers included in calculation should be shown
+        .getText(NumberTotalPlaybackPage.fifthNumberAnswerLabel()).should.eventually.contain('Fifth answer label number total')
         .getText(NumberTotalPlaybackPage.fifthNumberAnswer()).should.eventually.contain('78.91')
+        .getText(NumberTotalPlaybackPage.sixthNumberAnswerLabel()).should.eventually.contain('Sixth answer label number total')
         .getText(NumberTotalPlaybackPage.sixthNumberAnswer()).should.eventually.contain('45.67');
     });
 


### PR DESCRIPTION
### What is the context of this PR?
https://trello.com/c/smEWR8IV/2337-use-labels-instead-of-questions-within-the-total-playback-summary-type

### How to review 
Fill out the `test_calculated_summary` survey.  In the calculated summary pages (not the final summary), the single answers should end with 'label' where they used to end with title.

The final summary screen should be unaffected by this change.

### Checklist

* [x] New static content marked up for translation
* [x] Newly defined schema content included in eq-translations repo
