### PR TITLE
Add Filter for Formatting Repeating Answers

### DIFF
--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -320,6 +320,32 @@ def format_household_summary(context, names):
     return ''
 
 
+@evalcontextfilter
+@blueprint.app_template_filter()
+def format_repeating_summary(context, items, delimiter=' '):
+    """
+    Formats a summary from the input list using the provided delimiter
+    Input should be a list of lists.
+    If there is a third level of lists, these will be zipped together
+    e.g.
+    [['John', 'Smith'], [['Jane', 'Sarah'], ['Smith', 'Smith']]]
+    Should output a list for:
+    - John Smith
+    - Jane Smith
+    - Sarah Smith
+    """
+    if items:
+        intermediates = []
+        for item in items:
+            if item and isinstance(item[0], list):
+                intermediates.extend(list(map(list, zip(*item))))
+            else:
+                intermediates.append(item)
+        output = [concatenated_list(x, delimiter=delimiter) for x in intermediates]
+        return format_unordered_list(context, [output])
+    return ''
+
+
 @blueprint.app_template_filter()
 def format_number_to_alphabetic_letter(number):
     if 0 <= int(number) < 26:

--- a/app/templating/template_renderer.py
+++ b/app/templating/template_renderer.py
@@ -29,6 +29,7 @@ class TemplateRenderer:
         env.filters['format_date_custom'] = filters.format_date_custom
         env.globals['format_date_range_no_repeated_month_year'] = filters.format_date_range_no_repeated_month_year
         env.globals['calculate_offset_from_weekday_in_last_whole_week'] = filters.calculate_offset_from_weekday_in_last_whole_week
+        env.filters['format_repeating_summary'] = filters.format_repeating_summary
         self.environment = env
 
     def render(self, renderable, **context):

--- a/data/en/test_repeating_answer_summaries.json
+++ b/data/en/test_repeating_answer_summaries.json
@@ -1,0 +1,152 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "023",
+    "title": "Test Repeating Answer Summaries",
+    "description": "",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "metadata": [{
+        "name": "user_id",
+        "validator": "string"
+    }, {
+        "name": "period_id",
+        "validator": "string"
+    }, {
+        "name": "ru_name",
+        "validator": "string"
+    }],
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "id": "primary-group",
+            "title": "Your Details",
+            "blocks": [{
+                "type": "Question",
+                "id": "primary-name-block",
+                "title": "",
+                "description": "",
+                "questions": [{
+                    "description": "",
+                    "id": "primary-name-question",
+                    "title": "Please enter your name",
+                    "type": "General",
+                    "answers": [{
+                        "id": "primary-first-name",
+                        "label": "First name",
+                        "mandatory": true,
+                        "type": "TextField"
+                    }, {
+                        "id": "primary-middle-names",
+                        "label": "Middle names",
+                        "mandatory": false,
+                        "type": "TextField"
+                    }, {
+                        "id": "primary-last-name",
+                        "label": "Last name",
+                        "mandatory": false,
+                        "type": "TextField"
+                    }]
+                }]
+            }, {
+                "type": "Question",
+                "description": "<h2 class='neptune'>Does anybody else live at 3 Sunny Villas?</h2> {{ [[answers['primary-first-name'], answers['primary-middle-names'], answers['primary-last-name']]] | format_repeating_summary }}",
+                "id": "primary-anyone-else-block",
+                "questions": [{
+                    "type": "General",
+                    "id": "primary-anyone-else-question",
+                    "title": "Does anyone else live here?",
+                    "answers": [{
+                        "type": "Radio",
+                        "id": "primary-anyone-else",
+                        "mandatory": true,
+                        "options": [{
+                            "label": "Yes",
+                            "value": "Yes"
+                        }, {
+                            "label": "No",
+                            "value": "No"
+                        }]
+                    }]
+                }]
+            }]
+        }, {
+            "id": "repeating-group",
+            "title": "Other Household Members",
+            "skip_conditions": [{
+                "when": [{
+                    "id": "primary-anyone-else",
+                    "condition": "equals",
+                    "value": "No"
+                }]
+            }],
+            "routing_rules": [{
+                "repeat": {
+                    "type": "until",
+                    "when": [{
+                        "id": "repeating-anyone-else",
+                        "condition": "equals",
+                        "value": "No"
+                    }]
+                }
+            }],
+            "blocks": [{
+                "type": "Question",
+                "id": "repeating-name-block",
+                "title": "",
+                "description": "",
+                "questions": [{
+                    "description": "",
+                    "id": "repeating-name-question",
+                    "title": "Who else lives here?",
+                    "type": "General",
+                    "answers": [{
+                        "id": "repeating-first-name",
+                        "label": "First name",
+                        "mandatory": true,
+                        "type": "TextField"
+                    }, {
+                        "id": "repeating-middle-names",
+                        "label": "Middle names",
+                        "mandatory": false,
+                        "type": "TextField"
+                    }, {
+                        "id": "repeating-last-name",
+                        "label": "Last name",
+                        "mandatory": false,
+                        "type": "TextField"
+                    }]
+                }]
+            }, {
+                "type": "Question",
+                "id": "repeating-anyone-else-block",
+                "description": "<h2 class='neptune'>Does anybody else live at 3 Sunny Villas?</h2> {{ [[answers['primary-first-name'], answers['primary-middle-names'], answers['primary-last-name']], [answers['repeating-first-name'], answers['repeating-middle-names'], answers['repeating-last-name']]] | format_repeating_summary }}",
+                "questions": [{
+                    "type": "General",
+                    "id": "repeating-anyone-else-question",
+                    "title": "Does anyone else live here?",
+                    "answers": [{
+                        "type": "Radio",
+                        "id": "repeating-anyone-else",
+                        "mandatory": true,
+                        "options": [{
+                            "label": "Yes",
+                            "value": "Yes"
+                        }, {
+                            "label": "No",
+                            "value": "No"
+                        }]
+                    }]
+                }]
+            }]
+        }, {
+            "id": "summary-group",
+            "title": "",
+            "blocks": [{
+                "type": "Summary",
+                "id": "summary"
+            }]
+        }]
+    }]
+}

