### PR TITLE
Relationships support group instances and skip_conditions

### DIFF
--- a/app/questionnaire/group_dependencies.py
+++ b/app/questionnaire/group_dependencies.py
@@ -61,7 +61,7 @@ def get_group_dependencies(schema):
     dependencies = GroupDependencies()
 
     for group in schema.groups:
-        if group.get('routing_rules') and not _group_has_relationship_type(schema, group['blocks']):
+        if group.get('routing_rules'):
             for routing_rule in group['routing_rules']:
                 if _routing_rule_has_repeat(routing_rule):
                     dependencies.update(_build_routing_dependencies(schema, routing_rule, group['id']))
@@ -125,14 +125,6 @@ def _get_dependency_driver_from_answer_id(schema, dependent_group_id, answer_id)
     dependencies.add(dependent_group_id, block_id, 'block')
 
     return dependencies
-
-
-def _group_has_relationship_type(schema, blocks):
-    for block in blocks:
-        if schema.block_has_question_type(block['id'], 'Relationship'):
-            return True
-
-    return False
 
 
 def _routing_rule_has_repeat(routing_rule):

--- a/app/questionnaire/questionnaire_schema.py
+++ b/app/questionnaire/questionnaire_schema.py
@@ -68,8 +68,9 @@ class QuestionnaireSchema:  # pylint: disable=too-many-public-methods
     def get_groups_that_repeat_with_answer_id(self, answer_id):
         for group in self.groups:
             repeating_rule = self.get_repeat_rule(group)
-            if repeating_rule and repeating_rule['answer_id'] == answer_id:
-                yield group
+            if repeating_rule:
+                if repeating_rule.get('answer_id') == answer_id:
+                    yield group
 
     def group_has_questions(self, group_id):
         for block in self.get_group(group_id)['blocks']:

--- a/data/en/census_household.json
+++ b/data/en/census_household.json
@@ -326,6 +326,7 @@
                     "title": "How is <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}</em> related to the people below?",
                     "description": "If members are not related, select the \u2018unrelated\u2019 option.<br />If you are the parents of adopted children, select the \u2018Mother or father\u2019 option to show your relationship to them.<br />If you have foster children living with you, select the \u2018Unrelated\u2019 option.<br />Include half-brothers and half-sisters in the \u2018Step-brother or step-sister\u2019 category.<br />Same-sex civil partner is used to describe the relationship between two people who have legally registered a civil partnership.<br />If none of the options fully reflects your relationship, please select the one which you feel best describes your situation.",
                     "type": "Relationship",
