### PR TITLE
Change legal basis to non mandatory string

### DIFF
--- a/app/helpers/template_helper.py
+++ b/app/helpers/template_helper.py
@@ -70,14 +70,6 @@ def with_questionnaire_url_prefix(func):
     return url_prefix_wrapper
 
 
-def with_legal_basis(func):
-    @wraps(func)
-    def legal_basis_wrapper(*args, **kwargs):
-        return func(*args, legal_basis=g.schema.json['legal_basis'], **kwargs)
-
-    return legal_basis_wrapper
-
-
 def render_template(template, **kwargs):
     theme = g.schema.json.get('theme')
     template = '{}.html'.format(template).lower()

--- a/app/templates/introduction.html
+++ b/app/templates/introduction.html
@@ -58,9 +58,9 @@
                 {% endfor %}
             {% endif %}
 
-            {%- if legal_basis == 'StatisticsOfTradeAct' -%}
+            {%- if legal_basis -%}
                 <h2 class="neptune u-mb-xs">{{ _("Your response is legally required") }}</h2>
-                <p class="mars u-mb-m">{{ _("Notice is given under section 1 of the Statistics of Trade Act 1947") }}.</p>
+                <p class="mars u-mb-m">{{ legal_basis }}</p>
             {%- endif -%}
 
             {% block start_survey %}

--- a/app/themes/northernireland/templates/introduction.html
+++ b/app/themes/northernireland/templates/introduction.html
@@ -50,9 +50,9 @@
                 {% endfor %}
             {% endif %}
 
-            {%- if legal_basis == 'StatisticsOfTradeAct' -%}
+            {%- if legal_basis -%}
                 <h2 class="neptune u-mb-xs">Your response is legally required</h2>
-                <p class="mars u-mb-m">Notice is given under article 5 of the Statistics of Trade and Employment (Northern Ireland) Order 1988.</p>
+                <p class="mars u-mb-m">{{ legal_basis }}</p>
             {%- endif -%}
 
             {% block start_survey %}

--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-08-06 12:50+0100\n"
+"POT-Creation-Date: 2018-08-23 13:06+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -83,10 +83,6 @@ msgstr ""
 
 #: app/templates/introduction.html:62
 msgid "Your response is legally required"
-msgstr ""
-
-#: app/templates/introduction.html:63
-msgid "Notice is given under section 1 of the Statistics of Trade Act 1947"
 msgstr ""
 
 #: app/templates/multiple_survey.html:7

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -24,7 +24,7 @@ from app.helpers.schema_helpers import get_group_instance_id
 from app.helpers.schema_helpers import with_schema
 from app.helpers.session_helpers import with_answer_store, with_metadata, with_collection_metadata
 from app.helpers.template_helper import (with_session_timeout, with_metadata_context, with_analytics,
-                                         with_questionnaire_url_prefix, with_legal_basis, render_template)
+                                         with_questionnaire_url_prefix, render_template)
 
 from app.questionnaire.location import Location
 from app.questionnaire.navigation import Navigation
@@ -747,7 +747,6 @@ def _build_template(current_location, context, template, schema, answer_store, m
 @with_questionnaire_url_prefix
 @with_metadata_context
 @with_analytics
-@with_legal_basis
 def _render_template(context, current_location, template, front_end_navigation, previous_url, schema, metadata, answer_store, **kwargs):
     page_title = get_page_title_for_location(schema, current_location, metadata, answer_store)
 

--- a/data/cy/test_language.json
+++ b/data/cy/test_language.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Welsh Language Survey",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to demonstrate welsh language",
     "metadata": [{
         "validator": "string",

--- a/data/en/0_rogue_one.json
+++ b/data/en/0_rogue_one.json
@@ -6,7 +6,7 @@
     "title": "Rogue One ",
     "description": "Test with a confirmation page instead of a summary",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/0_star_wars.json
+++ b/data/en/0_star_wars.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Star Wars",
     "theme": "starwars",
-    "legal_basis": "Voluntary",
     "description": "Kitchen sink test for the Star Wars questionnaire",
     "metadata": [{
         "name": "user_id",

--- a/data/en/1_0005.json
+++ b/data/en/1_0005.json
@@ -2131,7 +2131,7 @@
             "title": "Summary"
         }]
     }],
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
     "survey_id": "134",

--- a/data/en/1_0102.json
+++ b/data/en/1_0102.json
@@ -6,7 +6,7 @@
     "title": "Monthly Business Survey - Retail Sales Index",
     "description": "RSI Description",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "variables": {
         "period": "{{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}"
     },

--- a/data/en/1_0112.json
+++ b/data/en/1_0112.json
@@ -6,7 +6,7 @@
     "title": "Monthly Business Survey - Retail Sales Index",
     "description": "RSI Description",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "view_submitted_response": {
         "enabled": true,
         "duration": 900

--- a/data/en/1_0203.json
+++ b/data/en/1_0203.json
@@ -6,7 +6,7 @@
     "title": "Monthly Business Survey - Retail Sales Index",
     "description": "MCI Description",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "variables": {
         "period": "{{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}"
     },

--- a/data/en/1_0205.json
+++ b/data/en/1_0205.json
@@ -6,7 +6,7 @@
     "title": "Monthly Business Survey - Retail Sales Index",
     "description": "MCI Description",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "variables": {
         "period": "{{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}"
     },

--- a/data/en/1_0213.json
+++ b/data/en/1_0213.json
@@ -6,7 +6,7 @@
     "title": "Monthly Business Survey - Retail Sales Index",
     "description": "MCI Description",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "view_submitted_response": {
         "enabled": true,
         "duration": 900

--- a/data/en/1_0215.json
+++ b/data/en/1_0215.json
@@ -6,7 +6,7 @@
     "title": "Monthly Business Survey - Retail Sales Index",
     "description": "MCI Description",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "view_submitted_response": {
         "enabled": true,
         "duration": 900

--- a/data/en/2_0001.json
+++ b/data/en/2_0001.json
@@ -195,7 +195,7 @@
             "title": "Quarterly Business Survey"
         }]
     }],
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
     "survey_id": "139",

