### PR TITLE
Fix code coverage with date validation

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: 95%
+        target: 100%
         threshold: null
         base: auto
     patch:

--- a/tests/app/forms/test_questionnaire_form.py
+++ b/tests/app/forms/test_questionnaire_form.py
@@ -658,11 +658,16 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 'date-range-to-year': '2018'
             }
 
-            form = generate_form(schema, block_json, store, metadata=None, group_instance=0, group_instance_id=None, formdata=data)
+            metadata = {
+                'eq_id': 'test',
+                'form_type': 'date_validation_range'
+            }
+
+            form = generate_form(schema, block_json, store, metadata=metadata, group_instance=0, group_instance_id=None, formdata=data)
+
 
             with self.assertRaises(Exception) as ite:
-                with patch('app.questionnaire.questionnaire_schema.QuestionnaireSchema.get_questions_for_block',
-                           return_value=[question_json]):
+                with patch('app.questionnaire.questionnaire_schema.QuestionnaireSchema.get_questions_for_block', return_value=[question_json]):
                     form.validate()
                     self.assertEqual('The schema has invalid date answer limits for date-range-question', str(ite.exception))
 


### PR DESCRIPTION
### What is the context of this PR?
Coverage dropped in a previous PR because get answer value now requires the schema. The schema was being retrieved from metadata, which was set to None in one test.
This adds the correct variables to metadata to allow it to load the schema.

### How to review 
Check the coverage

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
