### PR TITLE
Add answer comparison routing LMS2

### DIFF
--- a/data/en/lms_2.json
+++ b/data/en/lms_2.json
@@ -4020,9 +4020,9 @@
                                             "value": "employee"
                                         },
                                         {
-                                            "comparison_id": "two-jobs-j1-usual-hours-answer",
-                                            "condition": "less than",
-                                            "id": "two-jobs-j1-actual-hours-answer"
+                                            "id": "two-jobs-j1-actual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "two-jobs-j1-usual-hours-answer"
                                         }
                                     ]
                                 }
@@ -4036,9 +4036,9 @@
                                             "value": "employee"
                                         },
                                         {
-                                            "comparison_id": "two-jobs-j1-usual-hours-answer",
-                                            "condition": "less than",
-                                            "id": "two-jobs-j1-actual-hours-answer"
+                                            "id": "two-jobs-j1-actual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "two-jobs-j1-usual-hours-answer"
                                         }
                                     ]
                                 }
@@ -4052,9 +4052,9 @@
                                             "value": "employee"
                                         },
                                         {
-                                            "comparison_id": "two-jobs-j1-usual-hours-answer",
+                                            "id": "two-jobs-j1-actual-hours-answer",
                                             "condition": "equals",
-                                            "id": "two-jobs-j1-actual-hours-answer"
+                                            "comparison_id": "two-jobs-j1-usual-hours-answer"
                                         }
                                     ]
                                 }
@@ -4068,9 +4068,9 @@
                                             "value": "employee"
                                         },
                                         {
-                                            "comparison_id": "two-jobs-j1-usual-hours-answer",
+                                            "id": "two-jobs-j1-actual-hours-answer",
                                             "condition": "equals",
-                                            "id": "two-jobs-j1-actual-hours-answer"
+                                            "comparison_id": "two-jobs-j1-usual-hours-answer"
                                         }
                                     ]
                                 }
@@ -4084,9 +4084,9 @@
                                             "value": "employee"
                                         },
                                         {
-                                            "comparison_id": "two-jobs-j1-usual-hours-answer",
-                                            "condition": "greater than",
-                                            "id": "two-jobs-j1-actual-hours-answer"
+                                            "id": "two-jobs-j1-actual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "two-jobs-j1-usual-hours-answer"
                                         }
                                     ]
                                 }
@@ -4100,9 +4100,9 @@
                                             "value": "employee"
                                         },
                                         {
-                                            "comparison_id": "two-jobs-j1-usual-hours-answer",
-                                            "condition": "greater than",
-                                            "id": "two-jobs-j1-actual-hours-answer"
+                                            "id": "two-jobs-j1-actual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "two-jobs-j1-usual-hours-answer"
                                         }
                                     ]
                                 }
@@ -4116,9 +4116,9 @@
                                             "value": "Self-employed"
                                         },
                                         {
-                                            "comparison_id": "two-jobs-j1-usual-hours-answer",
-                                            "condition": "less than",
-                                            "id": "two-jobs-j1-actual-hours-answer"
+                                            "id": "two-jobs-j1-actual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "two-jobs-j1-usual-hours-answer"
                                         }
                                     ]
                                 }
@@ -4132,9 +4132,9 @@
                                             "value": "Self-employed"
                                         },
                                         {
-                                            "comparison_id": "two-jobs-j1-usual-hours-answer",
-                                            "condition": "less than",
-                                            "id": "two-jobs-j1-actual-hours-answer"
+                                            "id": "two-jobs-j1-actual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "two-jobs-j1-usual-hours-answer"
                                         }
                                     ]
                                 }
@@ -4148,9 +4148,9 @@
                                             "value": "Self-employed"
                                         },
                                         {
-                                            "comparison_id": "two-jobs-j1-usual-hours-answer",
+                                            "id": "two-jobs-j1-actual-hours-answer",
                                             "condition": "equals",
-                                            "id": "two-jobs-j1-actual-hours-answer"
+                                            "comparison_id": "two-jobs-j1-usual-hours-answer"
                                         }
                                     ]
                                 }