+                    "member_label": "[answers['first-name'], answers['middle-names'], answers['last-name']] | format_household_name",
                     "answers": [{
                         "id": "household-relationships-answer",
                         "label": "%(current_person)s is %(other_person)s's",

--- a/data/en/test_relationship_household.json
+++ b/data/en/test_relationship_household.json
@@ -67,6 +67,7 @@
                     "title": "Describe how this person is related to the others",
                     "description": "If members are not related, select the \u2018unrelated\u2019 option, including foster parents and foster children.",
                     "type": "Relationship",
+                    "member_label": "[answers['first-name'], answers['middle-names'], answers['last-name']] | format_household_name",
                     "answers": [{
                         "id": "who-is-related",
                         "label": "%(current_person)s is the &hellip; of %(other_person)s",

--- a/data/en/test_routing_on_answer_from_driving_repeating_group.json
+++ b/data/en/test_routing_on_answer_from_driving_repeating_group.json
@@ -134,6 +134,82 @@
                 ]
             },
             {
+                "id": "household-relationships",
+                "title": "Relationships",
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "primary-live-here",
+                        "condition": "equals",
+                        "value": "No"
+                    }]
+                }],
+                "routing_rules": [{
+                    "repeat": {
+                        "type": "answer_count_minus_one",
+                        "answer_ids": [
+                            "primary-name",
+                            "repeating-name"
+                        ]
+                    }
+                }],
+                "blocks": [{
+                    "type": "Question",
+                    "id": "relationships",
+                    "title": "Who lives here?",
+                    "questions": [{
+                        "id": "relationship-question",
+                        "title": "Describe how this person is related to the others",
+                        "description": "If members are not related, select the \u2018unrelated\u2019 option, including foster parents and foster children.",
+                        "type": "Relationship",
+                        "member_label": "answers['primary-name'] | default(answers['repeating-name'])",
+                        "answers": [{
+                            "id": "who-is-related",
+                            "label": "%(current_person)s is the &hellip; of %(other_person)s",
+                            "mandatory": false,
+                            "q_code": "2",
+                            "type": "Relationship",
+                            "options": [{
+                                    "label": "Husband or wife",
+                                    "value": "Husband or wife"
+                                },
+                                {
+                                    "label": "Partner",
+                                    "value": "Partner"
+                                },
+                                {
+                                    "label": "Mother or father",
+                                    "value": "Mother or father"
+                                },
+                                {
+                                    "label": "Son or daughter",
+                                    "value": "Son or daughter"
+                                },
+                                {
+                                    "label": "Brother or sister",
+                                    "value": "Brother or sister"
+                                },
+                                {
+                                    "label": "Relation - other",
+                                    "value": "Relation - other"
+                                },
+                                {
+                                    "label": "Grandparent",
+                                    "value": "Grandparent"
+                                },
+                                {
+                                    "label": "Grandchild",
+                                    "value": "Grandchild"
+                                },
+                                {
+                                    "label": "Unrelated",
+                                    "value": "Unrelated"
+                                }
+                            ]
+                        }]
+                    }]
+                }]
+            },
+            {
                 "id": "sex-group",
                 "title": "Household Member Details",
                 "skip_conditions": [{

--- a/tests/app/forms/test_household_relationship_form.py
+++ b/tests/app/forms/test_household_relationship_form.py
@@ -1,3 +1,5 @@
+import uuid
+
 from app.forms.household_relationship_form import build_relationship_choices, deserialise_relationship_answers, \
     serialise_relationship_answers, generate_relationship_form
 from app.data_model.answer_store import AnswerStore, Answer
@@ -12,41 +14,56 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
         return any(a_id == answer_id and msg in ordered_errors for a_id, ordered_errors in mapped_errors)
 
     def test_build_relationship_choices(self):
+
+        person_1 = str(uuid.uuid4())
+        person_2 = str(uuid.uuid4())
+        person_3 = str(uuid.uuid4())
+
         answer_store = AnswerStore([
             {
                 'answer_id': 'first-name',
                 'block_id': 'household-composition',
                 'value': 'Joe',
                 'answer_instance': 0,
+                'group_instance_id': person_1
             }, {
                 'answer_id': 'last-name',
                 'block_id': 'household-composition',
                 'value': 'Bloggs',
                 'answer_instance': 0,
+                'group_instance_id': person_1
             }, {
                 'answer_id': 'first-name',
                 'block_id': 'household-composition',
                 'value': 'Jane',
                 'answer_instance': 1,
+                'group_instance_id': person_2
             }, {
                 'answer_id': 'last-name',
                 'block_id': 'household-composition',
                 'value': 'Bloggs',
                 'answer_instance': 1,
+                'group_instance_id': person_2
             }, {
                 'answer_id': 'first-name',
                 'block_id': 'household-composition',
                 'value': 'Bob',
                 'answer_instance': 2,
+                'group_instance_id': person_3
             }, {
                 'answer_id': 'last-name',
                 'block_id': 'household-composition',
                 'value': '',
                 'answer_instance': 2,
+                'group_instance_id': person_3
             }
         ])
 
-        choices = build_relationship_choices(answer_store, 0)
+        answer_ids = ['first-name']
+
+        member_label = "[answers['first-name'], answers['last-name']] | format_household_name"
+
+        choices = build_relationship_choices(answer_ids, answer_store, 0, member_label)
 
         expected_choices = [
             ('Joe Bloggs', 'Jane Bloggs'),
@@ -56,7 +73,7 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
         self.assertEqual(expected_choices, choices)
 
         # Check each group is correct
-        choices = build_relationship_choices(answer_store, 1)
+        choices = build_relationship_choices(answer_ids, answer_store, 1, member_label)
 
         expected_choices = [
             ('Jane Bloggs', 'Bob'),
@@ -230,6 +247,8 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
                 value='Bloggs' + str(i),
             ))
 
-        choices = build_relationship_choices(answer_store, 0)
+            answer_ids = ['first-name']
+
+        choices = build_relationship_choices(answer_ids, answer_store, 0)
 
         self.assertEqual(len(choices), answer_store.EQ_MAX_NUM_REPEATS - 1)

--- a/tests/app/questionnaire/test_group_dependencies.py
+++ b/tests/app/questionnaire/test_group_dependencies.py
@@ -220,7 +220,7 @@ class TestGetDependencies(unittest.TestCase):
         self.assertEqual(dependencies['group_drivers'], [])
         self.assertEqual(dependencies['block_drivers'], ['driving-block'])
 
-    def test_repeat_with_relationship_block_not_added_to_dependencies(self):
+    def test_repeat_with_relationship_block_added_to_dependencies(self):
         survey_json = {
             'sections': [{
                 'id': 'default-section',
@@ -267,9 +267,9 @@ class TestGetDependencies(unittest.TestCase):
         schema = QuestionnaireSchema(survey_json)
         dependencies = get_group_dependencies(schema)
 
-        self.assertEqual(len(dependencies), 0)
+        self.assertEqual(len(dependencies), 1)
         self.assertEqual(dependencies['group_drivers'], [])
-        self.assertEqual(dependencies['block_drivers'], [])
+        self.assertEqual(dependencies['block_drivers'], ['driving-block'])
 
     def test_repeat_with_answer_value_not_added_to_dependencies(self):
         survey_json = {

--- a/tests/app/questionnaire/test_path_finder.py
+++ b/tests/app/questionnaire/test_path_finder.py
@@ -846,7 +846,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
             Location('repeating-group', 1, 'repeating-name-block'),
             Location('repeating-group', 2, 'repeating-anyone-else-block'),
         ]
-        expected_next_location = Location('sex-group', 1, 'sex-block')
+        expected_next_location = Location('household-relationships', 1, 'relationships')
 
         path_finder = PathFinder(schema, answer_store, metadata={}, completed_blocks=completed_blocks)
 

--- a/tests/functional/generate_pages.py
+++ b/tests/functional/generate_pages.py
@@ -73,6 +73,18 @@ ANSWER_GETTER = Template(r"""  ${answerName}() {
 
 """)
 
+RELATIONSHIP_ANSWER_GETTER = Template(r"""  ${answerName}(instance) {
+    return '[name="${answerId}-' + instance + '"]';
+  }
+
+""")
+
+RELATIONSHIP_ANSWER_SETTER = Template(r"""  relationship(instance, answer) {
+    return '#${answerId}-' + instance + ' > [value="' + answer + '"]';
+  }
+
+""")
+
 HOUSEHOLD_ANSWER_GETTER = Template(r"""  ${answerName}(index = '') {
     return '#household-0-${answerId}' + index;
   }
@@ -196,7 +208,17 @@ def process_answer(question_type, answer, page_spec, long_names, page_name):
     elif answer['type'] in 'Duration':
         page_spec.write(_write_duration_answer(answer['id'], answer['units'], prefix))
 
-    elif answer['type'] in ('TextField', 'Number', 'TextArea', 'Currency', 'Percentage', 'Relationship', 'Unit', 'Dropdown'):
+    elif answer['type'] in 'Relationship':
+        answer_context = {
+            'answerName': camel_case(answer_name),
+            'answerId': answer['id']
+        }
+
+        page_spec.write(RELATIONSHIP_ANSWER_GETTER.substitute(answer_context))
+        page_spec.write(RELATIONSHIP_ANSWER_SETTER.substitute(answer_context))
+        page_spec.write(ANSWER_LABEL_GETTER.substitute(answer_context))
+
+    elif answer['type'] in ('TextField', 'Number', 'TextArea', 'Currency', 'Percentage', 'Unit', 'Dropdown'):
 
         answer_context = {
             'answerName': camel_case(answer_name),

--- a/tests/functional/pages/surveys/routing_on_answer_from_driving_repeating_group/relationships.page.js
+++ b/tests/functional/pages/surveys/routing_on_answer_from_driving_repeating_group/relationships.page.js
@@ -1,0 +1,21 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class RelationshipsPage extends QuestionPage {
+
+  constructor() {
+    super('relationships');
+  }
+
+  answer(instance) {
+    return '[name="who-is-related-' + instance + '"]';
+  }
+
+  relationship(instance, answer) {
+    return '#who-is-related-' + instance + ' > [value="' + answer + '"]';
+  }
+
+  answerLabel() { return '#label-who-is-related'; }
+
+}
+module.exports = new RelationshipsPage();

--- a/tests/functional/pages/surveys/routing_on_answer_from_driving_repeating_group/summary.page.js
+++ b/tests/functional/pages/surveys/routing_on_answer_from_driving_repeating_group/summary.page.js
@@ -27,6 +27,12 @@ class SummaryPage extends QuestionPage {
 
   repeatingGroupTitle() { return '#repeating-group'; }
 
+  whoIsRelated() { return '#who-is-related-answer'; }
+
+  whoIsRelatedEdit() { return '[data-qa="who-is-related-edit"]'; }
+
+  householdRelationshipsTitle() { return '#household-relationships'; }
+
   sexAnswer() { return '#sex-answer-answer'; }
 
   sexAnswerEdit() { return '[data-qa="sex-answer-edit"]'; }

--- a/tests/functional/spec/routing_on_answer_from_repeat.spec.js
+++ b/tests/functional/spec/routing_on_answer_from_repeat.spec.js
@@ -5,6 +5,7 @@ const PrimaryLiveHereBlockPage = require('../pages/surveys/routing_on_answer_fro
 const RepeatingNamePage = require('../pages/surveys/routing_on_answer_from_driving_repeating_group/repeating-name-block.page.js');
 const RepeatingAnyoneElsePage = require('../pages/surveys/routing_on_answer_from_driving_repeating_group/repeating-anyone-else-block.page.js');
 const SexPage = require('../pages/surveys/routing_on_answer_from_driving_repeating_group/sex-block.page.js');
+const RelationshipsPage = require('../pages/surveys/routing_on_answer_from_driving_repeating_group/relationships.page.js');
 const SummaryPage = require('../pages/surveys/routing_on_answer_from_driving_repeating_group/summary.page.js');
 
 describe('Routing on Answer from repeat', function() {
@@ -34,6 +35,9 @@ describe('Routing on Answer from repeat', function() {
 
         .click(RepeatingAnyoneElsePage.no())
         .click(RepeatingAnyoneElsePage.submit())
+
+        .click(RelationshipsPage.relationship(0, 'Husband or wife'))
+        .click(RelationshipsPage.submit())
 
         .getText(SexPage.questionText()).should.eventually.contain('Alice')
         .click(SexPage.female())

--- a/tests/integration/census/test_census_household_submission_data.py
+++ b/tests/integration/census/test_census_household_submission_data.py
@@ -101,7 +101,7 @@ class TestCensusHouseholdSubmissionData(IntegrationTestCase):
             {'value': 'Husband or wife',
              'answer_id': 'household-relationships-answer',
              'answer_instance': 0,
-             'group_instance_id': None,
+             'group_instance_id': '2',
              'group_instance': 0},
             {'value': 'Whole house or bungalow',
              'answer_id': 'type-of-accommodation-answer',

--- a/tests/integration/household_composition/test_repeating_relationship.py
+++ b/tests/integration/household_composition/test_repeating_relationship.py
@@ -1,3 +1,5 @@
+from mock import patch
+
 from tests.integration.integration_test_case import IntegrationTestCase
 
 
@@ -23,9 +25,9 @@ class TestRepeatingRelationship(IntegrationTestCase):
         self.get(url=last_relationship_page)
         self.assertInPage('Describe how this person is related to the others')
 
-    def test_multiple_relationship_groups(self):
+    @patch('app.helpers.schema_helpers.uuid4', side_effect=range(100))
+    def test_multiple_relationship_groups(self, mock): # pylint: disable=unused-argument
         # Given
-
         household_form_data = {
             'household-0-first-name': 'Han',
             'household-1-first-name': 'Leia',
@@ -56,21 +58,21 @@ class TestRepeatingRelationship(IntegrationTestCase):
                 'answer_id': 'who-is-related',
                 'answer_instance': 0,
                 'group_instance': 0,
-                'group_instance_id': None,
+                'group_instance_id': '1',
                 'value': 'Husband or wife'
             },
             {
                 'answer_id': 'who-is-related',
                 'answer_instance': 1,
                 'group_instance': 0,
-                'group_instance_id': None,
+                'group_instance_id': '1',
                 'value': 'Relation - other'
             },
             {
                 'answer_id': 'who-is-related',
                 'answer_instance': 0,
                 'group_instance': 1,
-                'group_instance_id': None,
+                'group_instance_id': '2',
                 'value': 'Brother or sister'
             }
         ]

--- a/tests/integration/views/test_dump.py
+++ b/tests/integration/views/test_dump.py
@@ -54,8 +54,7 @@ class TestDumpAnswers(IntegrationTestCase):
         self.launchSurvey('test', 'radio_mandatory_with_mandatory_other', roles=['dumper'])
 
         # When I submit an answer
-        with patch('app.helpers.schema_helpers.uuid4', side_effect=range(10)):
-            self.post(post_data={'radio-mandatory-answer': 'Toast'})
+        self.post(post_data={'radio-mandatory-answer': 'Toast'})
 
         # And I attempt to dump the answer store
         self.get('/dump/answers')


### PR DESCRIPTION
### What is the context of this PR?
Relationships question has been refactored to be more generic. It is no longer hard coded to specific answer ids, it can not be supplied a label to be rendered in the current group_instance_id.
The Relationships also now honour the skip conditions so if someone doesn't live in the household for example, then they wont be included in the matrix.
This now works for both repeating answers and repeating groups.

### How to review 
To test skip conditions in Relationships use schems `test_routing_on_answer_from_driving_repeating_group.json`
To test answer labels use `test_relationship_household.json`

