### PR TITLE
Wrap Currency values in span to ensure negative values wrap properly

### DIFF
--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -25,8 +25,14 @@ def format_number(value):
     return ''
 
 
-@blueprint.app_template_filter()
-def format_currency(value, currency='GBP'):
+@evalcontextfunction
+def format_currency(context, value, currency='GBP'):
+    currency_value = get_formatted_currency(value, currency)
+    result = "<span class='date'>{currency_value}</span>".format(currency_value=currency_value)
+    return mark_safe(context, result)
+
+
+def get_formatted_currency(value, currency='GBP'):
     if value or value == 0:
         return numbers.format_currency(number=value, currency=currency, locale=DEFAULT_LOCALE)
 
@@ -44,7 +50,7 @@ def format_currency_for_input(value, decimal_places=0):
         return ''
     if decimal_places is None or decimal_places == 0:
         return format_number(value)
-    return format_currency(value).replace(get_currency_symbol(), '')
+    return get_formatted_currency(value).replace(get_currency_symbol(), '')
 
 
 @blueprint.app_template_filter()

--- a/app/templating/template_renderer.py
+++ b/app/templating/template_renderer.py
@@ -17,7 +17,7 @@ class TemplateRenderer:
         env.filters['format_household_summary'] = filters.format_household_summary
         env.filters['format_unordered_list'] = filters.format_unordered_list
         env.globals['format_conditional_date'] = filters.format_conditional_date
-        env.filters['format_currency'] = filters.format_currency
+        env.globals['format_currency'] = filters.format_currency
         env.filters['format_number'] = filters.format_number
         env.filters['get_currency_symbol'] = filters.get_currency_symbol
         env.globals['format_date_range'] = filters.format_date_range

--- a/app/templating/view_context.py
+++ b/app/templating/view_context.py
@@ -1,5 +1,5 @@
 from flask_wtf import FlaskForm
-from app.jinja_filters import format_currency, format_number, format_unit, format_percentage
+from app.jinja_filters import get_formatted_currency, format_number, format_unit, format_percentage
 from app.helpers.form_helper import get_form_for_location
 from app.templating.summary_context import build_summary_rendering_context
 from app.templating.template_renderer import renderer
@@ -218,7 +218,7 @@ def _get_formatted_total(groups):
                     calculated_total += answer_value
 
     if answer_format['type'] == 'currency':
-        return format_currency(calculated_total, answer_format['currency'])
+        return get_formatted_currency(calculated_total, answer_format['currency'])
 
     if answer_format['type'] == 'unit':
         return format_unit(answer_format['unit'], calculated_total)

--- a/app/validation/validators.py
+++ b/app/validation/validators.py
@@ -11,7 +11,7 @@ from wtforms import validators
 from wtforms.compat import string_types
 from structlog import get_logger
 
-from app.jinja_filters import format_number, format_currency
+from app.jinja_filters import format_number, get_formatted_currency
 from app.settings import DEFAULT_LOCALE
 from app.validation.error_messages import error_messages
 from app.questionnaire.rules import convert_to_datetime
@@ -345,7 +345,7 @@ class SumCheck:
 
 def format_playback_value(value, currency=None):
     if currency:
-        return format_currency(value, currency)
+        return get_formatted_currency(value, currency)
     return format_number(value)
 
 

--- a/data/en/1_0005.json
+++ b/data/en/1_0005.json
@@ -376,7 +376,7 @@
                         }
                     }],
                     "id": "weekly-pay-breakdown-question",
-                    "title": "Of the <em>{{answers['weekly-pay-gross-pay-answer']|format_currency}}</em> paid to <em>weekly</em> paid employees in the last week of {{metadata['period_str']}}, what other amounts were paid? ",
+                    "title": "Of the <em>{{format_currency(answers['weekly-pay-gross-pay-answer'])}}</em> paid to <em>weekly</em> paid employees in the last week of {{metadata['period_str']}}, what other amounts were paid? ",
                     "type": "Calculated",
                     "calculations": [{
                         "calculation_type": "sum",
@@ -759,7 +759,7 @@
                         "answers_to_calculate": ["fortnightly-pay-breakdown-holiday-answer", "fortnightly-pay-breakdown-arrears-answer", "fortnightly-pay-breakdown-prp-answer"],
                         "conditions": ["less than", "equals"]
                     }],
