### PR TITLE
Allow for no answers being available for CalculatedSummary

### DIFF
--- a/app/templating/view_context.py
+++ b/app/templating/view_context.py
@@ -202,12 +202,12 @@ def _remove_unwanted_questions_answers(block, answers_in_block, answer_ids_to_ke
 
 def _get_formatted_total(groups):
     calculated_total = 0
-    answer_format = None
+    answer_format = {'type': None}
     for group in groups:
         for block in group['blocks']:
             for question in block['questions']:
                 for answer in question['answers']:
-                    if not answer_format:
+                    if not answer_format['type']:
                         answer_format = {
                             'type': answer['type'],
                             'unit': answer.get('unit'),


### PR DESCRIPTION
### What is the context of this PR?
There could be a situation where every answer in a CalculatedSummary is skipped or routed past. This would currently cause a 500 error.

### How to review 
In `test_calculated_summary.json` for the `currency-total-playback` block delete all but the fourth numbers so that the answers to calculate looks like this
```
"answers_to_calculate": [
   "fourth-number-answer",
   "fourth-number-answer-also-in-total"
],
```
The when asked to skip that block do so. When you get to the CalculatedSummary the total should be zero and no answers are displayed.