### PR TITLE
Add collection_metadata, make metadata immutable

### DIFF
--- a/app/authentication/authenticator.py
+++ b/app/authentication/authenticator.py
@@ -107,7 +107,7 @@ def store_session(metadata):
     create_session_store(eq_session_id, user_id, user_ik, session_data)
 
     questionnaire_store = get_questionnaire_store(user_id, user_ik)
-    questionnaire_store.metadata = metadata
+    questionnaire_store.set_metadata(metadata)
     questionnaire_store.add_or_update()
 
     # Set the user in Flask such that anyone calling current_user for the duration of this request doesn't have to

--- a/app/globals.py
+++ b/app/globals.py
@@ -54,6 +54,11 @@ def get_metadata(user):
     return questionnaire_store.metadata
 
 
+def get_collection_metadata(user):
+    questionnaire_store = get_questionnaire_store(user.user_id, user.user_ik)
+    return questionnaire_store.collection_metadata
+
+
 def get_answer_store(user):
     questionnaire_store = get_questionnaire_store(user.user_id, user.user_ik)
 
@@ -81,6 +86,7 @@ def get_completeness(user):
         routing_path = path_finder.get_full_routing_path()
 
         completeness_object = g._completeness = Completeness(
-            g.schema, answer_store, completed_blocks, routing_path, metadata)
+            g.schema, answer_store, completed_blocks, routing_path, metadata,
+        )
 
     return completeness_object

--- a/app/helpers/session_helpers.py
+++ b/app/helpers/session_helpers.py
@@ -2,7 +2,7 @@ from functools import wraps
 
 from flask_login import current_user
 
-from app.globals import get_answer_store, get_metadata
+from app.globals import get_answer_store, get_metadata, get_collection_metadata
 
 
 def with_answer_store(function):
@@ -26,4 +26,16 @@ def with_metadata(function):
     def other_wrapped_function(*args, **kwargs):
         metadata = get_metadata(current_user)
         return function(metadata, *args, **kwargs)
+    return other_wrapped_function
+
+
+def with_collection_metadata(function):
+    """Adds `collection_metadata` as an argument, where the `current_user` is defined.
+    Use on flask request handlers or methods called by flask request handlers.
+
+    May error unless there is a `current_user`."""
+    @wraps(function)
+    def other_wrapped_function(*args, **kwargs):
+        collection_metadata = get_collection_metadata(current_user)
+        return function(collection_metadata, *args, **kwargs)
     return other_wrapped_function

--- a/app/submitter/converter.py
+++ b/app/submitter/converter.py
@@ -15,10 +15,11 @@ class DataVersionError(Exception):
         return 'Data version {} not supported'.format(self.version)
 
 