-                    "title": "Of the <em>{{answers['fortnightly-pay-gross-pay-answer']|format_currency}}</em> paid to <em>fortnightly</em> paid employees in the last week of {{metadata['period_str']}}, what other amounts were paid?",
+                    "title": "Of the <em>{{format_currency(answers['fortnightly-pay-gross-pay-answer'])}}</em> paid to <em>fortnightly</em> paid employees in the last week of {{metadata['period_str']}}, what other amounts were paid?",
                     "guidance": {
                         "content": [{
                             "title": "Include:",
@@ -1124,7 +1124,7 @@
                         "answers_to_calculate": ["calendar-monthly-pay-breakdown-arrears-answer", "calendar-monthly-pay-breakdown-prp-answer"],
                         "conditions": ["less than"]
                     }],
-                    "title": "Of the <em>{{answers['calendar-monthly-pay-gross-pay-answer']|format_currency}}</em> paid to <em>calendar monthly</em> paid employees in {{metadata['period_str']}}, what other amounts were paid?",
+                    "title": "Of the <em>{{format_currency(answers['calendar-monthly-pay-gross-pay-answer'])}}</em> paid to <em>calendar monthly</em> paid employees in {{metadata['period_str']}}, what other amounts were paid?",
                     "guidance": {
                         "content": [{
                             "title": "Include:",
@@ -1489,7 +1489,7 @@
                         "answers_to_calculate": ["four-weekly-pay-breakdown-arrears-answer", "four-weekly-pay-breakdown-prp-answer"],
                         "conditions": ["less than"]
                     }],
-                    "title": "Of the <em>{{answers['four-weekly-pay-gross-pay-answer']|format_currency}}</em> paid to <em>four weekly</em> paid employees in {{metadata['period_str']}}, what other amounts were paid?",
+                    "title": "Of the <em>{{format_currency(answers['four-weekly-pay-gross-pay-answer'])}}</em> paid to <em>four weekly</em> paid employees in {{metadata['period_str']}}, what other amounts were paid?",
                     "guidance": {
                         "content": [{
                             "title": "Include:",
@@ -1854,7 +1854,7 @@
                         }
                     }],
                     "id": "five-weekly-pay-breakdown-question",
-                    "title": "Of the <em>{{answers['five-weekly-pay-gross-pay-answer']|format_currency}}</em> paid to <em>five weekly paid employees</em> in {{metadata['period_str']}}, what other amounts were paid?",
+                    "title": "Of the <em>{{format_currency(answers['five-weekly-pay-gross-pay-answer'])}}</em> paid to <em>five weekly paid employees</em> in {{metadata['period_str']}}, what other amounts were paid?",
                     "type": "Calculated",
                     "calculations": [{
                         "calculation_type": "sum",

--- a/data/en/1_0102.json
+++ b/data/en/1_0102.json
@@ -252,7 +252,7 @@
                         }
                     }],
                     "id": "internet-sales-question",
-                    "title": "Of the <em>{{answers['total-retail-turnover-answer']|format_currency}}</em> total retail turnover, what was the value of <em>internet</em> sales?",
+                    "title": "Of the <em>{{format_currency(answers['total-retail-turnover-answer'])}}</em> total retail turnover, what was the value of <em>internet</em> sales?",
                     "type": "General"
                 }],
                 "title": "Retail turnover"

--- a/data/en/1_0112.json
+++ b/data/en/1_0112.json
@@ -273,7 +273,7 @@
                         }
                     }],
                     "id": "internet-sales-question",
-                    "title": "Of the <em>{{answers['total-retail-turnover-answer']|format_currency}}</em> total retail turnover, what was the value of <em>internet</em> sales?",
+                    "title": "Of the <em>{{format_currency(answers['total-retail-turnover-answer'])}}</em> total retail turnover, what was the value of <em>internet</em> sales?",
                     "type": "General"
                 }],
                 "title": "Retail turnover"