@@ -4180,9 +4180,9 @@
                                             "value": "Self-employed"
                                         },
                                         {
-                                            "comparison_id": "two-jobs-j1-usual-hours-answer",
-                                            "condition": "greater than",
-                                            "id": "two-jobs-j1-actual-hours-answer"
+                                            "id": "two-jobs-j1-actual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "two-jobs-j1-usual-hours-answer"
                                         }
                                     ]
                                 }
@@ -4196,9 +4196,9 @@
                                             "value": "Self-employed"
                                         },
                                         {
-                                            "comparison_id": "two-jobs-j1-usual-hours-answer",
-                                            "condition": "greater than",
-                                            "id": "two-jobs-j1-actual-hours-answer"
+                                            "id": "two-jobs-j1-actual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "two-jobs-j1-usual-hours-answer"
                                         }
                                     ]
                                 }

--- a/data/en/lms_2.json
+++ b/data/en/lms_2.json
@@ -2974,7 +2974,8 @@
                                 "id": "one-job-no-days-worked-no-overtime-answer",
                                 "mandatory": false,
                                 "type": "Unit",
-                                "unit": "duration-hour"
+                                "unit": "duration-hour",
+                                "label": "Usual hours"
                             }]
                         }],
                         "routing_rules": [{
@@ -2983,7 +2984,8 @@
                                     "when": [{
                                         "id": "one-job-emp-status-emp-or-self-answer",
                                         "condition": "equals",
-                                        "value": "employee"
+                                        "value": "employee",
+                                        "label": "Usual hours"
                                     }]
                                 }
                             },
@@ -3026,7 +3028,8 @@
                                 "id": "two-jobs-j1-no-days-worked-no-overtime-answer",
                                 "mandatory": false,
                                 "type": "Unit",
-                                "unit": "duration-hour"
+                                "unit": "duration-hour",
+                                "label": "Usual hours"
                             }]
                         }]
                     },
@@ -3052,7 +3055,8 @@
                                 "id": "two-jobs-j2-no-days-worked-no-overtime-answer",
                                 "mandatory": false,
                                 "type": "Unit",
-                                "unit": "duration-hour"
+                                "unit": "duration-hour",
+                                "label": "Usual hours"
                             }]
                         }],
                         "routing_rules": [{
@@ -3471,7 +3475,7 @@
                                 "mandatory": false,
                                 "type": "Unit",
                                 "unit": "duration-hour",
-                                "label": "Hours"
+                                "label": "Usual hours"
                             }],
                             "guidance": {
                                 "content": [{
@@ -3608,7 +3612,7 @@
                                 "mandatory": false,
                                 "type": "Unit",
                                 "unit": "duration-hour",
-                                "label": "Hours"
+                                "label": "Usual hours"
                             }],
                             "guidance": {
                                 "content": [{

--- a/data/en/lms_2.json
+++ b/data/en/lms_2.json
@@ -3195,7 +3195,7 @@
                         }],
                         "routing_rules": [{
                                 "goto": {
-                                    "block": "hours-totalized-w13",
+                                    "block": "one-job-hours-totalized-w13",
                                     "when": [{
                                         "id": "working-days-answer",
                                         "condition": "contains",
@@ -3258,7 +3258,7 @@
                             },
                             {
                                 "goto": {
-                                    "block": "hours-totalized-w13"
+                                    "block": "one-job-hours-totalized-w13"
                                 }
                             }
                         ]
@@ -3309,7 +3309,7 @@
                             },
                             {
                                 "goto": {
-                                    "block": "hours-totalized-w13"
+                                    "block": "one-job-hours-totalized-w13"
                                 }
                             }
                         ]
@@ -3663,7 +3663,7 @@
                             },
                             {
                                 "goto": {
-                                    "block": "hours-totalized-w13"
+                                    "block": "two-jobs-hours-totalized-w13-1"
                                 }
                             }
                         ]
@@ -3714,12 +3714,11 @@
                             },
                             {
                                 "goto": {
-                                    "block": "hours-totalized-w13"
+                                    "block": "two-jobs-hours-totalized-w13-1"
                                 }
                             }
                         ]
                     },