--- a/tests/functional/pages/surveys/repeating_answer_summaries/primary-anyone-else-block.page.js
+++ b/tests/functional/pages/surveys/repeating_answer_summaries/primary-anyone-else-block.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class PrimaryAnyoneElseBlockPage extends QuestionPage {
+
+  constructor() {
+    super('primary-anyone-else-block');
+  }
+
+  yes() {
+    return '#primary-anyone-else-0';
+  }
+
+  yesLabel() { return '#label-primary-anyone-else-0'; }
+
+  no() {
+    return '#primary-anyone-else-1';
+  }
+
+  noLabel() { return '#label-primary-anyone-else-1'; }
+
+}
+module.exports = new PrimaryAnyoneElseBlockPage();

--- a/tests/functional/pages/surveys/repeating_answer_summaries/primary-name-block.page.js
+++ b/tests/functional/pages/surveys/repeating_answer_summaries/primary-name-block.page.js
@@ -1,0 +1,29 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class PrimaryNameBlockPage extends QuestionPage {
+
+  constructor() {
+    super('primary-name-block');
+  }
+
+  primaryFirstName() {
+    return '#primary-first-name';
+  }
+
+  primaryFirstNameLabel() { return '#label-primary-first-name'; }
+
+  primaryMiddleNames() {
+    return '#primary-middle-names';
+  }
+
+  primaryMiddleNamesLabel() { return '#label-primary-middle-names'; }
+
+  primaryLastName() {
+    return '#primary-last-name';
+  }
+
+  primaryLastNameLabel() { return '#label-primary-last-name'; }
+
+}
+module.exports = new PrimaryNameBlockPage();

