### PR TITLE
Allow for missing keys in answer matching

### DIFF
--- a/app/data_model/answer_store.py
+++ b/app/data_model/answer_store.py
@@ -41,11 +41,11 @@ class Answer:
         """
 
         return self.matches(Answer(
-            answer_dict['answer_id'],
-            answer_dict['value'],
-            answer_dict['group_instance_id'],
-            answer_dict['group_instance'],
-            answer_dict['answer_instance'],
+            answer_dict.get('answer_id'),
+            answer_dict.get('value'),
+            answer_dict.get('group_instance_id'),
+            answer_dict.get('group_instance', 0),
+            answer_dict.get('answer_instance', 0),
         ))
 
 

--- a/tests/app/data_model/test_answer_store.py
+++ b/tests/app/data_model/test_answer_store.py
@@ -48,6 +48,46 @@ class TestAnswer(unittest.TestCase):
         self.assertEqual(answer_1.matches_dict(answer_2), True)
 
 
+    def test_matches_answer_dict_missing_key(self):
+        # No group_instance_id
+        answer_1 = Answer(
+            answer_id='4',
+            answer_instance=1,
+            group_instance=1,
+            value=25,
+        )
+        # No group_instance_id
+        answer_2 = {
+            'answer_id': '4',
+            'answer_instance': 1,
+            'group_instance': 1,
+            'value': 25,
+        }
+
+        self.assertEqual(answer_1.matches_dict(answer_2), True)
+
+
+    def test_matches_new_answer_against_old_answer(self):
+        # Has group_instance_id
+        answer_1 = Answer(
+            answer_id='4',
+            answer_instance=1,
+            group_instance=1,
+            group_instance_id=None,
+            value=25,
+        )
+
+        # No group_instance_id
+        answer_2 = {
+            'answer_id': '4',
+            'answer_instance': 1,
+            'group_instance': 1,
+            'value': 25,
+        }
+
+        self.assertEqual(answer_1.matches_dict(answer_2), True)
+
+
 class TestAnswerStore(unittest.TestCase):  # pylint: disable=too-many-public-methods
     def setUp(self):
         self.store = AnswerStore()


### PR DESCRIPTION
### What is the context of this PR?
When matching answers it relied on all keys being present
Allowing for keys to be missing allows easier forward compatibility

### How to test
- Run `v2.55.0` of the code when `group_instance_id` isn't available and save some data. 
- Move to `v2.57.2` and save an answer. Should result in 500 error.
- Move over to this branch of the code and attempt the same.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