-
                     {
                         "id": "casual-hours-worked-casac",
                         "type": "Question",
@@ -3748,7 +3747,7 @@
                         }]
                     },
                     {
-                        "id": "hours-totalized-w13",
+                        "id": "one-job-hours-totalized-w13",
                         "type": "CalculatedSummary",
                         "titles": [{
                                 "value": "We calculate the total number of hours that <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}</em> worked in their job, including overtime, to be %(total)s hours for the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}. Is this correct? ",
@@ -3768,7 +3767,234 @@
                                 "one-job-actual-hours-answer",
                                 "paid-overtime-answer",
                                 "unpaid-overtime-answer",
-                                "casual-hours-answer",
+                                "casual-hours-answer"
+                            ],
+                            "titles": [{
+                                "value": "Total hours worked"
+                            }]
+                        },
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                        "id": "not-working-casual-work-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "one-job-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "one-job-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "one-job-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "one-job-emp-status-emp-or-self-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "one-job-emp-status-emp-or-self-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "reason-why-fewer-hours-than-usual-self-employed-w14-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "one-job-emp-status-emp-or-self-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "reason-why-fewer-hours-than-usual-self-employed-w14-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "two-jobs-hours-totalized-w13-1",
+                        "type": "CalculatedSummary",
+                        "titles": [{
+                                "value": "We calculate the total number of hours that <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}</em> worked in their main and second jobs, including overtime, to be %(total)s hours for the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}. Is this correct? ",
+                                "when": [{
+                                    "id": "proxy-check-answer",
+                                    "condition": "equals",
+                                    "value": "proxy"
+                                }]
+                            },
+                            {
+                                "value": "We calculate the total number of hours that you worked in your main and second jobs, including overtime, to be %(total)s hours for the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}. Is this correct? "
+                            }
+                        ],
+                        "calculation": {
+                            "calculation_type": "sum",
+                            "answers_to_calculate": [
                                 "two-jobs-j1-actual-hours-answer",
                                 "two-jobs-j2-actual-hours-answer",
                                 "two-jobs-j1-paid-overtime-answer",
@@ -3782,27 +4008,194 @@
                         },
                         "routing_rules": [{
                                 "goto": {
-                                    "block": "reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "block": "main-job-when-start-working-current-business-red6-emp",
                                     "when": [{
-                                        "id": "one-job-emp-status-emp-or-self-answer",
-                                        "condition": "equals",
-                                        "value": "employee"
-                                    }]
+                                            "condition": "equals",
+                                            "id": "two-jobs-j1-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "comparison_id": "two-jobs-j1-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "id": "two-jobs-j1-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "two-jobs-j1-emp-status-emp-or-self-proxy-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "comparison_id": "two-jobs-j1-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "id": "two-jobs-j1-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "two-jobs-j1-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "comparison_id": "two-jobs-j1-usual-hours-answer",
+                                            "condition": "equals",
+                                            "id": "two-jobs-j1-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "two-jobs-j1-emp-status-emp-or-self-proxy-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "comparison_id": "two-jobs-j1-usual-hours-answer",
+                                            "condition": "equals",
+                                            "id": "two-jobs-j1-actual-hours-answer"
+                                        }
+                                    ]
                                 }
                             },
                             {
                                 "goto": {
                                     "block": "reason-why-fewer-hours-than-usual-employee-w14-emp",
                                     "when": [{
-                                        "id": "one-job-emp-status-emp-or-self-proxy-answer",
-                                        "condition": "equals",
-                                        "value": "employee"
-                                    }]
+                                            "condition": "equals",
+                                            "id": "two-jobs-j1-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "comparison_id": "two-jobs-j1-usual-hours-answer",
+                                            "condition": "less than",
+                                            "id": "two-jobs-j1-actual-hours-answer"
+                                        }
+                                    ]
                                 }
                             },
                             {
                                 "goto": {
-                                    "block": "reason-why-fewer-hours-than-usual-self-employed-w14-semp"
+                                    "block": "reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "two-jobs-j1-emp-status-emp-or-self-proxy-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "comparison_id": "two-jobs-j1-usual-hours-answer",
+                                            "condition": "less than",
+                                            "id": "two-jobs-j1-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "two-jobs-j1-emp-status-emp-or-self-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "comparison_id": "two-jobs-j1-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "id": "two-jobs-j1-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "two-jobs-j1-emp-status-emp-or-self-proxy-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "comparison_id": "two-jobs-j1-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "id": "two-jobs-j1-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "two-jobs-j1-emp-status-emp-or-self-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "comparison_id": "two-jobs-j1-usual-hours-answer",
+                                            "condition": "equals",
+                                            "id": "two-jobs-j1-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "two-jobs-j1-emp-status-emp-or-self-proxy-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "comparison_id": "two-jobs-j1-usual-hours-answer",
+                                            "condition": "equals",
+                                            "id": "two-jobs-j1-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "reason-why-fewer-hours-than-usual-self-employed-w14-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "two-jobs-j1-emp-status-emp-or-self-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "comparison_id": "two-jobs-j1-usual-hours-answer",
+                                            "condition": "less than",
+                                            "id": "two-jobs-j1-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "reason-why-fewer-hours-than-usual-self-employed-w14-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "two-jobs-j1-emp-status-emp-or-self-proxy-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "comparison_id": "two-jobs-j1-usual-hours-answer",
+                                            "condition": "less than",
+                                            "id": "two-jobs-j1-actual-hours-answer"
+                                        }
+                                    ]
                                 }
                             }
                         ]

