### PR TITLE
Allow comparison of answer values in when clause

### DIFF
--- a/app/forms/date_form.py
+++ b/app/forms/date_form.py
@@ -11,6 +11,7 @@ from babel.dates import get_month_names
 from app.forms.custom_fields import CustomIntegerField
 from app.questionnaire.rules import get_metadata_value, get_answer_store_value, convert_to_datetime
 from app.validation.validators import DateCheck, OptionalForm, DateRequired, MonthYearCheck, YearCheck, SingleDatePeriodCheck
+from app.utilities.schema import load_schema_from_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -282,7 +283,8 @@ def get_referenced_offset_value(answer_min_or_max, answer_store, metadata):
     elif 'meta' in answer_min_or_max:
         value = get_metadata_value(metadata, answer_min_or_max['meta'])
     elif 'answer_id' in answer_min_or_max:
-        value = get_answer_store_value(answer_min_or_max['answer_id'], answer_store, group_instance=0)
+        schema = load_schema_from_metadata(metadata)
+        value = get_answer_store_value(answer_min_or_max['answer_id'], answer_store, schema, group_instance=0)
 
     value = convert_to_datetime(value)
 

--- a/app/forms/questionnaire_form.py
+++ b/app/forms/questionnaire_form.py
@@ -256,7 +256,7 @@ class QuestionnaireForm(FlaskForm):
         return None
 
 
-def get_answer_fields(question, data, error_messages, schema, answer_store, metadata, group_instance):
+def get_answer_fields(question, data, error_messages, schema, answer_store, metadata, group_instance, group_instance_id):
     answer_fields = {}
     for answer in question.get('answers', []):
         if 'parent_answer_id' in answer and answer['parent_answer_id'] in data and \
@@ -264,7 +264,7 @@ def get_answer_fields(question, data, error_messages, schema, answer_store, meta
             answer['mandatory'] = \
                 next(a['mandatory'] for a in question['answers'] if a['id'] == answer['parent_answer_id'])
 
-        name = answer.get('label') or get_question_title(question, answer_store, schema, metadata, group_instance)
+        name = answer.get('label') or get_question_title(question, answer_store, schema, metadata, group_instance, group_instance_id)
         answer_fields[answer['id']] = get_field(answer, name, error_messages, answer_store, metadata)
     return answer_fields
 
@@ -295,7 +295,7 @@ def map_child_option_errors(errors, answer_json):
     return child_errors
 
 
-def generate_form(schema, block_json, answer_store, metadata, group_instance, data=None, formdata=None):
+def generate_form(schema, block_json, answer_store, metadata, group_instance, group_instance_id, data=None, formdata=None):
     class DynamicForm(QuestionnaireForm):
         pass
 
@@ -309,6 +309,7 @@ def generate_form(schema, block_json, answer_store, metadata, group_instance, da
             answer_store,
             metadata,
             group_instance,
+            group_instance_id,
         ))
 
     for answer_id, field in answer_fields.items():

--- a/app/helpers/form_helper.py
+++ b/app/helpers/form_helper.py
@@ -71,7 +71,7 @@ def get_form_for_location(schema, block_json, location, answer_store, metadata, 
         block_id=location.block_id,
     )
 
-    return generate_form(schema, block_json, answer_store, metadata, location.group_instance, data=mapped_answers)
+    return generate_form(schema, block_json, answer_store, metadata, location.group_instance, group_instance_id, data=mapped_answers)
 
 
 def post_form_for_location(schema, block_json, location, answer_store, metadata, request_form, disable_mandatory=False):
