### PR TITLE
Replace ru_name with display_adderss

### DIFF
--- a/data/en/lms_2.json
+++ b/data/en/lms_2.json
@@ -27,6 +27,10 @@
         {
             "name": "country",
             "validator": "string"
+        },
+        {
+            "name": "display_address",
+            "validator": "string"
         }
     ],
     "sections": [{
@@ -38,7 +42,7 @@
                     "blocks": [{
                             "type": "Interstitial",
                             "id": "about-household",
-                            "title": "About you and people who live at {{ metadata['ru_name'] }}",
+                            "title": "About you and people who live at {{ metadata['display_address'] }}",
                             "description": "In this section, we’re going to ask about you, and the people that live with you.",
                             "content": [{
                                 "title": "Information you need",
@@ -52,7 +56,7 @@
                             "type": "Question",
                             "id": "address-check-block",
                             "title": "Your address:",
-                            "description": "{{metadata['ru_name']}}",
+                            "description": "{{metadata['display_address']}}",
                             "questions": [{
                                 "id": "address-check-question",
                                 "title": "Is the address above your main residence?",
@@ -104,7 +108,7 @@
                         {
                             "type": "Question",
                             "id": "address-type-check-block",
-                            "title": "You said {{ metadata['ru_name'] }} is not your main residence",
+                            "title": "You said {{ metadata['display_address'] }} is not your main residence",
                             "description": "",
                             "questions": [{
                                 "id": "address-type-check-question",
@@ -161,7 +165,7 @@
                             "type": "Question",
                             "questions": [{
                                 "id": "household-composition-question",
-                                "title": "What are the names of everyone who lives in the <em>{{ metadata['ru_name'] }}</em> household?",
+                                "title": "What are the names of everyone who lives in the <em>{{ metadata['display_address'] }}</em> household?",
                                 "type": "RepeatingAnswer",
                                 "answers": [{
                                         "id": "first-name",


### PR DESCRIPTION
### What is the context of this PR?
https://trello.com/c/iugfWgRR/2392-add-address-fields-to-lms-schema

Just like the lms_1 survey, lms_2 needs a display address so that people can confirm their address.

### How to review 
`display_address` should appear as a metadata field when you open it in launcher.  The the address questions should contain that `display_address` that was passed through.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