--- a/data/en/1_0203.json
+++ b/data/en/1_0203.json
@@ -292,7 +292,7 @@
                     }],
                     "description": "",
                     "id": "total-sales-food-question",
-                    "title": "Of the <em>{{answers['total-retail-turnover']|format_currency}}</em> total retail turnover, what was the value of <em>food</em> sales?",
+                    "title": "Of the <em>{{format_currency(answers['total-retail-turnover'])}}</em> total retail turnover, what was the value of <em>food</em> sales?",
                     "type": "General"
                 }],
                 "title": "Retail turnover"
@@ -320,7 +320,7 @@
                     }],
                     "description": "",
                     "id": "total-sales-alcohol-question",
-                    "title": "Of the <em>{{answers['total-retail-turnover']|format_currency}}</em> total retail turnover, what was the value of <em>alcohol, confectionery and tobacco</em> sales?",
+                    "title": "Of the <em>{{format_currency(answers['total-retail-turnover'])}}</em> total retail turnover, what was the value of <em>alcohol, confectionery and tobacco</em> sales?",
                     "type": "General"
                 }],
                 "title": "Retail turnover"
@@ -348,7 +348,7 @@
                     }],
                     "description": "",
                     "id": "total-sales-clothing-question",
-                    "title": "Of the <em>{{answers['total-retail-turnover']|format_currency}}</em> total retail turnover, what was the value of <em>clothing and footwear</em> sales?",
+                    "title": "Of the <em>{{format_currency(answers['total-retail-turnover'])}}</em> total retail turnover, what was the value of <em>clothing and footwear</em> sales?",
                     "type": "General"
                 }],
                 "title": "Retail turnover"
@@ -377,7 +377,7 @@
                         }
                     }],
                     "id": "total-sales-household-goods-question",
-                    "title": "Of the <em>{{answers['total-retail-turnover']|format_currency}}</em> total retail turnover, what was the value of sales for <em>household goods</em>?",
+                    "title": "Of the <em>{{format_currency(answers['total-retail-turnover'])}}</em> total retail turnover, what was the value of sales for <em>household goods</em>?",
                     "type": "General"
                 }],
                 "title": "Retail turnover"
@@ -410,7 +410,7 @@
                     }],
                     "description": "",
                     "id": "total-sales-other-goods-question",
-                    "title": "Of the <em>{{answers['total-retail-turnover']|format_currency}}</em> total retail turnover, what was the value of <em>other</em> sales?",
+                    "title": "Of the <em>{{format_currency(answers['total-retail-turnover'])}}</em> total retail turnover, what was the value of <em>other</em> sales?",
                     "type": "General"
                 }],
                 "title": "Retail turnover"
@@ -438,7 +438,7 @@
                     }],
                     "description": "",
                     "id": "internet-sales-question",
-                    "title": "Of the <em>{{answers['total-retail-turnover']|format_currency}}</em> total retail turnover, what was the value of <em>internet</em> sales?",
+                    "title": "Of the <em>{{format_currency(answers['total-retail-turnover'])}}</em> total retail turnover, what was the value of <em>internet</em> sales?",
                     "type": "General"
                 }],
                 "title": "Retail turnover"

--- a/data/en/1_0205.json
+++ b/data/en/1_0205.json
@@ -300,7 +300,7 @@
                         }
                     }],
                     "id": "total-sales-food-question",
-                    "title": "Of the <em>{{answers['total-retail-turnover']|format_currency}}</em> total retail turnover, what was the value of <em>food</em> sales?",
+                    "title": "Of the <em>{{format_currency(answers['total-retail-turnover'])}}</em> total retail turnover, what was the value of <em>food</em> sales?",
                     "type": "General"
                 }],
                 "title": "Retail turnover"
@@ -328,7 +328,7 @@
                     }],
                     "description": "",
                     "id": "total-sales-alcohol-question",
