### PR TITLE
Change number to hour value in lms

### DIFF
--- a/data/en/lms_2.json
+++ b/data/en/lms_2.json
@@ -2995,7 +2995,8 @@
                             "answers": [{
                                 "id": "one-job-no-days-worked-no-overtime-answer",
                                 "mandatory": false,
-                                "type": "Number"
+                                "type": "Unit",
+                                "unit": "duration-hour"
                             }]
                         }],
                         "routing_rules": [{
@@ -3046,7 +3047,8 @@
                             "answers": [{
                                 "id": "two-jobs-j1-no-days-worked-no-overtime-answer",
                                 "mandatory": false,
-                                "type": "Number"
+                                "type": "Unit",
+                                "unit": "duration-hour"
                             }]
                         }]
                     },
@@ -3071,7 +3073,8 @@
                             "answers": [{
                                 "id": "two-jobs-j2-no-days-worked-no-overtime-answer",
                                 "mandatory": false,
-                                "type": "Number"
+                                "type": "Unit",
+                                "unit": "duration-hour"
                             }]
                         }],
                         "routing_rules": [{
@@ -3124,7 +3127,8 @@
                             "answers": [{
                                 "id": "unpaid-overtime-answer",
                                 "mandatory": false,
-                                "type": "Number",
+                                "type": "Unit",
+                                "unit": "duration-hour",
                                 "label": "Unpaid overtime hours"
                             }]
                         }],
@@ -3173,7 +3177,8 @@
                             "answers": [{
                                 "id": "paid-overtime-answer",
                                 "mandatory": false,
-                                "type": "Number",
+                                "type": "Unit",
+                                "unit": "duration-hour",
                                 "label": "Paid overtime hours"
                             }]
                         }]
@@ -3201,7 +3206,8 @@
                             "answers": [{
                                 "id": "one-job-usual-hours-answer",
                                 "mandatory": false,
-                                "type": "Number"
+                                "type": "Unit",
+                                "unit": "duration-hour"
                             }],
                             "guidance": {
                                 "content": [{
@@ -3248,7 +3254,8 @@
                             "answers": [{
                                 "id": "one-job-actual-hours-answer",
                                 "mandatory": false,
-                                "type": "Number",
+                                "type": "Unit",
+                                "unit": "duration-hour",
                                 "label": "Actual hours"
                             }]
                         }],
@@ -3351,7 +3358,8 @@
                                 "id": "two-jobs-j1-unpaid-overtime-answer",
                                 "label": "Unpaid overtime hours, main job",
                                 "mandatory": false,
-                                "type": "Number"
+                                "type": "Unit",
+                                "unit": "duration-hour"
                             }]
                         }]
                     },
@@ -3376,7 +3384,8 @@
                             "answers": [{
                                 "id": "two-jobs-j2-unpaid-overtime-answer",
                                 "mandatory": false,
-                                "type": "Number",
+                                "type": "Unit",
+                                "unit": "duration-hour",
                                 "label": "Unpaid overtime hours, second job"
                             }]
                         }],
@@ -3418,7 +3427,8 @@
                             "answers": [{
                                 "id": "two-jobs-j1-paid-overtime-answer",
                                 "mandatory": false,
-                                "type": "Number",
+                                "type": "Unit",
+                                "unit": "duration-hour",
                                 "label": "Paid overtime hours, main job"
                             }]
                         }]
@@ -3451,7 +3461,8 @@
                             "answers": [{
                                 "id": "two-jobs-j2-paid-overtime-answer",
                                 "mandatory": false,
-                                "type": "Number",
+                                "type": "Unit",
+                                "unit": "duration-hour",
                                 "label": "Paid overtime hours, second job"
                             }]
                         }]
@@ -3479,7 +3490,8 @@
                             "answers": [{
                                 "id": "two-jobs-j1-usual-hours-answer",
                                 "mandatory": false,
-                                "type": "Number",
+                                "type": "Unit",
+                                "unit": "duration-hour",
                                 "label": "Hours"
                             }],
                             "guidance": {
@@ -3510,7 +3522,8 @@
                             "answers": [{
                                 "id": "two-jobs-j1-actual-hours-answer",
                                 "mandatory": false,
-                                "type": "Number",
+                                "type": "Unit",
+                                "unit": "duration-hour",
                                 "label": "Actual hours main job"
                             }]
                         }],
@@ -3614,7 +3627,8 @@
                             "answers": [{
                                 "id": "two-jobs-j2-usual-hours-answer",
                                 "mandatory": false,
-                                "type": "Number",
+                                "type": "Unit",
+                                "unit": "duration-hour",
                                 "label": "Hours"
                             }],
                             "guidance": {
@@ -3645,7 +3659,8 @@
                             "answers": [{
                                 "id": "two-jobs-j2-actual-hours-answer",
                                 "mandatory": false,
-                                "type": "Number",
+                                "type": "Unit",
+                                "unit": "duration-hour",
                                 "label": "Actual hours, second job"
                             }]
                         }],
@@ -3748,7 +3763,8 @@
                             "answers": [{
                                 "id": "casual-hours-answer",
                                 "mandatory": false,
-                                "type": "Number",
+                                "type": "Unit",
+                                "unit": "duration-hour",
                                 "label": "Casual hours"
                             }]
                         }]

--- a/tests/app/test_jinja_filters.py
+++ b/tests/app/test_jinja_filters.py
@@ -455,6 +455,7 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
         self.assertEqual(format_unit('volume-liter', 100), '100 l')
         self.assertEqual(format_unit('volume-hectoliter', 100), '100 hl')
         self.assertEqual(format_unit('volume-megaliter', 100), '100 Ml')
+        self.assertEqual(format_unit('duration-hour', 100), '100 hrs')
 
     def test_format_year_month_duration(self):
         with self.app_request_context('/'):


### PR DESCRIPTION
### What is the context of this PR?
https://trello.com/c/SH28V5uH/2391-change-hours-answers-from-number-to-hours-unit

The hour values on the LMS survey needed to change from number to hour units so there is extra formatting on the answer entry field.

### How to review 
open `lms_2.json` schema and fill in answers until you get to the questions about jobs.  The fields that ask for an hour value should have an extra box on the side (like volume or currency fields) that indicate what unit the measurement is in.  The summary page should also have 'hrs' in it.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
