### PR TITLE
Add address fields to lms schema

### DIFF
--- a/app/storage/metadata_parser.py
+++ b/app/storage/metadata_parser.py
@@ -88,6 +88,10 @@ def _validate_metadata_is_present(metadata, required_metadata):
     :param required_metadata:
     """
     for metadata_field in required_metadata:
+        # If the field is optional then skip validation on field
+        if metadata_field.get('optional') is True:
+            continue
+
         name = metadata_field['name']
         if name == 'trad_as_or_ru_name':
             # either of 'trad_as' or 'ru_name' is required

--- a/data/en/lms_2.json
+++ b/data/en/lms_2.json
@@ -29,6 +29,31 @@
             "validator": "string"
         },
         {
+            "name": "address_line1",
+            "validator": "string",
+            "optional": true
+        },
+        {
+            "name": "address_line2",
+            "validator": "string",
+            "optional": true
+        },
+        {
+            "name": "locality",
+            "validator": "string",
+            "optional": true
+        },
+        {
+            "name": "town_name",
+            "validator": "string",
+            "optional": true
+        },
+        {
+            "name": "postcode",
+            "validator": "string",
+            "optional": true
+        },
+        {
             "name": "display_address",
             "validator": "string"
         }

--- a/data/en/lms_2.json
+++ b/data/en/lms_2.json
@@ -27,6 +27,10 @@
         {
             "name": "country",
             "validator": "string"
+        },
+        {
+            "name": "display_address",
+            "validator": "string"
         }
     ],
     "sections": [{
@@ -38,7 +42,7 @@
                     "blocks": [{
                             "type": "Interstitial",
                             "id": "about-household",
-                            "title": "About you and people who live at {{ metadata['ru_name'] }}",
+                            "title": "About you and people who live at {{ metadata['display_address'] }}",
                             "description": "In this section, we’re going to ask about you, and the people that live with you.",
                             "content": [{
                                 "title": "Information you need",
@@ -52,7 +56,7 @@
                             "type": "Question",
                             "id": "address-check-block",
                             "title": "Your address:",
-                            "description": "{{metadata['ru_name']}}",
+                            "description": "{{metadata['display_address']}}",
                             "questions": [{
                                 "id": "address-check-question",
                                 "title": "Is the address above your main residence?",
@@ -104,7 +108,7 @@
                         {
                             "type": "Question",
                             "id": "address-type-check-block",
-                            "title": "You said {{ metadata['ru_name'] }} is not your main residence",
+                            "title": "You said {{ metadata['display_address'] }} is not your main residence",
                             "description": "",
                             "questions": [{
                                 "id": "address-type-check-question",
@@ -161,7 +165,7 @@
                             "type": "Question",
                             "questions": [{
                                 "id": "household-composition-question",
-                                "title": "What are the names of everyone who lives in the <em>{{ metadata['ru_name'] }}</em> household?",
+                                "title": "What are the names of everyone who lives in the <em>{{ metadata['display_address'] }}</em> household?",
                                 "type": "RepeatingAnswer",
                                 "answers": [{
                                         "id": "first-name",

--- a/tests/app/parser/test_metadata_parser.py
+++ b/tests/app/parser/test_metadata_parser.py
@@ -308,6 +308,26 @@ class TestMetadataParser(SurveyRunnerTestCase):  # pylint: disable=too-many-publ
 
         self.assertEqual('Invalid validator for schema metadata - invalidValidator', ite.exception.args[0])
 
+    def test_optional_metadata(self):
+        metadata = {
+            'jti': str(uuid.uuid4()),
+            'user_id': '1',
+            'form_type': 'a',
+            'collection_exercise_sid': 'test-sid',
+            'eq_id': '2',
+            'period_id': '3',
+            'ru_ref': '2016-04-04',
+            'period_str': 'May 2016',
+            'case_id': str(uuid.uuid4())
+        }
+
+        self.schema_metadata.append({'name': 'address_line1', 'validator': 'string', 'optional': True})
+        validate_metadata(metadata, self.schema_metadata)
+
+        metadata['address_line1'] = '123 awesome place'
+        validate_metadata(metadata, self.schema_metadata)
+
+
     def test_clean_leading_trailing_spaces(self):
         metadata = self.metadata.copy()
         metadata['trad_as'] = ' '


### PR DESCRIPTION
### What is the context of this PR?
https://trello.com/c/iugfWgRR/2392-add-address-fields-to-lms-schema

The individual address fields needed to be passed in, but addresses being what they are, can have empty fields.  This PR adds those fields and allows metadata to be labelled as optional also.

### How to review 
Open the lms_2.json schema in launcher.  Remove the value of any of the 5 individual address fields.  It should launch the survey fine.  Every other field not labelled with optional: true should still fail validation if it's empty.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