-                    "title": "Of the <em>{{answers['total-retail-turnover']|format_currency}}</em> total retail turnover, what was the value of <em>alcohol, confectionery and tobacco</em> sales?",
+                    "title": "Of the <em>{{format_currency(answers['total-retail-turnover'])}}</em> total retail turnover, what was the value of <em>alcohol, confectionery and tobacco</em> sales?",
                     "type": "General"
                 }],
                 "title": "Retail turnover"
@@ -355,7 +355,7 @@
                         }
                     }],
                     "id": "total-sales-clothing-question",
-                    "title": "Of the <em>{{answers['total-retail-turnover']|format_currency}}</em> total retail turnover, what was the value of <em>clothing and footwear</em> sales?",
+                    "title": "Of the <em>{{format_currency(answers['total-retail-turnover'])}}</em> total retail turnover, what was the value of <em>clothing and footwear</em> sales?",
                     "type": "General"
                 }],
                 "title": "Retail turnover"
@@ -384,7 +384,7 @@
                         }
                     }],
                     "id": "total-sales-household-goods-question",
-                    "title": "Of the <em>{{answers['total-retail-turnover']|format_currency}}</em> total retail turnover, what was the value of sales for <em>household goods</em>?",
+                    "title": "Of the <em>{{format_currency(answers['total-retail-turnover'])}}</em> total retail turnover, what was the value of sales for <em>household goods</em>?",
                     "type": "General"
                 }],
                 "title": "Retail turnover"
@@ -417,7 +417,7 @@
                         }
                     }],
                     "id": "total-sales-other-goods-question",
-                    "title": "Of the <em>{{answers['total-retail-turnover']|format_currency}}</em> total retail turnover, what was the value of <em>other</em> sales?",
+                    "title": "Of the <em>{{format_currency(answers['total-retail-turnover'])}}</em> total retail turnover, what was the value of <em>other</em> sales?",
                     "type": "General"
                 }],
                 "title": "Retail turnover"
@@ -444,7 +444,7 @@
                         }
                     }],
                     "id": "internet-sales-question",
-                    "title": "Of the <em>{{answers['total-retail-turnover']|format_currency}}</em> total retail turnover, what was the value of <em>internet</em> sales?",
+                    "title": "Of the <em>{{format_currency(answers['total-retail-turnover'])}}</em> total retail turnover, what was the value of <em>internet</em> sales?",
                     "type": "General"
                 }],
                 "title": "Retail turnover"

--- a/data/en/1_0213.json
+++ b/data/en/1_0213.json
@@ -312,7 +312,7 @@
                         }
                     }],
                     "id": "total-sales-food-question",
-                    "title": "Of the <em>{{answers['total-retail-turnover']|format_currency}}</em> total retail turnover, what was the value of <em>food</em> sales?",
+                    "title": "Of the <em>{{format_currency(answers['total-retail-turnover'])}}</em> total retail turnover, what was the value of <em>food</em> sales?",
                     "type": "General"
                 }],
                 "title": "Retail turnover"
@@ -339,7 +339,7 @@
                         }
                     }],
                     "id": "total-sales-alcohol-question",
-                    "title": "Of the <em>{{answers['total-retail-turnover']|format_currency}}</em> total retail turnover, what was the value of <em>alcohol, confectionery and tobacco</em> sales?",
+                    "title": "Of the <em>{{format_currency(answers['total-retail-turnover'])}}</em> total retail turnover, what was the value of <em>alcohol, confectionery and tobacco</em> sales?",
                     "type": "General"
                 }],
                 "title": "Retail turnover"
@@ -366,7 +366,7 @@
                         }
                     }],
                     "id": "total-sales-clothing-question",
-                    "title": "Of the <em>{{answers['total-retail-turnover']|format_currency}}</em> total retail turnover, what was the value of <em>clothing and footwear</em> sales?",
+                    "title": "Of the <em>{{format_currency(answers['total-retail-turnover'])}}</em> total retail turnover, what was the value of <em>clothing and footwear</em> sales?",
                     "type": "General"
                 }],
                 "title": "Retail turnover"
@@ -395,7 +395,7 @@
                         }
                     }],
                     "id": "total-sales-household-goods-question",