--- a/data/en/census_communal.json
+++ b/data/en/census_communal.json
@@ -6,7 +6,6 @@
     "title": "2017 Census Test",
     "description": "Census England Communal Schema",
     "theme": "census",
-    "legal_basis": "Voluntary",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/census_household.json
+++ b/data/en/census_household.json
@@ -6,7 +6,6 @@
     "title": "2017 Census Test",
     "description": "Census England Household Schema",
     "theme": "census",
-    "legal_basis": "Voluntary",
     "navigation": {
         "visible": true
     },

--- a/data/en/census_individual.json
+++ b/data/en/census_individual.json
@@ -6,7 +6,6 @@
     "title": "2017 Census Test",
     "description": "Census England Individual Schema",
     "theme": "census",
-    "legal_basis": "Voluntary",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/e_commerce.json
+++ b/data/en/e_commerce.json
@@ -2748,6 +2748,6 @@
         }]
     }],
     "title": "e-commerce",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "description": "manifest"
 }

--- a/data/en/lms_1.json
+++ b/data/en/lms_1.json
@@ -6,7 +6,6 @@
     "title": "Online Household Study (Alpha)",
     "description": "Online Household Study Schema (Alpha)",
     "theme": "default",
-    "legal_basis": "Voluntary",
     "eq_id": "lms",
     "form_type": "1",
     "navigation": {

--- a/data/en/mbs_0106.json
+++ b/data/en/mbs_0106.json
@@ -5,7 +5,7 @@
     "theme": "default",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "description": "mbs_0106",
     "view_submitted_response": {
         "enabled": true,

--- a/data/en/mbs_0111.json
+++ b/data/en/mbs_0111.json
@@ -5,7 +5,7 @@
     "theme": "default",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "description": "mbs",
     "eq_id": "mbs",
     "form_type": "0161",

--- a/data/en/mbs_0117.json
+++ b/data/en/mbs_0117.json
@@ -5,7 +5,7 @@
     "theme": "default",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "description": "mbs",
     "form_type": "0117",
     "view_submitted_response": {

--- a/data/en/mbs_0123.json
+++ b/data/en/mbs_0123.json
@@ -5,7 +5,7 @@
     "theme": "default",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "description": "mbs 0123",
     "eq_id": "mbs",
     "form_type": "0123",

--- a/data/en/mbs_0158.json
+++ b/data/en/mbs_0158.json
@@ -5,7 +5,7 @@
     "theme": "default",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "description": "mbs",
     "eq_id": "mbs",
     "form_type": "0158",

--- a/data/en/mbs_0161.json
+++ b/data/en/mbs_0161.json
@@ -5,7 +5,7 @@
     "theme": "default",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "description": "mbs",
     "eq_id": "mbs",
     "form_type": "0161",

--- a/data/en/mbs_0167.json
+++ b/data/en/mbs_0167.json
@@ -5,7 +5,7 @@
     "theme": "default",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "description": "mbs",
     "form_type": "0167",
     "view_submitted_response": {

--- a/data/en/mbs_0173.json
+++ b/data/en/mbs_0173.json
@@ -5,7 +5,7 @@
     "theme": "default",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "description": "mbs 0173",
     "eq_id": "mbs",
     "form_type": "0173",

--- a/data/en/mbs_0201.json
+++ b/data/en/mbs_0201.json
@@ -5,7 +5,7 @@
     "theme": "default",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "description": "mbs",
     "form_type": "0251",
     "view_submitted_response": {

--- a/data/en/mbs_0202.json
+++ b/data/en/mbs_0202.json
@@ -5,7 +5,7 @@
     "theme": "northernireland",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under article 5 of the Statistics of Trade and Employment (Northern Ireland) Order 1988.",
     "description": "mbs",
     "form_type": "0202",
     "view_submitted_response": {

--- a/data/en/mbs_0203.json
+++ b/data/en/mbs_0203.json
@@ -5,7 +5,7 @@
     "theme": "default",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "description": "mbs",
     "view_submitted_response": {
         "enabled": true,

--- a/data/en/mbs_0204.json
+++ b/data/en/mbs_0204.json
@@ -5,7 +5,7 @@
     "theme": "northernireland",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under article 5 of the Statistics of Trade and Employment (Northern Ireland) Order 1988.",
     "description": "mbs",
     "view_submitted_response": {
         "enabled": true,

--- a/data/en/mbs_0205.json
+++ b/data/en/mbs_0205.json
@@ -5,7 +5,7 @@
     "theme": "default",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "description": "mbs",
     "view_submitted_response": {
         "enabled": true,

--- a/data/en/mbs_0216.json
+++ b/data/en/mbs_0216.json
@@ -5,7 +5,7 @@
     "theme": "northernireland",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under article 5 of the Statistics of Trade and Employment (Northern Ireland) Order 1988.",
     "description": "mbs",
     "view_submitted_response": {
         "enabled": true,

--- a/data/en/mbs_0251.json
+++ b/data/en/mbs_0251.json
@@ -5,7 +5,7 @@
     "theme": "default",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "description": "mbs",
     "form_type": "0251",
     "view_submitted_response": {

--- a/data/en/mbs_0253.json
+++ b/data/en/mbs_0253.json
@@ -5,7 +5,7 @@
     "theme": "default",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "description": "mbs",
     "view_submitted_response": {
         "enabled": true,

--- a/data/en/mbs_0255.json
+++ b/data/en/mbs_0255.json
@@ -5,7 +5,7 @@
     "theme": "default",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "description": "mbs",
     "eq_id": "mbs",
     "form_type": "0255",

--- a/data/en/mbs_0817.json
+++ b/data/en/mbs_0817.json
@@ -5,7 +5,7 @@
     "theme": "default",
     "data_version": "0.0.1",
     "title": "Monthly Business Survey",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "description": "mbs",
     "view_submitted_response": {
         "enabled": true,

--- a/data/en/mbs_0823.json
+++ b/data/en/mbs_0823.json
@@ -5,7 +5,7 @@
     "theme": "default",
     "data_version": "0.0.1",
     "title": "Monthly Business Survey",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "description": "mbs",
     "view_submitted_response": {
         "enabled": true,

--- a/data/en/mbs_0867.json
+++ b/data/en/mbs_0867.json
@@ -5,7 +5,7 @@
     "theme": "default",
     "data_version": "0.0.1",
     "title": "Monthly Business Survey",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "description": "mbs",
     "view_submitted_response": {
         "enabled": true,

--- a/data/en/mbs_0873.json
+++ b/data/en/mbs_0873.json
@@ -5,7 +5,7 @@
     "theme": "default",
     "data_version": "0.0.1",
     "title": "Monthly Business Survey",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "description": "mbs",
     "view_submitted_response": {
         "enabled": true,

--- a/data/en/mci_transformation.json
+++ b/data/en/mci_transformation.json
@@ -6,7 +6,7 @@
     "title": "Monthly Turnover Survey",
     "description": "MCI Description",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "eq_id": "mci",
     "form_type": "transformation",
     "view_submitted_response": {

--- a/data/en/mts_1.json
+++ b/data/en/mts_1.json
@@ -5,7 +5,7 @@
     "theme": "default",
     "data_version": "0.0.1",
     "title": "Monthly Turnover Survey",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "description": "mts",
     "view_submitted_response": {
         "enabled": true,

--- a/data/en/multiple_answers.json
+++ b/data/en/multiple_answers.json
@@ -6,7 +6,7 @@
     "title": "Multiple answers per question",
     "description": "A survey containing questions which have more than one answer",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/qcas_0018.json
+++ b/data/en/qcas_0018.json
@@ -7,7 +7,7 @@
     "survey_id": "019",
     "title": "Quarterly Acquisitions and Disposals of Capital Assets Survey",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 4 of the statistics of trade act.",
     "view_submitted_response": {
         "enabled": true,
         "duration": 900

--- a/data/en/qcas_0019.json
+++ b/data/en/qcas_0019.json
@@ -7,7 +7,7 @@
     "survey_id": "019",
     "title": "Quarterly Acquisitions and Disposals of Capital Assets Survey",
     "theme": "northernireland",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under article 8 of the statistics of trade order (Northern Ireland) 1988.",
     "view_submitted_response": {
         "enabled": true,
         "duration": 900

--- a/data/en/qcas_0020.json
+++ b/data/en/qcas_0020.json
@@ -7,7 +7,7 @@
     "survey_id": "019",
     "title": "Quarterly Acquisitions and Disposals of Capital Assets Survey",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 4 of the statistics of trade act.",
     "view_submitted_response": {
         "enabled": true,
         "duration": 900

--- a/data/en/rsi_transformation.json
+++ b/data/en/rsi_transformation.json
@@ -6,7 +6,7 @@
     "title": "Monthly Turnover Survey",
     "description": "RSI Description",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "eq_id": "rsi",
     "form_type": "transformation",
     "view_submitted_response": {

--- a/data/en/test_0102.json
+++ b/data/en/test_0102.json
@@ -6,7 +6,7 @@
     "title": "Monthly Business Survey - Retail Sales Index",
     "description": "RSI Description",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_0112.json
+++ b/data/en/test_0112.json
@@ -6,7 +6,7 @@
     "title": "Monthly Business Survey - Retail Sales Index",
     "description": "RSI Description",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_0203.json
+++ b/data/en/test_0203.json
@@ -6,7 +6,7 @@
     "title": "Monthly Business Survey - Retail Sales Index",
     "description": "MCI Description",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_0205.json
+++ b/data/en/test_0205.json
@@ -6,7 +6,7 @@
     "title": "Monthly Business Survey - Retail Sales Index",
     "description": "MCI Description",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_0213.json
+++ b/data/en/test_0213.json
@@ -6,7 +6,7 @@
     "title": "Monthly Business Survey - Retail Sales Index",
     "description": "MCI Description",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_big_list_naughty_strings.json
+++ b/data/en/test_big_list_naughty_strings.json
@@ -3080,7 +3080,6 @@
     "description": "A questionnaire to test textareas.",
     "data_version": "0.0.1",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "schema_version": "0.0.1",
     "survey_id": "0"
 }

--- a/data/en/test_calculated_summary.json
+++ b/data/en/test_calculated_summary.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "A test schema to validate a sum of answers are Equal to a given total",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A survey that tests grouped and calculated answers against a total",
     "metadata": [{
             "name": "user_id",

--- a/data/en/test_checkbox.json
+++ b/data/en/test_checkbox.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Other input fields",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to demo checkbox field Other input.",
     "messages": {
         "NUMBER_TOO_LARGE": "Number is too large",

--- a/data/en/test_checkbox_mutually_exclusive.json
+++ b/data/en/test_checkbox_mutually_exclusive.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Other input fields",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to demo checkbox field Other input.",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_conditional_dates.json
+++ b/data/en/test_conditional_dates.json
@@ -6,7 +6,6 @@
     "title": "Date formats",
     "description": "A test schema for different date formats",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_conditional_routing.json
+++ b/data/en/test_conditional_routing.json
@@ -6,7 +6,6 @@
     "title": "Test Conditional Routing",
     "description": "",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_confirmation_question.json
+++ b/data/en/test_confirmation_question.json
@@ -1,5 +1,4 @@
 {
-    "legal_basis": "StatisticsOfTradeAct",
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
     "survey_id": "139",

--- a/data/en/test_currency.json
+++ b/data/en/test_currency.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Other input fields",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test currency input type",
     "messages": {
         "NUMBER_TOO_LARGE": "Number is too large",

--- a/data/en/test_date_validation_combined.json
+++ b/data/en/test_date_validation_combined.json
@@ -6,7 +6,6 @@
     "title": "Date formats",
     "description": "A test schema for different date formats",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_date_validation_mm_yyyy_combined.json
+++ b/data/en/test_date_validation_mm_yyyy_combined.json
@@ -6,7 +6,6 @@
     "title": "Date formats",
     "description": "A test schema for different date formats",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "variables": {
         "period": "{{ format_conditional_date (answers.period_from, metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers.period_to, metadata['ref_p_end_date'])}}"
     },

--- a/data/en/test_date_validation_range.json
+++ b/data/en/test_date_validation_range.json
@@ -6,7 +6,6 @@
     "title": "Date formats",
     "description": "A test schema for different date formats",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_date_validation_single.json
+++ b/data/en/test_date_validation_single.json
@@ -6,7 +6,6 @@
     "title": "Date formats",
     "description": "A test schema for single date period validation",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_date_validation_yyyy_combined.json
+++ b/data/en/test_date_validation_yyyy_combined.json
@@ -6,7 +6,6 @@
     "title": "Date formats",
     "description": "A test schema for different date formats",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "variables": {
         "period": "{{ format_conditional_date (answers.period_from, metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers.period_to, metadata['ref_p_end_date'])}}"
     },

--- a/data/en/test_dates.json
+++ b/data/en/test_dates.json
@@ -6,7 +6,6 @@
     "title": "Date formats",
     "description": "A test schema for different date formats",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_default.json
+++ b/data/en/test_default.json
@@ -5,7 +5,6 @@
     "survey_id": "001",
     "title": "Test Routing Number Equals",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A test survey for routing based on an number equals",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_dependencies.json
+++ b/data/en/test_dependencies.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "A test schema to validate a sum of answers are Equal to a given total",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A survey that tests grouped and calculated answers against a total",
     "navigation": {
         "visible": true

--- a/data/en/test_dependencies_calculation.json
+++ b/data/en/test_dependencies_calculation.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "A test schema to validate a sum of answers are Equal to a given total",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A survey that tests grouped and calculated answers against a total",
     "navigation": {
         "visible": true

--- a/data/en/test_dependencies_max_value.json
+++ b/data/en/test_dependencies_max_value.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Maximum Answer Value Dependency Check",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A survey with an maximum validation dependency",
     "navigation": {
         "visible": true

--- a/data/en/test_dependencies_min_value.json
+++ b/data/en/test_dependencies_min_value.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Minimum Answer Value Dependency Check",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A survey with an minimum validation dependency",
     "navigation": {
         "visible": true

--- a/data/en/test_difference_in_years.json
+++ b/data/en/test_difference_in_years.json
@@ -6,7 +6,6 @@
     "title": "Difference between two dates",
     "description": "A test schema for calculate age from date",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_difference_in_years_month_year.json
+++ b/data/en/test_difference_in_years_month_year.json
@@ -6,7 +6,6 @@
     "title": "Difference between two dates",
     "description": "A test schema for calculate age from date",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_difference_in_years_month_year_range.json
+++ b/data/en/test_difference_in_years_month_year_range.json
@@ -6,7 +6,6 @@
     "title": "Difference between two dates",
     "description": "A test schema for calculate age from date",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_difference_in_years_range.json
+++ b/data/en/test_difference_in_years_range.json
@@ -6,7 +6,6 @@
     "title": "Difference between two dates",
     "description": "A test schema for calculate age from date",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_dropdown_mandatory.json
+++ b/data/en/test_dropdown_mandatory.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Dropdown Mandatory",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_dropdown_mandatory_with_overridden_error.json
+++ b/data/en/test_dropdown_mandatory_with_overridden_error.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Dropdown Mandatory With Overridden Error",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_dropdown_optional.json
+++ b/data/en/test_dropdown_optional.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Dropdown Mandatory",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_durations.json
+++ b/data/en/test_durations.json
@@ -6,7 +6,6 @@
     "title": "Durations",
     "description": "A test schema for different durations",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_error_messages.json
+++ b/data/en/test_error_messages.json
@@ -6,7 +6,6 @@
     "title": "Test Error Messages",
     "description": "Test Description",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_final_confirmation.json
+++ b/data/en/test_final_confirmation.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Final confirmation to submit",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to demo final confirmation to submit.",
     "navigation": {
         "visible": true

--- a/data/en/test_household_question.json
+++ b/data/en/test_household_question.json
@@ -6,7 +6,6 @@
     "title": "Census Theme",
     "description": "",
     "theme": "census",
-    "legal_basis": "Voluntary",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_interstitial_page.json
+++ b/data/en/test_interstitial_page.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Interstitial Pages",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to demo interstitial pages.",
     "messages": {
         "NUMBER_TOO_LARGE": "Number is too large",

--- a/data/en/test_introduction.json
+++ b/data/en/test_introduction.json
@@ -152,6 +152,5 @@
     "schema_version": "0.0.1",
     "survey_id": "144",
     "theme": "default",
-    "legal_basis": "Voluntary",
     "title": "Test Introduction"
 }

--- a/data/en/test_is_skipping_to_end.json
+++ b/data/en/test_is_skipping_to_end.json
@@ -4,7 +4,6 @@
     "survey_id": "137",
     "theme": "default",
     "title": "Test Skipping To End",
-    "legal_basis": "StatisticsOfTradeAct",
     "mime_type": "application/json/ons/eq",
     "navigation": {
         "visible": true

--- a/data/en/test_language.json
+++ b/data/en/test_language.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "English Language Survey",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to demonstrate english language",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_markup.json
+++ b/data/en/test_markup.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Markup test",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test rendering of markup in questionnaires",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_metadata_routing.json
+++ b/data/en/test_metadata_routing.json
@@ -6,7 +6,6 @@
     "title": "Census England Household Schema",
     "description": "Census England Household Schema",
     "theme": "census",
-    "legal_basis": "Voluntary",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_metadata_validation.json
+++ b/data/en/test_metadata_validation.json
@@ -1,7 +1,6 @@
 {
     "data_version": "0.0.1",
     "description": "Test Metadata validations",
-    "legal_basis": "Voluntary",
     "metadata": [{
             "name": "ref_p_start_date",
             "validator": "date"

--- a/data/en/test_multiple_piping.json
+++ b/data/en/test_multiple_piping.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Multiple piping test survey",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test multiple piping into a question and answer",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_navigation.json
+++ b/data/en/test_navigation.json
@@ -6,7 +6,6 @@
     "title": "Home Insurance",
     "description": "Home Insurance",
     "theme": "default",
-    "legal_basis": "Voluntary",
     "navigation": {
         "visible": true
     },

--- a/data/en/test_navigation_completeness.json
+++ b/data/en/test_navigation_completeness.json
@@ -6,7 +6,6 @@
     "title": "Test Navigation Completeness",
     "description": "",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "navigation": {
         "visible": true
     },

--- a/data/en/test_navigation_confirmation.json
+++ b/data/en/test_navigation_confirmation.json
@@ -6,7 +6,6 @@
     "title": "Home Insurance",
     "description": "Home Insurance",
     "theme": "census",
-    "legal_basis": "Voluntary",
     "navigation": {
         "visible": true
     },

--- a/data/en/test_navigation_routing.json
+++ b/data/en/test_navigation_routing.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Routing Group",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "navigation": {
         "visible": true
     },

--- a/data/en/test_numbers.json
+++ b/data/en/test_numbers.json
@@ -6,7 +6,6 @@
     "title": "Test Numeric Range",
     "description": "Test Description",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_percentage.json
+++ b/data/en/test_percentage.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Percentage Field Demo",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test percentage input type",
     "navigation": {
         "visible": true

--- a/data/en/test_question_definition.json
+++ b/data/en/test_question_definition.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Other input fields",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test definitions.",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_question_guidance.json
+++ b/data/en/test_question_guidance.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Question Guidance Test",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test question guidance content",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_radio_checkbox_descriptions.json
+++ b/data/en/test_radio_checkbox_descriptions.json
@@ -6,7 +6,6 @@
     "title": "Test Survey - Checkbox and Radio option descriptions",
     "description": "",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_radio_mandatory.json
+++ b/data/en/test_radio_mandatory.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Radio Mandatory",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_radio_mandatory_with_mandatory_other.json
+++ b/data/en/test_radio_mandatory_with_mandatory_other.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Radio Mandatory with Mandatory Other",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_radio_mandatory_with_mandatory_other_overridden_error.json
+++ b/data/en/test_radio_mandatory_with_mandatory_other_overridden_error.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Radio Mandatory with Mandatory Other Overridden Error",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_radio_mandatory_with_optional_other.json
+++ b/data/en/test_radio_mandatory_with_optional_other.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Radio Mandatory with Optional Other",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_radio_mandatory_with_overridden_error.json
+++ b/data/en/test_radio_mandatory_with_overridden_error.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Radio Mandatory with Overridden Error",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_radio_optional.json
+++ b/data/en/test_radio_optional.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Radio Optional",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_radio_optional_with_mandatory_other.json
+++ b/data/en/test_radio_optional_with_mandatory_other.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Radio Optional with Mandatory Other",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_radio_optional_with_mandatory_other_overridden_error.json
+++ b/data/en/test_radio_optional_with_mandatory_other_overridden_error.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Radio Optional with Mandatory Other Overridden Error",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_radio_optional_with_optional_other.json
+++ b/data/en/test_radio_optional_with_optional_other.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Radio Optional with Optional Other",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_relationship_household.json
+++ b/data/en/test_relationship_household.json
@@ -6,7 +6,6 @@
     "title": "Household relationship",
     "description": "",
     "theme": "census",
-    "legal_basis": "Voluntary",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_repeating_and_conditional_routing.json
+++ b/data/en/test_repeating_and_conditional_routing.json
@@ -6,7 +6,6 @@
     "title": "Test Repeating",
     "description": "",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_repeating_household.json
+++ b/data/en/test_repeating_household.json
@@ -6,7 +6,6 @@
     "title": "Test Repeating",
     "description": "",
     "theme": "census",
-    "legal_basis": "Voluntary",
     "navigation": {
         "visible": true
     },

--- a/data/en/test_repeating_household_routing.json
+++ b/data/en/test_repeating_household_routing.json
@@ -6,7 +6,6 @@
     "title": "Test repeating household routing",
     "description": "Tests a repeating group with alternate paths based on an optional answer",
     "theme": "census",
-    "legal_basis": "Voluntary",
     "eq_id": "1",
     "form_type": "1",
     "metadata": [{

--- a/data/en/test_routing_answer_count.json
+++ b/data/en/test_routing_answer_count.json
@@ -6,7 +6,6 @@
     "title": "Test Routing Answer Count",
     "description": "",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_routing_date_equals.json
+++ b/data/en/test_routing_date_equals.json
@@ -5,7 +5,6 @@
     "survey_id": "001",
     "title": "Test Routing Date Equals",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A test survey for routing based on equal dates",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_routing_date_greater_than.json
+++ b/data/en/test_routing_date_greater_than.json
@@ -5,7 +5,6 @@
     "survey_id": "001",
     "title": "Test Routing Date Greater Than",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A test survey for routing based on a date greater than",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_routing_date_less_than.json
+++ b/data/en/test_routing_date_less_than.json
@@ -5,7 +5,6 @@
     "survey_id": "001",
     "title": "Test Routing Date Less Than",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A test survey for routing based on a Date less than",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_routing_date_not_equals.json
+++ b/data/en/test_routing_date_not_equals.json
@@ -5,7 +5,6 @@
     "survey_id": "001",
     "title": "Test Routing Date Not Equals",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A test survey for routing based on a date not equals",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_routing_group.json
+++ b/data/en/test_routing_group.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Routing Group",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_routing_number_equals.json
+++ b/data/en/test_routing_number_equals.json
@@ -5,7 +5,6 @@
     "survey_id": "001",
     "title": "Test Routing Number Equals",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A test survey for routing based on an number equals",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_routing_number_greater_than.json
+++ b/data/en/test_routing_number_greater_than.json
@@ -5,7 +5,6 @@
     "survey_id": "001",
     "title": "Test Routing Number Greater Than",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A test survey for routing based on a number greater than",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_routing_number_greater_than_or_equal.json
+++ b/data/en/test_routing_number_greater_than_or_equal.json
@@ -5,7 +5,6 @@
     "survey_id": "001",
     "title": "Test Routing Number Greater Than or Equal",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A test survey for routing based on a number greater than or equal",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_routing_number_less_than.json
+++ b/data/en/test_routing_number_less_than.json
@@ -5,7 +5,6 @@
     "survey_id": "001",
     "title": "Test Routing Number Less Than",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A test survey for routing based on a number less than",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_routing_number_less_than_or_equal.json
+++ b/data/en/test_routing_number_less_than_or_equal.json
@@ -5,7 +5,6 @@
     "survey_id": "001",
     "title": "Test Routing Number Less Than or Equal",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A test survey for routing based on a number less than or equal",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_routing_number_not_equals.json
+++ b/data/en/test_routing_number_not_equals.json
@@ -5,7 +5,6 @@
     "survey_id": "001",
     "title": "Test Routing Number Not Equals",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A test survey for routing based on a number not equals",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_routing_on_multiple_select.json
+++ b/data/en/test_routing_on_multiple_select.json
@@ -6,7 +6,6 @@
     "title": "Test schema for routing on multiple selected answers",
     "description": "Test schema for routing on multiple selected answers",
     "theme": "census",
-    "legal_basis": "Voluntary",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_routing_repeat_until.json
+++ b/data/en/test_routing_repeat_until.json
@@ -6,7 +6,6 @@
     "title": "Test Repeat Until",
     "description": "",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_schema_context.json
+++ b/data/en/test_schema_context.json
@@ -5,7 +5,6 @@
     "schema_version": "0.0.1",
     "survey_id": "144",
     "theme": "default",
-    "legal_basis": "Voluntary",
     "title": "Test Schema Context",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_section_summary.json
+++ b/data/en/test_section_summary.json
@@ -6,7 +6,6 @@
     "title": "Section Summary",
     "description": "A questionnaire to test section summaries",
     "theme": "default",
-    "legal_basis": "Voluntary",
     "view_submitted_response": {
         "enabled": true,
         "duration": 9000

--- a/data/en/test_skip_condition.json
+++ b/data/en/test_skip_condition.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Test skip condition",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test skip condition.",
     "messages": {},
     "metadata": [{

--- a/data/en/test_skip_condition_block.json
+++ b/data/en/test_skip_condition_block.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Skip group",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_skip_condition_group.json
+++ b/data/en/test_skip_condition_group.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Skip group",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_skip_condition_not_set.json
+++ b/data/en/test_skip_condition_not_set.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Test not set skip condition",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test skip condition not set.",
     "messages": {},
     "metadata": [{

--- a/data/en/test_skip_condition_question.json
+++ b/data/en/test_skip_condition_question.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Skip group",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_skip_condition_set.json
+++ b/data/en/test_skip_condition_set.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Test set skip condition",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test skip condition set.",
     "messages": {},
     "metadata": [{

--- a/data/en/test_skip_conditions_from_repeating_group_based_on_non_repeating_answer.json
+++ b/data/en/test_skip_conditions_from_repeating_group_based_on_non_repeating_answer.json
@@ -6,7 +6,6 @@
     "title": "A Test Schema to test skip conditions in a non repeating  answer in a repeating group",
     "description": "Tests skip conditions in repeating group when referencing a non repeating answer ",
     "theme": "default",
-    "legal_basis": "Voluntary",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_skip_conditions_on_blocks_repeating_group.json
+++ b/data/en/test_skip_conditions_on_blocks_repeating_group.json
@@ -6,7 +6,6 @@
     "title": "A Test Schema to test skip conditions in a repeating group",
     "description": "A survey that has an answer in one repeating group being the independent variable for a skip condition on a block in another repeating group ",
     "theme": "default",
-    "legal_basis": "Voluntary",
     "form_type": "1",
     "navigation": {
         "visible": true

--- a/data/en/test_sum_equal_or_less_validation_against_total.json
+++ b/data/en/test_sum_equal_or_less_validation_against_total.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "A test schema to validate a sum of answers are Less Than or Equal to a given total",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A survey that tests grouped and calculated answers against a total",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_sum_equal_validation_against_total.json
+++ b/data/en/test_sum_equal_validation_against_total.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "A test schema to validate a sum of answers are Equal to a given total",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A survey that tests grouped and calculated answers against a total",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_sum_less_validation_against_total.json
+++ b/data/en/test_sum_less_validation_against_total.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "A test schema to validate a sum of answers are Less Than a given total",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A survey that tests grouped and calculated answers against a total",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_sum_multi_validation_against_total.json
+++ b/data/en/test_sum_multi_validation_against_total.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Grouped validation against total test survey",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A survey that tests grouped and calculated answers against a total",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_summary.json
+++ b/data/en/test_summary.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Other input fields",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to demo radio field Other input.",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_textarea.json
+++ b/data/en/test_textarea.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Other input fields",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test textareas.",
     "messages": {
         "NUMBER_TOO_LARGE": "Number is too large",

--- a/data/en/test_textfield.json
+++ b/data/en/test_textfield.json
@@ -5,7 +5,6 @@
     "survey_id": "001",
     "title": "Other input fields",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test textfields",
     "messages": {
         "NUMBER_TOO_LARGE": "Number is too large",

--- a/data/en/test_timeout.json
+++ b/data/en/test_timeout.json
@@ -7,7 +7,6 @@
     "session_prompt_in_seconds": 4,
     "title": "Timeout test",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test the time out functionality",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_titles.json
+++ b/data/en/test_titles.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Multiple Question Title Test",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test multiple question title versions",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_titles_conditional_within_repeating_block.json
+++ b/data/en/test_titles_conditional_within_repeating_block.json
@@ -6,7 +6,6 @@
     "title": "Test conditional within repeating group",
     "description": "Test conditional within repeating group",
     "theme": "default",
-    "legal_basis": "Voluntary",
     "form_type": "0",
     "navigation": {
         "visible": true

--- a/data/en/test_titles_radio_and_checkbox.json
+++ b/data/en/test_titles_radio_and_checkbox.json
@@ -6,7 +6,6 @@
     "title": "Test Survey - Checkbox and Radio titles",
     "description": "",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_titles_repeating_non_repeating_dependency.json
+++ b/data/en/test_titles_repeating_non_repeating_dependency.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Multiple Question Title Test",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test multiple question title versions",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_titles_within_repeating_blocks.json
+++ b/data/en/test_titles_within_repeating_blocks.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Multiple Question Title Test",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test multiple question title versions",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_total_breakdown.json
+++ b/data/en/test_total_breakdown.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Total field test survey",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A survey that tests the totalling of percentage input fields",
     "metadata": [{
         "name": "user_id",

--- a/data/en/test_unit_patterns.json
+++ b/data/en/test_unit_patterns.json
@@ -6,7 +6,6 @@
     "title": "Test Unit Patterns",
     "description": "Tests for localised (UK rendering) measurements.",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "metadata": [{
         "name": "user_id",
         "validator": "string"

--- a/data/en/test_view_submitted_response.json
+++ b/data/en/test_view_submitted_response.json
@@ -5,7 +5,6 @@
     "survey_id": "0",
     "title": "Test Submitted Answers Survey",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to demo radio field Other input.",
     "view_submitted_response": {
         "enabled": true,

--- a/tests/app/parser/test_schemas/calculated-answer.json
+++ b/tests/app/parser/test_schemas/calculated-answer.json
@@ -5,7 +5,7 @@
     "survey_id": "0",
     "title": "Total field test survey",
     "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
     "description": "A survey that tests the totalling of percentage input fields",
     "messages": {
       "NUMBER_TOO_LARGE": "Number cannot be greater than one hundred",


### PR DESCRIPTION
### What is the context of this PR?
- Changed legal basis to be a non mandatory string.
- This is required as there are multiple types of trade acts for different surveys.

### How to review 
- Check that all schemas have the correct messages.
- Check that [schema validator is correct with this pr](https://github.com/ONSdigital/eq-schema-validator/pull/78)
- Check [eq-translations is working correctly](https://github.com/ONSdigital/eq-translations/pull/21)

### Checklist

* [x] New static content marked up for translation
* [x] Newly defined schema content included in eq-translations repo
