### PR TITLE
Fix safe_content regex for jinja filters in titles

### DIFF
--- a/app/templating/template_renderer.py
+++ b/app/templating/template_renderer.py
@@ -61,7 +61,7 @@ class TemplateRenderer:
         """
         if content is not None:
             # Replace piping with ellipsis
-            content = re.sub(r'{{[^}]+}}', '…', content)
+            content = re.sub(r'{{.*?}}', '…', content)
             # Strip HTML Tags
             content = re.sub(r'</?[^>]+>', '', content)
         return content

--- a/tests/app/templating/test_template_renderer.py
+++ b/tests/app/templating/test_template_renderer.py
@@ -158,6 +158,13 @@ class TestTemplateRenderer(AppContextTestCase):
 
         self.assertEqual(safe_content, 'Is … correct?')
 
+    def test_should_replace_jinja_template_variable_containing_curly_braces(self):
+        content = 'Is {{ calculate_offset_from_weekday_in_last_whole_week(collection_metadata[started_at], {}, SU) }} correct?'
+
+        safe_content = TemplateRenderer.safe_content(content)
+
+        self.assertEqual(safe_content, 'Is … correct?')
+
     def test_should_replace_jinja_template_condtional_dates(self):
         content = 'Is {{ format_condtional_date(metadata.ref_p_start_date, metadata.ref_p_end_date)}} correct?'
 


### PR DESCRIPTION
### What is the context of this PR?
@dcdarrell9 noticed that some titles on LMS2 were including jinja filters.

The regex was not matching anything that contained curly braces (which we use for date offsets).

### How to review 
Test LMS2 and make sure reference date filters etc. are not shown in titles.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
