### PR TITLE
Remove title from QCAS summary

### DIFF
--- a/data/en/qcas_0018.json
+++ b/data/en/qcas_0018.json
@@ -41,8 +41,8 @@
             "id": "qcas-section",
             "title": "QCAS",
             "groups": [{
-                "id": "introduction-group",
-                "title": "Introduction",
+                "id": "qcas",
+                "title": "",
                 "blocks": [{
                         "type": "Introduction",
                         "id": "introduction-block",

--- a/data/en/qcas_0019.json
+++ b/data/en/qcas_0019.json
@@ -41,8 +41,8 @@
             "id": "qcas-section",
             "title": "QCAS",
             "groups": [{
-                "id": "introduction-group",
-                "title": "Introduction",
+                "id": "qcas",
+                "title": "",
                 "blocks": [{
                         "type": "Introduction",
                         "id": "introduction-block",

--- a/data/en/qcas_0020.json
+++ b/data/en/qcas_0020.json
@@ -41,8 +41,8 @@
             "id": "qcas-section",
             "title": "QCAS",
             "groups": [{
-                "id": "introduction-group",
-                "title": "Introduction",
+                "id": "qcas",
+                "title": "",
                 "blocks": [{
                         "type": "Introduction",
                         "id": "introduction-block",


### PR DESCRIPTION
### What is the context of this PR?
Removed the group title from displaying on the QCAS summary page.

### How to review 
- Make sure the group title `Introduction` doesn't display on the summary page.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