-def convert_answers(metadata, schema, answer_store, routing_path, flushed=False):
+def convert_answers(metadata, collection_metadata, schema, answer_store, routing_path, flushed=False):
     """
     Create the JSON answer format for down stream processing
     :param metadata: metadata for the questionnaire
+    :param collection_metadata: Any metadata about the collection of the questionnaire
     :param schema: QuestionnaireSchema class with populated schema json
     :param answer_store: the users answers
     :param routing_path: the path followed by the user when answering the questionnaire
@@ -59,9 +60,13 @@ def convert_answers(metadata, schema, answer_store, routing_path, flushed=False)
         'metadata': _build_metadata(metadata),
         'case_id': metadata['case_id'],
     }
-    if 'started_at' in metadata and metadata['started_at']:
+    if collection_metadata.get('started_at'):
+        payload['started_at'] = collection_metadata['started_at']
+    elif metadata.get('started_at'):
         payload['started_at'] = metadata['started_at']
-    if 'case_ref' in metadata and metadata['case_ref']:
+    if metadata.get('case_id'):
+        payload['case_id'] = metadata['case_id']
+    if metadata.get('case_ref'):
         payload['case_ref'] = metadata['case_ref']
 
     if schema.json['data_version'] == '0.0.2':

--- a/app/views/dump.py
+++ b/app/views/dump.py
@@ -4,7 +4,8 @@ from flask import Blueprint, jsonify
 
 
 from app.authentication.roles import role_required
-from app.globals import get_answer_store, get_metadata, get_completed_blocks, get_session_store
+from app.globals import (get_answer_store, get_metadata, get_completed_blocks, get_session_store,
+                         get_collection_metadata)
 from app.submitter.converter import convert_answers
 from app.utilities.schema import load_schema_from_session_data
 from app.questionnaire.path_finder import PathFinder
@@ -27,9 +28,10 @@ def dump_answers():
 def dump_submission():
     answer_store = get_answer_store(current_user)
     metadata = get_metadata(current_user)
+    collection_metadata = get_collection_metadata(current_user)
     session_data = get_session_store().session_data
     schema = load_schema_from_session_data(session_data)
     completed_blocks = get_completed_blocks(current_user)
     routing_path = PathFinder(schema, answer_store, metadata, completed_blocks).get_full_routing_path()
-    response = {'submission': convert_answers(metadata, schema, answer_store, routing_path)}
+    response = {'submission': convert_answers(metadata, collection_metadata, schema, answer_store, routing_path)}
     return jsonify(response), 200

--- a/app/views/flush.py
+++ b/app/views/flush.py
@@ -4,7 +4,8 @@ from sdc.crypto.decrypter import decrypt
 
 
 from app.authentication.user import User
-from app.globals import get_answer_store, get_metadata, get_questionnaire_store, get_completed_blocks
+from app.globals import (get_answer_store, get_metadata, get_questionnaire_store,
+                         get_completed_blocks, get_collection_metadata)
 from app.questionnaire.path_finder import PathFinder
 from app.keys import KEY_PURPOSE_AUTHENTICATION, KEY_PURPOSE_SUBMISSION
 from app.submitter.converter import convert_answers
@@ -46,11 +47,12 @@ def _submit_data(user):
 
     if answer_store.answers:
         metadata = get_metadata(user)
+        collection_metadata = get_collection_metadata(user)
         schema = load_schema_from_metadata(metadata)
         completed_blocks = get_completed_blocks(user)
         routing_path = PathFinder(schema, answer_store, metadata, completed_blocks).get_full_routing_path()
 
-        message = convert_answers(metadata, schema, answer_store, routing_path, flushed=True)
+        message = convert_answers(metadata, collection_metadata, schema, answer_store, routing_path, flushed=True)
         encrypted_message = encrypt(message, current_app.eq['key_store'], KEY_PURPOSE_SUBMISSION)
 
         sent = current_app.eq['submitter'].send_message(encrypted_message, current_app.config['EQ_RABBITMQ_QUEUE_NAME'], metadata['tx_id'])

--- a/tests/app/submitter/test_convert_payload_0_0_1.py
+++ b/tests/app/submitter/test_convert_payload_0_0_1.py
@@ -62,7 +62,7 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
 
             routing_path = [Location(group_id='group-1', group_instance=0, block_id='block-1')]
 
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
 
             # Check the converter correctly
             self.assertEqual('0', answer_object['data']['003'])
@@ -86,7 +86,7 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
 
             routing_path = [Location(group_id='group-1', group_instance=0, block_id='block-1')]
 
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
 
             # Check the converter correctly
             self.assertEqual('10.02', answer_object['data']['003'])
@@ -110,7 +110,7 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
 
             routing_path = [Location(group_id='group-1', group_instance=0, block_id='block-1')]
 
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
 
             # Check the converter correctly
             self.assertEqual('String test + !', answer_object['data']['003'])
@@ -136,7 +136,7 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
 
             routing_path = [Location(group_id='group-1', group_instance=0, block_id='block-1')]
 
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
 
             # Check the converter correctly
             self.assertEqual(answer_object['data']['003'], ['0', '1', '2'])
@@ -159,7 +159,7 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
 
             routing_path = [Location(group_id='group-1', group_instance=0, block_id='block-1')]
 
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
 
             self.assertEqual(len(answer_object['data']), 0)
 
@@ -199,14 +199,14 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
 
         #  STANDARD CHECKBOX
         with self.assertRaises(Exception) as err:
-            convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
+            convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
         self.assertEqual('Multiple answers found for {}'.format('other-answer-mandatory'), str(err.exception))
 
 
         #  MUTUALLY EXCLUSIVE CHECKBOX
         questionnaire['sections'][0]['groups'][0]['blocks'][0]['questions'][0]['answers'][0]['type'] = 'MutuallyExclusiveCheckbox'
         with self.assertRaises(Exception) as err:
-            convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
+            convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
         self.assertEqual('Multiple answers found for {}'.format('other-answer-mandatory'), str(err.exception))
 
     def test_converter_checkboxes_with_q_codes(self):
@@ -261,7 +261,7 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
             ])
 
             # When STANDARD CHECKBOX
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
 
             # Then
             self.assertEqual(len(answer_object['data']), 2)
@@ -270,7 +270,7 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
 
             # when MUTUALLY EXCLUSIVE CHECKBOX
             questionnaire['sections'][0]['groups'][0]['blocks'][0]['questions'][0]['answers'][0]['type'] = 'MutuallyExclusiveCheckbox'
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers),
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers),
                                             routing_path)
 
             # Then
@@ -332,7 +332,7 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
             ])
 
             # When STANDARD CHECKBOX
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
 
             # Then
             self.assertEqual(len(answer_object['data']), 2)
@@ -341,7 +341,7 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
 
             # when MUTUALLY EXCLUSIVE CHECKBOX
             questionnaire['sections'][0]['groups'][0]['blocks'][0]['questions'][0]['answers'][0]['type'] = 'MutuallyExclusiveCheckbox'
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers),
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers),
                                             routing_path)
 
             # Then
@@ -403,7 +403,7 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
             ])
 
             # When STANDARD CHECKBOX
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
 
             # Then
             self.assertEqual(len(answer_object['data']), 2)
@@ -412,7 +412,7 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
 
             # when MUTUALLY EXCLUSIVE CHECKBOX
             questionnaire['sections'][0]['groups'][0]['blocks'][0]['questions'][0]['answers'][0]['type'] = 'MutuallyExclusiveCheckbox'
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers),
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers),
                                             routing_path)
 
             # Then
@@ -448,7 +448,7 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
             ])
 
             # When
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
 
             # Then
             self.assertEqual(len(answer_object['data']), 1)
@@ -483,7 +483,7 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
             ])
 
             # When
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
 
             # Then
             self.assertEqual(len(answer_object['data']), 1)
@@ -508,7 +508,7 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
             ])
 
             # When
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
 
             # Then
             self.assertEqual(len(answer_object['data']), 1)
@@ -533,7 +533,7 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
             ])
 
             # When
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
 
             # Then
             self.assertEqual(len(answer_object['data']), 1)
@@ -558,7 +558,7 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
             ])
 
             # When
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
 
             # Then
             self.assertEqual(len(answer_object['data']), 1)
@@ -583,7 +583,7 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
             ])
 
             # When
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
 
             # Then
             self.assertEqual(len(answer_object['data']), 1)
@@ -622,7 +622,7 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
             ])
 
             # When
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
 
             # Then
             self.assertEqual(len(answer_object['data']), 1)
@@ -657,7 +657,7 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
                 }
             ])
             # When
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
 
             # Then
             self.assertEqual(len(answer_object['data']), 2)
@@ -683,7 +683,7 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
             ])
 
             # When
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
 
             # Then
             self.assertEqual(len(answer_object['data']), 1)
@@ -727,7 +727,7 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
             ])
 
             # When
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
 
             # Then
             self.assertEqual(len(answer_object['data']), 1)

--- a/tests/app/submitter/test_convert_payload_0_0_2.py
+++ b/tests/app/submitter/test_convert_payload_0_0_2.py
@@ -71,7 +71,7 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             }
 
             # When
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
 
             # Then
             self.assertEqual(len(answer_object['data']), 4)
@@ -132,7 +132,7 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             ])
 
             # When
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(answers), routing_path)
 
             # Then
             self.assertEqual(len(answer_object['data']), 1)
@@ -170,7 +170,7 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             ])
 
             # When
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
 
             # Then
             self.assertEqual(len(answer_object['data']), 1)
@@ -198,7 +198,7 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             ])
 
             # When
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
 
             # Then
             self.assertEqual(len(answer_object['data']), 1)
@@ -226,7 +226,7 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             ])
 
             # When
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
 
             # Then
             self.assertEqual(len(answer_object['data']), 1)
@@ -254,7 +254,7 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             ])
 
             # When
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
 
             # Then
             self.assertEqual(len(answer_object['data']), 1)
@@ -282,7 +282,7 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             ])
 
             # When
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
 
             # Then
             self.assertEqual(len(answer_object['data']), 1)
@@ -324,7 +324,7 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             ])
 
             # When
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
 
             # Then
             self.assertEqual(len(answer_object['data']), 1)
@@ -362,7 +362,7 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             ])
 
             # When
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
 
             # Then
             self.assertEqual(len(answer_object['data']), 2)
@@ -396,7 +396,7 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             ])
 
             # When
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
 
             # Then
             self.assertEqual(len(answer_object['data']), 1)
@@ -444,7 +444,7 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             ])
 
             # When
-            answer_object = convert_answers(self.metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
 
             # Then
             self.assertEqual(len(answer_object['data']), 3)

--- a/tests/integration/session/test_multiple_login.py
+++ b/tests/integration/session/test_multiple_login.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+import json
 from tests.integration.integration_test_case import IntegrationTestCase
 
 
@@ -21,6 +23,17 @@ class MultipleClientTestCase(IntegrationTestCase):
         )
 
         self._cache_response(client, environ, response)
+
+    def dumpSubmission(self, client):
+        cache = self.cache[client]
+
+        self.get(client, '/dump/submission')
+
+        self.assertEqual(cache['last_response'].status_code, 200)
+
+        # And the JSON response contains the data I submitted
+        dump_submission = json.loads(cache.get('last_response').get_data(True))
+        return dump_submission
 
     def post(self, client, post_data=None, url=None, action='save_continue', action_value='', **kwargs):
         cache = self.cache[client]
@@ -100,3 +113,41 @@ class TestMultipleLogin(MultipleClientTestCase):
         self.post(self.client_b, {'answer': 'bar baz'})
         last_response_b = self.cache[self.client_b]['last_response']
         self.assertEqual(last_response_b.status_code, 401)
+
+
+class TestCollectionMetadataStorage(MultipleClientTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.client_a = self._application.test_client()
+        self.client_b = self._application.test_client()
+
+        self.cache = {
+            self.client_a: {},
+            self.client_b: {}
+        }
+
+    def test_multiple_logins_have_same_started_at(self):
+        """
+        Ensure that started_at is retained between collections
+        """
+        # User A starts a survey
+        self.launchSurvey(self.client_a, '1', '0112', roles=['dumper'])
+        # And starts the questionnaire
+        self.post(self.client_a, action='start_questionnaire')
+
+        # We dump their submission
+        a_submission = self.dumpSubmission(self.client_a)['submission']
+
+        # User B loads the survey
+        self.launchSurvey(self.client_b, '1', '0112', roles=['dumper'])
+        # And we dump their submission
+        b_submission = self.dumpSubmission(self.client_b)['submission']
+
+        # Making sure that the started_at field is a datetime and that
+        # it is the same for both users
+        self.assertEqual(a_submission['started_at'], b_submission['started_at'])
+
+        started_at_datetime = datetime.strptime(a_submission['started_at'], '%Y-%m-%dT%H:%M:%S.%f')
+
+        self.assertIsNotNone(started_at_datetime)


### PR DESCRIPTION
### What is the context of this PR?
[Trello](https://trello.com/c/ET4X7qU4/2343-eq-survey-runner-1731-startedat-wiped-from-metadata-when-a-questionnaire-is-re-launched-issue)

Closes #1731 

Metadata is passed in and shouldn't be changed. It should be immutable.

We have metadata around the collection of the questionnaire which can't be immutable and doesn't fit in with the rest of `metadata` (started_at). Store it in `collection_metadata`.

`MappingProxyType` is used to make `metadata` a read-only view of `_metadata`. 

### How to review 
- Launch a questionnaire taking note of `RU Ref` and `Collection Exercise SID`
- Tap start survey and ensure `started_at` has been set.
- Launch with the same `RU Ref` and `Collection Exercise SID` and ensure `started_at` doesn't change.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
