### PR TITLE
Added language switcher

### DIFF
--- a/app/assets/styles/themes/social/theme.scss
+++ b/app/assets/styles/themes/social/theme.scss
@@ -1,0 +1,2 @@
+@import "../../themes-common/config";
+@import "../../themes-common/ui";

--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -403,6 +403,11 @@ def max_value(a, b):
         raise Exception(msg)
 
 
+@blueprint.app_template_filter()
+def language_urls(languages, current_language):
+    return [language for language in languages if language[0] != current_language]
+
+
 @contextfunction
 @blueprint.app_template_filter()
 def get_question_title(context, question_id):
@@ -487,6 +492,11 @@ def format_currency_for_input_processor():
 @blueprint.app_context_processor
 def format_number_processor():
     return dict(format_number=format_number)
+
+
+@blueprint.app_context_processor
+def language_urls_processor():
+    return dict(language_urls=language_urls)
 
 
 def mark_safe(context, value):

--- a/app/templates/partials/header2.html
+++ b/app/templates/partials/header2.html
@@ -1,0 +1,12 @@
+<div class="container">
+    <div class="header">
+        <div class="logo header__logo">
+            {% block logo %}
+            {% set logo_cdn = cdn_url_prefix~"/img/logo.svg" %}
+            <img src="{{ logo_cdn }}" alt="Office for National Statistics"
+                 class="logo__img"/>
+            {% endblock logo %}
+        </div>
+    </div>
+
+</div>

--- a/app/themes/social/info.json
+++ b/app/themes/social/info.json
@@ -1,0 +1,9 @@
+{
+    "application": "surveyrunner",
+    "identifier": "social",
+    "name": "Social",
+    "author": "jonshaw",
+    "description": "Theme for Social surveys",
+    "license": "MIT/X11",
+    "version": "1.0.0"
+}

--- a/app/themes/social/templates/layouts/_base.html
+++ b/app/themes/social/templates/layouts/_base.html
@@ -1,0 +1,5 @@
+{% extends 'layouts/_base.html' %}
+
+{% block header %}
+  {% include theme('partials/header.html') %}
+{% endblock %}

--- a/app/themes/social/templates/partials/header.html
+++ b/app/themes/social/templates/partials/header.html
@@ -1,0 +1,52 @@
+{% if language_code  %}
+  {% set languages = language_urls([['cy', 'Cymraeg'], ['en', 'English']], language_code) %}
+{% endif %}
+
+<header class="header u-mb-xs">
+    <div class="header__top" role="banner">
+        <div class="container">
+            <div class="grid grid--gutterless">
+                <div class="grid__col col-6@s">
+                {% block logo %}
+                {% set logo_cdn_print = cdn_url_prefix~"/img/ons-logo-black-en.svg" %}
+                {% set logo_cdn_web = cdn_url_prefix~"/img/ons-logo-pos.svg" %}
+                    <div class="logo">
+                        <img src="{{ logo_cdn_print }}" alt="Office for National Statistics logo" class="logo__img header__logo--print">
+                        <img src="{{ logo_cdn_web }}" alt="Office for National Statistics logo" class="logo__img header__logo print__hidden">
+                    </div>
+                {% endblock logo %}
+                </div>
+                <div class="grid__col col-6@s">
+                    <nav class="nav nav--horizontal  u-d-no--@xs@s u-fr" aria-label="Site services menu">
+                        <ul class="nav__list" role="menubar" aria-label="Site services menu">
+                          {% for language in languages %}
+                              <li class="nav__item" role="menuitem"><a data-qa="switch-language-{{language[0]}}" class="nav__link" href="?language_code={{language[0]}}">{{language[1]}}</a></li>
+                          {% endfor %}
+                        </ul>
+                    </nav>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="header__main">
+        <div class="container">
+            <div class="grid grid--gutterless grid--align-mid u-cf">
+                <div class="grid__col">
+                    <h1 class="header__title ">{{ survey_title }}</h1>
+                </div>
+                <button class="btn btn--mobile js-nav-btn u-fr u-d-no--@s" type="button" id="menu-btn" aria-expanded="false" aria-controls="main-nav" aria-label="Toggle main navigation" aria-haspopup="true"><span class="btn--mobile__label"></span></button>
+            </div>
+        </div>
+    </div>
+    <div class="header__nav">
+        <div class="container">
+            <nav class="nav nav--horizontal nav--light nav--main nav--h-m js-main-nav" aria-label="Main menu" aria-hidden="true" id="main-nav">
+                <ul class="nav__list" aria-label="Navigation menu" role="menubar">
+                  {% for language in languages %}
+                      <li class="nav__item nav__item--secondary u-d-no--@s" role="menuitem"><a data-qa="switch-language-{{language[0]}}" class="nav__link print__hidden" href="?language_code={{language[0]}}">{{language[1]}}</a></li>
+                  {% endfor %}
+                </ul>
+            </nav>
+        </div>
+    </div>
+</header>

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -82,7 +82,14 @@ def before_questionnaire_request():
                        session_form_type=metadata['form_type'],
                        session_collection_id=metadata['collection_exercise_sid'])
 