--- a/data/en/lms_2.json
+++ b/data/en/lms_2.json
@@ -3185,7 +3185,8 @@
                                 "id": "one-job-usual-hours-answer",
                                 "mandatory": false,
                                 "type": "Unit",
-                                "unit": "duration-hour"
+                                "unit": "duration-hour",
+                                "label": "Usual hours"
                             }],
                             "guidance": {
                                 "content": [{
@@ -3793,7 +3794,7 @@
                                         },
                                         {
                                             "id": "one-job-usual-hours-answer",
-                                            "condition": "greater than",
+                                            "condition": "less than",
                                             "comparison_id": "one-job-actual-hours-answer"
                                         }
                                     ]
@@ -3809,7 +3810,7 @@
                                         },
                                         {
                                             "id": "one-job-usual-hours-answer",
-                                            "condition": "greater than",
+                                            "condition": "less than",
                                             "comparison_id": "one-job-actual-hours-answer"
                                         }
                                     ]
@@ -3857,7 +3858,7 @@
                                         },
                                         {
                                             "id": "one-job-usual-hours-answer",
-                                            "condition": "less than",
+                                            "condition": "greater than",
                                             "comparison_id": "one-job-actual-hours-answer"
                                         }
                                     ]
@@ -3873,7 +3874,7 @@
                                         },
                                         {
                                             "id": "one-job-usual-hours-answer",
-                                            "condition": "less than",
+                                            "condition": "greater than",
                                             "comparison_id": "one-job-actual-hours-answer"
                                         }
                                     ]
@@ -3889,7 +3890,7 @@
                                         },
                                         {
                                             "id": "one-job-usual-hours-answer",
-                                            "condition": "greater than",
+                                            "condition": "less than",
                                             "comparison_id": "one-job-actual-hours-answer"
                                         }
                                     ]
@@ -3905,7 +3906,7 @@
                                         },
                                         {
                                             "id": "one-job-usual-hours-answer",
-                                            "condition": "greater than",
+                                            "condition": "less than",
                                             "comparison_id": "one-job-actual-hours-answer"
                                         }
                                     ]
