### PR TITLE
Remove in-flight handling for started_at

### DIFF
--- a/app/data_model/questionnaire_store.py
+++ b/app/data_model/questionnaire_store.py
@@ -37,13 +37,6 @@ class QuestionnaireStore:
         self._metadata = to_set
         self.metadata = MappingProxyType(self._metadata)
 
-    def set_metadata_key(self, key, value):
-        """
-        Temporary method to allow setting a key on our 'immutable' metadata.
-        This should be removed after deployment of collection_metadata changes.
-        """
-        self._metadata[key] = value
-
     def ensure_latest_version(self, schema):
         """ If the code has been updated, the data being loaded may need
         transforming to match the latest code. """

--- a/app/submitter/converter.py
+++ b/app/submitter/converter.py
@@ -62,8 +62,6 @@ def convert_answers(metadata, collection_metadata, schema, answer_store, routing
     }
     if collection_metadata.get('started_at'):
         payload['started_at'] = collection_metadata['started_at']
-    elif metadata.get('started_at'):
-        payload['started_at'] = metadata['started_at']
     if metadata.get('case_id'):
         payload['case_id'] = metadata['case_id']
     if metadata.get('case_ref'):


### PR DESCRIPTION
### What is the context of this PR?
There was a little bit of code handling started_at in-flight data left in the code base, which wasn't covered by tests.

Since the rest of this has been removed, I've removed these two instances too.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