-                    "title": "Of the <em>{{answers['total-retail-turnover']|format_currency}}</em> total retail turnover, what was the value of sales for <em>household goods</em>?",
+                    "title": "Of the <em>{{format_currency(answers['total-retail-turnover'])}}</em> total retail turnover, what was the value of sales for <em>household goods</em>?",
                     "type": "General"
                 }],
                 "title": "Retail turnover"
@@ -427,7 +427,7 @@
                         }
                     }],
                     "id": "total-sales-other-goods-question",
-                    "title": "Of the <em>{{answers['total-retail-turnover']|format_currency}}</em> total retail turnover, what was the value of <em>other</em> sales?",
+                    "title": "Of the <em>{{format_currency(answers['total-retail-turnover'])}}</em> total retail turnover, what was the value of <em>other</em> sales?",
                     "type": "General"
                 }],
                 "title": "Retail turnover"
@@ -454,7 +454,7 @@
                         }
                     }],
                     "id": "internet-sales-question",
-                    "title": "Of the <em>{{answers['total-retail-turnover']|format_currency}}</em> total retail turnover, what was the value of <em>internet</em> sales?",
+                    "title": "Of the <em>{{format_currency(answers['total-retail-turnover'])}}</em> total retail turnover, what was the value of <em>internet</em> sales?",
                     "type": "General"
                 }],
                 "title": "Retail turnover"

--- a/data/en/1_0215.json
+++ b/data/en/1_0215.json
@@ -321,7 +321,7 @@
                         }
                     }],
                     "id": "total-sales-food-question",
-                    "title": "Of the <em>{{answers['total-retail-turnover']|format_currency}}</em> total retail turnover, what was the value of <em>food</em> sales?",
+                    "title": "Of the <em>{{format_currency(answers['total-retail-turnover'])}}</em> total retail turnover, what was the value of <em>food</em> sales?",
                     "type": "General"
                 }],
                 "title": "Retail turnover"
@@ -348,7 +348,7 @@
                         }
                     }],
                     "id": "total-sales-alcohol-question",
-                    "title": "Of the <em>{{answers['total-retail-turnover']|format_currency}}</em> total retail turnover, what was the value of <em>alcohol, confectionery and tobacco</em> sales?",
+                    "title": "Of the <em>{{format_currency(answers['total-retail-turnover'])}}</em> total retail turnover, what was the value of <em>alcohol, confectionery and tobacco</em> sales?",
                     "type": "General"
                 }],
                 "title": "Retail turnover"
@@ -375,7 +375,7 @@
                         }
                     }],
                     "id": "total-sales-clothing-question",
-                    "title": "Of the <em>{{answers['total-retail-turnover']|format_currency}}</em> total retail turnover, what was the value of <em>clothing and footwear</em> sales?",
+                    "title": "Of the <em>{{format_currency(answers['total-retail-turnover'])}}</em> total retail turnover, what was the value of <em>clothing and footwear</em> sales?",
                     "type": "General"
                 }],
                 "title": "Retail turnover"
@@ -405,7 +405,7 @@
                         }
                     }],
                     "id": "total-sales-household-goods-question",
-                    "title": "Of the <em>{{answers['total-retail-turnover']|format_currency}}</em> total retail turnover, what was the value of sales for <em>household goods</em>?",
+                    "title": "Of the <em>{{format_currency(answers['total-retail-turnover'])}}</em> total retail turnover, what was the value of sales for <em>household goods</em>?",
                     "type": "General"
                 }],
                 "title": "Retail turnover"
@@ -439,7 +439,7 @@
                         }
                     }],
                     "id": "total-sales-other-goods-question",
-                    "title": "Of the <em>{{answers['total-retail-turnover']|format_currency}}</em> total retail turnover, what was the value of <em>other</em> sales?",
+                    "title": "Of the <em>{{format_currency(answers['total-retail-turnover'])}}</em> total retail turnover, what was the value of <em>other</em> sales?",
                     "type": "General"
                 }],
                 "title": "Retail turnover"