@@ -3953,7 +3954,7 @@
                                         },
                                         {
                                             "id": "one-job-usual-hours-answer",
-                                            "condition": "less than",
+                                            "condition": "greater than",
                                             "comparison_id": "one-job-actual-hours-answer"
                                         }
                                     ]
@@ -3969,7 +3970,7 @@
                                         },
                                         {
                                             "id": "one-job-usual-hours-answer",
-                                            "condition": "less than",
+                                            "condition": "greater than",
                                             "comparison_id": "one-job-actual-hours-answer"
                                         }
                                     ]
@@ -4016,7 +4017,7 @@
                                         },
                                         {
                                             "comparison_id": "two-jobs-j1-usual-hours-answer",
-                                            "condition": "greater than",
+                                            "condition": "less than",
                                             "id": "two-jobs-j1-actual-hours-answer"
                                         }
                                     ]
@@ -4032,7 +4033,7 @@
                                         },
                                         {
                                             "comparison_id": "two-jobs-j1-usual-hours-answer",
-                                            "condition": "greater than",
+                                            "condition": "less than",
                                             "id": "two-jobs-j1-actual-hours-answer"
                                         }
                                     ]
@@ -4080,7 +4081,7 @@
                                         },
                                         {
                                             "comparison_id": "two-jobs-j1-usual-hours-answer",
-                                            "condition": "less than",
+                                            "condition": "greater than",
                                             "id": "two-jobs-j1-actual-hours-answer"
                                         }
                                     ]
@@ -4096,7 +4097,7 @@
                                         },
                                         {
                                             "comparison_id": "two-jobs-j1-usual-hours-answer",
-                                            "condition": "less than",
+                                            "condition": "greater than",
                                             "id": "two-jobs-j1-actual-hours-answer"
                                         }
                                     ]
@@ -4112,7 +4113,7 @@
                                         },
                                         {
                                             "comparison_id": "two-jobs-j1-usual-hours-answer",
-                                            "condition": "greater than",
+                                            "condition": "less than",
                                             "id": "two-jobs-j1-actual-hours-answer"
                                         }
                                     ]
@@ -4128,7 +4129,7 @@
                                         },
                                         {
                                             "comparison_id": "two-jobs-j1-usual-hours-answer",
-                                            "condition": "greater than",
+                                            "condition": "less than",
                                             "id": "two-jobs-j1-actual-hours-answer"
                                         }
                                     ]
@@ -4176,7 +4177,7 @@
                                         },
                                         {
                                             "comparison_id": "two-jobs-j1-usual-hours-answer",
-                                            "condition": "less than",
+                                            "condition": "greater than",
                                             "id": "two-jobs-j1-actual-hours-answer"
                                         }
                                     ]
@@ -4192,7 +4193,7 @@
                                         },
                                         {
                                             "comparison_id": "two-jobs-j1-usual-hours-answer",
-                                            "condition": "less than",
+                                            "condition": "greater than",
                                             "id": "two-jobs-j1-actual-hours-answer"
                                         }
                                     ]

--- a/data/en/lms_2.json
+++ b/data/en/lms_2.json
@@ -2984,8 +2984,7 @@
                                     "when": [{
                                         "id": "one-job-emp-status-emp-or-self-answer",
                                         "condition": "equals",
-                                        "value": "employee",
-                                        "label": "Usual hours"
+                                        "value": "employee"
                                     }]
                                 }
                             },


### PR DESCRIPTION
### What is the context of this PR?
LMS 2 has two totalisers with answer comparison routing.

### How to review 
In the spec, look at TOTAC1 and TOTAC2 questions. These are asked when the user has one or two jobs respectively. The various rules defined in red for each question show how routing should be done going out of the totaliser.

There is a proxy answer for self employed, so both need to be checked. We also do not have a `greater than or equal` condition, so have to use `>` and `=` separately. This gives 12 conditions for each question.

Testing would consist of checking each of the >,=,< paths while choosing employed and self employed and checking while proxying.


### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
