### PR TITLE
Answers not on routing path excluded from CalculatedSummary

### DIFF
--- a/data/en/test_calculated_summary.json
+++ b/data/en/test_calculated_summary.json
@@ -117,6 +117,36 @@
                 },
                 {
                     "type": "Question",
+                    "id": "skip-fourth-block",
+                    "questions": [{
+                        "type": "General",
+                        "id": "skip-fourth-block-question",
+                        "title": "Skip Fourth Block so it doesn't appear in Total?",
+                        "answers": [{
+                            "type": "Radio",
+                            "id": "skip-fourth-block-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Yes",
+                                    "value": "Yes"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "No"
+                                }
+                            ]
+                        }]
+                    }]
+                },
+                {
+                    "skip_conditions": [{
+                        "when": [{
+                            "id": "skip-fourth-block-answer",
+                            "condition": "equals",
+                            "value": "Yes"
+                        }]
+                    }],
+                    "type": "Question",
                     "title": "Fourth Number Block Title",
                     "id": "fourth-number-block",
                     "description": "",
@@ -208,8 +238,17 @@
                     "type": "CalculatedSummary",
                     "id": "currency-total-playback",
                     "titles": [{
-                        "value": "We calculate the total of currency values entered to be %(total)s. Is this correct?"
-                    }],
+                            "value": "We calculate the total of currency values entered to be %(total)s. Is this correct? (Skipped Fourth)",
+                            "when": [{
+                                "id": "skip-fourth-block-answer",
+                                "condition": "equals",
+                                "value": "Yes"
+                            }]
+                        },
+                        {
+                            "value": "We calculate the total of currency values entered to be %(total)s. Is this correct? (With Fourth)"
+                        }
+                    ],
                     "calculation": {
                         "calculation_type": "sum",
                         "answers_to_calculate": [

--- a/tests/functional/pages/features/calculated_summary/skip-fourth-block.page.js
+++ b/tests/functional/pages/features/calculated_summary/skip-fourth-block.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class SkipFourthBlockPage extends QuestionPage {
+
+  constructor() {
+    super('skip-fourth-block');
+  }
+
+  yes() {
+    return '#skip-fourth-block-answer-0';
+  }
+
+  yesLabel() { return '#label-skip-fourth-block-answer-0'; }
+
+  no() {
+    return '#skip-fourth-block-answer-1';
+  }
+
+  noLabel() { return '#label-skip-fourth-block-answer-1'; }
+
+}
+module.exports = new SkipFourthBlockPage();

--- a/tests/functional/spec/features/calculated_summary.spec.js
+++ b/tests/functional/spec/features/calculated_summary.spec.js
@@ -3,6 +3,7 @@ const helpers = require('../../helpers');
 const FirstNumberBlockPage = require('../../pages/features/calculated_summary/first-number-block.page.js');
 const SecondNumberBlockPage = require('../../pages/features/calculated_summary/second-number-block.page.js');
 const ThirdNumberBlockPage = require('../../pages/features/calculated_summary/third-number-block.page.js');
+const SkipFourthBlockPage = require('../../pages/features/calculated_summary/skip-fourth-block.page.js');
 const FourthNumberBlockPage = require('../../pages/features/calculated_summary/fourth-number-block.page.js');
 const FifthNumberBlockPage = require('../../pages/features/calculated_summary/fifth-number-block.page.js');
 const SixthNumberBlockPage = require('../../pages/features/calculated_summary/sixth-number-block.page.js');
@@ -31,6 +32,9 @@ describe('Feature: Calculated Summary', function() {
         .setValue(ThirdNumberBlockPage.thirdNumber(), 3.45)
         .setValue(ThirdNumberBlockPage.thirdNumberUnitTotal(), 678)
         .click(ThirdNumberBlockPage.submit())
+
+        .click(SkipFourthBlockPage.no())
+        .click(SkipFourthBlockPage.submit())
 
         .setValue(FourthNumberBlockPage.fourthNumber(), 9.01)
         .setValue(FourthNumberBlockPage.fourthNumberAlsoInTotal(), 2.34)
@@ -105,6 +109,26 @@ describe('Feature: Calculated Summary', function() {
         .getText(CurrencyTotalPlaybackPage.calculatedSummaryTitle()).should.eventually.contain('We calculate the total of currency values entered to be £9.36. Is this correct?')
         .getText(CurrencyTotalPlaybackPage.calculatedSummaryAnswer()).should.eventually.contain('£9.36')
         .getText(CurrencyTotalPlaybackPage.fourthNumberAnswer()).should.eventually.contain('No answer provided');
+    });
+
+
+    it('Given I skip the fourth page, When i get to the playback, Then I can should not see it in the total', function() {
+      return browser
+        .click(CurrencyTotalPlaybackPage.thirdNumberAnswerEdit())
+        .click(ThirdNumberBlockPage.submit())
+
+        .click(SkipFourthBlockPage.yes())
+        .click(SkipFourthBlockPage.submit())
+
+        .click(FifthNumberBlockPage.submit())
+        .click(SixthNumberBlockPage.submit())
+
+        .getUrl().should.eventually.contain(CurrencyTotalPlaybackPage.pageName)
+        .elements(CurrencyTotalPlaybackPage.fourthNumberAnswer()).then(result => result.value).should.eventually.be.empty
+        .elements(CurrencyTotalPlaybackPage.fourthNumberAnswerAlsoInTotal()).then(result => result.value).should.eventually.be.empty
+        .getText(CurrencyTotalPlaybackPage.calculatedSummaryTitle()).should.eventually.contain('We calculate the total of currency values entered to be £9.36. Is this correct?')
+        .getText(CurrencyTotalPlaybackPage.calculatedSummaryAnswer()).should.eventually.contain('£9.36');
+
     });
 
     it('Given I complete every question, When i get to the unit summary, Then I should see the correct total', function() {

--- a/tests/integration/views/test_questionnaire.py
+++ b/tests/integration/views/test_questionnaire.py
@@ -569,7 +569,7 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         # Then
         self.assertTrue('summary' in view_context)
         self.assertTrue('calculated_question' in view_context['summary'])
-        self.assertEqual(view_context['summary']['title'], 'We calculate the total of currency values entered to be £13.00. Is this correct?')
+        self.assertEqual(view_context['summary']['title'], 'We calculate the total of currency values entered to be £13.00. Is this correct? (With Fourth)')
 
     def test_answer_non_repeating_dependency_repeating_validate_all_of_block_and_group_removed(self):
         """ load a schema with a non repeating independent answer and a repeating one that depends on it


### PR DESCRIPTION
The summary context already excludes blocks not on the path.
This uses the values in that context to create the total instead.

### What is the context of this PR?
Skipped answers were still be added to the total of the calculated summary. The answers themselves were however not shown on the page. 

### How to review 
The option to skip the fourth block is now part of the calculated summary test schema.