@@ -466,7 +466,7 @@
                         }
                     }],
                     "id": "internet-sales-question",
-                    "title": "Of the <em>{{answers['total-retail-turnover']|format_currency}}</em> total retail turnover, what was the value of <em>internet</em> sales?",
+                    "title": "Of the <em>{{format_currency(answers['total-retail-turnover'])}}</em> total retail turnover, what was the value of <em>internet</em> sales?",
                     "type": "General"
                 }],
                 "title": "Retail turnover"

--- a/data/en/mbs_0106.json
+++ b/data/en/mbs_0106.json
@@ -201,7 +201,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {

--- a/data/en/mbs_0111.json
+++ b/data/en/mbs_0111.json
@@ -203,7 +203,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {

--- a/data/en/mbs_0117.json
+++ b/data/en/mbs_0117.json
@@ -208,7 +208,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {

--- a/data/en/mbs_0123.json
+++ b/data/en/mbs_0123.json
@@ -198,7 +198,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-commission-and-fees-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total commission and fees was <em>{{answers['commission-and-fees-answer']|format_currency}}</em>, is this correct?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total commission and fees was <em>{{format_currency(answers['commission-and-fees-answer'])}}</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {

--- a/data/en/mbs_0158.json
+++ b/data/en/mbs_0158.json
@@ -229,7 +229,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {

--- a/data/en/mbs_0161.json
+++ b/data/en/mbs_0161.json
@@ -229,7 +229,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {

--- a/data/en/mbs_0167.json
+++ b/data/en/mbs_0167.json
@@ -234,7 +234,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {

--- a/data/en/mbs_0173.json
+++ b/data/en/mbs_0173.json
@@ -221,7 +221,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total commission and fees was <em>{{answers['commission-and-fees-answer']|format_currency}}</em>, is this correct?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total commission and fees was <em>{{format_currency(answers['commission-and-fees-answer'])}}</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {

--- a/data/en/mbs_0201.json
+++ b/data/en/mbs_0201.json
@@ -223,7 +223,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {
@@ -259,7 +259,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-zero-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {
@@ -300,7 +300,7 @@
                         }
                     }],
                     "type": "General",
-                    "title": "Of the <em>{{answers['turnover-answer']|format_currency}}</em> total turnover, what was the value of <em>exports?</em>"
+                    "title": "Of the <em>{{format_currency(answers['turnover-answer'])}}</em> total turnover, what was the value of <em>exports?</em>"
                 }],
                 "title": "Exports"
             }, {

--- a/data/en/mbs_0202.json
+++ b/data/en/mbs_0202.json
@@ -223,7 +223,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {
@@ -259,7 +259,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-zero-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {
@@ -300,7 +300,7 @@
                         }
                     }],
                     "type": "General",
-                    "title": "Of the <em>{{answers['turnover-answer']|format_currency}}</em> total turnover, what was the value of <em>exports?</em>"
+                    "title": "Of the <em>{{format_currency(answers['turnover-answer'])}}</em> total turnover, what was the value of <em>exports?</em>"
                 }],
                 "title": "Exports"
             }, {

--- a/data/en/mbs_0205.json
+++ b/data/en/mbs_0205.json
@@ -209,7 +209,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {

--- a/data/en/mbs_0216.json
+++ b/data/en/mbs_0216.json
@@ -209,7 +209,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {

--- a/data/en/mbs_0251.json
+++ b/data/en/mbs_0251.json
@@ -249,7 +249,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {
@@ -294,7 +294,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-zero-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {
@@ -335,7 +335,7 @@
                         }
                     }],
                     "type": "General",
-                    "title": "Of the <em>{{answers['turnover-answer']|format_currency}}</em> total turnover, what was the value of <em>exports?</em>"
+                    "title": "Of the <em>{{format_currency(answers['turnover-answer'])}}</em> total turnover, what was the value of <em>exports?</em>"
                 }],
                 "title": "Exports"
             }, {

--- a/data/en/mbs_0255.json
+++ b/data/en/mbs_0255.json
@@ -237,7 +237,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {

--- a/data/en/mbs_0817.json
+++ b/data/en/mbs_0817.json
@@ -201,7 +201,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {

--- a/data/en/mbs_0823.json
+++ b/data/en/mbs_0823.json
@@ -201,7 +201,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {

--- a/data/en/mbs_0867.json
+++ b/data/en/mbs_0867.json
@@ -227,7 +227,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {

--- a/data/en/mbs_0873.json
+++ b/data/en/mbs_0873.json
@@ -227,7 +227,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{answers['turnover-answer']|format_currency}}</em>, is this correct?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {

--- a/data/en/mci_transformation.json
+++ b/data/en/mci_transformation.json
@@ -366,7 +366,7 @@
                 "title": "Retail sales including VAT",
                 "questions": [{
                     "id": "food-sales-question",
-                    "title": "Of the {{answers['retail-sales-answer']|format_currency}} retail sales, how much were your <em>food, drink and tobacco sales</em>?",
+                    "title": "Of the {{format_currency(answers['retail-sales-answer'])}} retail sales, how much were your <em>food, drink and tobacco sales</em>?",
                     "type": "General",
                     "guidance": {
                         "content": [{
@@ -396,7 +396,7 @@
                 "title": "Retail sales including VAT",
                 "questions": [{
                     "id": "clothing-sales-question",
-                    "title": "Of the {{answers['retail-sales-answer']|format_currency}} retail sales, how much were your <em>clothing and footwear sales</em>?",
+                    "title": "Of the {{format_currency(answers['retail-sales-answer'])}} retail sales, how much were your <em>clothing and footwear sales</em>?",
                     "type": "General",
                     "guidance": {
                         "content": [{
@@ -426,7 +426,7 @@
                 "title": "Retail sales including VAT",
                 "questions": [{
                     "id": "household-goods-sales-question",
-                    "title": "Of the {{answers['retail-sales-answer']|format_currency}} retail sales, how much were your sales of <em>household goods</em>?",
+                    "title": "Of the {{format_currency(answers['retail-sales-answer'])}} retail sales, how much were your sales of <em>household goods</em>?",
                     "type": "General",
                     "guidance": {
                         "content": [{
@@ -456,7 +456,7 @@
                 "title": "Retail sales including VAT",
                 "questions": [{
                     "id": "automotive-fuel-sales-question",
-                    "title": "Of the {{answers['retail-sales-answer']|format_currency}} retail sales, how much were your sales of <em>automotive fuel</em>?",
+                    "title": "Of the {{format_currency(answers['retail-sales-answer'])}} retail sales, how much were your sales of <em>automotive fuel</em>?",
                     "type": "General",
                     "guidance": {
                         "content": [{
@@ -486,7 +486,7 @@
                 "title": "Retail sales including VAT",
                 "questions": [{
                     "id": "other-goods-sales-question",
-                    "title": "Of the {{answers['retail-sales-answer']|format_currency}} retail sales, how much were your sales of <em>other goods</em>?",
+                    "title": "Of the {{format_currency(answers['retail-sales-answer'])}} retail sales, how much were your sales of <em>other goods</em>?",
                     "type": "General",
                     "guidance": {
                         "content": [{
@@ -516,7 +516,7 @@
                 "title": "Retail sales including VAT",
                 "questions": [{
                     "id": "online-sales-question",
-                    "title": "Of the <em>{{answers['retail-sales-answer']|format_currency}}</em> retail sales, how much were your <em>online sales</em>?",
+                    "title": "Of the <em>{{format_currency(answers['retail-sales-answer'])}}</em> retail sales, how much were your <em>online sales</em>?",
                     "description": "These are sales of goods made online, irrespective of the delivery method.",
                     "type": "General",
                     "guidance": {

--- a/data/en/qcas_0018.json
+++ b/data/en/qcas_0018.json
@@ -376,7 +376,7 @@
                                 "mandatory": true
                             }],
                             "id": "confirm-improvements-construction-question",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the total capital expenditure on major improvements and construction work was <em>{{answers['improvements-construction-answer']|format_currency}}</em>, is this correct?"
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the total capital expenditure on major improvements and construction work was <em>{{format_currency(answers['improvements-construction-answer'])}}</em>, is this correct?"
                         }],
                         "routing_rules": [{
                                 "goto": {

--- a/data/en/qcas_0019.json
+++ b/data/en/qcas_0019.json
@@ -376,7 +376,7 @@
                                 "mandatory": true
                             }],
                             "id": "confirm-improvements-construction-question",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the total capital expenditure on major improvements and construction work was <em>{{answers['improvements-construction-answer']|format_currency}}</em>, is this correct?"
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the total capital expenditure on major improvements and construction work was <em>{{format_currency(answers['improvements-construction-answer'])}}</em>, is this correct?"
                         }],
                         "routing_rules": [{
                                 "goto": {

--- a/data/en/qcas_0020.json
+++ b/data/en/qcas_0020.json
@@ -390,7 +390,7 @@
                                 "mandatory": true
                             }],
                             "id": "confirm-improvements-construction-question",
-                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the total capital expenditure on major improvements and construction work was <em>{{answers['improvements-construction-answer']|format_currency}}</em>, is this correct?"
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the total capital expenditure on major improvements and construction work was <em>{{format_currency(answers['improvements-construction-answer'])}}</em>, is this correct?"
                         }],
                         "routing_rules": [{
                                 "goto": {

--- a/data/en/rsi_transformation.json
+++ b/data/en/rsi_transformation.json
@@ -340,7 +340,7 @@
                         "mandatory": true
                     }],
                     "id": "online-sales-question",
-                    "title": "Of the <em>{{answers['retail-sales-answer']|format_currency}}</em> retail sales, how much were your <em>online sales</em>?",
+                    "title": "Of the <em>{{format_currency(answers['retail-sales-answer'])}}</em> retail sales, how much were your <em>online sales</em>?",
                     "description": "These are sales of goods made online, irrespective of the delivery method.",
                     "type": "General"
                 }],

--- a/tests/app/test_jinja_filters.py
+++ b/tests/app/test_jinja_filters.py
@@ -49,14 +49,14 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
         self.assertEqual(get_currency_symbol(''), '')
 
     def test_format_currency(self):
-        self.assertEqual(format_currency('11', 'GBP'), '£11.00')
-        self.assertEqual(format_currency('11.99', 'GBP'), '£11.99')
-        self.assertEqual(format_currency('11000', 'USD'), 'US$11,000.00')
-        self.assertEqual(format_currency(0), '£0.00')
-        self.assertEqual(format_currency(0.00), '£0.00')
-        self.assertEqual(format_currency('', ), '')
-        self.assertEqual(format_currency(None), '')
-        self.assertEqual(format_currency(Undefined()), '')
+        self.assertEqual(format_currency(self.autoescape_context, '11', 'GBP'), "<span class='date'>£11.00</span>")
+        self.assertEqual(format_currency(self.autoescape_context, '11.99', 'GBP'), "<span class='date'>£11.99</span>")
+        self.assertEqual(format_currency(self.autoescape_context, '11000', 'USD'), "<span class='date'>US$11,000.00</span>")
+        self.assertEqual(format_currency(self.autoescape_context, 0), "<span class='date'>£0.00</span>")
+        self.assertEqual(format_currency(self.autoescape_context, 0.00), "<span class='date'>£0.00</span>")
+        self.assertEqual(format_currency(self.autoescape_context, '', ), "<span class='date'></span>")
+        self.assertEqual(format_currency(self.autoescape_context, None), "<span class='date'></span>")
+        self.assertEqual(format_currency(self.autoescape_context, Undefined()), "<span class='date'></span>")
 
     def test_format_number(self):
         self.assertEqual(format_number(123), '123')


### PR DESCRIPTION
### What is the context of this PR?
Now that QCAS supports negative values it was noticed when the formatted currency value was displayed on the confirmation page it wrapped on the negative symbol rather than defining the whole thing as a single entity.

### How to review 
Start QCAS and enter a negative value. The corresponding confirmation page should have the complete formatted entered value in a span.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