@@ -86,11 +86,14 @@ def post_form_for_location(schema, block_json, location, answer_store, metadata,
     :param error_messages: The default error messages to use within the form
     :param disable_mandatory: Make mandatory answers optional
     """
+
     if disable_mandatory:
         block_json = disable_mandatory_answers(block_json)
 
     if location.block_id == 'household-composition':
         return generate_household_composition_form(schema, block_json, request_form, metadata, location.group_instance)
+
+    group_instance_id = get_group_instance_id(schema, answer_store, location)
 
     if schema.block_has_question_type(location.block_id, 'Relationship'):
         group = schema.get_group(location.group_id)
@@ -105,13 +108,12 @@ def post_form_for_location(schema, block_json, location, answer_store, metadata,
             answer_ids.append(repeat_rule['answer_id'])
 
         relationship_choices = build_relationship_choices(answer_ids, answer_store, location.group_instance)
-        group_instance_id = get_group_instance_id(schema, answer_store, location)
         form = generate_relationship_form(schema, block_json, relationship_choices, request_form, location.group_instance, group_instance_id)
 
         return form
 
     data = clear_other_text_field(request_form, schema.get_questions_for_block(block_json))
-    return generate_form(schema, block_json, answer_store, metadata, location.group_instance, formdata=data)
+    return generate_form(schema, block_json, answer_store, metadata, location.group_instance, group_instance_id, formdata=data)
 
 
 def disable_mandatory_answers(block_json):

--- a/app/questionnaire/navigation.py
+++ b/app/questionnaire/navigation.py
@@ -82,7 +82,7 @@ class Navigation:
     def _build_repeating_navigation(self, repeating_rule, section, current_group_id, current_group_instance):
         groups = section['groups']
         answer_ids_on_path = get_answer_ids_on_routing_path(self.schema, self.routing_path)
-        no_of_repeats = evaluate_repeat(repeating_rule, self.answer_store, answer_ids_on_path)
+        no_of_repeats = evaluate_repeat(self.schema, repeating_rule, self.answer_store, answer_ids_on_path)
 
         repeating_nav = []
         if repeating_rule['type'] == 'answer_count':

--- a/app/questionnaire/path_finder.py
+++ b/app/questionnaire/path_finder.py
@@ -134,7 +134,13 @@ class PathFinder:
 
     def _evaluate_routing_rules(self, this_location, blocks, block, block_index, path):
         for rule in filter(is_goto_rule, block['routing_rules']):
-            should_goto = evaluate_goto(rule['goto'], self.schema, self.metadata, self.answer_store, this_location.group_instance)
+            group_instance_id = get_group_instance_id(self.schema, self.answer_store, this_location)
+            should_goto = evaluate_goto(rule['goto'],
+                                        self.schema,
+                                        self.metadata,
+                                        self.answer_store,
+                                        this_location.group_instance,
+                                        group_instance_id=group_instance_id)
 
             if should_goto:
                 return self._follow_routing_rule(this_location, rule, blocks, block_index, path)

--- a/app/templating/utils.py
+++ b/app/templating/utils.py
@@ -1,7 +1,7 @@
 from app.questionnaire.rules import evaluate_when_rules
 
 
-def get_question_title(question_schema, answer_store, schema, metadata, group_instance):
+def get_question_title(question_schema, answer_store, schema, metadata, group_instance, group_instance_id=None):
     """Return the value that should be used as the title to a question
     May be from question.title or question.titles"""
 
@@ -10,7 +10,7 @@ def get_question_title(question_schema, answer_store, schema, metadata, group_in
 
     titles = question_schema.get('titles')
 
-    return get_title_from_titles(metadata, schema, answer_store, titles, group_instance)
+    return get_title_from_titles(metadata, schema, answer_store, titles, group_instance, group_instance_id=group_instance_id)
 
 
 def get_title_from_titles(metadata, schema, answer_store, titles, group_instance, group_instance_id=None):

--- a/app/templating/view_context.py
+++ b/app/templating/view_context.py
@@ -4,6 +4,7 @@ from app.helpers.form_helper import get_form_for_location
 from app.templating.summary_context import build_summary_rendering_context
 from app.templating.template_renderer import renderer
 from app.templating.utils import get_title_from_titles, get_question_title
+from app.helpers.schema_helpers import get_group_instance_id
 
 
 def build_view_context(block_type, metadata, schema, answer_store, schema_context, rendered_block, current_location,
@@ -44,7 +45,7 @@ def build_view_context_for_non_question(variables, csrf_token, rendered_block):
     }
 
 
-def build_view_context_for_question(metadata, schema, answer_store, current_location, variables, rendered_block, form):  # noqa: C901, E501  pylint: disable=too-complex,line-too-long
+def build_view_context_for_question(metadata, schema, answer_store, current_location, variables, rendered_block, form):  # noqa: C901, E501  pylint: disable=too-complex,line-too-long,too-many-locals
 
     context = {
         'variables': variables,
@@ -65,9 +66,11 @@ def build_view_context_for_question(metadata, schema, answer_store, current_loca
     answer_ids = []
     for question in rendered_block.get('questions'):
         if question.get('titles'):
+            group_instance_id = get_group_instance_id(schema, answer_store, current_location)
             context['question_titles'][question['id']] = get_title_from_titles(metadata, schema, answer_store,
                                                                                question['titles'],
-                                                                               current_location.group_instance)
+                                                                               current_location.group_instance,
+                                                                               group_instance_id)
         for answer in question['answers']:
             if current_location.block_id == 'household-composition':
                 for repeated_form in form.household:

--- a/data/en/test_repeating_answer_comparison.json
+++ b/data/en/test_repeating_answer_comparison.json
@@ -1,0 +1,81 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "001",
+    "title": "Test Routing Answer Comparisons",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "description": "A test survey for routing based comparison with answers",
+    "metadata": [{
+        "name": "user_id",
+        "validator": "string"
+    }, {
+        "name": "period_id",
+        "validator": "string"
+    }, {
+        "name": "ru_name",
+        "validator": "string"
+    }],
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "id": "repeating-comparison",
+            "title": "Repeat until comparison",
+            "routing_rules": [{
+                "repeat": {
+                    "type": "until",
+                    "when": [{
+                        "id": "repeating-comparison-1-answer",
+                        "condition": "equals",
+                        "comparison_id": "repeating-comparison-2-answer"
+                    }]
+                }
+            }],
+            "blocks": [{
+                "type": "Question",
+                "id": "repeating-comparison-1-block",
+                "title": "",
+                "description": "",
+                "questions": [{
+                    "description": "",
+                    "id": "repeating-comparison-1-question",
+                    "title": "Enter a number",
+                    "type": "General",
+                    "answers": [{
+                        "id": "repeating-comparison-1-answer",
+                        "description": "",
+                        "label": "A number",
+                        "mandatory": true,
+                        "type": "Number"
+                    }]
+                }]
+            }, {
+                "type": "Question",
+                "id": "repeating-comparison-2-block",
+                "title": "Enter the same number to stop",
+                "description": "",
+                "questions": [{
+                    "description": "",
+                    "id": "repeating-comparison-2-question",
+                    "title": "Enter another number",
+                    "type": "General",
+                    "answers": [{
+                        "id": "repeating-comparison-2-answer",
+                        "description": "",
+                        "label": "Another number",
+                        "mandatory": true,
+                        "type": "Number"
+                    }]
+                }]
+            }]
+        }, {
+            "id": "summary-group",
+            "title": "",
+            "blocks": [{
+                "type": "Summary",
+                "id": "summary"
+            }]
+        }]
+    }]
+}

--- a/data/en/test_repeating_answer_comparison_different_groups.json
+++ b/data/en/test_repeating_answer_comparison_different_groups.json
@@ -1,0 +1,84 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "001",
+    "title": "Test Routing Answer Comparisons",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "description": "A test survey for comparisons between answers",
+    "metadata": [{
+        "name": "user_id",
+        "validator": "string"
+    }, {
+        "name": "period_id",
+        "validator": "string"
+    }, {
+        "name": "ru_name",
+        "validator": "string"
+    }],
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "id": "primary-group",
+            "title": "Normal Question",
+            "blocks": [{
+                "type": "Question",
+                "id": "primary-block",
+                "title": "",
+                "description": "",
+                "questions": [{
+                    "description": "",
+                    "id": "primary-question",
+                    "title": "Enter a number",
+                    "type": "General",
+                    "answers": [{
+                        "id": "primary-answer",
+                        "label": "Number",
+                        "mandatory": true,
+                        "type": "Number"
+                    }]
+                }]
+            }]
+        }, {
+            "id": "repeating-comparison",
+            "title": "Repeat until comparison",
+            "routing_rules": [{
+                "repeat": {
+                    "type": "until",
+                    "when": [{
+                        "id": "repeating-comparison-1-answer",
+                        "condition": "equals",
+                        "comparison_id": "primary-answer"
+                    }]
+                }
+            }],
+            "blocks": [{
+                "type": "Question",
+                "id": "repeating-comparison-1-block",
+                "title": "",
+                "description": "",
+                "questions": [{
+                    "description": "",
+                    "id": "repeating-comparison-1-question",
+                    "title": "Enter a different number to repeat this question",
+                    "type": "General",
+                    "answers": [{
+                        "id": "repeating-comparison-1-answer",
+                        "description": "",
+                        "label": "A number",
+                        "mandatory": true,
+                        "type": "Number"
+                    }]
+                }]
+            }]
+        }, {
+            "id": "summary-group",
+            "title": "",
+            "blocks": [{
+                "type": "Summary",
+                "id": "summary"
+            }]
+        }]
+    }]
+}

--- a/data/en/test_routing_answer_comparison.json
+++ b/data/en/test_routing_answer_comparison.json
@@ -1,0 +1,91 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "001",
+    "title": "Test Routing Answer Comparisons",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "description": "A test survey for routing based comparison with answers",
+    "metadata": [{
+        "name": "user_id",
+        "validator": "string"
+    }, {
+        "name": "period_id",
+        "validator": "string"
+    }, {
+        "name": "ru_name",
+        "validator": "string"
+    }],
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "id": "route-group",
+            "title": "",
+            "blocks": [{
+                "type": "Question",
+                "id": "route-comparison-1",
+                "description": "",
+                "questions": [{
+                    "answers": [{
+                        "id": "route-comparison-1-answer",
+                        "label": "1st Number",
+                        "mandatory": true,
+                        "type": "Number"
+                    }],
+                    "description": "",
+                    "id": "route-comparison-1-question",
+                    "title": "Enter your first number",
+                    "type": "General"
+                }]
+            }, {
+                "type": "Question",
+                "id": "route-comparison-2",
+                "description": "",
+                "questions": [{
+                    "answers": [{
+                        "id": "route-comparison-2-answer",
+                        "label": "2nd Number",
+                        "mandatory": true,
+                        "type": "Number"
+                    }],
+                    "description": "",
+                    "id": "route-comparison-2-question",
+                    "title": "Enter a higher number to skip the next interstitial",
+                    "type": "General"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "block": "route-comparison-4",
+                        "when": [{
+                            "id": "route-comparison-2-answer",
+                            "condition": "greater than",
+                            "comparison_id": "route-comparison-1-answer"
+                        }]
+                    }
+                }, {
+                    "goto": {
+                        "block": "route-comparison-3"
+                    }
+                }]
+            }, {
+                "type": "Interstitial",
+                "id": "route-comparison-3",
+                "title": "Your second number was lower or equal",
+                "description": "This page should be skipped if your second answer was higher than your first"
+            }, {
+                "type": "Interstitial",
+                "id": "route-comparison-4",
+                "title": "Your second number was higher",
+                "description": "This page should never be skipped"
+            }]
+        }, {
+            "id": "summary-group",
+            "title": "",
+            "blocks": [{
+                "type": "Summary",
+                "id": "summary"
+            }]
+        }]
+    }]
+}

--- a/data/en/test_skip_condition_answer_comparison.json
+++ b/data/en/test_skip_condition_answer_comparison.json
@@ -1,0 +1,115 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "001",
+    "title": "Test Routing Answer Comparisons",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "description": "A test survey for routing based comparison with answers",
+    "metadata": [{
+        "name": "user_id",
+        "validator": "string"
+    }, {
+        "name": "period_id",
+        "validator": "string"
+    }, {
+        "name": "ru_name",
+        "validator": "string"
+    }],
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "blocks": [{
+                "type": "Question",
+                "id": "comparison-1",
+                "description": "",
+                "questions": [{
+                    "answers": [{
+                        "id": "comparison-1-answer",
+                        "label": "1st Number",
+                        "mandatory": true,
+                        "type": "Number"
+                    }],
+                    "description": "",
+                    "id": "comparison-1-question",
+                    "title": "Enter your first number",
+                    "type": "General"
+                }]
+            }, {
+                "type": "Question",
+                "id": "comparison-2",
+                "description": "",
+                "questions": [{
+                    "answers": [{
+                        "id": "comparison-2-answer",
+                        "label": "2nd Number",
+                        "mandatory": true,
+                        "type": "Number"
+                    }],
+                    "description": "",
+                    "id": "comparison-2-question",
+                    "title": "Enter your second number",
+                    "type": "General"
+                }]
+            }, {
+                "type": "Interstitial",
+                "id": "equals-answers",
+                "title": "Second equal first",
+                "description": "Your second number was equal to your first number",
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "comparison-1-answer",
+                        "condition": "not equals",
+                        "comparison_id": "comparison-2-answer"
+                    }]
+                }]
+            }, {
+                "type": "Interstitial",
+                "id": "less-than-answers",
+                "title": "First less than second",
+                "description": "Your first answer was less than your second number",
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "comparison-1-answer",
+                        "condition": "greater than",
+                        "comparison_id": "comparison-2-answer"
+                    }]
+                }, {
+                    "when": [{
+                        "id": "comparison-1-answer",
+                        "condition": "equals",
+                        "comparison_id": "comparison-2-answer"
+                    }]
+                }]
+            }, {
+                "type": "Interstitial",
+                "id": "greater-than-answers",
+                "title": "First greater than second",
+                "description": "Your first answer was greater than your second number",
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "comparison-1-answer",
+                        "condition": "less than",
+                        "comparison_id": "comparison-2-answer"
+                    }]
+                }, {
+                    "when": [{
+                        "id": "comparison-1-answer",
+                        "condition": "equals",
+                        "comparison_id": "comparison-2-answer"
+                    }]
+                }]
+            }],
+            "id": "skip-group",
+            "title": ""
+        }, {
+            "id": "summary-group",
+            "title": "",
+            "blocks": [{
+                "type": "Summary",
+                "id": "summary"
+            }]
+        }]
+    }]
+}

--- a/tests/app/data_model/test_answer_store.py
+++ b/tests/app/data_model/test_answer_store.py
@@ -541,7 +541,7 @@ class TestAnswerStore(unittest.TestCase):  # pylint: disable=too-many-public-met
         with patch('app.data_model.answer_store.UPGRADE_TRANSFORMS', UPGRADE_TRANSFORMS):
             answer_store.upgrade(1, schema)
 
-        upgrade_0.assert_not_called(answer_store, schema)
+        upgrade_0.assert_not_called()
         upgrade_1.assert_called_once_with(answer_store, schema)
         upgrade_2.assert_called_once_with(answer_store, schema)
 

--- a/tests/app/forms/test_date_form.py
+++ b/tests/app/forms/test_date_form.py
@@ -212,7 +212,9 @@ class TestDateForm(AppContextTestCase):
 
         self.assertEqual(value, convert_to_datetime('2018-02-10'))
 
-    def test_get_referenced_offset_value_for_answer_id(self):
+    # pylint: disable=unused-argument
+    @patch('app.forms.date_form.load_schema_from_metadata')
+    def test_get_referenced_offset_value_for_answer_id(self, mock1):
         store = AnswerStore()
 
         test_answer_id = Answer(
@@ -243,7 +245,9 @@ class TestDateForm(AppContextTestCase):
 
         self.assertEqual(value, convert_to_datetime('2017-06-11'))
 
-    def test_minimum_and_maximum_offset_dates(self):
+    # pylint: disable=unused-argument
+    @patch('app.forms.date_form.load_schema_from_metadata')
+    def test_minimum_and_maximum_offset_dates(self, mock1):
         test_metadata = {'date': '2018-02-20'}
         store = AnswerStore()
 

--- a/tests/app/forms/test_questionnaire_form.py
+++ b/tests/app/forms/test_questionnaire_form.py
@@ -23,7 +23,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
 
             block_json = schema.get_block('reporting-period')
 
-            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0)
+            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, group_instance_id=None)
 
             for answer in schema.get_answers_for_block('reporting-period'):
                 self.assertTrue(hasattr(form, answer['id']))
@@ -48,7 +48,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'period-from': '2016-03-01',
                 'period-to': '2016-03-31'
             }
-            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, group_instance_id=None, formdata=data)
 
             self.assertEqual(form.data, expected_form_data)
 
@@ -72,7 +72,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'period-from': '2016-12-25',
                 'period-to': '2016-12-25'
             }
-            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, group_instance_id=None, formdata=data)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -99,7 +99,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'period-from': '2016-12-25',
                 'period-to': '2016-12-24'
             }
-            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, group_instance_id=None, formdata=data)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -126,7 +126,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-from': '2016-12-25',
                 'date-range-to': '2017-12-24'
             }
-            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, group_instance_id=None, formdata=data)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -153,7 +153,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-from': '2016-12-25',
                 'date-range-to': '2016-12-26'
             }
-            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, group_instance_id=None, formdata=data)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -180,7 +180,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-from': '2016-12-25',
                 'date-range-to': '2017-01-26'
             }
-            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, group_instance_id=None, formdata=data)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -210,7 +210,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-from': '2017-01-01',
                 'date-range-to': '2017-03-14'
             }
-            form = generate_form(schema, block_json, AnswerStore(), metadata, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, AnswerStore(), metadata, group_instance=0, group_instance_id=None, formdata=data)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -245,7 +245,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-from': '2017-01-01',
                 'date-range-to': '2017-01-10'
             }
-            form = generate_form(schema, block_json, AnswerStore(), metadata, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, AnswerStore(), metadata, group_instance=0, group_instance_id=None, formdata=data)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -277,7 +277,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-from': '2017-01-01',
                 'date-range-to': '2017-02-21'
             }
-            form = generate_form(schema, block_json, AnswerStore(), metadata, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, AnswerStore(), metadata, group_instance=0, group_instance_id=None, formdata=data)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -307,7 +307,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-from': '2016-11',
                 'date-range-to': '2017-06'
             }
-            form = generate_form(schema, block_json, AnswerStore(), metadata, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, AnswerStore(), metadata, group_instance=0, group_instance_id=None, formdata=data)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -340,7 +340,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-from': '2017-01',
                 'date-range-to': '2017-02'
             }
-            form = generate_form(schema, block_json, AnswerStore(), metadata, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, AnswerStore(), metadata, group_instance=0, group_instance_id=None, formdata=data)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -370,7 +370,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-from': '2017-01',
                 'date-range-to': '2017-05'
             }
-            form = generate_form(schema, block_json, AnswerStore(), metadata, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, AnswerStore(), metadata, group_instance=0, group_instance_id=None, formdata=data)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -392,7 +392,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-from': '2015',
                 'date-range-to': '2021'
             }
-            form = generate_form(schema, block_json, AnswerStore(), metadata, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, AnswerStore(), metadata, group_instance=0, group_instance_id=None, formdata=data)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -417,7 +417,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-from': '2016',
                 'date-range-to': '2017'
             }
-            form = generate_form(schema, block_json, AnswerStore(), metadata, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, AnswerStore(), metadata, group_instance=0, group_instance_id=None, formdata=data)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -439,7 +439,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-from': '2016',
                 'date-range-to': '2020'
             }
-            form = generate_form(schema, block_json, AnswerStore(), metadata, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, AnswerStore(), metadata, group_instance=0, group_instance_id=None, formdata=data)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -487,7 +487,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-to-year': '2018'
             }
 
-            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, group_instance_id=None, formdata=data)
 
             with patch('app.questionnaire.questionnaire_schema.QuestionnaireSchema.get_questions_for_block',
                        return_value=[question_json]):
@@ -542,7 +542,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-to-year': '2018'
             }
 
-            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, group_instance_id=None, formdata=data)
 
             with self.assertRaises(Exception) as ite:
                 with patch('app.questionnaire.questionnaire_schema.QuestionnaireSchema.get_questions_for_block',
@@ -598,7 +598,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-to-year': '2018'
             }
 
-            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, group_instance_id=None, formdata=data)
 
             with self.assertRaises(Exception) as ite:
                 with patch('app.questionnaire.questionnaire_schema.QuestionnaireSchema.get_questions_for_block',
@@ -658,7 +658,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-to-year': '2018'
             }
 
-            form = generate_form(schema, block_json, store, metadata=None, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, store, metadata=None, group_instance=0, group_instance_id=None, formdata=data)
 
             with self.assertRaises(Exception) as ite:
                 with patch('app.questionnaire.questionnaire_schema.QuestionnaireSchema.get_questions_for_block',
@@ -713,7 +713,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'breakdown-2': '5',
             }
 
-            form = generate_form(schema, block_json, store, metadata=None, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, store, metadata=None, group_instance=0, group_instance_id=None, formdata=data)
 
             with self.assertRaises(Exception) as ite:
                 with patch('app.questionnaire.questionnaire_schema.QuestionnaireSchema.get_questions_for_block',
@@ -773,7 +773,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'breakdown-2': '5',
             }
 
-            form = generate_form(schema, block_json, store, metadata=None, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, store, metadata=None, group_instance=0, group_instance_id=None, formdata=data)
 
             with patch('app.questionnaire.questionnaire_schema.QuestionnaireSchema.get_questions_for_block',
                        return_value=[question_json]):
@@ -811,7 +811,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'breakdown-3': Decimal('4'),
                 'breakdown-4': None
             }
-            form = generate_form(schema, block_json, store, metadata=None, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, store, metadata=None, group_instance=0, group_instance_id=None, formdata=data)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -849,7 +849,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'breakdown-3': Decimal('4'),
                 'breakdown-4': Decimal('1')
             }
-            form = generate_form(schema, block_json, store, metadata=None, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, store, metadata=None, group_instance=0, group_instance_id=None, formdata=data)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -885,7 +885,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'breakdown-3': None,
                 'breakdown-4': None
             }
-            form = generate_form(schema, block_json, store, metadata=None, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, store, metadata=None, group_instance=0, group_instance_id=None, formdata=data)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -917,7 +917,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             }
 
             # With no answers question validation should pass
-            form = generate_form(schema, block_json, store, metadata=None, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, store, metadata=None, group_instance=0, group_instance_id=None, formdata=data)
             form.validate()
 
             self.assertEqual(len(form.question_errors), 0)
@@ -925,7 +925,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             # With the data equaling the total question validation should pass
             data['breakdown-1'] = '10'
 
-            form = generate_form(schema, block_json, store, metadata=None, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, store, metadata=None, group_instance=0, group_instance_id=None, formdata=data)
             form.validate()
 
             self.assertEqual(len(form.question_errors), 0)
@@ -933,7 +933,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             # With the data not equaling zero or the total, question validation should fail
             data['breakdown-1'] = '1'
 
-            form = generate_form(schema, block_json, store, metadata=None, group_instance=0, formdata=data)
+            form = generate_form(schema, block_json, store, metadata=None, group_instance=0, group_instance_id=None, formdata=data)
             form.validate()
 
             self.assertEqual(form.question_errors['breakdown-question'],
@@ -972,7 +972,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'sure-answer': 'yes'
             }
             with patch('app.questionnaire.path_finder.evaluate_goto', return_value=False):
-                form = generate_form(schema, block_json, store, metadata={}, group_instance=0, formdata=data)
+                form = generate_form(schema, block_json, store, metadata={}, group_instance=0, group_instance_id=None, formdata=data)
 
             form.validate()
             self.assertEqual(form.data, expected_form_data)
@@ -983,7 +983,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
 
             block_json = schema.get_block('total-retail-turnover')
 
-            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0)
+            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, group_instance_id=None)
 
             form.validate()
             mapped_errors = form.map_errors()
@@ -998,7 +998,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
 
             block_json = schema.get_block('reporting-period')
 
-            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0)
+            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, group_instance_id=None)
 
             form.validate()
             mapped_errors = form.map_errors()
@@ -1012,7 +1012,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
 
             block_json = schema.get_block('radio-mandatory')
 
-            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, formdata={
+            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, group_instance_id=None, formdata={
                 'radio-mandatory-answer': 'Other'
             })
 
@@ -1026,7 +1026,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
 
             block_json = schema.get_block('radio-mandatory')
 
-            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, formdata={
+            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, group_instance_id=None, formdata={
                 'radio-mandatory-answer': 'Other'
             })
 
@@ -1044,7 +1044,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
 
             block_json = schema.get_block('number-of-employees')
 
-            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, formdata={
+            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, group_instance_id=None, formdata={
                 'total-number-employees': '-1'
             })
 
@@ -1058,7 +1058,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             schema = load_schema_from_params('test', 'checkbox')
             block_json = schema.get_block('mandatory-checkbox')
 
-            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, formdata={})
+            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, group_instance_id=None, formdata={})
 
             self.assertFalse(form.option_has_other('mandatory-checkbox-answer', 1))
             self.assertTrue(form.option_has_other('mandatory-checkbox-answer', 6))
@@ -1067,7 +1067,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             schema = load_schema_from_params('test', 'checkbox_mutually_exclusive')
             block_json = schema.get_block('mandatory-checkbox')
 
-            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, formdata={})
+            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, group_instance_id=None, formdata={})
 
             self.assertFalse(form.option_has_other('mandatory-checkbox-answer', 1))
             self.assertTrue(form.option_has_other('mandatory-checkbox-answer', 5))
@@ -1078,7 +1078,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             schema = load_schema_from_params('test', 'checkbox')
             block_json = schema.get_block('mandatory-checkbox')
 
-            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, formdata={
+            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, group_instance_id=None, formdata={
                 'other-answer-mandatory': 'Some data'
             })
 
@@ -1090,7 +1090,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             schema = load_schema_from_params('test', 'checkbox_mutually_exclusive')
             block_json = schema.get_block('mandatory-checkbox')
 
-            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, formdata={
+            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, group_instance_id=None, formdata={
                 'other-answer-mandatory': 'Some data'
             })
 
@@ -1104,7 +1104,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             schema = load_schema_from_params('test', 'checkbox')
             block_json = schema.get_block('mandatory-checkbox')
 
-            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, formdata={
+            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, group_instance_id=None, formdata={
                 'other-answer-mandatory': 'Some data'
             })
 
@@ -1116,7 +1116,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             schema = load_schema_from_params('test', 'checkbox_mutually_exclusive')
             block_json = schema.get_block('mandatory-checkbox')
 
-            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, formdata={
+            form = generate_form(schema, block_json, AnswerStore(), metadata=None, group_instance=0, group_instance_id=None, formdata={
                 'other-answer-mandatory': 'Some data'
             })
 

--- a/tests/app/questionnaire/test_path_finder.py
+++ b/tests/app/questionnaire/test_path_finder.py
@@ -638,14 +638,14 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
 
         answer_2 = Answer(
             group_instance=0,
-            group_instance_id='group-0',
+            group_instance_id=None,
             answer_id='conditional-answer',
             value='Age and Shoe Size'
         )
 
         answer_3 = Answer(
             group_instance=1,
-            group_instance_id='group-1',
+            group_instance_id=None,
             answer_id='conditional-answer',
             value='Shoe Size Only'
         )
@@ -869,7 +869,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         for i in range(50):
             answers.add(Answer(
                 group_instance=i,
-                group_instance_id='group-1-{}'.format(i),
+                group_instance_id=None,
                 answer_id='conditional-answer',
                 value='Shoe Size Only'
             ))

--- a/tests/functional/pages/features/answer_comparison/repeating_groups/repeating-comparison-1-block.page.js
+++ b/tests/functional/pages/features/answer_comparison/repeating_groups/repeating-comparison-1-block.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class RepeatingComparison1BlockPage extends QuestionPage {
+
+  constructor() {
+    super('repeating-comparison-1-block');
+  }
+
+  answer() {
+    return '#repeating-comparison-1-answer';
+  }
+
+  answerLabel() { return '#label-repeating-comparison-1-answer'; }
+
+}
+module.exports = new RepeatingComparison1BlockPage();

--- a/tests/functional/pages/features/answer_comparison/repeating_groups/repeating-comparison-2-block.page.js
+++ b/tests/functional/pages/features/answer_comparison/repeating_groups/repeating-comparison-2-block.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class RepeatingComparison2BlockPage extends QuestionPage {
+
+  constructor() {
+    super('repeating-comparison-2-block');
+  }
+
+  answer() {
+    return '#repeating-comparison-2-answer';
+  }
+
+  answerLabel() { return '#label-repeating-comparison-2-answer'; }
+
+}
+module.exports = new RepeatingComparison2BlockPage();

--- a/tests/functional/pages/features/answer_comparison/repeating_groups/summary.page.js
+++ b/tests/functional/pages/features/answer_comparison/repeating_groups/summary.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  repeatingComparison1Answer() { return '#repeating-comparison-1-answer-answer'; }
+
+  repeatingComparison1AnswerEdit() { return '[data-qa="repeating-comparison-1-answer-edit"]'; }
+
+  repeatingComparison2Answer() { return '#repeating-comparison-2-answer-answer'; }
+
+  repeatingComparison2AnswerEdit() { return '[data-qa="repeating-comparison-2-answer-edit"]'; }
+
+  repeatingComparisonTitle() { return '#repeating-comparison'; }
+
+  summaryGroupTitle() { return '#summary-group'; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/pages/features/answer_comparison/routing/route-comparison-1.page.js
+++ b/tests/functional/pages/features/answer_comparison/routing/route-comparison-1.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class RouteComparison1Page extends QuestionPage {
+
+  constructor() {
+    super('route-comparison-1');
+  }
+
+  answer() {
+    return '#route-comparison-1-answer';
+  }
+
+  answerLabel() { return '#label-route-comparison-1-answer'; }
+
+}
+module.exports = new RouteComparison1Page();

--- a/tests/functional/pages/features/answer_comparison/routing/route-comparison-2.page.js
+++ b/tests/functional/pages/features/answer_comparison/routing/route-comparison-2.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class RouteComparison2Page extends QuestionPage {
+
+  constructor() {
+    super('route-comparison-2');
+  }
+
+  answer() {
+    return '#route-comparison-2-answer';
+  }
+
+  answerLabel() { return '#label-route-comparison-2-answer'; }
+
+}
+module.exports = new RouteComparison2Page();

--- a/tests/functional/pages/features/answer_comparison/routing/route-comparison-3.page.js
+++ b/tests/functional/pages/features/answer_comparison/routing/route-comparison-3.page.js
@@ -1,0 +1,11 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class RouteComparison3Page extends QuestionPage {
+
+  constructor() {
+    super('route-comparison-3');
+  }
+
+}
+module.exports = new RouteComparison3Page();

--- a/tests/functional/pages/features/answer_comparison/routing/route-comparison-4.page.js
+++ b/tests/functional/pages/features/answer_comparison/routing/route-comparison-4.page.js
@@ -1,0 +1,11 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class RouteComparison4Page extends QuestionPage {
+
+  constructor() {
+    super('route-comparison-4');
+  }
+
+}
+module.exports = new RouteComparison4Page();

--- a/tests/functional/pages/features/answer_comparison/routing/summary.page.js
+++ b/tests/functional/pages/features/answer_comparison/routing/summary.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  routeComparison1Answer() { return '#route-comparison-1-answer-answer'; }
+
+  routeComparison1AnswerEdit() { return '[data-qa="route-comparison-1-answer-edit"]'; }
+
+  routeComparison2Answer() { return '#route-comparison-2-answer-answer'; }
+
+  routeComparison2AnswerEdit() { return '[data-qa="route-comparison-2-answer-edit"]'; }
+
+  routeGroupTitle() { return '#route-group'; }
+
+  summaryGroupTitle() { return '#summary-group'; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/pages/features/answer_comparison/skip_conditions/comparison-1.page.js
+++ b/tests/functional/pages/features/answer_comparison/skip_conditions/comparison-1.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class Comparison1Page extends QuestionPage {
+
+  constructor() {
+    super('comparison-1');
+  }
+
+  answer() {
+    return '#comparison-1-answer';
+  }
+
+  answerLabel() { return '#label-comparison-1-answer'; }
+
+}
+module.exports = new Comparison1Page();

--- a/tests/functional/pages/features/answer_comparison/skip_conditions/comparison-2.page.js
+++ b/tests/functional/pages/features/answer_comparison/skip_conditions/comparison-2.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class Comparison2Page extends QuestionPage {
+
+  constructor() {
+    super('comparison-2');
+  }
+
+  answer() {
+    return '#comparison-2-answer';
+  }
+
+  answerLabel() { return '#label-comparison-2-answer'; }
+
+}
+module.exports = new Comparison2Page();

--- a/tests/functional/pages/features/answer_comparison/skip_conditions/equals-answers.page.js
+++ b/tests/functional/pages/features/answer_comparison/skip_conditions/equals-answers.page.js
@@ -1,0 +1,11 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class EqualsAnswersPage extends QuestionPage {
+
+  constructor() {
+    super('equals-answers');
+  }
+
+}
+module.exports = new EqualsAnswersPage();

--- a/tests/functional/pages/features/answer_comparison/skip_conditions/greater-than-answers.page.js
+++ b/tests/functional/pages/features/answer_comparison/skip_conditions/greater-than-answers.page.js
@@ -1,0 +1,11 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class GreaterThanAnswersPage extends QuestionPage {
+
+  constructor() {
+    super('greater-than-answers');
+  }
+
+}
+module.exports = new GreaterThanAnswersPage();

--- a/tests/functional/pages/features/answer_comparison/skip_conditions/less-than-answers.page.js
+++ b/tests/functional/pages/features/answer_comparison/skip_conditions/less-than-answers.page.js
@@ -1,0 +1,11 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class LessThanAnswersPage extends QuestionPage {
+
+  constructor() {
+    super('less-than-answers');
+  }
+
+}
+module.exports = new LessThanAnswersPage();

--- a/tests/functional/pages/features/answer_comparison/skip_conditions/summary.page.js
+++ b/tests/functional/pages/features/answer_comparison/skip_conditions/summary.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  comparison1Answer() { return '#comparison-1-answer-answer'; }
+
+  comparison1AnswerEdit() { return '[data-qa="comparison-1-answer-edit"]'; }
+
+  comparison2Answer() { return '#comparison-2-answer-answer'; }
+
+  comparison2AnswerEdit() { return '[data-qa="comparison-2-answer-edit"]'; }
+
+  skipGroupTitle() { return '#skip-group'; }
+
+  summaryGroupTitle() { return '#summary-group'; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/pages/surveys/question.page.js
+++ b/tests/functional/pages/surveys/question.page.js
@@ -28,6 +28,8 @@ class QuestionPage extends BasePage {
 
   saveSignOut() { return '[data-qa="btn-save-sign-out"]'; }
 
+  interstitialHeader() { return '#main > form > h1';}
+
   switchLanguage(language_code) { return '[data-qa="switch-language-' + language_code + '"]'; }
 
 }

--- a/tests/functional/spec/features/repeating/answer_comparison_repeating_groups.spec.js
+++ b/tests/functional/spec/features/repeating/answer_comparison_repeating_groups.spec.js
@@ -1,0 +1,31 @@
+const helpers = require('../../../helpers');
+
+const RepeatingComparison1BlockPage = require('../../../pages/features/answer_comparison/repeating_groups/repeating-comparison-1-block.page.js');
+const RepeatingComparison2BlockPage = require('../../../pages/features/answer_comparison/repeating_groups/repeating-comparison-2-block.page.js');
+const SummaryPage = require('../../../pages/features/answer_comparison/repeating_groups/summary.page.js');
+
+describe('Test repeating with answer comparisons', function() {
+
+  beforeEach(function() {
+    return helpers.openQuestionnaire('test_repeating_answer_comparison.json');
+  });
+
+  it('Given we open the repeating comparison test When we enter different numbers, Then the question should repeat', function() {
+    return browser
+      .setValue(RepeatingComparison1BlockPage.answer(), 5)
+      .click(RepeatingComparison1BlockPage.submit())
+      .setValue(RepeatingComparison2BlockPage.answer(), 6)
+      .click(RepeatingComparison2BlockPage.submit())
+      .getText(RepeatingComparison2BlockPage.questionText()).should.eventually.contain('Enter a number');
+  });
+
+  it('Given we open the repeating comparison test When we enter the same numbers, Then the question should not repeat', function() {
+    return browser
+      .setValue(RepeatingComparison1BlockPage.answer(), 5)
+      .click(RepeatingComparison1BlockPage.submit())
+      .setValue(RepeatingComparison2BlockPage.answer(), 5)
+      .click(RepeatingComparison2BlockPage.submit())
+      .getText(SummaryPage.summaryQuestionText()).should.eventually.contain('Enter a number');
+  });
+});
+

--- a/tests/functional/spec/features/routing/answer_comparison_routing.spec.js
+++ b/tests/functional/spec/features/routing/answer_comparison_routing.spec.js
@@ -1,0 +1,41 @@
+const helpers = require('../../../helpers');
+
+const RouteComparison1Page = require('../../../pages/features/answer_comparison/routing/route-comparison-1.page.js');
+const RouteComparison2Page = require('../../../pages/features/answer_comparison/routing/route-comparison-2.page.js');
+const RouteComparison3Page = require('../../../pages/features/answer_comparison/routing/route-comparison-3.page.js');
+const RouteComparison4Page = require('../../../pages/features/answer_comparison/routing/route-comparison-4.page.js');
+
+describe('Test routing skip', function() {
+
+  beforeEach(function() {
+    return helpers.openQuestionnaire('test_routing_answer_comparison.json');
+  });
+
+  it('Given we start the routing test survey, When we enter a low number then a high number, Then, we should be routed to the fourth page', function() {
+    return browser
+      .setValue(RouteComparison1Page.answer(), 1)
+      .click(RouteComparison1Page.submit())
+      .setValue(RouteComparison2Page.answer(), 2)
+      .click(RouteComparison2Page.submit())
+      .getText(RouteComparison4Page.interstitialHeader()).should.eventually.contain('Your second number was higher');
+    });
+
+  it('Given we start the routing test survey, When we enter a high number then a low number, Then, we should be routed to the third page', function() {
+    return browser
+      .setValue(RouteComparison1Page.answer(), 1)
+      .click(RouteComparison1Page.submit())
+      .setValue(RouteComparison2Page.answer(), 0)
+      .click(RouteComparison2Page.submit())
+      .getText(RouteComparison3Page.interstitialHeader()).should.eventually.contain('Your second number was lower or equal');
+    });
+
+  it('Given we start the routing test survey, When we enter an equal number on both questions, Then, we should be routed to the third page', function() {
+    return browser
+      .setValue(RouteComparison1Page.answer(), 1)
+      .click(RouteComparison1Page.submit())
+      .setValue(RouteComparison2Page.answer(), 1)
+      .click(RouteComparison2Page.submit())
+      .getText(RouteComparison3Page.interstitialHeader()).should.eventually.contain('Your second number was lower or equal');
+    });
+});
+

--- a/tests/functional/spec/features/skipping/answer_comparison_skip_conditions.spec.js
+++ b/tests/functional/spec/features/skipping/answer_comparison_skip_conditions.spec.js
@@ -1,0 +1,40 @@
+const helpers = require('../../../helpers');
+
+const Comparison1Page = require('../../../pages/features/answer_comparison/skip_conditions/comparison-1.page.js');
+const Comparison2Page = require('../../../pages/features/answer_comparison/skip_conditions/comparison-2.page.js');
+const EqualsAnswersPage = require('../../../pages/features/answer_comparison/skip_conditions/equals-answers.page.js');
+const LessThanAnswersPage = require('../../../pages/features/answer_comparison/skip_conditions/less-than-answers.page.js');
+const GreaterThanAnswersPage = require('../../../pages/features/answer_comparison/skip_conditions/greater-than-answers.page.js');
+
+describe('Test skip condition answer comparisons', function() {
+
+  beforeEach(function() {
+    return helpers.openQuestionnaire('test_skip_condition_answer_comparison.json');
+  });
+
+  it('Given we start the skip condition survey, when we enter the same answers, then the interstitial should show that the answers are the same', function() {
+    return browser
+      .setValue(Comparison1Page.answer(), 1)
+      .click(Comparison1Page.submit())
+      .setValue(Comparison2Page.answer(), 1)
+      .click(Comparison2Page.submit())
+      .getText(EqualsAnswersPage.interstitialHeader()).should.eventually.contain('Second equal first');
+    });
+  it('Given we start the skip condition survey, when we enter a high number then a low number, then the interstitial should show that the answers are low then high', function() {
+    return browser
+      .setValue(Comparison1Page.answer(), 3)
+      .click(Comparison1Page.submit())
+      .setValue(Comparison2Page.answer(), 2)
+      .click(Comparison2Page.submit())
+      .getText(LessThanAnswersPage.interstitialHeader()).should.eventually.contain('First greater than second');
+    });
+  it('Given we start the skip condition survey, when we enter a low number then a high number, then the interstitial should show that the answers are high then low', function() {
+    return browser
+      .setValue(Comparison1Page.answer(), 1)
+      .click(Comparison1Page.submit())
+      .setValue(Comparison2Page.answer(), 2)
+      .click(Comparison2Page.submit())
+      .getText(GreaterThanAnswersPage.interstitialHeader()).should.eventually.contain('First less than second');
+    });
+});
+

--- a/tests/integration/routing/test_answer_comparison.py
+++ b/tests/integration/routing/test_answer_comparison.py
@@ -1,0 +1,170 @@
+from tests.integration.integration_test_case import IntegrationTestCase
+
+class TestAnswerComparisonsSkips(IntegrationTestCase):
+    """
+    Test that skip conditions work correctly when answer comparisons are
+    used in the `when` clause.
+    """
+
+    def test_skip_condition_answer_comparison(self):
+        self.launchSurvey('test',
+                          'skip_condition_answer_comparison',
+                          )
+
+        self.post(action='start_questionnaire')
+
+        # We are in the Questionnaire
+        self.assertInPage('Enter your first number')
+
+        self.post({
+            'comparison-1-answer': 2
+        })
+
+        self.assertInPage('Enter your second number')
+
+        second_page = self.last_url
+
+        self.post({
+            'comparison-2-answer': 3
+        })
+
+        self.assertInPage('First less than second')
+
+        # Go back to the second question and change the answer
+        self.post({
+            'comparison-2-answer': 2
+        }, url=second_page)
+
+        self.assertInPage('Second equal first')
+
+        # Go back to the second question and change the answer
+        self.post({
+            'comparison-2-answer': 1
+        }, url=second_page)
+
+        self.assertInPage('First greater than second')
+
+class TestAnswerComparisonsRoutes(IntegrationTestCase):
+    """
+    Test routing when answer comparisons are used in the `when` clause.
+    """
+
+    def test_routes_over_interstitial(self):
+        self.launchSurvey('test', 'routing_answer_comparison')
+
+        self.post(action='start_questionnaire')
+
+        # We are in the Questionnaire
+        self.assertInPage('Enter your first number')
+
+        self.post({
+            'route-comparison-1-answer': 2
+        })
+
+        self.assertInPage('Enter a higher number to skip')
+
+        second_page = self.last_url
+
+        # Enter a higher number
+        self.post({
+            'route-comparison-2-answer': 3
+        })
+
+        self.assertInPage('Your second number was higher')
+
+        # Go back to the second question and change the answer to a lower one
+        self.post({
+            'route-comparison-2-answer': 1
+        }, url=second_page)
+
+        self.assertInPage('Your second number was lower or equal')
+
+
+class TestAnswerComparisonsRepeating(IntegrationTestCase):
+    """
+    Test the repeat until clause using an answer comparison in the when
+    clause.
+    """
+
+    def test_repeat_until_comparison(self):
+        self.launchSurvey('test', 'repeating_answer_comparison')
+
+        self.post(action='start_questionnaire')
+
+        # We are in the Questionnaire
+        self.assertInPage('Enter a number')
+
+        self.post({
+            'repeating-comparison-1-answer': 2
+        })
+
+        self.assertInPage('Enter the same number to stop')
+
+        # Enter a different number, the question should repeat
+        self.post({
+            'repeating-comparison-2-answer': 3
+        })
+
+        self.assertInPage('Enter a number')
+
+        # The question should have repeated
+        self.post({
+            'repeating-comparison-1-answer': 1
+        })
+
+        self.assertInPage('Enter the same number to stop')
+
+        # Enter the same number, the summary should appear
+        self.post({
+            'repeating-comparison-2-answer': 1
+        })
+
+        self.assertInPage('Check your answers and submit')
+
+
+class TestRepeatingAnswerComparisonToNormalAnswer(IntegrationTestCase):
+    """
+    Test that comparing a repeating group answer to a normal answer works
+    """
+
+    def test_repeating_answer_comparison_to_normal_answer(self):
+        self.launchSurvey('test', 'repeating_answer_comparison_different_groups')
+
+        self.post(action='start_questionnaire')
+
+        # We are in the Questionnaire
+        self.assertInPage('Enter a number')
+
+        self.post({
+            'primary-answer': 10
+        })
+
+        self.assertInPage('Enter a different number to repeat this question')
+
+        # Enter a different number, the question should repeat
+        self.post({
+            'repeating-comparison-1-answer': 3
+        })
+
+        self.assertInPage('Enter a different number to repeat this question')
+
+        # The question should have repeated
+        self.post({
+            'repeating-comparison-1-answer': 1
+        })
+
+        self.assertInPage('Enter a different number to repeat this question')
+
+        # The question should have repeated
+        self.post({
+            'repeating-comparison-1-answer': 7
+        })
+
+        self.assertInPage('Enter a different number to repeat this question')
+
+        # Enter the same number, the summary should appear
+        self.post({
+            'repeating-comparison-1-answer': 10
+        })
+
+        self.assertInPage('Check your answers and submit')


### PR DESCRIPTION
### What is the context of this PR?
[Trello](https://trello.com/c/Lzc6bQVK/2323-route-based-comparing-one-answer-to-another-s-m)

[Validator PR](https://github.com/ONSdigital/eq-schema-validator/pull/83)

We need to be able to compare numeric answers against other numeric answers when doing routing. 
This PR adds a generic way of doing this that should work in all `when` clauses except titles.

It adds a `comparison_id` to the `when` clause. This is used to refer to an answer_id, for which the answer value is used in the comparison. Since this is in the when clause, it means comparisons can also be used for skip conditions, and repeating groups.

I've disallowed the use of `comparison_id` in titles (since there's no user need and it could cause issues with dependencies).

I've removed a couple of skip conditions which aren't needed in `1_0005.json` which refer to invalid answer ids. They were breaking the new validation.
### How to review 
There are test schemas for these when clauses when used for routing, skipping, and repeats.

Check `test_repeating_answer_comparison.json`, `test_routing_answer_comparison.json` and `test_skip_condition_answer_comparison.json`

#### test_repeating_answer_comparison.json
This test should repeat until the questions match

#### test_routing_answer_comparison.json
This test should route around an interstitial depending on the two answers.

#### test_skip_condition_answer_comparison.json
This test should skip interstitials depending on the two answers

### Check this code in particular
- `evaluate_repeat()` in `rules.py`
- The removed skip conditions in `1_00005.json`
### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