--- a/tests/functional/pages/surveys/repeating_answer_summaries/repeating-anyone-else-block.page.js
+++ b/tests/functional/pages/surveys/repeating_answer_summaries/repeating-anyone-else-block.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class RepeatingAnyoneElseBlockPage extends QuestionPage {
+
+  constructor() {
+    super('repeating-anyone-else-block');
+  }
+
+  yes() {
+    return '#repeating-anyone-else-0';
+  }
+
+  yesLabel() { return '#label-repeating-anyone-else-0'; }
+
+  no() {
+    return '#repeating-anyone-else-1';
+  }
+
+  noLabel() { return '#label-repeating-anyone-else-1'; }
+
+}
+module.exports = new RepeatingAnyoneElseBlockPage();

--- a/tests/functional/pages/surveys/repeating_answer_summaries/repeating-name-block.page.js
+++ b/tests/functional/pages/surveys/repeating_answer_summaries/repeating-name-block.page.js
@@ -1,0 +1,29 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class RepeatingNameBlockPage extends QuestionPage {
+
+  constructor() {
+    super('repeating-name-block');
+  }
+
+  repeatingFirstName() {
+    return '#repeating-first-name';
+  }
+
+  repeatingFirstNameLabel() { return '#label-repeating-first-name'; }
+
+  repeatingMiddleNames() {
+    return '#repeating-middle-names';
+  }
+
+  repeatingMiddleNamesLabel() { return '#label-repeating-middle-names'; }
+
+  repeatingLastName() {
+    return '#repeating-last-name';
+  }
+
+  repeatingLastNameLabel() { return '#label-repeating-last-name'; }
+
+}
+module.exports = new RepeatingNameBlockPage();