-    session_data = get_session_store().session_data
+    session_store = get_session_store()
+    session_data = session_store.session_data
+
+    language_code = request.args.get('language_code')
+    if language_code:
+        session_data.language_code = language_code
+        session_store.save()
+
     g.schema = load_schema_from_session_data(session_data)
 
 
@@ -744,6 +751,9 @@ def _build_template(current_location, context, template, schema, answer_store, m
 def _render_template(context, current_location, template, front_end_navigation, previous_url, schema, metadata, answer_store, **kwargs):
     page_title = get_page_title_for_location(schema, current_location, metadata, answer_store)
 
+    session_store = get_session_store()
+    session_data = session_store.session_data
+
     return render_template(
         template,
         content=context,
@@ -752,6 +762,7 @@ def _render_template(context, current_location, template, front_end_navigation, 
         previous_location=previous_url,
         page_title=page_title,
         metadata=kwargs.pop('metadata_context'),  # `metadata_context` is used as `metadata` in the jinja templates
+        language_code=session_data.language_code,
         **kwargs
     )
 

--- a/application.py
+++ b/application.py
@@ -65,5 +65,5 @@ application = create_app()
 if __name__ == '__main__':
     manager = Manager(application)
     port = int(os.environ.get('PORT', 5000))
-    manager.add_command("runserver", Server(host='0.0.0.0', port=port))
+    manager.add_command("runserver", Server(host='0.0.0.0', port=port, threaded=True))
     manager.run()

--- a/data/cy/test_language.json
+++ b/data/cy/test_language.json
@@ -4,7 +4,7 @@
     "data_version": "0.0.1",
     "survey_id": "0",
     "title": "Welsh Language Survey",
-    "theme": "default",
+    "theme": "social",
     "description": "A questionnaire to demonstrate welsh language",
     "metadata": [{
         "validator": "string",
@@ -12,9 +12,6 @@
     }, {
         "validator": "string",
         "name": "period_id"
-    }, {
-        "validator": "string",
-        "name": "ru_name"
     }],
     "sections": [{
         "id": "default-section",

--- a/data/en/test_language.json
+++ b/data/en/test_language.json
@@ -4,16 +4,13 @@
     "data_version": "0.0.1",
     "survey_id": "0",
     "title": "English Language Survey",
-    "theme": "default",
+    "theme": "social",
     "description": "A questionnaire to demonstrate english language",
     "metadata": [{
         "name": "user_id",
         "validator": "string"
     }, {
         "name": "period_id",
-        "validator": "string"
-    }, {
-        "name": "ru_name",
         "validator": "string"
     }],
     "sections": [{

--- a/tests/functional/pages/surveys/question.page.js
+++ b/tests/functional/pages/surveys/question.page.js
@@ -28,6 +28,8 @@ class QuestionPage extends BasePage {
 
   saveSignOut() { return '[data-qa="btn-save-sign-out"]'; }
 
+  switchLanguage(language_code) { return '[data-qa="switch-language-' + language_code + '"]'; }
+
 }
 
 module.exports = QuestionPage;

--- a/tests/functional/spec/language_code.spec.js
+++ b/tests/functional/spec/language_code.spec.js
@@ -45,4 +45,46 @@ describe('Language Code', function() {
     });
   });
 
+  it('Given the language code en, When I select Cymraeg lanuage, Then the language should be switched to Welsh', function() {
+
+    return helpers.openQuestionnaire('test_language.json', helpers.getRandomString(10), helpers.getRandomString(10), '201605', 'May 2016', 'GB-ENG', 'en').then(() => {
+
+      return browser
+        .getText(LanguagePage.displayedName()).should.eventually.equal('English Questionnaire')
+        .click(SummaryPage.switchLanguage('cy'))
+        .getText(LanguagePage.displayedName()).should.eventually.equal('Holiadur Cymraeg')
+        .click(SummaryPage.switchLanguage('en'))
+        .selectByValue(LanguagePage.Month(), 4)
+        .setValue(LanguagePage.Year(), 2018)
+        .click(LanguagePage.submit())
+
+        .getUrl().should.eventually.contain(SummaryPage.pageName)
+        .getText(SummaryPage.monthYearAnswer()).should.eventually.contain('April 2018')
+
+        .click(SummaryPage.switchLanguage('cy'))
+        .getText(SummaryPage.monthYearAnswer()).should.eventually.contain('Ebrill 2018');
+    });
+  });
+
+  it('Given the language code cy, When I select English lanuage, Then the language should be switched to English', function() {
+
+    return helpers.openQuestionnaire('test_language.json', helpers.getRandomString(10), helpers.getRandomString(10), '201605', 'May 2016', 'GB-ENG', 'cy').then(() => {
+
+      return browser
+        .getText(LanguagePage.displayedName()).should.eventually.equal('Holiadur Cymraeg')
+        .click(SummaryPage.switchLanguage('en'))
+        .getText(LanguagePage.displayedName()).should.eventually.equal('English Questionnaire')
+        .click(SummaryPage.switchLanguage('cy'))
+        .selectByValue(LanguagePage.Month(), 4)
+        .setValue(LanguagePage.Year(), 2018)
+        .click(LanguagePage.submit())
+
+        .getUrl().should.eventually.contain(SummaryPage.pageName)
+        .getText(SummaryPage.monthYearAnswer()).should.eventually.contain('Ebrill 2018')
+
+        .click(LanguagePage.switchLanguage('en'))
+        .getText(SummaryPage.monthYearAnswer()).should.eventually.contain('April 2018');
+    });
+  });
+
 });

--- a/tests/integration/views/test_questionnaire.py
+++ b/tests/integration/views/test_questionnaire.py
@@ -630,17 +630,3 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         self.question_store.remove_completed_blocks(group_id='group2', block_id='block1')
 
         # no exception equates to passed
-
-class TestQuestionnaireLanguage(IntegrationTestCase):
-    """ Tests that the language selection from tokens works """
-    def test_load_cy_survey(self):
-        # When: load a cy survey
-        self.launchSurvey('test', 'language', language_code='cy')
-        # Then: welsh
-        self.assertInPage('Holiadur Cymraeg')
-
-    def test_load_non_existant_lang_fallback(self):
-        # When: load a hindi survey
-        self.launchSurvey('test', 'language', language_code='hi')
-        # Then: Falls back to english
-        self.assertInPage('English Questionnaire')

--- a/tests/integration/views/test_questionnaire_language.py
+++ b/tests/integration/views/test_questionnaire_language.py
@@ -1,0 +1,24 @@
+from tests.integration.integration_test_case import IntegrationTestCase
+
+class TestQuestionnaireLanguage(IntegrationTestCase):
+    """ Tests that the language selection from tokens works """
+    def test_load_cy_survey(self):
+        # When: load a cy survey
+        self.launchSurvey('test', 'language', language_code='cy')
+        # Then: welsh
+        self.assertInPage('Holiadur Cymraeg')
+
+    def test_load_non_existant_lang_fallback(self):
+        # When: load a hindi survey
+        self.launchSurvey('test', 'language', language_code='hi')
+        # Then: Falls back to english
+        self.assertInPage('English Questionnaire')
+
+    def test_language_switch_in_flight(self):
+        # load a english survey
+        self.launchSurvey('test', 'language', language_code='en')
+        # The language is english
+        self.assertInPage('English Questionnaire')
+        # Switch the language to welsh
+        self.get('{}?language_code=cy'.format(self.last_url))
+        self.assertInPage('Holiadur Cymraeg')


### PR DESCRIPTION
### What is the context of this PR?
Allows language to be switched for social surveys
Currently hard coded to en/cy

### How to review 
load `test_language.json` and use the switcher in the top right