--- a/tests/functional/pages/surveys/repeating_answer_summaries/summary.page.js
+++ b/tests/functional/pages/surveys/repeating_answer_summaries/summary.page.js
@@ -1,0 +1,33 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  primaryLastName() { return '#primary-last-name-answer'; }
+
+  primaryLastNameEdit() { return '[data-qa="primary-last-name-edit"]'; }
+
+  primaryAnyoneElse() { return '#primary-anyone-else-answer'; }
+
+  primaryAnyoneElseEdit() { return '[data-qa="primary-anyone-else-edit"]'; }
+
+  primaryGroupTitle() { return '#primary-group'; }
+
+  repeatingLastName() { return '#repeating-last-name-answer'; }
+
+  repeatingLastNameEdit() { return '[data-qa="repeating-last-name-edit"]'; }
+
+  repeatingAnyoneElse() { return '#repeating-anyone-else-answer'; }
+
+  repeatingAnyoneElseEdit() { return '[data-qa="repeating-anyone-else-edit"]'; }
+
+  repeatingGroupTitle() { return '#repeating-group'; }
+
+  summaryGroupTitle() { return '#summary-group'; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/spec/repeating_answer_summaries.spec.js
+++ b/tests/functional/spec/repeating_answer_summaries.spec.js
@@ -1,0 +1,44 @@
+const helpers = require('../helpers');
+
+const PrimaryNamePage = require('../pages/surveys/repeating_answer_summaries/primary-name-block.page.js');
+const PrimaryAnyoneElsePage = require('../pages/surveys/repeating_answer_summaries/primary-anyone-else-block.page.js');
+const RepeatingNamePage = require('../pages/surveys/repeating_answer_summaries/repeating-name-block.page.js');
+const RepeatingAnyoneElsePage = require('../pages/surveys/repeating_answer_summaries/repeating-anyone-else-block.page.js');
+
+describe('Routing Repeat Until', function() {
+
+  it('Given the test_routing_repeat_until survey is selected, a list of users will be shown on the next page, when more people are added they are shown in the does anyone else live here page.', function() {
+
+    return helpers.openQuestionnaire('test_repeating_answer_summaries.json').then(() => {
+
+      return browser
+        .setValue(PrimaryNamePage.primaryFirstName(), 'Bob')
+        .setValue(PrimaryNamePage.primaryMiddleNames(), 'Bertie')
+        .setValue(PrimaryNamePage.primaryLastName(), 'Bourne')
+        .click(PrimaryNamePage.submit())
+
+        .getText(PrimaryAnyoneElsePage.displayedDescription()).should.eventually.contain('Bob Bertie Bourne')
+        .click(PrimaryAnyoneElsePage.yes())
+        .click(PrimaryAnyoneElsePage.submit())
+
+        .setValue(RepeatingNamePage.repeatingFirstName(), 'Carrie')
+        .setValue(RepeatingNamePage.repeatingMiddleNames(), 'Cormorant')
+        .setValue(RepeatingNamePage.repeatingLastName(), 'Court')
+        .click(RepeatingNamePage.submit())
+
+        .getText(RepeatingAnyoneElsePage.displayedDescription()).should.eventually.contain('Bob Bertie Bourne')
+        .getText(RepeatingAnyoneElsePage.displayedDescription()).should.eventually.contain('Carrie Cormorant Court')
+        .click(RepeatingAnyoneElsePage.yes())
+        .click(RepeatingAnyoneElsePage.submit())
+
+        .setValue(RepeatingNamePage.repeatingFirstName(), 'David')
+        .setValue(RepeatingNamePage.repeatingMiddleNames(), 'Dorian')
+        .setValue(RepeatingNamePage.repeatingLastName(), 'Davies')
+        .click(RepeatingNamePage.submit())
+
+        .getText(RepeatingAnyoneElsePage.displayedDescription()).should.eventually.contain('Bob Bertie Bourne')
+        .getText(RepeatingAnyoneElsePage.displayedDescription()).should.eventually.contain('Carrie Cormorant Court')
+        .getText(RepeatingAnyoneElsePage.displayedDescription()).should.eventually.contain('David Dorian Davies');
+    });
+  });
+});

--- a/tests/integration/questionnaire/test_questionnaire_repeating_answer_summaries.py
+++ b/tests/integration/questionnaire/test_questionnaire_repeating_answer_summaries.py
@@ -1,0 +1,52 @@
+from tests.integration.integration_test_case import IntegrationTestCase
+
+class TestHouseholdWhenRouting(IntegrationTestCase):
+    """Test repeating repeating answers build up a summary
+    using the format_repeating_answers filter
+    """
+    def setUp(self):
+        super().setUp()
+        self.launchSurvey('test', 'repeating_answer_summaries',
+                          roles=['dumper'])
+
+    def test_names_appear_in_summaries(self):
+        """
+        Assert that all entered names are shown on each confirmation question
+        page.
+        """
+        form_data = {
+            'primary-first-name': 'Joe',
+            'primary-middle-names': '',
+            'primary-last-name': 'Bloggs'
+        }
+
+        self.post(form_data)
+
+        self.assertInPage('Joe Bloggs')
+
+        self.post({'primary-anyone-else': 'Yes'})
+
+        form_data = {
+            'repeating-first-name': 'Jonny',
+            'repeating-middle-names': '',
+            'repeating-last-name': 'Jones'
+        }
+
+        self.post(form_data)
+
+        self.assertInPage('Joe Bloggs')
+        self.assertInPage('Jonny Jones')
+
+        self.post({'repeating-anyone-else': 'Yes'})
+
+        form_data = {
+            'repeating-first-name': 'Jane',
+            'repeating-middle-names': 'Mary Sarah',
+            'repeating-last-name': 'Davies'
+        }
+
+        self.post(form_data)
+
+        self.assertInPage('Joe Bloggs')
+        self.assertInPage('Jonny Jones')
+        self.assertInPage('Jane Mary Sarah Davies')


### PR DESCRIPTION
### What is the context of this PR?
[Trello](https://trello.com/c/MIDRKUbr/2253-playback-of-a-repeating-answers)

This adds a filter to display lists of items (currently names, in future addresses etc.). These items can be from multiple groups.

### How to review 
- Run `test_repeating_answer_summaries`
- Enter a name
- Ensure that name is displayed on the confirmation question
- Ensure that each of the following confirmation questions also show the current list of names.

- There is an example of the LMS survey which this should 'match' in trello.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
