### PR TITLE
Display repeating groups in summary

### DIFF
--- a/app/helpers/schema_helpers.py
+++ b/app/helpers/schema_helpers.py
@@ -49,8 +49,9 @@ def get_group_instance_id(schema, answer_store, location, answer_instance=0):
         existing_answers = answer_store.filter(answer_ids=block_answer_ids, answer_instance=answer_instance)
 
     # If there are existing answers with a group_instance_id
-    if existing_answers and [x for x in existing_answers if x.get('group_instance_id')]:
-        return existing_answers[0]['group_instance_id']
+    existing_answers_with_group_instance_id = [answer for answer in existing_answers if answer.get('group_instance_id')]
+    if existing_answers_with_group_instance_id:
+        return existing_answers_with_group_instance_id[0]['group_instance_id']
 
     return str(uuid4())
 

--- a/app/templates/partials/summary/question-single-answer.html
+++ b/app/templates/partials/summary/question-single-answer.html
@@ -4,7 +4,7 @@
         {% set is_textarea = answer_is_type(answer, 'textarea') %}
 
         <div class="grid__col col-12@xs mars {{ 'col-10@m' if is_textarea else 'col-6@m' }}">
-            {% if content.summary.summary_type == 'CalculatedSummary' and answer.label %}
+            {% if (answer.type == 'relationship' or content.summary.summary_type == 'CalculatedSummary') and answer.label %}
                 {%- include theme(['partials/summary/display-answer-label.html']) -%}
             {% else %}
                 {%- include theme(['partials/summary/display-question.html']) -%}

--- a/app/templates/partials/summary/summary.html
+++ b/app/templates/partials/summary/summary.html
@@ -5,9 +5,9 @@
         {%- for group in content.summary.groups -%}
             {%- if group.title -%}
                 <h2 class="summary__title neptune" id="{{ group.id }}">{{ group.title }}</h2>
+                <div class="summary__block u-mb-l">
             {%- endif -%}
 
-            <div class="summary__block u-mb-l">
                 {%- for block in group.blocks -%}
                     {%- for question in block.questions -%}
 
@@ -24,7 +24,9 @@
                 {%- if content.summary.summary_type == 'CalculatedSummary' -%}
                     {%- include theme(['partials/summary/calculated-summary-answer.html']) -%}
                 {%- endif -%}
-            </div>
+            {%- if loop.last or loop.nextitem.title-%}
+                </div>
+            {%- endif -%}
         {%- endfor -%}
     {%- endif -%}
 </div>

--- a/app/templating/summary/answer.py
+++ b/app/templating/summary/answer.py
@@ -1,7 +1,7 @@
 class Answer:
 
-    def __init__(self, answer_schema, answer, child_answer_value=None):
-        self.id = answer_schema['id']
+    def __init__(self, answer_schema, answer, group_instance, child_answer_value=None):
+        self.id = answer_schema['id'] + '-' + str(group_instance)
         self.label = answer_schema.get('label')
         self.value = answer
         self.type = answer_schema['type'].lower()

--- a/app/templating/summary/block.py
+++ b/app/templating/summary/block.py
@@ -6,30 +6,30 @@ from app.templating.summary.question import Question
 
 class Block:
 
-    def __init__(self, block_schema, group_id, answer_store, metadata, schema):
+    def __init__(self, block_schema, group_id, answer_store, metadata, schema, group_instance):
         self.id = block_schema['id']
         self.title = block_schema.get('title')
         self.number = block_schema.get('number')
-        self.link = self._build_link(block_schema, group_id, metadata)
-        self.questions = self._build_questions(block_schema, answer_store, metadata, schema)
+        self.link = self._build_link(block_schema, group_id, metadata, group_instance)
+        self.questions = self._build_questions(block_schema, answer_store, metadata, schema, group_instance)
 
     @staticmethod
-    def _build_link(block_schema, group_id, metadata):
+    def _build_link(block_schema, group_id, metadata, group_instance):
         return url_for('questionnaire.get_block',
                        eq_id=metadata['eq_id'],
                        form_type=metadata['form_type'],
                        collection_id=metadata['collection_exercise_sid'],
                        group_id=group_id,
-                       group_instance=0,
+                       group_instance=group_instance,
                        block_id=block_schema['id'])
 
     @staticmethod
-    def _build_questions(block_schema, answer_store, metadata, schema):
+    def _build_questions(block_schema, answer_store, metadata, schema, group_instance):
         questions = []
         for question_schema in block_schema.get('questions', []):
             is_skipped = evaluate_skip_conditions(question_schema.get('skip_conditions'), schema, metadata, answer_store)
             if not is_skipped:
-                question = Question(question_schema, answer_store, metadata, schema).serialize()
+                question = Question(question_schema, answer_store, metadata, schema, group_instance).serialize()
                 questions.append(question)
         return questions
 

--- a/app/templating/summary/group.py
+++ b/app/templating/summary/group.py
@@ -1,29 +1,63 @@
+from copy import deepcopy
+
 from app.templating.summary.block import Block
+from app.helpers.schema_helpers import get_group_instance_id
+from app.questionnaire.location import Location
+from app.templating.template_renderer import renderer
 
 
 class Group:
 
-    def __init__(self, group_schema, path, answer_store, metadata, schema):
-        self.id = group_schema['id']
-        self.title = group_schema.get('title')
-        self.blocks = self._build_blocks(group_schema, path, answer_store, metadata, schema)
+    def __init__(self, group_schema, path, answer_store, metadata, schema, group_instance, schema_context):
+        self.id = group_schema['id'] + '-' + str(group_instance)
+        self.schema_context = schema_context
+
+        location = Location(group_schema['id'], group_instance, group_schema['blocks'][0]['id'])
+        self.group_instance_id = get_group_instance_id(schema, answer_store, location)
+
+        self.title = self._get_title(group_schema, schema, answer_store, group_instance)
+
+        self.blocks = self._build_blocks(group_schema, path, answer_store, metadata, schema, group_instance)
 
     @staticmethod
-    def _build_blocks(group_schema, path, answer_store, metadata, schema):
+    def _build_blocks(group_schema, path, answer_store, metadata, schema, group_instance):
         blocks = []
 
-        block_ids_on_path = [location.block_id for location in path]
+        block_ids_on_path = [location.block_id for location in path if location.group_id == group_schema['id'] and location.group_instance == group_instance]
 
         for block in group_schema['blocks']:
             if block['id'] in block_ids_on_path and \
                     block['type'] == 'Question':
-                blocks.extend([Block(block, group_schema['id'], answer_store, metadata, schema).serialize()])
+                blocks.extend([Block(block, group_schema['id'], answer_store, metadata, schema, group_instance).serialize()])
 
         return blocks
 
+    def _get_title(self, group_schema, schema, answer_store, group_instance):
+        section = schema.get_section(schema.get_group(group_schema['id'])['parent_id'])
+        answer_values = []
+        title_answer_ids = section.get('title_from_answers', [])
+
+        for answer_id in title_answer_ids:
+            for answer in answer_store.filter(answer_ids=[answer_id],
+                                              group_instance_id=self.group_instance_id).escaped():
+                if answer['value']:
+                    answer_values.append(answer['value'])
+
+        if answer_values:
+            return ' '.join(answer_values)
+
+        if group_instance == 0:
+            return group_schema.get('title')
+
     def serialize(self):
-        return {
-            'id': self.id,
-            'title': self.title,
-            'blocks': self.blocks,
-        }
+        schema_context_with_group_instance_id = deepcopy(self.schema_context)
+        schema_context_with_group_instance_id['group_instance_id'] = self.group_instance_id
+
+        return renderer.render(
+            {
+                'id': self.id,
+                'title': self.title,
+                'blocks': self.blocks,
+            },
+            **schema_context_with_group_instance_id
+        )

--- a/app/templating/summary/question.py
+++ b/app/templating/summary/question.py
@@ -1,63 +1,81 @@
 import collections
 
+from app.forms.household_relationship_form import build_relationship_choices
 from app.templating.summary.answer import Answer
 from app.templating.utils import get_question_title
 
 
 class Question:
 
-    def __init__(self, question_schema, answer_store, metadata, schema):
-        self.id = question_schema['id']
+    def __init__(self, question_schema, answer_store, metadata, schema, group_instance):
+        self.id = question_schema['id'] + '-' + str(group_instance)
         self.type = question_schema['type']
-
+        self.schema = schema
         answer_schemas = iter(question_schema['answers'])
 
-        # Using group instance as 0 for now as summary rendering context only has knowledge of current locations group instance (i.e. 0)
-        self.title = get_question_title(question_schema, answer_store, schema, metadata, group_instance=0) or question_schema['answers'][0]['label']
+        self.title = (get_question_title(question_schema, answer_store, schema, metadata, group_instance=group_instance) or
+                      question_schema['answers'][0]['label'])
         self.number = question_schema.get('number', None)
-        self.answers = self._build_answers(answer_store, question_schema, answer_schemas)
+        self.answers = self._build_answers(answer_store, question_schema, answer_schemas, group_instance)
 
     @staticmethod
-    def _get_answers(answer_store, answer_id):
-        return answer_store.filter(answer_ids=[answer_id]).escaped().values()
+    def _get_answers(answer_store, answer_id, group_instance):
+        answers = answer_store.filter(answer_ids=[answer_id], group_instance=group_instance).values()
 
-    def _get_answer(self, answer_store, answer_id):
-        try:
-            return self._get_answers(answer_store, answer_id)[0]
-        except IndexError:
-            return None
+        return answers or [None]
 
-    def _build_answers(self, answer_store, question_schema, answer_schemas):
+    def _get_answer(self, answer_store, answer_id, group_instance):
+        return self._get_answers(answer_store, answer_id, group_instance)[0]
+
+    def _build_answers(self, answer_store, question_schema, answer_schemas, group_instance):
         summary_answers = []
         for answer_schema in answer_schemas:
             if 'parent_answer_id' in answer_schema:
                 continue
-            if question_schema['type'] == 'RepeatingAnswer':
-                for answer_value in self._get_answers(answer_store, answer_schema['id']):
-                    answer = self._build_answer(answer_store, question_schema, answer_schema, answer_schemas,
-                                                answer_value)
-                    summary_answers.append(Answer(answer_schema, answer))
             else:
-                answer_value = self._get_answer(answer_store, answer_schema['id'])
-                answer = self._build_answer(answer_store, question_schema, answer_schema, answer_schemas, answer_value)
-                child_answer_value = self._find_other_value_in_answers(answer_store, answer_schema, answer)
-                summary_answers.append(Answer(answer_schema, answer, child_answer_value).serialize())
+                answer_values = self._get_answers(answer_store, answer_schema['id'], group_instance)
+                for answer_value in answer_values:
+                    answer = self._build_answer(answer_store, question_schema, answer_schema, answer_schemas,
+                                                group_instance, answer_value)
+                    child_answer_value = self._find_other_value_in_answers(answer_store, answer_schema, answer, group_instance)
+                    summary_answer = Answer(answer_schema, answer, group_instance, child_answer_value).serialize()
+                    if summary_answer['type'] == 'relationship':
+                        summary_answer['label'] = self._relationship_answer_label(summary_answer['label'], question_schema['parent_id'],
+                                                                                  answer_store, group_instance, question_schema.get('member_label'),
+                                                                                  answer_values.index(answer_value))
+                    summary_answers.append(summary_answer)
+
         return summary_answers
 
-    def _find_other_value_in_answers(self, answer_store, answer_schema, answer):
+    def _relationship_answer_label(self, answer_label, block_id, answer_store, group_instance, member_label, index):
+        group = self.schema.get_group(self.schema.get_block(block_id)['parent_id'])
+        answer_ids = []
+
+        repeat_rule = group['routing_rules'][0]['repeat']
+        if 'answer_ids' in repeat_rule:
+            for answer_id in repeat_rule['answer_ids']:
+                answer_ids.append(answer_id)
+        if 'answer_id' in repeat_rule:
+            answer_ids.append(repeat_rule['answer_id'])
+
+        choice = build_relationship_choices(answer_ids, answer_store, group_instance, member_label)[index]
+        label = answer_label % dict(current_person=choice[0], other_person=choice[1])
+        return label
+
+    def _find_other_value_in_answers(self, answer_store, answer_schema, answer, group_instance):
         if answer is not None and 'options' in answer_schema:
             options = answer_schema['options']
             for option in options:
                 if option['label'] in [a[0] for a in answer] or option['label'] == answer:
                     if 'child_answer_id' in option:
-                        return self._get_answer(answer_store, option['child_answer_id'])
+                        return self._get_answer(answer_store, option['child_answer_id'], group_instance)
         return None
 
-    def _build_answer(self, answer_store, question_schema, answer_schema, answer_schemas, answer_value=None):
+    def _build_answer(self, answer_store, question_schema, answer_schema, answer_schemas, group_instance, answer_value=None):
         if answer_value is None:
             return None
         if question_schema['type'] == 'DateRange':
-            return self._build_date_range_answer(answer_store, answer_value, answer_schemas)
+            return self._build_date_range_answer(answer_store, answer_value, answer_schemas, group_instance)
         if answer_schema['type'] in ['Checkbox', 'MutuallyExclusiveCheckbox']:
             checkbox_answers = self._build_checkbox_answers(answer_value, answer_schema)
             return checkbox_answers or None
@@ -82,9 +100,9 @@ class Question:
                                                                   should_display_other=False))
         return multiple_answers
 
-    def _build_date_range_answer(self, answer_store, answer, answer_schemas):
+    def _build_date_range_answer(self, answer_store, answer, answer_schemas, group_instance):
         next_answer = next(answer_schemas)
-        to_date = self._get_answer(answer_store, next_answer['id'])
+        to_date = self._get_answer(answer_store, next_answer['id'], group_instance)
         return {
             'from': answer,
             'to': to_date,

--- a/app/templating/summary_context.py
+++ b/app/templating/summary_context.py
@@ -4,13 +4,14 @@ from app.questionnaire.path_finder import PathFinder
 from app.templating.summary.group import Group
 
 
-def build_summary_rendering_context(schema, sections, answer_store, metadata):
+def build_summary_rendering_context(schema, sections, answer_store, metadata, schema_context):
     """
     Build questionnaire summary context containing metadata and content from the answers of the questionnaire
     :param schema: schema of the current questionnaire
     :param sections: the sections of the current schema
     :param answer_store: all of the answers to the questionnaire
     :param metadata: all of the metadata
+    :param schema_context: The schema context
     :return: questionnaire summary context
     """
     navigator = PathFinder(schema, answer_store, metadata, [])
@@ -25,8 +26,18 @@ def build_summary_rendering_context(schema, sections, answer_store, metadata):
     group_ids_on_path = [location.group_id for location in path]
 
     for group in itertools.chain.from_iterable(group_lists):
-        if group['id'] in group_ids_on_path \
-                and schema.group_has_questions(group['id']):
-            groups.extend([Group(group, path, answer_store, metadata, schema).serialize()])
+        if (group['id'] in group_ids_on_path and schema.group_has_questions(group['id'])):
+            no_of_repeats = _number_of_repeats(group, path)
+            repeating_groups = []
+            for instance_idx in range(0, no_of_repeats):
+                summary_group = Group(group, path, answer_store, metadata, schema, instance_idx, schema_context).serialize()
+                if summary_group['blocks']:
+                    repeating_groups.extend([summary_group])
+            groups.extend(repeating_groups)
 
     return groups
+
+
+def _number_of_repeats(group, path):
+    group_instances_on_path = [location.group_instance for location in path if location.group_id == group['id']]
+    return len(set(group_instances_on_path))

--- a/app/templating/template_renderer.py
+++ b/app/templating/template_renderer.py
@@ -1,8 +1,8 @@
 # coding: utf-8
 
-import json
-
 import re
+import simplejson as json
+
 from jinja2 import Environment
 
 import app.jinja_filters as filters

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -319,8 +319,8 @@ def get_view_submission(schema, eq_id, form_type):  # pylint: disable=unused-arg
             routing_path = PathFinder(schema, answer_store, metadata, []).get_full_routing_path()
 
             schema_context = _get_schema_context(routing_path, None, metadata, collection_metadata, answer_store, schema)
-            rendered_schema = renderer.render(schema.json, **schema_context)
-            summary_rendered_context = build_summary_rendering_context(schema, rendered_schema['sections'], answer_store, metadata)
+            section_list = schema.json['sections']
+            summary_rendered_context = build_summary_rendering_context(schema, section_list, answer_store, metadata, schema_context)
 
             context = {
                 'summary': {

--- a/data/en/test_relationship_household.json
+++ b/data/en/test_relationship_household.json
@@ -50,7 +50,7 @@
             }]
         }, {
             "id": "household-relationships",
-            "title": "",
+            "title": "Relationships",
             "routing_rules": [{
                 "repeat": {
                     "type": "answer_count_minus_one",

--- a/data/en/test_repeat_until_summaries.json
+++ b/data/en/test_repeat_until_summaries.json
@@ -1,0 +1,222 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "023",
+    "title": "Test Repeat Until",
+    "description": "",
+    "theme": "default",
+    "metadata": [{
+            "name": "user_id",
+            "validator": "string"
+        },
+        {
+            "name": "period_id",
+            "validator": "string"
+        },
+        {
+            "name": "ru_name",
+            "validator": "string"
+        }
+    ],
+    "view_submitted_response": {
+        "enabled": true,
+        "duration": 60
+    },
+    "sections": [{
+            "id": "household-section",
+            "title": "Household Composition",
+            "groups": [{
+                    "id": "primary-group",
+                    "title": "Your Details",
+                    "blocks": [{
+                        "type": "Question",
+                        "id": "primary-name-block",
+                        "title": "",
+                        "description": "",
+                        "questions": [{
+                            "description": "",
+                            "id": "primary-name-question",
+                            "title": "Please enter your name",
+                            "type": "General",
+                            "answers": [{
+                                "id": "primary-name",
+                                "description": "",
+                                "label": "First Name",
+                                "mandatory": true,
+                                "type": "TextField"
+                            }]
+                        }]
+                    }]
+                },
+                {
+                    "id": "repeating-group",
+                    "title": "Other Household Members",
+                    "routing_rules": [{
+                        "repeat": {
+                            "type": "until",
+                            "when": [{
+                                "id": "repeating-anyone-else",
+                                "condition": "equals",
+                                "value": "No"
+                            }]
+                        }
+                    }],
+                    "blocks": [{
+                            "type": "ConfirmationQuestion",
+                            "id": "repeating-anyone-else-block",
+                            "questions": [{
+                                "type": "General",
+                                "id": "repeating-anyone-else-question",
+                                "title": "Does anyone else live here?",
+                                "answers": [{
+                                    "type": "Radio",
+                                    "id": "repeating-anyone-else",
+                                    "mandatory": true,
+                                    "options": [{
+                                            "label": "Yes",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "No"
+                                        }
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "type": "Question",
+                            "id": "repeating-name-block",
+                            "title": "",
+                            "description": "",
+                            "questions": [{
+                                "description": "",
+                                "id": "repeating-name-question",
+                                "title": "Who else lives here?",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "repeating-name",
+                                    "description": "",
+                                    "label": "First Name",
+                                    "mandatory": true,
+                                    "type": "TextField"
+                                }]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "repeating-anyone-else",
+                                    "condition": "equals",
+                                    "value": "No"
+                                }]
+                            }]
+                        }
+                    ]
+                },
+                {
+                    "id": "household-summary-group",
+                    "title": "",
+                    "blocks": [{
+                        "type": "SectionSummary",
+                        "id": "household-summary-block"
+                    }]
+                }
+            ]
+        },
+        {
+            "id": "member-details-section",
+            "title": "Household Member Details",
+            "title_from_answers": ["primary-name", "repeating-name"],
+            "groups": [{
+                    "id": "member-group",
+                    "title": "Household Member Details",
+                    "routing_rules": [{
+                        "repeat": {
+                            "type": "answer_count",
+                            "answer_ids": [
+                                "primary-name",
+                                "repeating-name"
+                            ]
+                        }
+                    }],
+                    "blocks": [{
+                            "type": "Question",
+                            "title": "{{ group_instances[group_instance_id]['repeating-name']|default(group_instances[group_instance_id]['primary-name']) }}",
+                            "id": "first-number-block",
+                            "description": "",
+                            "questions": [{
+                                "id": "first-number-question",
+                                "title": "What is the first value for {{ group_instances[group_instance_id]['repeating-name']|default(group_instances[group_instance_id]['primary-name']) }}",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "first-number-answer",
+                                    "label": "First value for {{ group_instances[group_instance_id]['repeating-name']|default(group_instances[group_instance_id]['primary-name']) }}",
+                                    "mandatory": true,
+                                    "type": "Currency",
+                                    "currency": "GBP",
+                                    "decimal_places": 2
+                                }]
+                            }]
+                        },
+                        {
+                            "type": "Question",
+                            "title": "{{ group_instances[group_instance_id]['repeating-name']|default(group_instances[group_instance_id]['primary-name']) }}",
+                            "id": "second-number-block",
+                            "description": "",
+                            "questions": [{
+                                "id": "second-number-question",
+                                "title": "What is the second value for {{ group_instances[group_instance_id]['repeating-name']|default(group_instances[group_instance_id]['primary-name']) }}",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "second-number-answer",
+                                    "label": "Second value for {{ group_instances[group_instance_id]['repeating-name']|default(group_instances[group_instance_id]['primary-name']) }}",
+                                    "mandatory": true,
+                                    "type": "Currency",
+                                    "currency": "GBP",
+                                    "decimal_places": 2
+                                }]
+                            }]
+                        },
+                        {
+                            "type": "CalculatedSummary",
+                            "id": "currency-total-playback",
+                            "titles": [{
+                                "value": "We calculate the total of currency values entered for {{ group_instances[group_instance_id]['repeating-name']|default(group_instances[group_instance_id]['primary-name']) }} to be %(total)s. Is this correct?"
+                            }],
+                            "calculation": {
+                                "calculation_type": "sum",
+                                "answers_to_calculate": [
+                                    "first-number-answer",
+                                    "second-number-answer"
+                                ],
+                                "titles": [{
+                                    "value": "Grand total of previous values"
+                                }]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "member-summary-group",
+                    "title": "",
+                    "blocks": [{
+                        "type": "SectionSummary",
+                        "id": "member-summary-block"
+                    }]
+                }
+            ]
+        },
+        {
+            "id": "summary-section",
+            "title": "Summary",
+            "groups": [{
+                "id": "summary-group",
+                "title": "Summary",
+                "blocks": [{
+                    "id": "summary",
+                    "type": "Summary"
+                }]
+            }]
+        }
+    ]
+}

--- a/data/en/test_repeating_household.json
+++ b/data/en/test_repeating_household.json
@@ -59,7 +59,7 @@
         }]
     }, {
         "id": "first-names-section",
-        "title_from_answers": ["first-name"],
+        "title_from_answers": ["first-name", "last-name"],
         "groups": [{
             "blocks": [{
                 "type": "Question",

--- a/tests/app/templating/summary/test_answer.py
+++ b/tests/app/templating/summary/test_answer.py
@@ -7,24 +7,24 @@ class TestAnswer(TestCase):
 
     def test_create_answer(self):
         # Given
-        answer_schema = {'id': 'answer_1', 'label': 'answer_label', 'type': 'date'}
+        answer_schema = {'id': 'answer-id', 'label': 'Answer Label', 'type': 'date'}
         user_answer = 'An answer'
 
         # When
-        answer = Answer(answer_schema, user_answer)
+        answer = Answer(answer_schema, user_answer, 2)
 
         # Then
-        self.assertEqual(answer.id, 'answer_1')
-        self.assertEqual(answer.label, 'answer_label')
+        self.assertEqual(answer.id, 'answer-id-2')
+        self.assertEqual(answer.label, 'Answer Label')
         self.assertEqual(answer.value, user_answer)
 
     def test_date_answer_type(self):
         # Given
-        answer_schema = {'id': 'answer_1', 'label': '', 'type': 'date'}
+        answer_schema = {'id': 'answer-id', 'label': '', 'type': 'date'}
         user_answer = None
 
         # When
-        answer = Answer(answer_schema, user_answer)
+        answer = Answer(answer_schema, user_answer, 0)
 
         # Then
         self.assertEqual(answer.type, 'date')

--- a/tests/app/templating/summary/test_block.py
+++ b/tests/app/templating/summary/test_block.py
@@ -33,7 +33,7 @@ class TestSection(TestCase):
         with patch('app.templating.summary.block.Question', return_value=get_mock_question('A Question')), \
                 patch('app.templating.summary.block.evaluate_skip_conditions', return_value=False), \
                 patch('app.templating.summary.block.url_for', return_value='http://a.url/'):
-            block = Block(block_schema, 'group_id', self.answer_store, self.metadata, self.schema)
+            block = Block(block_schema, 'group_id', self.answer_store, self.metadata, self.schema, 0)
 
         # Then
         self.assertEqual(block.id, 'block_id')
@@ -51,7 +51,7 @@ class TestSection(TestCase):
                    side_effect=[get_mock_question('A Question'), get_mock_question('A Second Question')]), \
                 patch('app.templating.summary.block.evaluate_skip_conditions', return_value=False), \
                 patch('app.templating.summary.block.url_for', return_value='http://a.url/'):
-            block = Block(block_schema, 'group_id', self.answer_store, self.metadata, self.schema)
+            block = Block(block_schema, 'group_id', self.answer_store, self.metadata, self.schema, 0)
 
         # Then
         self.assertEqual(len(block.questions), 2)
@@ -70,7 +70,7 @@ class TestSection(TestCase):
                 patch('app.templating.summary.block.evaluate_skip_conditions', side_effect=[False, True]), \
                 patch('app.templating.summary.block.url_for', return_value='http://a.url/'):
             # When
-            block = Block(block_schema, 'group_id', self.answer_store, self.metadata, self.schema)
+            block = Block(block_schema, 'group_id', self.answer_store, self.metadata, self.schema, 0)
 
         # Then
         patched_question_context.assert_called_once()

--- a/tests/functional/generate_pages.py
+++ b/tests/functional/generate_pages.py
@@ -107,24 +107,24 @@ REPEATING_ANSWER_LEGEND = r"""  personLegend(index = 1) {
   }
 """
 
-SECTION_SUMMARY_ANSWER_GETTER = Template(r"""  ${answerName}() { return '#${answerId}-answer'; }
+SECTION_SUMMARY_ANSWER_GETTER = Template(r"""  ${answerName}(index = 0) { return '#${answerId}-' + index + '-answer'; }
 
 """)
 
-SECTION_SUMMARY_ANSWER_EDIT_GETTER = Template(r"""  ${answerName}Edit() { return '[data-qa="${answerId}-edit"]'; }
+SECTION_SUMMARY_ANSWER_EDIT_GETTER = Template(r"""  ${answerName}Edit(index = 0) { return '[data-qa="${answerId}-' + index + '-edit"]'; }
 
 """)
 
-SUMMARY_ANSWER_GETTER = Template(r"""  ${answerName}() { return '#${answerId}-answer'; }
+SUMMARY_ANSWER_GETTER = Template(r"""  ${answerName}(index = 0) { return '#${answerId}-' + index + '-answer'; }
 
 """)
 
 
-SUMMARY_ANSWER_EDIT_GETTER = Template(r"""  ${answerName}Edit() { return '[data-qa="${answerId}-edit"]'; }
+SUMMARY_ANSWER_EDIT_GETTER = Template(r"""  ${answerName}Edit(index = 0) { return '[data-qa="${answerId}-' + index + '-edit"]'; }
 
 """)
 
-SUMMARY_TITLE_GETTER = Template(r"""  ${group_id_camel}Title() { return '#${group_id}'; }
+SUMMARY_TITLE_GETTER = Template(r"""  ${group_id_camel}Title(index = 0) { return '#${group_id}-' + index; }
 
 """)
 
@@ -136,7 +136,11 @@ ANSWER_SUMMARY_LABEL_GETTER = Template(r"""  ${answerName}Label(index = 1) { ret
 
 """)
 
-CALCULATED_SUMMARY_LABEL_GETTER = Template(r"""  ${answerName}Label() { return '#${answerId}-label'; } 
+SUMMARY_QUESTION_GETTER = Template(r"""  ${questionName}(index = 0) { return '#${questionId}-' + index; }
+
+""")
+
+CALCULATED_SUMMARY_LABEL_GETTER = Template(r"""  ${answerName}Label(index = 0) { return '#${answerId}-' + index + '-label'; } 
 
 """)
 
@@ -296,6 +300,10 @@ def process_summary(schema_data, page_spec):
         for group in section['groups']:
             for block in group['blocks']:
                 for question in block.get('questions', []):
+                    question_context = {
+                        'questionId': question['id'],
+                        'questionName': camel_case(generate_pascal_case_from_id(question['id']))
+                    }
                     for answer in question['answers']:
                         answer_name = generate_pascal_case_from_id(answer['id'])
                         answer_context = {
@@ -305,7 +313,7 @@ def process_summary(schema_data, page_spec):
                         if block['type'] == 'SectionSummary':
                             page_spec.write(SECTION_SUMMARY_ANSWER_GETTER.substitute(answer_context))
                             page_spec.write(SECTION_SUMMARY_ANSWER_EDIT_GETTER.substitute(answer_context))
-
+                    page_spec.write(SUMMARY_QUESTION_GETTER.substitute(question_context))
                     page_spec.write(SUMMARY_ANSWER_GETTER.substitute(answer_context))
                     page_spec.write(SUMMARY_ANSWER_EDIT_GETTER.substitute(answer_context))
 
@@ -313,8 +321,7 @@ def process_summary(schema_data, page_spec):
                 'group_id_camel': camel_case(generate_pascal_case_from_id(group['id'])),
                 'group_id': group['id']
             }
-            page_spec.write(
-                SUMMARY_TITLE_GETTER.substitute(group_context))
+            page_spec.write(SUMMARY_TITLE_GETTER.substitute(group_context))
 
 
 def long_names_required(question, num_questions):

--- a/tests/functional/pages/components/checkbox/mutually-exclusive/summary.page.js
+++ b/tests/functional/pages/components/checkbox/mutually-exclusive/summary.page.js
@@ -7,11 +7,11 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  answer() { return '#mandatory-checkbox-answer-answer'; }
+  answer(index = 0) { return '#mandatory-checkbox-answer-' + index + '-answer'; }
 
-  answerEdit() { return '[data-qa="mandatory-checkbox-answer-edit"]'; }
+  answerEdit(index = 0) { return '[data-qa="mandatory-checkbox-answer-' + index + '-edit"]'; }
 
-  checkboxesTitle() { return '#checkboxes'; }
+  checkboxesTitle(index = 0) { return '#checkboxes' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/components/dropdown/mandatory/summary.page.js
+++ b/tests/functional/pages/components/dropdown/mandatory/summary.page.js
@@ -7,9 +7,9 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  dropdownMandatoryAnswer() { return '#dropdown-mandatory-answer-answer'; }
+  dropdownMandatoryAnswer(index = 0) { return '#dropdown-mandatory-answer-' + index + '-answer'; }
 
-  dropdownMandatoryAnswerEdit() { return '[data-qa="dropdown-mandatory-answer-edit"]'; }
+  dropdownMandatoryAnswerEdit(index = 0) { return '[data-qa="dropdown-mandatory-answer-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/components/dropdown/mandatory_with_label/summary.page.js
+++ b/tests/functional/pages/components/dropdown/mandatory_with_label/summary.page.js
@@ -7,9 +7,9 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  dropdownMandatoryWithLabelAnswer() { return '#dropdown-mandatory-with-label-answer-answer'; }
+  dropdownMandatoryWithLabelAnswer(index = 0) { return '#dropdown-mandatory-with-label-answer-' + index + '-answer'; }
 
-  dropdownMandatoryWithLabelAnswerEdit() { return '[data-qa="dropdown-mandatory-with-label-answer-edit"]'; }
+  dropdownMandatoryWithLabelAnswerEdit(index = 0) { return '[data-qa="dropdown-mandatory-with-label-answer-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/components/dropdown/mandatory_with_overridden_error/summary.page.js
+++ b/tests/functional/pages/components/dropdown/mandatory_with_overridden_error/summary.page.js
@@ -7,9 +7,9 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  dropdownMandatoryWithOverriddenAnswer() { return '#dropdown-mandatory-with-overridden-answer-answer'; }
+  dropdownMandatoryWithOverriddenAnswer(index = 0) { return '#dropdown-mandatory-with-overridden-answer-' + index + '-answer'; }
 
-  dropdownMandatoryWithOverriddenAnswerEdit() { return '[data-qa="dropdown-mandatory-with-overridden-answer-edit"]'; }
+  dropdownMandatoryWithOverriddenAnswerEdit(index = 0) { return '[data-qa="dropdown-mandatory-with-overridden-answer-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/components/dropdown/optional/summary.page.js
+++ b/tests/functional/pages/components/dropdown/optional/summary.page.js
@@ -7,9 +7,9 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  dropdownOptionalAnswer() { return '#dropdown-optional-answer-answer'; }
+  dropdownOptionalAnswer(index = 0 ) { return '#dropdown-optional-answer-' + index + '-answer'; }
 
-  dropdownOptionalAnswerEdit() { return '[data-qa="dropdown-optional-answer-edit"]'; }
+  dropdownOptionalAnswerEdit(index = 0) { return '[data-qa="dropdown-optional-answer-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/components/radio/mandatory/summary.page.js
+++ b/tests/functional/pages/components/radio/mandatory/summary.page.js
@@ -7,9 +7,9 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  radioMandatoryAnswer() { return '#radio-mandatory-answer-answer'; }
+  radioMandatoryAnswer(index = 0) { return '#radio-mandatory-answer-' + index + '-answer'; }
 
-  radioMandatoryAnswerEdit() { return '[data-qa="radio-mandatory-answer-edit"]'; }
+  radioMandatoryAnswerEdit(index = 0) { return '[data-qa="radio-mandatory-answer-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/components/radio/mandatory_with_mandatory_other/summary.page.js
+++ b/tests/functional/pages/components/radio/mandatory_with_mandatory_other/summary.page.js
@@ -7,13 +7,13 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  radioMandatoryAnswer() { return '#radio-mandatory-answer-answer'; }
+  radioMandatoryAnswer(index = 0) { return '#radio-mandatory-answer-' + index + '-answer'; }
 
-  radioMandatoryAnswerEdit() { return '[data-qa="radio-mandatory-answer-edit"]'; }
+  radioMandatoryAnswerEdit(index = 0) { return '[data-qa="radio-mandatory-answer-' + index + '-edit"]'; }
 
-  otherAnswerMandatory() { return '#other-answer-mandatory-answer'; }
+  otherAnswerMandatory(index = 0) { return '#other-answer-mandatory-' + index + '-answer'; }
 
-  otherAnswerMandatoryEdit() { return '[data-qa="other-answer-mandatory-edit"]'; }
+  otherAnswerMandatoryEdit(index = 0) { return '[data-qa="other-answer-mandatory-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/components/radio/mandatory_with_mandatory_other_overridden_error/summary.page.js
+++ b/tests/functional/pages/components/radio/mandatory_with_mandatory_other_overridden_error/summary.page.js
@@ -7,13 +7,13 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  radioMandatoryAnswer() { return '#radio-mandatory-answer-answer'; }
+  radioMandatoryAnswer(index = 0) { return '#radio-mandatory-answer-' + index + '-answer'; }
 
-  radioMandatoryAnswerEdit() { return '[data-qa="radio-mandatory-answer-edit"]'; }
+  radioMandatoryAnswerEdit(index = 0) { return '[data-qa="radio-mandatory-answer-' + index + '-edit"]'; }
 
-  otherAnswerMandatory() { return '#other-answer-mandatory-answer'; }
+  otherAnswerMandatory(index = 0) { return '#other-answer-mandatory-' + index + '-answer'; }
 
-  otherAnswerMandatoryEdit() { return '[data-qa="other-answer-mandatory-edit"]'; }
+  otherAnswerMandatoryEdit(index = 0) { return '[data-qa="other-answer-mandatory-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/components/radio/mandatory_with_optional_other/summary.page.js
+++ b/tests/functional/pages/components/radio/mandatory_with_optional_other/summary.page.js
@@ -7,13 +7,13 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  radioMandatoryAnswer() { return '#radio-mandatory-answer-answer'; }
+  radioMandatoryAnswer(index = 0) { return '#radio-mandatory-answer-' + index + '-answer'; }
 
-  radioMandatoryAnswerEdit() { return '[data-qa="radio-mandatory-answer-edit"]'; }
+  radioMandatoryAnswerEdit(index = 0) { return '[data-qa="radio-mandatory-answer-' + index + '-edit"]'; }
 
-  otherAnswerMandatory() { return '#other-answer-mandatory-answer'; }
+  otherAnswerMandatory(index = 0) { return '#other-answer-mandatory-' + index + '-answer'; }
 
-  otherAnswerMandatoryEdit() { return '[data-qa="other-answer-mandatory-edit"]'; }
+  otherAnswerMandatoryEdit(index = 0) { return '[data-qa="other-answer-mandatory-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/components/radio/mandatory_with_overridden_error/summary.page.js
+++ b/tests/functional/pages/components/radio/mandatory_with_overridden_error/summary.page.js
@@ -7,9 +7,9 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  radioMandatoryAnswer() { return '#radio-mandatory-answer-answer'; }
+  radioMandatoryAnswer(index = 0) { return '#radio-mandatory-answer-' + index + '-answer'; }
 
-  radioMandatoryAnswerEdit() { return '[data-qa="radio-mandatory-answer-edit"]'; }
+  radioMandatoryAnswerEdit(index = 0) { return '[data-qa="radio-mandatory-answer-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/components/radio/optional/summary.page.js
+++ b/tests/functional/pages/components/radio/optional/summary.page.js
@@ -7,9 +7,9 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  radioNonMandatoryAnswer() { return '#radio-non-mandatory-answer-answer'; }
+  radioNonMandatoryAnswer(index = 0) { return '#radio-non-mandatory-answer-' + index + '-answer'; }
 
-  radioNonMandatoryAnswerEdit() { return '[data-qa="radio-non-mandatory-answer-edit"]'; }
+  radioNonMandatoryAnswerEdit(index = 0) { return '[data-qa="radio-non-mandatory-answer-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/components/radio/optional_other_overridden_error_message_with_mandatory_other/summary.page.js
+++ b/tests/functional/pages/components/radio/optional_other_overridden_error_message_with_mandatory_other/summary.page.js
@@ -7,13 +7,13 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  radioNonMandatoryAnswer() { return '#radio-non-mandatory-answer-answer'; }
+  radioNonMandatoryAnswer(index = 0) { return '#radio-non-mandatory-answer-' + index + '-answer'; }
 
-  radioNonMandatoryAnswerEdit() { return '[data-qa="radio-non-mandatory-answer-edit"]'; }
+  radioNonMandatoryAnswerEdit(index = 0) { return '[data-qa="radio-non-mandatory-answer-' + index + '-edit"]'; }
 
-  otherAnswerNonMandatory() { return '#other-answer-non-mandatory-answer'; }
+  otherAnswerNonMandatory(index = 0) { return '#other-answer-non-mandatory-' + index + '-answer'; }
 
-  otherAnswerNonMandatoryEdit() { return '[data-qa="other-answer-non-mandatory-edit"]'; }
+  otherAnswerNonMandatoryEdit(index = 0) { return '[data-qa="other-answer-non-mandatory-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/components/radio/optional_with_mandatory_other/summary.page.js
+++ b/tests/functional/pages/components/radio/optional_with_mandatory_other/summary.page.js
@@ -7,13 +7,13 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  radioNonMandatoryAnswer() { return '#radio-non-mandatory-answer-answer'; }
+  radioNonMandatoryAnswer(index = 0) { return '#radio-non-mandatory-answer-' + index + '-answer'; }
 
-  radioNonMandatoryAnswerEdit() { return '[data-qa="radio-non-mandatory-answer-edit"]'; }
+  radioNonMandatoryAnswerEdit(index = 0) { return '[data-qa="radio-non-mandatory-answer-' + index + '-edit"]'; }
 
-  otherAnswerNonMandatory() { return '#other-answer-non-mandatory-answer'; }
+  otherAnswerNonMandatory(index = 0) { return '#other-answer-non-mandatory-' + index + '-answer'; }
 
-  otherAnswerNonMandatoryEdit() { return '[data-qa="other-answer-non-mandatory-edit"]'; }
+  otherAnswerNonMandatoryEdit(index = 0) { return '[data-qa="other-answer-non-mandatory-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/components/radio/optional_with_mandatory_other_overridden_error/summary.page.js
+++ b/tests/functional/pages/components/radio/optional_with_mandatory_other_overridden_error/summary.page.js
@@ -7,13 +7,13 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  radioNonMandatoryAnswer() { return '#radio-non-mandatory-answer-answer'; }
+  radioNonMandatoryAnswer(index = 0) { return '#radio-non-mandatory-answer-' + index + '-answer'; }
 
-  radioNonMandatoryAnswerEdit() { return '[data-qa="radio-non-mandatory-answer-edit"]'; }
+  radioNonMandatoryAnswerEdit(index = 0) { return '[data-qa="radio-non-mandatory-answer-' + index + '-edit"]'; }
 
-  otherAnswerNonMandatory() { return '#other-answer-non-mandatory-answer'; }
+  otherAnswerNonMandatory(index = 0) { return '#other-answer-non-mandatory-' + index + '-answer'; }
 
-  otherAnswerNonMandatoryEdit() { return '[data-qa="other-answer-non-mandatory-edit"]'; }
+  otherAnswerNonMandatoryEdit(index = 0) { return '[data-qa="other-answer-non-mandatory-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/components/radio/optional_with_optional_other/summary.page.js
+++ b/tests/functional/pages/components/radio/optional_with_optional_other/summary.page.js
@@ -7,13 +7,13 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  radioNonMandatoryAnswer() { return '#radio-non-mandatory-answer-answer'; }
+  radioNonMandatoryAnswer(index = 0) { return '#radio-non-mandatory-answer-' + index + '-answer'; }
 
-  radioNonMandatoryAnswerEdit() { return '[data-qa="radio-non-mandatory-answer-edit"]'; }
+  radioNonMandatoryAnswerEdit(index = 0) { return '[data-qa="radio-non-mandatory-answer-' + index + '-edit"]'; }
 
-  otherAnswerNonMandatory() { return '#other-answer-non-mandatory-answer'; }
+  otherAnswerNonMandatory(index = 0) { return '#other-answer-non-mandatory-' + index + '-answer'; }
 
-  otherAnswerNonMandatoryEdit() { return '[data-qa="other-answer-non-mandatory-edit"]'; }
+  otherAnswerNonMandatoryEdit(index = 0) { return '[data-qa="other-answer-non-mandatory-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/answer_comparison/repeating_groups/summary.page.js
+++ b/tests/functional/pages/features/answer_comparison/repeating_groups/summary.page.js
@@ -7,17 +7,17 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  repeatingComparison1Answer() { return '#repeating-comparison-1-answer-answer'; }
+  repeatingComparison1Answer(index = 0) { return '#repeating-comparison-1-answer-' + index + '-answer'; }
 
-  repeatingComparison1AnswerEdit() { return '[data-qa="repeating-comparison-1-answer-edit"]'; }
+  repeatingComparison1AnswerEdit(index = 0) { return '[data-qa="repeating-comparison-1-answer-' + index + '-edit"]'; }
 
-  repeatingComparison2Answer() { return '#repeating-comparison-2-answer-answer'; }
+  repeatingComparison2Answer(index = 0) { return '#repeating-comparison-2-answer-' + index + '-answer'; }
 
-  repeatingComparison2AnswerEdit() { return '[data-qa="repeating-comparison-2-answer-edit"]'; }
+  repeatingComparison2AnswerEdit(index = 0) { return '[data-qa="repeating-comparison-2-answer-' + index + '-edit"]'; }
 
-  repeatingComparisonTitle() { return '#repeating-comparison'; }
+  repeatingComparisonTitle(index = 0) { return '#repeating-comparison-' + index; }
 
-  summaryGroupTitle() { return '#summary-group'; }
+  summaryGroupTitle(index = 0) { return '#summary-group-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/answer_comparison/routing/summary.page.js
+++ b/tests/functional/pages/features/answer_comparison/routing/summary.page.js
@@ -7,17 +7,17 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  routeComparison1Answer() { return '#route-comparison-1-answer-answer'; }
+  routeComparison1Answer(index = 0) { return '#route-comparison-1-answer-' + index + '-answer'; }
 
-  routeComparison1AnswerEdit() { return '[data-qa="route-comparison-1-answer-edit"]'; }
+  routeComparison1AnswerEdit(index = 0) { return '[data-qa="route-comparison-1-answer-' + index + '-edit"]'; }
 
-  routeComparison2Answer() { return '#route-comparison-2-answer-answer'; }
+  routeComparison2Answer(index = 0) { return '#route-comparison-2-answer-' + index + '-answer'; }
 
-  routeComparison2AnswerEdit() { return '[data-qa="route-comparison-2-answer-edit"]'; }
+  routeComparison2AnswerEdit(index = 0) { return '[data-qa="route-comparison-2-answer-' + index + '-edit"]'; }
 
-  routeGroupTitle() { return '#route-group'; }
+  routeGroupTitle(index = 0) { return '#route-group-' + index; }
 
-  summaryGroupTitle() { return '#summary-group'; }
+  summaryGroupTitle(index = 0) { return '#summary-group-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/answer_comparison/skip_conditions/summary.page.js
+++ b/tests/functional/pages/features/answer_comparison/skip_conditions/summary.page.js
@@ -7,17 +7,17 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  comparison1Answer() { return '#comparison-1-answer-answer'; }
+  comparison1Answer(index = 0) { return '#comparison-1-answer-' + index + '-answer'; }
 
-  comparison1AnswerEdit() { return '[data-qa="comparison-1-answer-edit"]'; }
+  comparison1AnswerEdit(index = 0) { return '[data-qa="comparison-1-answer-' + index + '-edit"]'; }
 
-  comparison2Answer() { return '#comparison-2-answer-answer'; }
+  comparison2Answer(index = 0) { return '#comparison-2-answer-' + index + '-answer'; }
 
-  comparison2AnswerEdit() { return '[data-qa="comparison-2-answer-edit"]'; }
+  comparison2AnswerEdit(index = 0) { return '[data-qa="comparison-2-answer-' + index + '-edit"]'; }
 
-  skipGroupTitle() { return '#skip-group'; }
+  skipGroupTitle(index = 0) { return '#skip-group-' + index; }
 
-  summaryGroupTitle() { return '#summary-group'; }
+  summaryGroupTitle(index = 0) { return '#summary-group-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/calculated_summary/currency-total-playback.page.js
+++ b/tests/functional/pages/features/calculated_summary/currency-total-playback.page.js
@@ -7,41 +7,41 @@ class CurrencyTotalPlaybackPage extends CalculatedSummaryPage {
     super('currency-total-playback');
   }
 
-  firstNumberAnswer() { return '#first-number-answer-answer'; }
+  firstNumberAnswer(index = 0) { return '#first-number-answer-' + index + '-answer'; }
 
-  firstNumberAnswerEdit() { return '[data-qa="first-number-answer-edit"]'; }
+  firstNumberAnswerEdit(index = 0) { return '[data-qa="first-number-answer-' + index + '-edit"]'; }
 
-  firstNumberAnswerLabel() { return '#first-number-answer-label'; } 
+  firstNumberAnswerLabel(index = 0) { return '#first-number-answer-' + index + '-label'; }
 
-  secondNumberAnswer() { return '#second-number-answer-answer'; }
+  secondNumberAnswer(index = 0) { return '#second-number-answer-' + index + '-answer'; }
 
-  secondNumberAnswerEdit() { return '[data-qa="second-number-answer-edit"]'; }
+  secondNumberAnswerEdit(index = 0) { return '[data-qa="second-number-answer-' + index + '-edit"]'; }
 
-  secondNumberAnswerLabel() { return '#second-number-answer-label'; } 
+  secondNumberAnswerLabel(index = 0) { return '#second-number-answer-' + index + '-label'; }
 
-  secondNumberAnswerAlsoInTotal() { return '#second-number-answer-also-in-total-answer'; }
+  secondNumberAnswerAlsoInTotal(index = 0) { return '#second-number-answer-also-in-total-' + index + '-answer'; }
 
-  secondNumberAnswerAlsoInTotalEdit() { return '[data-qa="second-number-answer-also-in-total-edit"]'; }
+  secondNumberAnswerAlsoInTotalEdit(index = 0) { return '[data-qa="second-number-answer-also-in-total-' + index + '-edit"]'; }
 
-  secondNumberAnswerAlsoInTotalLabel() { return '#second-number-answer-also-in-total-label'; } 
+  secondNumberAnswerAlsoInTotalLabel(index = 0) { return '#second-number-answer-also-in-total-' + index + '-label'; }
 
-  thirdNumberAnswer() { return '#third-number-answer-answer'; }
+  thirdNumberAnswer(index = 0) { return '#third-number-answer-' + index + '-answer'; }
 
-  thirdNumberAnswerEdit() { return '[data-qa="third-number-answer-edit"]'; }
+  thirdNumberAnswerEdit(index = 0) { return '[data-qa="third-number-answer-' + index + '-edit"]'; }
 
-  thirdNumberAnswerLabel() { return '#third-number-answer-label'; } 
+  thirdNumberAnswerLabel(index = 0) { return '#third-number-answer-' + index + '-label'; }
 
-  fourthNumberAnswer() { return '#fourth-number-answer-answer'; }
+  fourthNumberAnswer(index = 0) { return '#fourth-number-answer-' + index + '-answer'; }
 
-  fourthNumberAnswerEdit() { return '[data-qa="fourth-number-answer-edit"]'; }
+  fourthNumberAnswerEdit(index = 0) { return '[data-qa="fourth-number-answer-' + index + '-edit"]'; }
 
-  fourthNumberAnswerLabel() { return '#fourth-number-answer-label'; } 
+  fourthNumberAnswerLabel(index = 0) { return '#fourth-number-answer-' + index + '-label'; }
 
-  fourthNumberAnswerAlsoInTotal() { return '#fourth-number-answer-also-in-total-answer'; }
+  fourthNumberAnswerAlsoInTotal(index = 0) { return '#fourth-number-answer-also-in-total-' + index + '-answer'; }
 
-  fourthNumberAnswerAlsoInTotalEdit() { return '[data-qa="fourth-number-answer-also-in-total-edit"]'; }
+  fourthNumberAnswerAlsoInTotalEdit(index = 0) { return '[data-qa="fourth-number-answer-also-in-total-' + index + '-edit"]'; }
 
-  fourthNumberAnswerAlsoInTotalLabel() { return '#fourth-number-answer-also-in-total-label'; } 
+  fourthNumberAnswerAlsoInTotalLabel(index = 0) { return '#fourth-number-answer-also-in-total-' + index + '-label'; }
 
 }
 module.exports = new CurrencyTotalPlaybackPage();

--- a/tests/functional/pages/features/calculated_summary/number-total-playback.page.js
+++ b/tests/functional/pages/features/calculated_summary/number-total-playback.page.js
@@ -7,17 +7,17 @@ class NumberTotalPlaybackPage extends CalculatedSummaryPage {
     super('number-total-playback');
   }
 
-  fifthNumberAnswer() { return '#fifth-number-answer-answer'; }
+  fifthNumberAnswer(index = 0) { return '#fifth-number-answer-' + index + '-answer'; }
 
-  fifthNumberAnswerEdit() { return '[data-qa="fifth-number-answer-edit"]'; }
+  fifthNumberAnswerEdit(index = 0) { return '[data-qa="fifth-number-answer-' + index + '-edit"]'; }
 
-  fifthNumberAnswerLabel() { return '#fifth-number-answer-label'; } 
+  fifthNumberAnswerLabel(index = 0) { return '#fifth-number-answer-' + index + '-label'; }
 
-  sixthNumberAnswer() { return '#sixth-number-answer-answer'; }
+  sixthNumberAnswer(index = 0) { return '#sixth-number-answer-' + index + '-answer'; }
 
-  sixthNumberAnswerEdit() { return '[data-qa="sixth-number-answer-edit"]'; }
+  sixthNumberAnswerEdit(index = 0) { return '[data-qa="sixth-number-answer-' + index + '-edit"]'; }
 
-  sixthNumberAnswerLabel() { return '#sixth-number-answer-label'; } 
+  sixthNumberAnswerLabel(index = 0) { return '#sixth-number-answer-' + index + '-label'; }
 
 }
 module.exports = new NumberTotalPlaybackPage();

--- a/tests/functional/pages/features/calculated_summary/percentage-total-playback.page.js
+++ b/tests/functional/pages/features/calculated_summary/percentage-total-playback.page.js
@@ -7,17 +7,17 @@ class PercentageTotalPlaybackPage extends CalculatedSummaryPage {
     super('percentage-total-playback');
   }
 
-  fifthPercentAnswer() { return '#fifth-percent-answer-answer'; }
+  fifthPercentAnswer(index = 0) { return '#fifth-percent-answer-' + index + '-answer'; }
 
-  fifthPercentAnswerEdit() { return '[data-qa="fifth-percent-answer-edit"]'; }
+  fifthPercentAnswerEdit(index = 0) { return '[data-qa="fifth-percent-answer-' + index + '-edit"]'; }
 
-  fifthPercentAnswerLabel() { return '#fifth-percent-answer-label'; } 
+  fifthPercentAnswerLabel(index = 0) { return '#fifth-percent-answer-' + index + '-label'; }
 
-  sixthPercentAnswer() { return '#sixth-percent-answer-answer'; }
+  sixthPercentAnswer(index = 0) { return '#sixth-percent-answer-' + index + '-answer'; }
 
-  sixthPercentAnswerEdit() { return '[data-qa="sixth-percent-answer-edit"]'; }
+  sixthPercentAnswerEdit(index = 0) { return '[data-qa="sixth-percent-answer-' + index + '-edit"]'; }
 
-  sixthPercentAnswerLabel() { return '#sixth-percent-answer-label'; } 
+  sixthPercentAnswerLabel(index = 0) { return '#sixth-percent-answer-' + index + '-label'; }
 
 }
 module.exports = new PercentageTotalPlaybackPage();

--- a/tests/functional/pages/features/calculated_summary/unit-total-playback.page.js
+++ b/tests/functional/pages/features/calculated_summary/unit-total-playback.page.js
@@ -7,17 +7,17 @@ class UnitTotalPlaybackPage extends CalculatedSummaryPage {
     super('unit-total-playback');
   }
 
-  secondNumberAnswerUnitTotal() { return '#second-number-answer-unit-total-answer'; }
+  secondNumberAnswerUnitTotal(index = 0) { return '#second-number-answer-unit-total-' + index + '-answer'; }
 
-  secondNumberAnswerUnitTotalEdit() { return '[data-qa="second-number-answer-unit-total-edit"]'; }
+  secondNumberAnswerUnitTotalEdit(index = 0) { return '[data-qa="second-number-answer-unit-total-' + index + '-edit"]'; }
 
-  secondNumberAnswerUnitTotalLabel() { return '#second-number-answer-unit-total-label'; } 
+  secondNumberAnswerUnitTotalLabel(index = 0) { return '#second-number-answer-unit-total-' + index + '-label'; }
 
-  thirdNumberAnswerUnitTotal() { return '#third-number-answer-unit-total-answer'; }
+  thirdNumberAnswerUnitTotal(index = 0) { return '#third-number-answer-unit-total-' + index + '-answer'; }
 
-  thirdNumberAnswerUnitTotalEdit() { return '[data-qa="third-number-answer-unit-total-edit"]'; }
+  thirdNumberAnswerUnitTotalEdit(index = 0) { return '[data-qa="third-number-answer-unit-total-' + index + '-edit"]'; }
 
-  thirdNumberAnswerUnitTotalLabel() { return '#third-number-answer-unit-total-label'; } 
+  thirdNumberAnswerUnitTotalLabel(index = 0) { return '#third-number-answer-unit-total-' + index + '-label'; }
 
 }
 module.exports = new UnitTotalPlaybackPage();

--- a/tests/functional/pages/features/conditional_checkbox_titles/summary.page.js
+++ b/tests/functional/pages/features/conditional_checkbox_titles/summary.page.js
@@ -7,19 +7,19 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  nameAnswer() { return '#name-answer-answer'; }
+  nameAnswer(index = 0) { return '#name-answer-' + index + '-answer'; }
 
-  nameAnswerEdit() { return '[data-qa="name-answer-edit"]'; }
+  nameAnswerEdit(index = 0) { return '[data-qa="name-answer-' + index + '-edit"]'; }
 
-  checkboxAnswer() { return '#checkbox-answer-answer'; }
+  checkboxAnswer(index = 0) { return '#checkbox-answer-' + index + '-answer'; }
 
-  checkboxAnswerEdit() { return '[data-qa="checkbox-answer-edit"]'; }
+  checkboxAnswerEdit(index = 0) { return '[data-qa="checkbox-answer-' + index + '-edit"]'; }
 
-  radioAnswer() { return '#radio-answer-answer'; }
+  radioAnswer(index = 0) { return '#radio-answer-' + index + '-answer'; }
 
-  radioAnswerEdit() { return '[data-qa="radio-answer-edit"]'; }
+  radioAnswerEdit(index = 0) { return '[data-qa="radio-answer-' + index + '-edit"]'; }
 
-  radioCheckboxDescriptioTitle() { return '#radio-checkbox-descriptio'; }
+  radioCheckboxDescriptioTitle(index = 0) { return '#radio-checkbox-descriptio-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/conditional_question_title/repeating_blocks/summary.page.js
+++ b/tests/functional/pages/features/conditional_question_title/repeating_blocks/summary.page.js
@@ -7,27 +7,27 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  behalfOfAnswer() { return '#behalf-of-answer-answer'; }
+  behalfOfAnswer(index = 0) { return '#behalf-of-answer-' + index + '-answer'; }
 
-  behalfOfAnswerEdit() { return '[data-qa="behalf-of-answer-edit"]'; }
+  behalfOfAnswerEdit(index = 0) { return '[data-qa="behalf-of-answer-' + index + '-edit"]'; }
 
-  firstName() { return '#first-name-answer'; }
+  firstName(index = 0) { return '#first-name-' + index + '-answer'; }
 
-  firstNameEdit() { return '[data-qa="first-name-edit"]'; }
+  firstNameEdit(index = 0) { return '[data-qa="first-name-' + index + '-edit"]'; }
 
-  groupTitle() { return '#group'; }
+  groupTitle(index = 0) { return '#group-' + index; }
 
-  ageDifference() { return '#age-difference-answer'; }
+  ageDifference(index = 0) { return '#age-difference-' + index + '-answer'; }
 
-  ageDifferenceEdit() { return '[data-qa="age-difference-edit"]'; }
+  ageDifferenceEdit(index = 0) { return '[data-qa="age-difference-' + index + '-edit"]'; }
 
-  confirmAnswer() { return '#confirm-answer-answer'; }
+  confirmAnswer(index = 0) { return '#confirm-answer-' + index + '-answer'; }
 
-  confirmAnswerEdit() { return '[data-qa="confirm-answer-edit"]'; }
+  confirmAnswerEdit(index = 0) { return '[data-qa="confirm-answer-' + index + '-edit"]'; }
 
-  repeatingGroupTitle() { return '#repeating-group'; }
+  repeatingGroupTitle(index = 0) { return '#repeating-group-' + index; }
 
-  summaryGroupTitle() { return '#summary-group'; }
+  summaryGroupTitle(index = 0) { return '#summary-group-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/conditional_question_title/repeating_dependant_on_non_repeating/summary.page.js
+++ b/tests/functional/pages/features/conditional_question_title/repeating_dependant_on_non_repeating/summary.page.js
@@ -7,25 +7,25 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  favColourAnswer() { return '#fav-colour-answer-answer'; }
+  favColourAnswer(index = 0) { return '#fav-colour-answer-' + index + '-answer'; }
 
-  favColourAnswerEdit() { return '[data-qa="fav-colour-answer-edit"]'; }
+  favColourAnswerEdit(index = 0) { return '[data-qa="fav-colour-answer-' + index + '-edit"]'; }
 
-  colourGroupTitle() { return '#colour-group'; }
+  colourGroupTitle(index = 0) { return '#colour-group-' + index; }
 
-  firstName() { return '#first-name-answer'; }
+  firstName(index = 0) { return '#first-name-' + index + '-answer'; }
 
-  firstNameEdit() { return '[data-qa="first-name-edit"]'; }
+  firstNameEdit(index = 0) { return '[data-qa="first-name-' + index + '-edit"]'; }
 
-  groupTitle() { return '#group'; }
+  groupTitle(index = 0) { return '#group-' + index; }
 
-  confirmAnswer() { return '#confirm-answer-answer'; }
+  confirmAnswer(index = 0) { return '#confirm-answer-' + index + '-answer'; }
 
-  confirmAnswerEdit() { return '[data-qa="confirm-answer-edit"]'; }
+  confirmAnswerEdit(index = 0) { return '[data-qa="confirm-answer-' + index + '-edit"]'; }
 
-  repeatingGroupTitle() { return '#repeating-group'; }
+  repeatingGroupTitle(index = 0) { return '#repeating-group-' + index; }
 
-  summaryGroupTitle() { return '#summary-group'; }
+  summaryGroupTitle(index = 0) { return '#summary-group-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/conditional_question_title/summary.page.js
+++ b/tests/functional/pages/features/conditional_question_title/summary.page.js
@@ -7,27 +7,27 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  feelingAnswer() { return '#feeling-answer-answer'; }
+  feelingAnswer(index = 0) { return '#feeling-answer-' + index + '-answer'; }
 
-  feelingAnswerEdit() { return '[data-qa="feeling-answer-edit"]'; }
+  feelingAnswerEdit(index = 0) { return '[data-qa="feeling-answer-' + index + '-edit"]'; }
 
-  behalfOfAnswer() { return '#behalf-of-answer-answer'; }
+  behalfOfAnswer(index = 0) { return '#behalf-of-answer-' + index + '-answer'; }
 
-  behalfOfAnswerEdit() { return '[data-qa="behalf-of-answer-edit"]'; }
+  behalfOfAnswerEdit(index = 0) { return '[data-qa="behalf-of-answer-' + index + 'edit"]'; }
 
-  genderAnswer() { return '#gender-answer-answer'; }
+  genderAnswer(index = 0) { return '#gender-answer-' + index + '-answer'; }
 
-  genderAnswerEdit() { return '[data-qa="gender-answer-edit"]'; }
+  genderAnswerEdit(index = 0) { return '[data-qa="gender-answer-' + index + '-edit"]'; }
 
-  ageAnswer() { return '#age-answer-answer'; }
+  ageAnswer(index = 0) { return '#age-answer-' + index + '-answer'; }
 
-  ageAnswerEdit() { return '[data-qa="age-answer-edit"]'; }
+  ageAnswerEdit(index = 0) { return '[data-qa="age-answer-' + index + '-edit"]'; }
 
-  sureAnswer() { return '#sure-answer-answer'; }
+  sureAnswer(index = 0) { return '#sure-answer-' + index + '-answer'; }
 
-  sureAnswerEdit() { return '[data-qa="sure-answer-edit"]'; }
+  sureAnswerEdit(index = 0) { return '[data-qa="sure-answer-' + index + '-edit"]'; }
 
-  groupTitle() { return '#group'; }
+  groupTitle(index = 0) { return '#group-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/confirmation_question/summary.page.js
+++ b/tests/functional/pages/features/confirmation_question/summary.page.js
@@ -7,23 +7,23 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  numberOfEmployeesTotal() { return '#number-of-employees-total-answer'; }
+  numberOfEmployeesTotal(index = 0) { return '#number-of-employees-total-' + index + '-answer'; }
 
-  numberOfEmployeesTotalEdit() { return '[data-qa="number-of-employees-total-edit"]'; }
+  numberOfEmployeesTotalEdit(index = 0) { return '[data-qa="number-of-employees-total-' + index + '-edit"]'; }
 
-  confirmZeroEmployeesAnswer() { return '#confirm-zero-employees-answer-answer'; }
+  confirmZeroEmployeesAnswer(index = 0) { return '#confirm-zero-employees-answer-' + index + '-answer'; }
 
-  confirmZeroEmployeesAnswerEdit() { return '[data-qa="confirm-zero-employees-answer-edit"]'; }
+  confirmZeroEmployeesAnswerEdit(index = 0) { return '[data-qa="confirm-zero-employees-answer-' + index + '-edit"]'; }
 
-  numberOfEmployeesMaleMore30Hours() { return '#number-of-employees-male-more-30-hours-answer'; }
+  numberOfEmployeesMaleMore30Hours(index = 0) { return '#number-of-employees-male-more-30-hours-' + index + '-answer'; }
 
-  numberOfEmployeesMaleMore30HoursEdit() { return '[data-qa="number-of-employees-male-more-30-hours-edit"]'; }
+  numberOfEmployeesMaleMore30HoursEdit(index = 0) { return '[data-qa="number-of-employees-male-more-30-hours-' + index + '-edit"]'; }
 
-  numberOfEmployeesFemaleMore30Hours() { return '#number-of-employees-female-more-30-hours-answer'; }
+  numberOfEmployeesFemaleMore30Hours(index = 0) { return '#number-of-employees-female-more-30-hours-' + index + '-answer'; }
 
-  numberOfEmployeesFemaleMore30HoursEdit() { return '[data-qa="number-of-employees-female-more-30-hours-edit"]'; }
+  numberOfEmployeesFemaleMore30HoursEdit(index = 0) { return '[data-qa="number-of-employees-female-more-30-hours-' + index + '-edit"]'; }
 
-  confirmationBlockTitle() { return '#confirmation-block'; }
+  confirmationBlockTitle(index = 0) { return '#confirmation-block-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/date_reference_ranges/summary.page.js
+++ b/tests/functional/pages/features/date_reference_ranges/summary.page.js
@@ -7,19 +7,19 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  manualRangeRadio() { return '#manual-range-radio-answer'; }
+  manualRangeRadio(index = 0) { return '#manual-range-radio-' + index + '-answer'; }
 
-  manualRangeRadioEdit() { return '[data-qa="manual-range-radio-edit"]'; }
+  manualRangeRadioEdit(index = 0) { return '[data-qa="manual-range-radio-' + index + '-edit"]'; }
 
-  dateSeparateRadio() { return '#date-separate-radio-answer'; }
+  dateSeparateRadio(index = 0) { return '#date-separate-radio-' + index + '-answer'; }
 
-  dateSeparateRadioEdit() { return '[data-qa="date-separate-radio-edit"]'; }
+  dateSeparateRadioEdit(index = 0) { return '[data-qa="date-separate-radio-' + index + '-edit"]'; }
 
-  dateRangeRadio() { return '#date-range-radio-answer'; }
+  dateRangeRadio(index = 0) { return '#date-range-radio-' + index + '-answer'; }
 
-  dateRangeRadioEdit() { return '[data-qa="date-range-radio-edit"]'; }
+  dateRangeRadioEdit(index = 0) { return '[data-qa="date-range-radio-' + index + '-edit"]'; }
 
-  datesTitle() { return '#dates'; }
+  datesTitle(index = 0) { return '#dates-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/default_value/summary.page.js
+++ b/tests/functional/pages/features/default_value/summary.page.js
@@ -7,11 +7,11 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  answer() { return '#answer-answer'; }
+  answer(index = 0) { return '#answer-' + index + '-answer'; }
 
-  answerEdit() { return '[data-qa="answer-edit"]'; }
+  answerEdit(index = 0) { return '[data-qa="answer-' + index + '-edit"]'; }
 
-  groupTitle() { return '#group'; }
+  groupTitle(index = 0) { return '#group-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/dependencies/calculation/summary.page.js
+++ b/tests/functional/pages/features/dependencies/calculation/summary.page.js
@@ -7,29 +7,29 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  totalAnswer() { return '#total-answer-answer'; }
+  totalAnswer(index = 0) { return '#total-answer-' + index + '-answer'; }
 
-  totalAnswerEdit() { return '[data-qa="total-answer-edit"]'; }
+  totalAnswerEdit(index = 0) { return '[data-qa="total-answer-' + index + '-edit"]'; }
 
-  breakdown1() { return '#breakdown-1-answer'; }
+  breakdown1(index = 0) { return '#breakdown-1-' + index + '-answer'; }
 
-  breakdown1Edit() { return '[data-qa="breakdown-1-edit"]'; }
+  breakdown1Edit(index = 0) { return '[data-qa="breakdown-1-' + index + '-edit"]'; }
 
-  breakdown2() { return '#breakdown-2-answer'; }
+  breakdown2(index = 0) { return '#breakdown-2-' + index + '-answer'; }
 
-  breakdown2Edit() { return '[data-qa="breakdown-2-edit"]'; }
+  breakdown2Edit(index = 0) { return '[data-qa="breakdown-2-' + index + '-edit"]'; }
 
-  breakdown3() { return '#breakdown-3-answer'; }
+  breakdown3(index = 0) { return '#breakdown-3-' + index + '-answer'; }
 
-  breakdown3Edit() { return '[data-qa="breakdown-3-edit"]'; }
+  breakdown3Edit(index = 0) { return '[data-qa="breakdown-3-' + index + '-edit"]'; }
 
-  breakdown4() { return '#breakdown-4-answer'; }
+  breakdown4(index = 0) { return '#breakdown-4-' + index + '-answer'; }
 
-  breakdown4Edit() { return '[data-qa="breakdown-4-edit"]'; }
+  breakdown4Edit(index = 0) { return '[data-qa="breakdown-4-' + index + '-edit"]'; }
 
-  groupTitle() { return '#group'; }
+  groupTitle(index = 0) { return '#group-' + index; }
 
-  summaryGroupTitle() { return '#summary-group'; }
+  summaryGroupTitle(index = 0) { return '#summary-group-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/dependencies/max/summary.page.js
+++ b/tests/functional/pages/features/dependencies/max/summary.page.js
@@ -7,17 +7,17 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  maxAnswer() { return '#max-answer-answer'; }
+  maxAnswer(index = 0) { return '#max-answer-' + index + '-answer'; }
 
-  maxAnswerEdit() { return '[data-qa="max-answer-edit"]'; }
+  maxAnswerEdit(index = 0) { return '[data-qa="max-answer-' + index + '-edit"]'; }
 
-  dependent1() { return '#dependent-1-answer'; }
+  dependent1(index = 0) { return '#dependent-1-' + index + '-answer'; }
 
-  dependent1Edit() { return '[data-qa="dependent-1-edit"]'; }
+  dependent1Edit(index = 0) { return '[data-qa="dependent-1-' + index + '-edit"]'; }
 
-  groupTitle() { return '#group'; }
+  groupTitle(index = 0) { return '#group-' + index; }
 
-  summaryGroupTitle() { return '#summary-group'; }
+  summaryGroupTitle(index = 0) { return '#summary-group-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/dependencies/min/summary.page.js
+++ b/tests/functional/pages/features/dependencies/min/summary.page.js
@@ -7,17 +7,17 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  minAnswer() { return '#min-answer-answer'; }
+  minAnswer(index = 0) { return '#min-answer-' + index + '-answer'; }
 
-  minAnswerEdit() { return '[data-qa="min-answer-edit"]'; }
+  minAnswerEdit(index = 0) { return '[data-qa="min-answer-' + index + '-edit"]'; }
 
-  dependent1() { return '#dependent-1-answer'; }
+  dependent1(index = 0) { return '#dependent-1-' + index + '-answer'; }
 
-  dependent1Edit() { return '[data-qa="dependent-1-edit"]'; }
+  dependent1Edit(index = 0) { return '[data-qa="dependent-1-' + index + '-edit"]'; }
 
-  groupTitle() { return '#group'; }
+  groupTitle(index = 0) { return '#group-' + index; }
 
-  summaryGroupTitle() { return '#summary-group'; }
+  summaryGroupTitle(index = 0) { return '#summary-group-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/routing/answer_count/summary.page.js
+++ b/tests/functional/pages/features/routing/answer_count/summary.page.js
@@ -7,31 +7,31 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  lastName() { return '#last-name-answer'; }
+  lastName(index = 0) { return '#last-name-' + index + '-answer'; }
 
-  lastNameEdit() { return '[data-qa="last-name-edit"]'; }
+  lastNameEdit(index = 0) { return '[data-qa="last-name-' + index + '-edit"]'; }
 
-  multipleQuestionsGroupTitle() { return '#multiple-questions-group'; }
+  multipleQuestionsGroupTitle(index = 0) { return '#multiple-questions-group-' + index; }
 
-  groupLessThan2Answer() { return '#group-less-than-2-answer-answer'; }
+  groupLessThan2Answer(index = 0) { return '#group-less-than-2-answer-' + index + '-answer'; }
 
-  groupLessThan2AnswerEdit() { return '[data-qa="group-less-than-2-answer-edit"]'; }
+  groupLessThan2AnswerEdit(index = 0) { return '[data-qa="group-less-than-2-answer-' + index + '-edit"]'; }
 
-  groupLessThan2Title() { return '#group-less-than-2'; }
+  groupLessThan2Title(index = 0) { return '#group-less-than-2-' + index; }
 
-  groupEqual2Answer() { return '#group-equal-2-answer-answer'; }
+  groupEqual2Answer(index = 0) { return '#group-equal-2-answer-' + index + '-answer'; }
 
-  groupEqual2AnswerEdit() { return '[data-qa="group-equal-2-answer-edit"]'; }
+  groupEqual2AnswerEdit(index = 0) { return '[data-qa="group-equal-2-answer-' + index + '-edit"]'; }
 
-  groupEqual2Title() { return '#group-equal-2'; }
+  groupEqual2Title(index = 0) { return '#group-equal-2-' + index; }
 
-  groupGreaterThan2Answer() { return '#group-greater-than-2-answer-answer'; }
+  groupGreaterThan2Answer(index = 0) { return '#group-greater-than-2-answer-' + index + '-answer'; }
 
-  groupGreaterThan2AnswerEdit() { return '[data-qa="group-greater-than-2-answer-edit"]'; }
+  groupGreaterThan2AnswerEdit(index = 0) { return '[data-qa="group-greater-than-2-answer-' + index + '-edit"]'; }
 
-  groupGreaterThan2Title() { return '#group-greater-than-2'; }
+  groupGreaterThan2Title(index = 0) { return '#group-greater-than-2-' + index; }
 
-  summaryGroupTitle() { return '#summary-group'; }
+  summaryGroupTitle(index = 0) { return '#summary-group-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/routing/number/equals/summary.page.js
+++ b/tests/functional/pages/features/routing/number/equals/summary.page.js
@@ -7,9 +7,9 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  answer() { return '#answer-answer'; }
+  answer(index = 0) { return '#answer-' + index + '-answer'; }
 
-  answerEdit() { return '[data-qa="answer-edit"]'; }
+  answerEdit(index = 0) { return '[data-qa="answer-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/routing/number/greater_than/summary.page.js
+++ b/tests/functional/pages/features/routing/number/greater_than/summary.page.js
@@ -7,9 +7,9 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  answer() { return '#answer-answer'; }
+  answer(index = 0) { return '#answer-' + index + '-answer'; }
 
-  answerEdit() { return '[data-qa="answer-edit"]'; }
+  answerEdit(index = 0) { return '[data-qa="answer-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/routing/number/greater_than_or_equal/summary.page.js
+++ b/tests/functional/pages/features/routing/number/greater_than_or_equal/summary.page.js
@@ -7,9 +7,9 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  answer() { return '#answer-answer'; }
+  answer(index = 0) { return '#answer-' + index + '-answer'; }
 
-  answerEdit() { return '[data-qa="answer-edit"]'; }
+  answerEdit(index = 0) { return '[data-qa="answer-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/routing/number/less_than/summary.page.js
+++ b/tests/functional/pages/features/routing/number/less_than/summary.page.js
@@ -7,9 +7,9 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  answer() { return '#answer-answer'; }
+  answer(index = 0) { return '#answer-' + index + '-answer'; }
 
-  answerEdit() { return '[data-qa="answer-edit"]'; }
+  answerEdit(index = 0) { return '[data-qa="answer-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/routing/number/less_than_or_equal/summary.page.js
+++ b/tests/functional/pages/features/routing/number/less_than_or_equal/summary.page.js
@@ -7,9 +7,9 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  answer() { return '#answer-answer'; }
+  answer(index = 0) { return '#answer-' + index + '-answer'; }
 
-  answerEdit() { return '[data-qa="answer-edit"]'; }
+  answerEdit(index = 0) { return '[data-qa="answer-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/routing/number/not_equals/summary.page.js
+++ b/tests/functional/pages/features/routing/number/not_equals/summary.page.js
@@ -7,9 +7,9 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  answer() { return '#answer-answer'; }
+  answer(index = 0) { return '#answer-' + index + '-answer'; }
 
-  answerEdit() { return '[data-qa="answer-edit"]'; }
+  answerEdit(index = 0) { return '[data-qa="answer-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/submitted_responses/submission.page.js
+++ b/tests/functional/pages/features/submitted_responses/submission.page.js
@@ -7,25 +7,25 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  radioAnswer() { return '#radio-answer-answer'; }
+  radioAnswer(index = 0) { return '#radio-answer-' + index + '-answer'; }
 
-  radioAnswerEdit() { return '[data-qa="radio-answer-edit"]'; }
+  radioAnswerEdit(index = 0) { return '[data-qa="radio-answer-' + index + '-edit"]'; }
 
-  otherAnswerMandatory() { return '#other-answer-mandatory-answer'; }
+  otherAnswerMandatory(index = 0) { return '#other-answer-mandatory-' + index + '-answer'; }
 
-  otherAnswerMandatoryEdit() { return '[data-qa="other-answer-mandatory-edit"]'; }
+  otherAnswerMandatoryEdit(index = 0) { return '[data-qa="other-answer-mandatory-' + index + '-edit"]'; }
 
-  testCurrency() { return '#test-currency-answer'; }
+  testCurrency(index = 0) { return '#test-currency-' + index + '-answer'; }
 
-  testCurrencyEdit() { return '[data-qa="test-currency-edit"]'; }
+  testCurrencyEdit(index = 0) { return '[data-qa="test-currency-' + index + '-edit"]'; }
 
-  squareKilometres() { return '#square-kilometres-answer'; }
+  squareKilometres(index = 0) { return '#square-kilometres-' + index + '-answer'; }
 
-  squareKilometresEdit() { return '[data-qa="square-kilometres-edit"]'; }
+  squareKilometresEdit(index = 0) { return '[data-qa="square-kilometres-' + index + '-edit"]'; }
 
-  testDecimal() { return '#test-decimal-answer'; }
+  testDecimal(index = 0) { return '#test-decimal-' + index + '-answer'; }
 
-  testDecimalEdit() { return '[data-qa="test-decimal-edit"]'; }
+  testDecimalEdit(index = 0) { return '[data-qa="test-decimal-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/validation/date-validation/date-combined-mm-yyyy/summary.page.js
+++ b/tests/functional/pages/features/validation/date-validation/date-combined-mm-yyyy/summary.page.js
@@ -7,11 +7,11 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  dateRange() { return '#date-range-from-answer'; }
+  dateRange(index = 0) { return '#date-range-from-' + index + '-answer'; }
 
-  dateRangeEdit() { return '[data-qa="date-range-from-edit"]'; }
+  dateRangeEdit(index = 0) { return '[data-qa="date-range-from-' + index + '-edit"]'; }
 
-  datesTitle() { return '#dates'; }
+  datesTitle(index = 0) { return '#dates-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/validation/date-validation/date-combined-yyyy/summary.page.js
+++ b/tests/functional/pages/features/validation/date-validation/date-combined-yyyy/summary.page.js
@@ -7,11 +7,11 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  dateRange() { return '#date-range-from-answer'; }
+  dateRange(index = 0) { return '#date-range-from-' + index + '-answer'; }
 
-  dateRangeEdit() { return '[data-qa="date-range-from-edit"]'; }
+  dateRangeEdit(index = 0) { return '[data-qa="date-range-from-' + index + '-edit"]'; }
 
-  datesTitle() { return '#dates'; }
+  datesTitle(index = 0) { return '#dates-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/validation/date-validation/date-combined/summary.page.js
+++ b/tests/functional/pages/features/validation/date-validation/date-combined/summary.page.js
@@ -7,11 +7,11 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  dateRange() { return '#date-range-from-answer'; }
+  dateRange(index = 0) { return '#date-range-from-' + index + '-answer'; }
 
-  dateRangeEdit() { return '[data-qa="date-range-from-edit"]'; }
+  dateRangeEdit(index = 0) { return '[data-qa="date-range-from-' + index + '-edit"]'; }
 
-  datesTitle() { return '#dates'; }
+  datesTitle(index = 0) { return '#dates-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/validation/date-validation/date-range/summary.page.js
+++ b/tests/functional/pages/features/validation/date-validation/date-range/summary.page.js
@@ -7,15 +7,15 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  dateRangeFrom() { return '#date-range-from-answer'; }
+  dateRangeFrom(index = 0) { return '#date-range-from-' + index + '-answer'; }
 
-  dateRangeFromEdit() { return '[data-qa="date-range-from-edit"]'; }
+  dateRangeFromEdit(index = 0) { return '[data-qa="date-range-from-' + index + '-edit"]'; }
 
-  dateRangeTo() { return '#date-range-to-answer'; }
+  dateRangeTo(index = 0) { return '#date-range-to-' + index + '-answer'; }
 
-  dateRangeToEdit() { return '[data-qa="date-range-to-edit"]'; }
+  dateRangeToEdit(index = 0) { return '[data-qa="date-range-to-' + index + '-edit"]'; }
 
-  datesTitle() { return '#dates'; }
+  datesTitle(index = 0) { return '#dates-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/validation/date-validation/date-single/summary.page.js
+++ b/tests/functional/pages/features/validation/date-validation/date-single/summary.page.js
@@ -7,15 +7,15 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  date() { return '#date-answer'; }
+  date(index = 0) { return '#date-' + index + '-answer'; }
 
-  dateEdit() { return '[data-qa="date-edit"]'; }
+  dateEdit(index = 0) { return '[data-qa="date-' + index + '-edit"]'; }
 
-  dateRangeTo() { return '#date-range-to-answer'; }
+  dateRangeTo(index = 0) { return '#date-range-to-' + index + '-answer'; }
 
-  dateRangeToEdit() { return '[data-qa="date-range-to-edit"]'; }
+  dateRangeToEdit(index = 0) { return '[data-qa="date-range-to-' + index + '-edit"]'; }
 
-  datesTitle() { return '#dates'; }
+  datesTitle(index = 0) { return '#dates-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/validation/sum/equal-to/summary.page.js
+++ b/tests/functional/pages/features/validation/sum/equal-to/summary.page.js
@@ -7,25 +7,25 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  totalAnswer() { return '#total-answer-answer'; }
+  totalAnswer(index = 0) { return '#total-answer-' + index + '-answer'; }
 
-  totalAnswerEdit() { return '[data-qa="total-answer-edit"]'; }
+  totalAnswerEdit(index = 0) { return '[data-qa="total-answer-' + index + '-edit"]'; }
 
-  breakdown1() { return '#breakdown-1-answer'; }
+  breakdown1(index = 0) { return '#breakdown-1-' + index + '-answer'; }
 
-  breakdown1Edit() { return '[data-qa="breakdown-1-edit"]'; }
+  breakdown1Edit(index = 0) { return '[data-qa="breakdown-1-' + index + '-edit"]'; }
 
-  breakdown2() { return '#breakdown-2-answer'; }
+  breakdown2(index = 0) { return '#breakdown-2-' + index + '-answer'; }
 
-  breakdown2Edit() { return '[data-qa="breakdown-2-edit"]'; }
+  breakdown2Edit(index = 0) { return '[data-qa="breakdown-2-' + index + '-edit"]'; }
 
-  breakdown3() { return '#breakdown-3-answer'; }
+  breakdown3(index = 0) { return '#breakdown-3-' + index + '-answer'; }
 
-  breakdown3Edit() { return '[data-qa="breakdown-3-edit"]'; }
+  breakdown3Edit(index = 0) { return '[data-qa="breakdown-3-' + index + '-edit"]'; }
 
-  breakdown4() { return '#breakdown-4-answer'; }
+  breakdown4(index = 0) { return '#breakdown-4-' + index + '-answer'; }
 
-  breakdown4Edit() { return '[data-qa="breakdown-4-edit"]'; }
+  breakdown4Edit(index = 0) { return '[data-qa="breakdown-4-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/validation/sum/less-than-equal-to/summary.page.js
+++ b/tests/functional/pages/features/validation/sum/less-than-equal-to/summary.page.js
@@ -7,25 +7,25 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  totalAnswer() { return '#total-answer-answer'; }
+  totalAnswer(index = 0) { return '#total-answer-' + index + '-answer'; }
 
-  totalAnswerEdit() { return '[data-qa="total-answer-edit"]'; }
+  totalAnswerEdit(index = 0) { return '[data-qa="total-answer-' + index + '-edit"]'; }
 
-  breakdown1() { return '#breakdown-1-answer'; }
+  breakdown1(index = 0) { return '#breakdown-1-' + index + '-answer'; }
 
-  breakdown1Edit() { return '[data-qa="breakdown-1-edit"]'; }
+  breakdown1Edit(index = 0) { return '[data-qa="breakdown-1-' + index + '-edit"]'; }
 
-  breakdown2() { return '#breakdown-2-answer'; }
+  breakdown2(index = 0) { return '#breakdown-2-' + index + '-answer'; }
 
-  breakdown2Edit() { return '[data-qa="breakdown-2-edit"]'; }
+  breakdown2Edit(index = 0) { return '[data-qa="breakdown-2-' + index + '-edit"]'; }
 
-  breakdown3() { return '#breakdown-3-answer'; }
+  breakdown3(index = 0) { return '#breakdown-3-' + index + '-answer'; }
 
-  breakdown3Edit() { return '[data-qa="breakdown-3-edit"]'; }
+  breakdown3Edit(index = 0) { return '[data-qa="breakdown-3-' + index + '-edit"]'; }
 
-  breakdown4() { return '#breakdown-4-answer'; }
+  breakdown4(index = 0) { return '#breakdown-4-' + index + '-answer'; }
 
-  breakdown4Edit() { return '[data-qa="breakdown-4-edit"]'; }
+  breakdown4Edit(index = 0) { return '[data-qa="breakdown-4-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/features/validation/sum/less-than/summary.page.js
+++ b/tests/functional/pages/features/validation/sum/less-than/summary.page.js
@@ -7,25 +7,25 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  totalAnswer() { return '#total-answer-answer'; }
+  totalAnswer(index = 0) { return '#total-answer-' + index + '-answer'; }
 
-  totalAnswerEdit() { return '[data-qa="total-answer-edit"]'; }
+  totalAnswerEdit(index = 0) { return '[data-qa="total-answer-' + index + '-edit"]'; }
 
-  breakdown1() { return '#breakdown-1-answer'; }
+  breakdown1(index = 0) { return '#breakdown-1-' + index + '-answer'; }
 
-  breakdown1Edit() { return '[data-qa="breakdown-1-edit"]'; }
+  breakdown1Edit(index = 0) { return '[data-qa="breakdown-1-' + index + '-edit"]'; }
 
-  breakdown2() { return '#breakdown-2-answer'; }
+  breakdown2(index = 0) { return '#breakdown-2-' + index + '-answer'; }
 
-  breakdown2Edit() { return '[data-qa="breakdown-2-edit"]'; }
+  breakdown2Edit(index = 0) { return '[data-qa="breakdown-2-' + index + '-edit"]'; }
 
-  breakdown3() { return '#breakdown-3-answer'; }
+  breakdown3(index = 0) { return '#breakdown-3-' + index + '-answer'; }
 
-  breakdown3Edit() { return '[data-qa="breakdown-3-edit"]'; }
+  breakdown3Edit(index = 0) { return '[data-qa="breakdown-3-' + index + '-edit"]'; }
 
-  breakdown4() { return '#breakdown-4-answer'; }
+  breakdown4(index = 0) { return '#breakdown-4-' + index + '-answer'; }
 
-  breakdown4Edit() { return '[data-qa="breakdown-4-edit"]'; }
+  breakdown4Edit(index = 0) { return '[data-qa="breakdown-4-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/surveys/checkbox/checkbox-summary.page.js
+++ b/tests/functional/pages/surveys/checkbox/checkbox-summary.page.js
@@ -2,20 +2,20 @@ const QuestionPage = require('../question.page');
 
 class CheckboxSummaryPage extends QuestionPage {
 
-  mandatoryAnswer() {
-    return '#mandatory-checkbox-answer-answer';
+  mandatoryAnswer(index = 0) {
+    return '#mandatory-checkbox-answer-' + index + '-answer';
   }
 
-  nonMandatoryAnswer() {
-    return '#non-mandatory-checkbox-answer-answer';
+  nonMandatoryAnswer(index = 0) {
+    return '#non-mandatory-checkbox-answer-' + index + '-answer';
   }
 
-  mandatoryOtherAnswer() {
-    return '[data-qa="other-answer-mandatory-answer"]';
+  mandatoryOtherAnswer(index = 0) {
+    return '[data-qa="other-answer-mandatory-' + index + '-answer"]';
   }
 
-  nonMandatoryOtherAnswer() {
-    return '#other-answer-non-mandatory-answer';
+  nonMandatoryOtherAnswer(index = 0) {
+    return '#other-answer-non-mandatory-' + index + '-answer';
   }
 
 }

--- a/tests/functional/pages/surveys/dates/summary.page.js
+++ b/tests/functional/pages/surveys/dates/summary.page.js
@@ -7,20 +7,20 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  dateRangeFromAnswer() {
-    return '#date-range-from-answer';
+  dateRangeFromAnswer(index = 0) {
+    return '#date-range-from-' + index + '-answer';
   }
 
-  monthYearAnswer() {
-    return '#month-year-answer-answer';
+  monthYearAnswer(index = 0) {
+    return '#month-year-answer-' + index + '-answer';
   }
 
-  singleDateAnswer() {
-    return '#single-date-answer-answer';
+  singleDateAnswer(index = 0) {
+    return '#single-date-answer-' + index + '-answer';
   }
 
-  nonMandatoryDateAnswer() {
-    return '#non-mandatory-date-answer-answer';
+  nonMandatoryDateAnswer(index = 0) {
+    return '#non-mandatory-date-answer-' + index + '-answer';
   }
 
 }

--- a/tests/functional/pages/surveys/dates_conditional/summary.page.js
+++ b/tests/functional/pages/surveys/dates_conditional/summary.page.js
@@ -7,12 +7,12 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  answer() {
-    return '#date-start-from-answer';
+  answer(index = 0) {
+    return '#date-start-from-' + index + '-answer';
   }
 
-  otheranswer() {
-    return '#date-test-answer-answer';
+  otheranswer(index = 0) {
+    return '#date-test-answer-' + index + '-answer';
   }
 
 }

--- a/tests/functional/pages/surveys/durations/summary.page.js
+++ b/tests/functional/pages/surveys/durations/summary.page.js
@@ -7,31 +7,31 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  yearMonthAnswer() { return '#year-month-answer-answer'; }
+  yearMonthAnswer(index = 0) { return '#year-month-answer-' + index + '-answer'; }
 
-  yearMonthAnswerEdit() { return '[data-qa="year-month-answer-edit"]'; }
+  yearMonthAnswerEdit(index = 0) { return '[data-qa="year-month-answer-' + index + '-edit"]'; }
 
-  mandatoryYearMonthAnswer() { return '#mandatory-year-month-answer-answer'; }
+  mandatoryYearMonthAnswer(index = 0) { return '#mandatory-year-month-answer-' + index + '-answer'; }
 
-  mandatoryYearMonthAnswerEdit() { return '[data-qa="mandatory-year-month-answer-edit"]'; }
+  mandatoryYearMonthAnswerEdit(index = 0) { return '[data-qa="mandatory-year-month-answer-' + index + '-edit"]'; }
 
-  yearAnswer() { return '#year-answer-answer'; }
+  yearAnswer(index = 0) { return '#year-answer-' + index + '-answer'; }
 
-  yearAnswerEdit() { return '[data-qa="year-answer-edit"]'; }
+  yearAnswerEdit(index = 0) { return '[data-qa="year-answer-' + index + '-edit"]'; }
 
-  mandatoryYearAnswer() { return '#mandatory-year-answer-answer'; }
+  mandatoryYearAnswer(index = 0) { return '#mandatory-year-answer-' + index + '-answer'; }
 
-  mandatoryYearAnswerEdit() { return '[data-qa="mandatory-year-answer-edit"]'; }
+  mandatoryYearAnswerEdit(index = 0) { return '[data-qa="mandatory-year-answer-' + index + '-edit"]'; }
 
-  monthAnswer() { return '#month-answer-answer'; }
+  monthAnswer(index = 0) { return '#month-answer-' + index + '-answer'; }
 
-  monthAnswerEdit() { return '[data-qa="month-answer-edit"]'; }
+  monthAnswerEdit(index = 0) { return '[data-qa="month-answer-' + index + '-edit"]'; }
 
-  mandatoryMonthAnswer() { return '#mandatory-month-answer-answer'; }
+  mandatoryMonthAnswer(index = 0) { return '#mandatory-month-answer-' + index + '-answer'; }
 
-  mandatoryMonthAnswerEdit() { return '[data-qa="mandatory-month-answer-edit"]'; }
+  mandatoryMonthAnswerEdit(index = 0) { return '[data-qa="mandatory-month-answer-' + index + '-edit"]'; }
 
-  durationsTitle() { return '#durations'; }
+  durationsTitle(index = 0) { return '#durations-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/surveys/household/summary.page.js
+++ b/tests/functional/pages/surveys/household/summary.page.js
@@ -7,27 +7,31 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  lastName() { return '#last-name-answer'; }
+  firstName(index = 0) { return '#first-name-' + index + '-answer'; }
 
-  lastNameEdit() { return '[data-qa="last-name-edit"]'; }
+  middleNames(index = 0) { return '#middle-names-' + index + '-answer'; }
 
-  multipleQuestionsGroupTitle() { return '#multiple-questions-group'; }
+  lastName(index = 0) { return '#last-name-' + index + '-answer'; }
 
-  whatIsYourAge() { return '#what-is-your-age-answer'; }
+  lastNameEdit(index = 0) { return '[data-qa="last-name-' + index + '-edit"]'; }
 
-  whatIsYourAgeEdit() { return '[data-qa="what-is-your-age-edit"]'; }
+  multipleQuestionsGroupTitle(index = 0) { return '#multiple-questions-group-' + index; }
 
-  whatIsYourShoeSize() { return '#what-is-your-shoe-size-answer'; }
+  whatIsYourAge(index = 0) { return '#what-is-your-age-' + index + '-answer'; }
 
-  whatIsYourShoeSizeEdit() { return '[data-qa="what-is-your-shoe-size-edit"]'; }
+  whatIsYourAgeEdit(index = 0) { return '[data-qa="what-is-your-age-' + index + '-edit"]'; }
 
-  confirmAnswer() { return '#confirm-answer-answer'; }
+  whatIsYourShoeSize(index = 0) { return '#what-is-your-shoe-size-' + index + '-answer'; }
 
-  confirmAnswerEdit() { return '[data-qa="confirm-answer-edit"]'; }
+  whatIsYourShoeSizeEdit(index = 0) { return '[data-qa="what-is-your-shoe-size-' + index + '-edit"]'; }
 
-  repeatingGroupTitle() { return '#repeating-group'; }
+  confirmAnswer(index = 0) { return '#confirm-answer-' + index + '-answer'; }
 
-  summaryGroupTitle() { return '#summary-group'; }
+  confirmAnswerEdit(index = 0) { return '[data-qa="confirm-answer-' + index + '-edit"]'; }
+
+  repeatingGroupTitle(index = 0) { return '#repeating-group-' + index; }
+
+  summaryGroupTitle(index = 0) { return '#summary-group-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/surveys/language_code/summary.page.js
+++ b/tests/functional/pages/surveys/language_code/summary.page.js
@@ -7,11 +7,11 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  monthYearAnswer() { return '#month-year-answer-answer'; }
+  monthYearAnswer(index = 0) { return '#month-year-answer-' + index + '-answer'; }
 
-  monthYearAnswerEdit() { return '[data-qa="month-year-answer-edit"]'; }
+  monthYearAnswerEdit(index = 0) { return '[data-qa="month-year-answer-' + index + '-edit"]'; }
 
-  languageGroupTitle() { return '#language-group'; }
+  languageGroupTitle(index = 0) { return '#language-group-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/surveys/multiple_answers/summary.page.js
+++ b/tests/functional/pages/surveys/multiple_answers/summary.page.js
@@ -7,16 +7,16 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  answer() {
-    return '#first-name-answer-answer';
+  answer(index = 0) {
+    return '#first-name-answer-' + index + '-answer';
   }
 
-  otherAnswer() {
-    return '#surname-answer-answer';
+  otherAnswer(index = 0) {
+    return '#surname-answer-' + index + '-answer';
   }
 
-  editFirstName() {
-     return '[data-qa="first-name-answer-edit"]';
+  editFirstName(index = 0) {
+     return '[data-qa="first-name-answer-' + index + '-edit"]';
   }
 
 

--- a/tests/functional/pages/surveys/multiple_piping/summary.page.js
+++ b/tests/functional/pages/surveys/multiple_piping/summary.page.js
@@ -7,49 +7,49 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  building() { return '#building-answer'; }
+  building(index = 0) { return '#building-' + index + '-answer'; }
 
-  buildingEdit() { return '[data-qa="building-edit"]'; }
+  buildingEdit(index = 0) { return '[data-qa="building-' + index + '-edit"]'; }
 
-  addressLine1() { return '#address-line-1-answer'; }
+  addressLine1(index = 0) { return '#address-line-1-' + index + '-answer'; }
 
-  addressLine1Edit() { return '[data-qa="address-line-1-edit"]'; }
+  addressLine1Edit(index = 0) { return '[data-qa="address-line-1-' + index + '-edit"]'; }
 
-  addressLine2() { return '#address-line-2-answer'; }
+  addressLine2(index = 0) { return '#address-line-2-' + index + '-answer'; }
 
-  addressLine2Edit() { return '[data-qa="address-line-2-edit"]'; }
+  addressLine2Edit(index = 0) { return '[data-qa="address-line-2-' + index + '-edit"]'; }
 
-  addressLine3() { return '#address-line-3-answer'; }
+  addressLine3(index = 0) { return '#address-line-3-' + index + '-answer'; }
 
-  addressLine3Edit() { return '[data-qa="address-line-3-edit"]'; }
+  addressLine3Edit(index = 0) { return '[data-qa="address-line-3-' + index + '-edit"]'; }
 
-  townCity() { return '#town-city-answer'; }
+  townCity(index = 0) { return '#town-city-' + index + '-answer'; }
 
-  townCityEdit() { return '[data-qa="town-city-edit"]'; }
+  townCityEdit(index = 0) { return '[data-qa="town-city-' + index + '-edit"]'; }
 
-  county() { return '#county-answer'; }
+  county(index = 0) { return '#county-' + index + '-answer'; }
 
-  countyEdit() { return '[data-qa="county-edit"]'; }
+  countyEdit(index = 0) { return '[data-qa="county-' + index + '-edit"]'; }
 
-  postcode() { return '#postcode-answer'; }
+  postcode(index = 0) { return '#postcode-' + index + '-answer'; }
 
-  postcodeEdit() { return '[data-qa="postcode-edit"]'; }
+  postcodeEdit(index = 0) { return '[data-qa="postcode-' + index + '-edit"]'; }
 
-  country() { return '#country-answer'; }
+  country(index = 0) { return '#country-' + index + '-answer'; }
 
-  countryEdit() { return '[data-qa="country-edit"]'; }
+  countryEdit(index = 0) { return '[data-qa="country-' + index + '-edit"]'; }
 
-  firstText() { return '#first-text-answer'; }
+  firstText(index = 0) { return '#first-text-' + index + '-answer'; }
 
-  firstTextEdit() { return '[data-qa="first-text-edit"]'; }
+  firstTextEdit(index = 0) { return '[data-qa="first-text-' + index + '-edit"]'; }
 
-  secondText() { return '#second-text-answer'; }
+  secondText(index = 0) { return '#second-text-' + index + '-answer'; }
 
-  secondTextEdit() { return '[data-qa="second-text-edit"]'; }
+  secondTextEdit(index = 0) { return '[data-qa="second-text-' + index + '-edit"]'; }
 
-  multiplePipingAnswer() { return '#multiple-piping-answer-answer'; }
+  multiplePipingAnswer(index = 0) { return '#multiple-piping-answer-' + index + '-answer'; }
 
-  multiplePipingAnswerEdit() { return '[data-qa="multiple-piping-answer-edit"]'; }
+  multiplePipingAnswerEdit(index = 0) { return '[data-qa="multiple-piping-answer-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/surveys/navigation/completeness/summary.page.js
+++ b/tests/functional/pages/surveys/navigation/completeness/summary.page.js
@@ -7,21 +7,21 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  coffeeAnswer() { return '#coffee-answer-answer'; }
+  coffeeAnswer(index = 0) { return '#coffee-answer-' + index + '-answer'; }
 
-  coffeeAnswerEdit() { return '[data-qa="coffee-answer-edit"]'; }
+  coffeeAnswerEdit(index = 0) { return '[data-qa="coffee-answer-' + index + '-edit"]'; }
 
-  responseYesNumberOfCups() { return '#response-yes-number-of-cups-answer'; }
+  responseYesNumberOfCups(index = 0) { return '#response-yes-number-of-cups-' + index + '-answer'; }
 
-  responseYesNumberOfCupsEdit() { return '[data-qa="response-yes-number-of-cups-edit"]'; }
+  responseYesNumberOfCupsEdit(index = 0) { return '[data-qa="response-yes-number-of-cups-' + index + '-edit"]'; }
 
-  responseNoNumberOfCups() { return '#response-no-number-of-cups-answer'; }
+  responseNoNumberOfCups(index = 0) { return '#response-no-number-of-cups-' + index + '-answer'; }
 
-  responseNoNumberOfCupsEdit() { return '[data-qa="response-no-number-of-cups-edit"]'; }
+  responseNoNumberOfCupsEdit(index = 0) { return '[data-qa="response-no-number-of-cups-' + index + '-edit"]'; }
 
-  toastAnswer() { return '#toast-answer-answer'; }
+  toastAnswer(index = 0) { return '#toast-answer-' + index + '-answer'; }
 
-  toastAnswerEdit() { return '[data-qa="toast-answer-edit"]'; }
+  toastAnswerEdit(index = 0) { return '[data-qa="toast-answer-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/surveys/numbers/summary.page.js
+++ b/tests/functional/pages/surveys/numbers/summary.page.js
@@ -7,33 +7,33 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  setMinimum() { return '#set-minimum-answer'; }
+  setMinimum(index = 0) { return '#set-minimum-' + index + '-answer'; }
 
-  setMinimumEdit() { return '[data-qa="set-minimum-edit"]'; }
+  setMinimumEdit(index = 0) { return '[data-qa="set-minimum-' + index + '-edit"]'; }
 
-  setMaximum() { return '#set-maximum-answer'; }
+  setMaximum(index = 0) { return '#set-maximum-' + index + '-answer'; }
 
-  setMaximumEdit() { return '[data-qa="set-maximum-edit"]'; }
+  setMaximumEdit(index = 0) { return '[data-qa="set-maximum-' + index + '-edit"]'; }
 
-  testRange() { return '#test-range-answer'; }
+  testRange(index = 0) { return '#test-range-' + index + '-answer'; }
 
-  testRangeEdit() { return '[data-qa="test-range-edit"]'; }
+  testRangeEdit(index = 0) { return '[data-qa="test-range-' + index + '-edit"]'; }
 
-  testMin() { return '#test-min-answer'; }
+  testMin(index = 0) { return '#test-min-' + index + '-answer'; }
 
-  testMinEdit() { return '[data-qa="test-min-edit"]'; }
+  testMinEdit(index = 0) { return '[data-qa="test-min-' + index + '-edit"]'; }
 
-  testMax() { return '#test-max-answer'; }
+  testMax(index = 0) { return '#test-max-' + index + '-answer'; }
 
-  testMaxEdit() { return '[data-qa="test-max-edit"]'; }
+  testMaxEdit(index = 0) { return '[data-qa="test-max-' + index + '-edit"]'; }
 
-  testPercent() { return '#test-percent-answer'; }
+  testPercent(index = 0) { return '#test-percent-' + index + '-answer'; }
 
-  testPercentEdit() { return '[data-qa="test-percent-edit"]'; }
+  testPercentEdit(index = 0) { return '[data-qa="test-percent-' + index + '-edit"]'; }
 
-  testDecimal() { return '#test-decimal-answer'; }
+  testDecimal(index = 0) { return '#test-decimal-' + index + '-answer'; }
 
-  testDecimalEdit() { return '[data-qa="test-decimal-edit"]'; }
+  testDecimalEdit(index = 0) { return '[data-qa="test-decimal-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/surveys/repeating_answer_summaries/summary.page.js
+++ b/tests/functional/pages/surveys/repeating_answer_summaries/summary.page.js
@@ -7,27 +7,27 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  primaryLastName() { return '#primary-last-name-answer'; }
+  primaryLastName(index = 0) { return '#primary-last-name-' + index + '-answer'; }
 
-  primaryLastNameEdit() { return '[data-qa="primary-last-name-edit"]'; }
+  primaryLastNameEdit(index = 0) { return '[data-qa="primary-last-name-' + index + '-edit"]'; }
 
-  primaryAnyoneElse() { return '#primary-anyone-else-answer'; }
+  primaryAnyoneElse(index = 0) { return '#primary-anyone-else-' + index + '-answer'; }
 
-  primaryAnyoneElseEdit() { return '[data-qa="primary-anyone-else-edit"]'; }
+  primaryAnyoneElseEdit(index = 0) { return '[data-qa="primary-anyone-else-' + index + '-edit"]'; }
 
-  primaryGroupTitle() { return '#primary-group'; }
+  primaryGroupTitle(index = 0) { return '#primary-group-' + index; }
 
-  repeatingLastName() { return '#repeating-last-name-answer'; }
+  repeatingLastName(index = 0) { return '#repeating-last-name-' + index + '-answer'; }
 
-  repeatingLastNameEdit() { return '[data-qa="repeating-last-name-edit"]'; }
+  repeatingLastNameEdit(index = 0) { return '[data-qa="repeating-last-name-' + index + '-edit"]'; }
 
-  repeatingAnyoneElse() { return '#repeating-anyone-else-answer'; }
+  repeatingAnyoneElse(index = 0) { return '#repeating-anyone-else-' + index + '-answer'; }
 
-  repeatingAnyoneElseEdit() { return '[data-qa="repeating-anyone-else-edit"]'; }
+  repeatingAnyoneElseEdit(index = 0) { return '[data-qa="repeating-anyone-else-' + index + '-edit"]'; }
 
-  repeatingGroupTitle() { return '#repeating-group'; }
+  repeatingGroupTitle(index = 0) { return '#repeating-group-' + index; }
 
-  summaryGroupTitle() { return '#summary-group'; }
+  summaryGroupTitle(index = 0) { return '#summary-group-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/surveys/repeating_groups/summary.page.js
+++ b/tests/functional/pages/surveys/repeating_groups/summary.page.js
@@ -7,21 +7,21 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  noOfRepeatsAnswer() { return '#no-of-repeats-answer-answer'; }
+  noOfRepeatsAnswer(index = 0) { return '#no-of-repeats-answer-' + index + '-answer'; }
 
-  noOfRepeatsAnswerEdit() { return '[data-qa="no-of-repeats-answer-edit"]'; }
+  noOfRepeatsAnswerEdit(index = 0) { return '[data-qa="no-of-repeats-answer-' + index + '-edit"]'; }
 
-  conditionalAnswer() { return '#conditional-answer-answer'; }
+  conditionalAnswer(index = 0) { return '#conditional-answer-' + index + '-answer'; }
 
-  conditionalAnswerEdit() { return '[data-qa="conditional-answer-edit"]'; }
+  conditionalAnswerEdit(index = 0) { return '[data-qa="conditional-answer-' + index + '-edit"]'; }
 
-  whatIsYourAge() { return '#what-is-your-age-answer'; }
+  whatIsYourAge(index = 0) { return '#what-is-your-age-' + index + '-answer'; }
 
-  whatIsYourAgeEdit() { return '[data-qa="what-is-your-age-edit"]'; }
+  whatIsYourAgeEdit(index = 0) { return '[data-qa="what-is-your-age-' + index + '-edit"]'; }
 
-  whatIsYourShoeSize() { return '#what-is-your-shoe-size-answer'; }
+  whatIsYourShoeSize(index = 0) { return '#what-is-your-shoe-size-' + index + '-answer'; }
 
-  whatIsYourShoeSizeEdit() { return '[data-qa="what-is-your-shoe-size-edit"]'; }
+  whatIsYourShoeSizeEdit(index = 0) { return '[data-qa="what-is-your-shoe-size-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/surveys/repeating_summaries/currency-total-playback.page.js
+++ b/tests/functional/pages/surveys/repeating_summaries/currency-total-playback.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const CalculatedSummaryPage = require('../../calculated-summary.page');
+
+class CurrencyTotalPlaybackPage extends CalculatedSummaryPage {
+
+  constructor() {
+    super('currency-total-playback');
+  }
+
+  firstNumberAnswer(index = 0) { return '#first-number-answer-' + index + '-answer'; }
+
+  firstNumberAnswerEdit(index = 0) { return '[data-qa="first-number-answer-' + index + '-edit"]'; }
+
+  firstNumberAnswerLabel(index = 0) { return '#first-number-answer-' + index + '-label'; } 
+
+  secondNumberAnswer(index = 0) { return '#second-number-answer-' + index + '-answer'; }
+
+  secondNumberAnswerEdit(index = 0) { return '[data-qa="second-number-answer-' + index + '-edit"]'; }
+
+  secondNumberAnswerLabel(index = 0) { return '#second-number-answer-' + index + '-label'; } 
+
+}
+module.exports = new CurrencyTotalPlaybackPage();

--- a/tests/functional/pages/surveys/repeating_summaries/first-number-block.page.js
+++ b/tests/functional/pages/surveys/repeating_summaries/first-number-block.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../surveys/../question.page');
+
+class FirstNumberBlockPage extends QuestionPage {
+
+  constructor() {
+    super('first-number-block');
+  }
+
+  answer() {
+    return '#first-number-answer';
+  }
+
+  answerLabel() { return '#label-first-number-answer'; }
+
+}
+module.exports = new FirstNumberBlockPage();

--- a/tests/functional/pages/surveys/repeating_summaries/household-summary-block.page.js
+++ b/tests/functional/pages/surveys/repeating_summaries/household-summary-block.page.js
@@ -1,0 +1,53 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../surveys/../question.page');
+
+class HouseholdSummaryBlockPage extends QuestionPage {
+
+  constructor() {
+    super('household-summary-block');
+  }
+
+  primaryNameQuestion(index = 0) { return '#primary-name-question-' + index; }
+
+  primaryName(index = 0) { return '#primary-name-' + index + '-answer'; }
+
+  primaryNameEdit(index = 0) { return '[data-qa="primary-name-' + index + '-edit"]'; }
+
+  primaryGroupTitle(index = 0) { return '#primary-group-' + index; }
+
+  repeatingAnyoneElseQuestion(index = 0) { return '#repeating-anyone-else-question-' + index; }
+
+  repeatingAnyoneElse(index = 0) { return '#repeating-anyone-else-' + index + '-answer'; }
+
+  repeatingAnyoneElseEdit(index = 0) { return '[data-qa="repeating-anyone-else-' + index + '-edit"]'; }
+
+  repeatingNameQuestion(index = 0) { return '#repeating-name-question-' + index; }
+
+  repeatingName(index = 0) { return '#repeating-name-' + index + '-answer'; }
+
+  repeatingNameEdit(index = 0) { return '[data-qa="repeating-name-' + index + '-edit"]'; }
+
+  repeatingGroupTitle(index = 0) { return '#repeating-group-' + index; }
+
+  householdSummaryGroupTitle(index = 0) { return '#household-summary-group-' + index; }
+
+  firstNumberQuestion(index = 0) { return '#first-number-question-' + index; }
+
+  firstNumberAnswer(index = 0) { return '#first-number-answer-' + index + '-answer'; }
+
+  firstNumberAnswerEdit(index = 0) { return '[data-qa="first-number-answer-' + index + '-edit"]'; }
+
+  secondNumberQuestion(index = 0) { return '#second-number-question-' + index; }
+
+  secondNumberAnswer(index = 0) { return '#second-number-answer-' + index + '-answer'; }
+
+  secondNumberAnswerEdit(index = 0) { return '[data-qa="second-number-answer-' + index + '-edit"]'; }
+
+  memberGroupTitle(index = 0) { return '#member-group-' + index; }
+
+  memberSummaryGroupTitle(index = 0) { return '#member-summary-group-' + index; }
+
+  summaryGroupTitle(index = 0) { return '#summary-group-' + index; }
+
+}
+module.exports = new HouseholdSummaryBlockPage();

--- a/tests/functional/pages/surveys/repeating_summaries/member-summary-block.page.js
+++ b/tests/functional/pages/surveys/repeating_summaries/member-summary-block.page.js
@@ -1,0 +1,53 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../surveys/../question.page');
+
+class MemberSummaryBlockPage extends QuestionPage {
+
+  constructor() {
+    super('member-summary-block');
+  }
+
+  primaryNameQuestion(index = 0) { return '#primary-name-question-' + index; }
+
+  primaryName(index = 0) { return '#primary-name-' + index + '-answer'; }
+
+  primaryNameEdit(index = 0) { return '[data-qa="primary-name-' + index + '-edit"]'; }
+
+  primaryGroupTitle(index = 0) { return '#primary-group-' + index; }
+
+  repeatingAnyoneElseQuestion(index = 0) { return '#repeating-anyone-else-question-' + index; }
+
+  repeatingAnyoneElse(index = 0) { return '#repeating-anyone-else-' + index + '-answer'; }
+
+  repeatingAnyoneElseEdit(index = 0) { return '[data-qa="repeating-anyone-else-' + index + '-edit"]'; }
+
+  repeatingNameQuestion(index = 0) { return '#repeating-name-question-' + index; }
+
+  repeatingName(index = 0) { return '#repeating-name-' + index + '-answer'; }
+
+  repeatingNameEdit(index = 0) { return '[data-qa="repeating-name-' + index + '-edit"]'; }
+
+  repeatingGroupTitle(index = 0) { return '#repeating-group-' + index; }
+
+  householdSummaryGroupTitle(index = 0) { return '#household-summary-group-' + index; }
+
+  firstNumberQuestion(index = 0) { return '#first-number-question-' + index; }
+
+  firstNumberAnswer(index = 0) { return '#first-number-answer-' + index + '-answer'; }
+
+  firstNumberAnswerEdit(index = 0) { return '[data-qa="first-number-answer-' + index + '-edit"]'; }
+
+  secondNumberQuestion(index = 0) { return '#second-number-question-' + index; }
+
+  secondNumberAnswer(index = 0) { return '#second-number-answer-' + index + '-answer'; }
+
+  secondNumberAnswerEdit(index = 0) { return '[data-qa="second-number-answer-' + index + '-edit"]'; }
+
+  memberGroupTitle(index = 0) { return '#member-group-' + index; }
+
+  memberSummaryGroupTitle(index = 0) { return '#member-summary-group-' + index; }
+
+  summaryGroupTitle(index = 0) { return '#summary-group-' + index; }
+
+}
+module.exports = new MemberSummaryBlockPage();

--- a/tests/functional/pages/surveys/repeating_summaries/primary-name-block.page.js
+++ b/tests/functional/pages/surveys/repeating_summaries/primary-name-block.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../surveys/../question.page');
+
+class PrimaryNameBlockPage extends QuestionPage {
+
+  constructor() {
+    super('primary-name-block');
+  }
+
+  answer() {
+    return '#primary-name';
+  }
+
+  answerLabel() { return '#label-primary-name'; }
+
+}
+module.exports = new PrimaryNameBlockPage();

--- a/tests/functional/pages/surveys/repeating_summaries/repeating-anyone-else-block.page.js
+++ b/tests/functional/pages/surveys/repeating_summaries/repeating-anyone-else-block.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../surveys/../question.page');
+
+class RepeatingAnyoneElseBlockPage extends QuestionPage {
+
+  constructor() {
+    super('repeating-anyone-else-block');
+  }
+
+  yes() {
+    return '#repeating-anyone-else-0';
+  }
+
+  yesLabel() { return '#label-repeating-anyone-else-0'; }
+
+  no() {
+    return '#repeating-anyone-else-1';
+  }
+
+  noLabel() { return '#label-repeating-anyone-else-1'; }
+
+}
+module.exports = new RepeatingAnyoneElseBlockPage();

--- a/tests/functional/pages/surveys/repeating_summaries/repeating-name-block.page.js
+++ b/tests/functional/pages/surveys/repeating_summaries/repeating-name-block.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../surveys/../question.page');
+
+class RepeatingNameBlockPage extends QuestionPage {
+
+  constructor() {
+    super('repeating-name-block');
+  }
+
+  answer() {
+    return '#repeating-name';
+  }
+
+  answerLabel() { return '#label-repeating-name'; }
+
+}
+module.exports = new RepeatingNameBlockPage();

--- a/tests/functional/pages/surveys/repeating_summaries/second-number-block.page.js
+++ b/tests/functional/pages/surveys/repeating_summaries/second-number-block.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../surveys/../question.page');
+
+class SecondNumberBlockPage extends QuestionPage {
+
+  constructor() {
+    super('second-number-block');
+  }
+
+  answer() {
+    return '#second-number-answer';
+  }
+
+  answerLabel() { return '#label-second-number-answer'; }
+
+}
+module.exports = new SecondNumberBlockPage();

--- a/tests/functional/pages/surveys/repeating_summaries/summary.page.js
+++ b/tests/functional/pages/surveys/repeating_summaries/summary.page.js
@@ -1,0 +1,53 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../surveys/../question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  primaryNameQuestion(index = 0) { return '#primary-name-question-' + index; }
+
+  primaryName(index = 0) { return '#primary-name-' + index + '-answer'; }
+
+  primaryNameEdit(index = 0) { return '[data-qa="primary-name-' + index + '-edit"]'; }
+
+  primaryGroupTitle(index = 0) { return '#primary-group-' + index; }
+
+  repeatingAnyoneElseQuestion(index = 0) { return '#repeating-anyone-else-question-' + index; }
+
+  repeatingAnyoneElse(index = 0) { return '#repeating-anyone-else-' + index + '-answer'; }
+
+  repeatingAnyoneElseEdit(index = 0) { return '[data-qa="repeating-anyone-else-' + index + '-edit"]'; }
+
+  repeatingNameQuestion(index = 0) { return '#repeating-name-question-' + index; }
+
+  repeatingName(index = 0) { return '#repeating-name-' + index + '-answer'; }
+
+  repeatingNameEdit(index = 0) { return '[data-qa="repeating-name-' + index + '-edit"]'; }
+
+  repeatingGroupTitle(index = 0) { return '#repeating-group-' + index; }
+
+  householdSummaryGroupTitle(index = 0) { return '#household-summary-group-' + index; }
+
+  firstNumberQuestion(index = 0) { return '#first-number-question-' + index; }
+
+  firstNumberAnswer(index = 0) { return '#first-number-answer-' + index + '-answer'; }
+
+  firstNumberAnswerEdit(index = 0) { return '[data-qa="first-number-answer-' + index + '-edit"]'; }
+
+  secondNumberQuestion(index = 0) { return '#second-number-question-' + index; }
+
+  secondNumberAnswer(index = 0) { return '#second-number-answer-' + index + '-answer'; }
+
+  secondNumberAnswerEdit(index = 0) { return '[data-qa="second-number-answer-' + index + '-edit"]'; }
+
+  memberGroupTitle(index = 0) { return '#member-group-' + index; }
+
+  memberSummaryGroupTitle(index = 0) { return '#member-summary-group-' + index; }
+
+  summaryGroupTitle(index = 0) { return '#summary-group-' + index; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/pages/surveys/routing_on_answer_from_driving_repeating_group/summary.page.js
+++ b/tests/functional/pages/surveys/routing_on_answer_from_driving_repeating_group/summary.page.js
@@ -7,39 +7,39 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  primaryName() { return '#primary-name-answer'; }
+  primaryName(index = 0) { return '#primary-name-' + index + 'answer'; }
 
-  primaryNameEdit() { return '[data-qa="primary-name-edit"]'; }
+  primaryNameEdit(index = 0) { return '[data-qa="primary-name-' + index + '-edit"]'; }
 
-  primaryLiveHere() { return '#primary-live-here-answer'; }
+  primaryLiveHere(index = 0) { return '#primary-live-here-' + index + '-answer'; }
 
-  primaryLiveHereEdit() { return '[data-qa="primary-live-here-edit"]'; }
+  primaryLiveHereEdit(index = 0) { return '[data-qa="primary-live-here-' + index + '-edit"]'; }
 
-  primaryGroupTitle() { return '#primary-group'; }
+  primaryGroupTitle(index = 0) { return '#primary-group-' + index; }
 
-  repeatingAnyoneElse() { return '#repeating-anyone-else-answer'; }
+  repeatingAnyoneElse(index = 0) { return '#repeating-anyone-else-' + index + '-answer'; }
 
-  repeatingAnyoneElseEdit() { return '[data-qa="repeating-anyone-else-edit"]'; }
+  repeatingAnyoneElseEdit(index = 0) { return '[data-qa="repeating-anyone-else-' + index + '-edit"]'; }
 
-  repeatingName() { return '#repeating-name-answer'; }
+  repeatingName(index = 0) { return '#repeating-name-' + index + '-answer'; }
 
-  repeatingNameEdit() { return '[data-qa="repeating-name-edit"]'; }
+  repeatingNameEdit(index = 0) { return '[data-qa="repeating-name-' + index + '-edit"]'; }
 
-  repeatingGroupTitle() { return '#repeating-group'; }
+  repeatingGroupTitle(index = 0) { return '#repeating-group-' + index; }
 
-  whoIsRelated() { return '#who-is-related-answer'; }
+  whoIsRelated(index = 0) { return '#who-is-related-' + index + '-answer'; }
 
-  whoIsRelatedEdit() { return '[data-qa="who-is-related-edit"]'; }
+  whoIsRelatedEdit(index = 0) { return '[data-qa="who-is-related-' + index + '-edit"]'; }
 
-  householdRelationshipsTitle() { return '#household-relationships'; }
+  householdRelationshipsTitle(index = 0) { return '#household-relationships-' + index; }
 
-  sexAnswer() { return '#sex-answer-answer'; }
+  sexAnswer(index = 0) { return '#sex-answer-answer-' + index; }
 
-  sexAnswerEdit() { return '[data-qa="sex-answer-edit"]'; }
+  sexAnswerEdit(index = 0) { return '[data-qa="sex-answer-' + index + '-edit"]'; }
 
-  sexGroupTitle() { return '#sex-group'; }
+  sexGroupTitle(index = 0) { return '#sex-group-' + index; }
 
-  summaryGroupTitle() { return '#summary-group'; }
+  summaryGroupTitle(index = 0) { return '#summary-group-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/surveys/routing_repeat_until/summary.page.js
+++ b/tests/functional/pages/surveys/routing_repeat_until/summary.page.js
@@ -7,29 +7,29 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  primaryName() { return '#primary-name-answer'; }
+  primaryName(index = 0) { return '#primary-name-' + index + '-answer'; }
 
-  primaryNameEdit() { return '[data-qa="primary-name-edit"]'; }
+  primaryNameEdit(index = 0) { return '[data-qa="primary-name-' + index + '-edit"]'; }
 
-  primaryGroupTitle() { return '#primary-group'; }
+  primaryGroupTitle(index = 0) { return '#primary-group-' + index; }
 
-  repeatingAnyoneElse() { return '#repeating-anyone-else-answer'; }
+  repeatingAnyoneElse(index = 0) { return '#repeating-anyone-else-' + index + '-answer'; }
 
-  repeatingAnyoneElseEdit() { return '[data-qa="repeating-anyone-else-edit"]'; }
+  repeatingAnyoneElseEdit(index = 0) { return '[data-qa="repeating-anyone-else-' + index + '-edit"]'; }
 
-  repeatingName() { return '#repeating-name-answer'; }
+  repeatingName(index = 0) { return '#repeating-name-' + index + '-answer'; }
 
-  repeatingNameEdit() { return '[data-qa="repeating-name-edit"]'; }
+  repeatingNameEdit(index = 0) { return '[data-qa="repeating-name-' + index + '-edit"]'; }
 
-  repeatingGroupTitle() { return '#repeating-group'; }
+  repeatingGroupTitle(index = 0) { return '#repeating-group-' + index; }
 
-  sexAnswer() { return '#sex-answer-answer'; }
+  sexAnswer(index = 0) { return '#sex-answer-' + index + '-answer'; }
 
-  sexAnswerEdit() { return '[data-qa="sex-answer-edit"]'; }
+  sexAnswerEdit(index = 0) { return '[data-qa="sex-answer-' + index + '-edit"]'; }
 
-  sexGroupTitle() { return '#sex-group'; }
+  sexGroupTitle(index = 0) { return '#sex-group-' + index; }
 
-  summaryGroupTitle() { return '#summary-group'; }
+  summaryGroupTitle(index = 0) { return '#summary-group-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/surveys/section_summary/final-summary.page.js
+++ b/tests/functional/pages/surveys/section_summary/final-summary.page.js
@@ -7,45 +7,45 @@ class PropertyDetailsSummaryPage extends QuestionPage {
     super('summary');
   }
 
-  insuranceTypeAnswer() { return '#insurance-type-answer-answer'; }
+  insuranceTypeAnswer(index = 0) { return '#insurance-type-answer-' + index + '-answer'; }
 
-  insuranceTypeAnswerEdit() { return '[data-qa="insurance-type-answer-edit"]'; }
+  insuranceTypeAnswerEdit(index = 0) { return '[data-qa="insurance-type-answer-' + index + '-edit"]'; }
 
-  insuranceAddressAnswer() { return '#insurance-address-answer-answer'; }
+  insuranceAddressAnswer(index = 0) { return '#insurance-address-answer-' + index + '-answer'; }
 
-  insuranceAddressAnswerEdit() { return '[data-qa="insurance-address-answer-edit"]'; }
+  insuranceAddressAnswerEdit(index = 0) { return '[data-qa="insurance-address-answer-' + index + '-edit"]'; }
 
-  propertyDetailsTitle() { return '#property-details'; }
+  propertyDetailsTitle(index = 0) { return '#property-details-' + index; }
 
-  addressDurationAnswer() { return '#address-duration-answer-answer'; }
+  addressDurationAnswer(index = 0) { return '#address-duration-answer-' + index + '-answer'; }
 
-  addressDurationAnswerEdit() { return '[data-qa="address-duration-answer-edit"]'; }
+  addressDurationAnswerEdit(index = 0) { return '[data-qa="address-duration-answer-' + index + '-edit"]'; }
 
-  addressLengthTitle() { return '#address-length'; }
+  addressLengthTitle(index = 0) { return '#address-length-' + index; }
 
-  propertyDetailsSectionSummaryTitle() { return '#property-details-section-summary'; }
+  propertyDetailsSectionSummaryTitle(index = 0) { return '#property-details-section-summary-' + index; }
 
-  houseTypeAnswer() { return '#house-type-answer-answer'; }
+  houseTypeAnswer(index = 0) { return '#house-type-answer-' + index + '-answer'; }
 
-  houseTypeAnswerEdit() { return '[data-qa="house-type-answer-edit"]'; }
+  houseTypeAnswerEdit(index = 0) { return '[data-qa="house-type-answer-' + index + '-edit"]'; }
 
-  houseDetailsTitle() { return '#house-details'; }
+  houseDetailsTitle(index = 0) { return '#house-details-' + index; }
 
-  householdDetailsSectionSummaryTitle() { return '#household-details-section-summary'; }
+  householdDetailsSectionSummaryTitle(index = 0) { return '#household-details-section-summary-' + index; }
 
-  lastName() { return '#last-name-answer'; }
+  lastName(index = 0) { return '#last-name-' + index + '-answer'; }
 
-  lastNameEdit() { return '[data-qa="last-name-edit"]'; }
+  lastNameEdit(index = 0) { return '[data-qa="last-name-' + index + '-edit"]'; }
 
-  multipleQuestionsGroupTitle() { return '#multiple-questions-group'; }
+  multipleQuestionsGroupTitle(index = 0) { return '#multiple-questions-group-' + index; }
 
-  summaryGroupTitle() { return '#summary-group'; }
+  summaryGroupTitle(index = 0) { return '#summary-group-' + index; }
 
   showAllButton() { return '[data-open-all-label="Show all"]'; }
 
   propertyDetailsDropDownButton() { return '#property-details-button'; }
 
-  propertyDetailsDropDownChangeLink() { return '[data-qa="insurance-type-answer-edit"]'; }
+  propertyDetailsDropDownChangeLink(index = 0) { return '[data-qa="insurance-type-answer-' + index + '-edit"]'; }
 
 }
 module.exports = new PropertyDetailsSummaryPage();

--- a/tests/functional/pages/surveys/section_summary/household-details-summary.page.js
+++ b/tests/functional/pages/surveys/section_summary/household-details-summary.page.js
@@ -7,39 +7,39 @@ class HouseholdDetailsSummaryPage extends QuestionPage {
     super('household-details-summary');
   }
 
-  insuranceTypeAnswer() { return '#insurance-type-answer-answer'; }
+  insuranceTypeAnswer(index = 0) { return '#insurance-type-answer-' + index + '-answer'; }
 
-  insuranceTypeAnswerEdit() { return '[data-qa="insurance-type-answer-edit"]'; }
+  insuranceTypeAnswerEdit(index = 0) { return '[data-qa="insurance-type-answer-' + index + '-edit"]'; }
 
-  insuranceAddressAnswer() { return '#insurance-address-answer-answer'; }
+  insuranceAddressAnswer(index = 0) { return '#insurance-address-answer-' + index + '-answer'; }
 
-  insuranceAddressAnswerEdit() { return '[data-qa="insurance-address-answer-edit"]'; }
+  insuranceAddressAnswerEdit(index = 0) { return '[data-qa="insurance-address-answer-' + index + '-edit"]'; }
 
-  propertyDetailsTitle() { return '#property-details'; }
+  propertyDetailsTitle(index = 0) { return '#property-details-' + index; }
 
-  addressDurationAnswer() { return '#address-duration-answer-answer'; }
+  addressDurationAnswer(index = 0) { return '#address-duration-answer-' + index + '-answer'; }
 
-  addressDurationAnswerEdit() { return '[data-qa="address-duration-answer-edit"]'; }
+  addressDurationAnswerEdit(index = 0) { return '[data-qa="address-duration-answer-' + index + '-edit"]'; }
 
-  addressLengthTitle() { return '#address-length'; }
+  addressLengthTitle(index = 0) { return '#address-length-' + index; }
 
-  propertyDetailsSummaryGroupTitle() { return '#property-details-summary-group'; }
+  propertyDetailsSummaryGroupTitle(index = 0) { return '#property-details-summary-group-' + index; }
 
-  houseTypeAnswer() { return '#house-type-answer-answer'; }
+  houseTypeAnswer(index = 0) { return '#house-type-answer-' + index + '-answer'; }
 
-  houseTypeAnswerEdit() { return '[data-qa="house-type-answer-edit"]'; }
+  houseTypeAnswerEdit(index = 0) { return '[data-qa="house-type-answer-' + index + '-edit"]'; }
 
-  houseDetailsTitle() { return '#house-details'; }
+  houseDetailsTitle(index = 0) { return '#house-details-' + index; }
 
-  householdDetailsSummaryGroupTitle() { return '#household-details-summary-group'; }
+  householdDetailsSummaryGroupTitle(index = 0) { return '#household-details-summary-group-' + index; }
 
-  lastName() { return '#last-name-answer'; }
+  lastName(index = 0) { return '#last-name-' + index + '-answer'; }
 
-  lastNameEdit() { return '[data-qa="last-name-edit"]'; }
+  lastNameEdit(index = 0) { return '[data-qa="last-name-' + index + '-edit"]'; }
 
-  multipleQuestionsGroupTitle() { return '#multiple-questions-group'; }
+  multipleQuestionsGroupTitle(index = 0) { return '#multiple-questions-group-' + index; }
 
-  summaryGroupTitle() { return '#summary-group'; }
+  summaryGroupTitle(index = 0) { return '#summary-group-' + index; }
 
 }
 module.exports = new HouseholdDetailsSummaryPage();

--- a/tests/functional/pages/surveys/section_summary/property-details-summary.page.js
+++ b/tests/functional/pages/surveys/section_summary/property-details-summary.page.js
@@ -7,39 +7,39 @@ class PropertyDetailsSummaryPage extends QuestionPage {
     super('property-details-summary');
   }
 
-  insuranceTypeAnswer() { return '#insurance-type-answer-answer'; }
+  insuranceTypeAnswer(index = 0) { return '#insurance-type-answer-' + index + '-answer'; }
 
-  insuranceTypeAnswerEdit() { return '[data-qa="insurance-type-answer-edit"]'; }
+  insuranceTypeAnswerEdit(index = 0) { return '[data-qa="insurance-type-answer-' + index + '-edit"]'; }
 
-  insuranceAddressAnswer() { return '#insurance-address-answer-answer'; }
+  insuranceAddressAnswer(index = 0) { return '#insurance-address-answer-' + index + '-answer'; }
 
-  insuranceAddressAnswerEdit() { return '[data-qa="insurance-address-answer-edit"]'; }
+  insuranceAddressAnswerEdit(index = 0) { return '[data-qa="insurance-address-answer-' + index + '-edit"]'; }
 
-  propertyDetailsTitle() { return '#property-details'; }
+  propertyDetailsTitle(index = 0) { return '#property-details-' + index; }
 
-  addressDurationAnswer() { return '#address-duration-answer-answer'; }
+  addressDurationAnswer(index = 0) { return '#address-duration-answer-' + index + '-answer'; }
 
-  addressDurationAnswerEdit() { return '[data-qa="address-duration-answer-edit"]'; }
+  addressDurationAnswerEdit(index = 0) { return '[data-qa="address-duration-answer-' + index + '-edit"]'; }
 
-  addressLengthTitle() { return '#address-length'; }
+  addressLengthTitle(index = 0) { return '#address-length-' + index; }
 
-  propertyDetailsSectionSummaryTitle() { return '#property-details-section-summary'; }
+  propertyDetailsSectionSummaryTitle(index = 0) { return '#property-details-section-summary-' + index; }
 
-  houseTypeAnswer() { return '#house-type-answer-answer'; }
+  houseTypeAnswer(index = 0) { return '#house-type-answer-' + index + '-answer'; }
 
-  houseTypeAnswerEdit() { return '[data-qa="house-type-answer-edit"]'; }
+  houseTypeAnswerEdit(index = 0) { return '[data-qa="house-type-answer-' + index + '-edit"]'; }
 
-  houseDetailsTitle() { return '#house-details'; }
+  houseDetailsTitle(index = 0) { return '#house-details-' + index; }
 
-  householdDetailsSectionSummaryTitle() { return '#household-details-section-summary'; }
+  householdDetailsSectionSummaryTitle(index = 0) { return '#household-details-section-summary-' + index; }
 
-  lastName() { return '#last-name-answer'; }
+  lastName(index = 0) { return '#last-name-' + index + '-answer'; }
 
-  lastNameEdit() { return '[data-qa="last-name-edit"]'; }
+  lastNameEdit(index = 0) { return '[data-qa="last-name-' + index + '-edit"]'; }
 
-  multipleQuestionsGroupTitle() { return '#multiple-questions-group'; }
+  multipleQuestionsGroupTitle(index = 0) { return '#multiple-questions-group-' + index; }
 
-  summaryGroupTitle() { return '#summary-group'; }
+  summaryGroupTitle(index = 0) { return '#summary-group-' + index; }
 
 }
 module.exports = new PropertyDetailsSummaryPage();

--- a/tests/functional/pages/surveys/section_summary/summary.page.js
+++ b/tests/functional/pages/surveys/section_summary/summary.page.js
@@ -7,39 +7,39 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  insuranceTypeAnswer() { return '#insurance-type-answer-answer'; }
+  insuranceTypeAnswer(index = 0) { return '#insurance-type-answer-' + index + '-answer'; }
 
-  insuranceTypeAnswerEdit() { return '[data-qa="insurance-type-answer-edit"]'; }
+  insuranceTypeAnswerEdit(index = 0) { return '[data-qa="insurance-type-answer-' + index + '-edit"]'; }
 
-  insuranceAddressAnswer() { return '#insurance-address-answer-answer'; }
+  insuranceAddressAnswer(index = 0) { return '#insurance-address-answer-' + index + '-answer'; }
 
-  insuranceAddressAnswerEdit() { return '[data-qa="insurance-address-answer-edit"]'; }
+  insuranceAddressAnswerEdit(index = 0) { return '[data-qa="insurance-address-answer-' + index + '-edit"]'; }
 
-  propertyDetailsTitle() { return '#property-details'; }
+  propertyDetailsTitle(index = 0) { return '#property-details-' + index; }
 
-  addressDurationAnswer() { return '#address-duration-answer-answer'; }
+  addressDurationAnswer(index = 0) { return '#address-duration-answer-' + index + '-answer'; }
 
-  addressDurationAnswerEdit() { return '[data-qa="address-duration-answer-edit"]'; }
+  addressDurationAnswerEdit(index = 0) { return '[data-qa="address-duration-answer-' + index + '-edit"]'; }
 
-  addressLengthTitle() { return '#address-length'; }
+  addressLengthTitle(index = 0) { return '#address-length-' + index; }
 
-  propertyDetailsSummaryGroupTitle() { return '#property-details-summary-group'; }
+  propertyDetailsSummaryGroupTitle(index = 0) { return '#property-details-summary-group-' + index; }
 
-  houseTypeAnswer() { return '#house-type-answer-answer'; }
+  houseTypeAnswer(index = 0) { return '#house-type-answer-' + index + '-answer'; }
 
-  houseTypeAnswerEdit() { return '[data-qa="house-type-answer-edit"]'; }
+  houseTypeAnswerEdit(index = 0) { return '[data-qa="house-type-answer-' + index + '-edit"]'; }
 
-  houseDetailsTitle() { return '#house-details'; }
+  houseDetailsTitle(index = 0) { return '#house-details-' + index; }
 
-  householdDetailsSummaryGroupTitle() { return '#household-details-summary-group'; }
+  householdDetailsSummaryGroupTitle(index = 0) { return '#household-details-summary-group-' + index; }
 
-  lastName() { return '#last-name-answer'; }
+  lastName(index = 0) { return '#last-name-answer-' + index; }
 
-  lastNameEdit() { return '[data-qa="last-name-edit"]'; }
+  lastNameEdit(index = 0) { return '[data-qa="last-name-' + index + '-edit"]'; }
 
-  multipleQuestionsGroupTitle() { return '#multiple-questions-group'; }
+  multipleQuestionsGroupTitle(index = 0) { return '#multiple-questions-group-' + index; }
 
-  summaryGroupTitle() { return '#summary-group'; }
+  summaryGroupTitle(index = 0) { return '#summary-group-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/surveys/skip_conditions/summary.page.js
+++ b/tests/functional/pages/surveys/skip_conditions/summary.page.js
@@ -7,15 +7,15 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  foodAnswer() { return '#food-answer-answer'; }
+  foodAnswer(index = 0) { return '#food-answer-' + index + '-answer'; }
 
-  foodAnswerEdit() { return '[data-qa="food-answer-edit"]'; }
+  foodAnswerEdit(index = 0) { return '[data-qa="food-answer-' + index + '-edit"]'; }
 
-  drinkAnswer() { return '#drink-answer-answer'; }
+  drinkAnswer(index = 0) { return '#drink-answer-' + index + '-answer'; }
 
-  drinkAnswerEdit() { return '[data-qa="drink-answer-edit"]'; }
+  drinkAnswerEdit(index = 0) { return '[data-qa="drink-answer-' + index + '-edit"]'; }
 
-  breakfastTitle() { return '#breakfast'; }
+  breakfastTitle(index = 0) { return '#breakfast-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/surveys/skip_conditions_not_set/summary.page.js
+++ b/tests/functional/pages/surveys/skip_conditions_not_set/summary.page.js
@@ -7,15 +7,15 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  foodAnswer() { return '#food-answer-answer'; }
+  foodAnswer(index = 0) { return '#food-answer-' + index + '-answer'; }
 
-  foodAnswerEdit() { return '[data-qa="food-answer-edit"]'; }
+  foodAnswerEdit(index = 0) { return '[data-qa="food-answer-' + index + '-edit"]'; }
 
-  drinkAnswer() { return '#drink-answer-answer'; }
+  drinkAnswer(index = 0) { return '#drink-answer-' + index + '-answer'; }
 
-  drinkAnswerEdit() { return '[data-qa="drink-answer-edit"]'; }
+  drinkAnswerEdit(index = 0) { return '[data-qa="drink-answer-' + index + '-edit"]'; }
 
-  breakfastTitle() { return '#breakfast'; }
+  breakfastTitle(index = 0) { return '#breakfast-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/surveys/skip_conditions_set/summary.page.js
+++ b/tests/functional/pages/surveys/skip_conditions_set/summary.page.js
@@ -7,15 +7,15 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  foodAnswer() { return '#food-answer-answer'; }
+  foodAnswer(index = 0) { return '#food-answer-' + index + '-answer'; }
 
-  foodAnswerEdit() { return '[data-qa="food-answer-edit"]'; }
+  foodAnswerEdit(index = 0) { return '[data-qa="food-answer-' + index + '-edit"]'; }
 
-  drinkAnswer() { return '#drink-answer-answer'; }
+  drinkAnswer(index = 0) { return '#drink-answer-' + index + '-answer'; }
 
-  drinkAnswerEdit() { return '[data-qa="drink-answer-edit"]'; }
+  drinkAnswerEdit(index = 0) { return '[data-qa="drink-answer-' + index + '-edit"]'; }
 
-  breakfastTitle() { return '#breakfast'; }
+  breakfastTitle(index = 0) { return '#breakfast-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/surveys/summary_screen/summary.page.js
+++ b/tests/functional/pages/surveys/summary_screen/summary.page.js
@@ -7,33 +7,33 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  radioAnswer() { return '#radio-answer-answer'; }
+  radioAnswer(index = 0) { return '#radio-answer-' + index + '-answer'; }
 
-  radioAnswerEdit() { return '[data-qa="radio-answer-edit"]'; }
+  radioAnswerEdit(index = 0) { return '[data-qa="radio-answer-' + index + '-edit"]'; }
 
-  otherAnswerMandatory() { return '#other-answer-mandatory-answer'; }
+  otherAnswerMandatory(index = 0) { return '#other-answer-mandatory-' + index + '-answer'; }
 
-  otherAnswerMandatoryEdit() { return '[data-qa="other-answer-mandatory-edit"]'; }
+  otherAnswerMandatoryEdit(index = 0) { return '[data-qa="other-answer-mandatory-' + index + '-edit"]'; }
 
-  testCurrency() { return '#test-currency-answer'; }
+  testCurrency(index = 0) { return '#test-currency-' + index + '-answer'; }
 
-  testCurrencyEdit() { return '[data-qa="test-currency-edit"]'; }
+  testCurrencyEdit(index = 0) { return '[data-qa="test-currency-' + index + '-edit"]'; }
 
-  squareKilometres() { return '#square-kilometres-answer'; }
+  squareKilometres(index = 0) { return '#square-kilometres-' + index + '-answer'; }
 
-  squareKilometresEdit() { return '[data-qa="square-kilometres-edit"]'; }
+  squareKilometresEdit(index = 0) { return '[data-qa="square-kilometres-' + index + '-edit"]'; }
 
-  testDecimal() { return '#test-decimal-answer'; }
+  testDecimal(index = 0) { return '#test-decimal-' + index + '-answer'; }
 
-  testDecimalEdit() { return '[data-qa="test-decimal-edit"]'; }
+  testDecimalEdit(index = 0) { return '[data-qa="test-decimal-' + index + '-edit"]'; }
 
-  summaryGroupTitle() { return '#summary-group'; }
+  summaryGroupTitle(index = 0) { return '#summary-group-' + index; }
 
-  dessert() { return '#dessert-answer'; }
+  dessert(index = 0) { return '#dessert-' + index + '-answer'; }
 
-  dessertEdit() { return '[data-qa="dessert-edit"]'; }
+  dessertEdit(index = 0) { return '[data-qa="dessert-' + index + '-edit"]'; }
 
-  dessertGroupTitle() { return '#dessert-group'; }
+  dessertGroupTitle(index = 0) { return '#dessert-group-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/surveys/textarea/textarea-summary.page.js
+++ b/tests/functional/pages/surveys/textarea/textarea-summary.page.js
@@ -7,11 +7,11 @@ class TextareaSummaryPage extends QuestionPage {
     super('textarea-summary');
   }
 
-  answer() {
-    return '#answer-answer ';
+  answer(index = 0) {
+    return '#answer-' + index + '-answer ';
   }
 
-  answerEdit() { return '[data-qa="answer-edit"]'; }
+  answerEdit(index = 0) { return '[data-qa="answer-' + index + '-edit"]'; }
 
 }
 module.exports = new TextareaSummaryPage();

--- a/tests/functional/pages/surveys/textfield/summary.page.js
+++ b/tests/functional/pages/surveys/textfield/summary.page.js
@@ -7,9 +7,9 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  answer() { return '#answer-answer'; }
+  answer(index = 0) { return '#answer-' + index + '-answer'; }
 
-  answerEdit() { return '[data-qa="answer-edit"]'; }
+  answerEdit(index = 0) { return '[data-qa="answer-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/surveys/timeout/summary.page.js
+++ b/tests/functional/pages/surveys/timeout/summary.page.js
@@ -7,9 +7,9 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  timeoutAnswer() { return '#timeout-answer-answer'; }
+  timeoutAnswer(index = 0) { return '#timeout-answer-' + index + '-answer'; }
 
-  timeoutAnswerEdit() { return '[data-qa="timeout-answer-edit"]'; }
+  timeoutAnswerEdit(index = 0) { return '[data-qa="timeout-answer-' + index + '-edit"]'; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/spec/features/repeating/answer_comparison_repeating_groups.spec.js
+++ b/tests/functional/spec/features/repeating/answer_comparison_repeating_groups.spec.js
@@ -27,5 +27,43 @@ describe('Test repeating with answer comparisons', function() {
       .click(RepeatingComparison2BlockPage.submit())
       .getText(SummaryPage.summaryQuestionText()).should.eventually.contain('Enter a number');
   });
+
+  it('Given we enter three sets of different numbers and one set of the same numbers, Then it shows a summary of all the entered values', function() {
+    return completeRepeatingQuestions(3)
+      .then(() => {
+        return browser
+          .getText(SummaryPage.repeatingComparison1Answer(0)).should.eventually.contain(0)
+          .getText(SummaryPage.repeatingComparison2Answer(0)).should.eventually.contain(1)
+          .getText(SummaryPage.repeatingComparison1Answer(1)).should.eventually.contain(1)
+          .getText(SummaryPage.repeatingComparison2Answer(1)).should.eventually.contain(2)
+          .getText(SummaryPage.repeatingComparison1Answer(2)).should.eventually.contain(2)
+          .getText(SummaryPage.repeatingComparison2Answer(2)).should.eventually.contain(3)
+          .getText(SummaryPage.repeatingComparison1Answer(3)).should.eventually.contain(100)
+          .getText(SummaryPage.repeatingComparison2Answer(3)).should.eventually.contain(100);
+      });
+  });
 });
 
+function completeRepeatingQuestions(numberOfRepeats) {
+  let chain = browser.pause(0);
+
+  for (let i = 0; i < numberOfRepeats; i++) {
+    chain = chain.then(() => {
+      return browser
+        .setValue(RepeatingComparison1BlockPage.answer(), i)
+        .click(RepeatingComparison1BlockPage.submit())
+        .setValue(RepeatingComparison2BlockPage.answer(), i+1)
+        .click(RepeatingComparison2BlockPage.submit());
+    });
+  }
+
+  chain = chain.then(() => {
+    return browser
+      .setValue(RepeatingComparison1BlockPage.answer(), 100)
+      .click(RepeatingComparison1BlockPage.submit())
+      .setValue(RepeatingComparison2BlockPage.answer(), 100)
+      .click(RepeatingComparison2BlockPage.submit());
+  });
+
+  return chain;
+}

--- a/tests/functional/spec/household-repeating.spec.js
+++ b/tests/functional/spec/household-repeating.spec.js
@@ -67,9 +67,34 @@ describe('Household Repeating', function() {
           .click(RepeatingBlock3Page.yes())
           .click(RepeatingBlock3Page.submit())
 
-          .getUrl().should.eventually.contain(SummaryPage.pageName);
+          .then(checkSummaryBlockPage);
     });
   });
-
 });
 
+
+function checkSummaryBlockPage() {
+  return browser
+    .getUrl().should.eventually.contain(SummaryPage.pageName)
+
+    .getText(SummaryPage.multipleQuestionsGroupTitle()).should.eventually.contain("Group 1")
+
+    .getText(SummaryPage.firstName()).should.eventually.contain("Alpha")
+    .getText(SummaryPage.middleNames()).should.eventually.contain("No answer provided")
+    .getText(SummaryPage.lastName()).should.eventually.contain("One")
+
+    .getText(SummaryPage.repeatingGroupTitle()).should.eventually.contain("Alpha One")
+    .getText(SummaryPage.whatIsYourAge()).should.eventually.contain("60")
+    .getText(SummaryPage.whatIsYourShoeSize()).should.eventually.contain("10")
+    .getText(SummaryPage.confirmAnswer()).should.eventually.contain("Yes")
+
+    .getText(SummaryPage.repeatingGroupTitle(1)).should.eventually.contain("Bravo Two")
+    .getText(SummaryPage.whatIsYourAge(1)).should.eventually.contain("50")
+    .getText(SummaryPage.whatIsYourShoeSize(1)).should.eventually.contain("11")
+    .getText(SummaryPage.confirmAnswer(1)).should.eventually.contain("Yes")
+
+    .getText(SummaryPage.repeatingGroupTitle(2)).should.eventually.contain("Charlie Three")
+    .getText(SummaryPage.whatIsYourAge(2)).should.eventually.contain("40")
+    .getText(SummaryPage.whatIsYourShoeSize(2)).should.eventually.contain("12")
+    .getText(SummaryPage.confirmAnswer(2)).should.eventually.contain("Yes");
+}

--- a/tests/functional/spec/repeating_groups.spec.js
+++ b/tests/functional/spec/repeating_groups.spec.js
@@ -8,62 +8,55 @@ const SummaryPage = require('../pages/surveys/repeating_groups/summary.page.js')
 
 describe('Repeating Groups', function() {
 
+  beforeEach(function() {
+    return helpers.startQuestionnaire('test_repeating_and_conditional_routing.json');
+  });
 
   it('Given a group of questions will repeat three times, when I complete the three groups of questions, then I should see a summary page of the questions.', function() {
-    return helpers.startQuestionnaire('test_repeating_and_conditional_routing.json')
-    .then(() => {
-      return completeRepeatingQuestions(3, 3);
-    })
+    return completeRepeatingQuestions(3, 3)
       .then(() => {
-      return browser
+        return browser
           .getUrl().should.eventually.contain(SummaryPage.pageName);
-    });
+      });
   });
 
   it('Given a group of questions will repeat two times, when I select age and shoe size, then I should see a question for age.', function() {
-    return helpers.startQuestionnaire('test_repeating_and_conditional_routing.json').then(() => {
-        return browser
-          .setValue(NoOfRepeatsPage.answer(), 2)
-          .click(NoOfRepeatsPage.submit())
-          .click(RepeatedBlockPage.ageAndShoeSize())
-          .click(RepeatedBlockPage.submit())
+      return browser
+        .setValue(NoOfRepeatsPage.answer(), 2)
+        .click(NoOfRepeatsPage.submit())
+        .click(RepeatedBlockPage.ageAndShoeSize())
+        .click(RepeatedBlockPage.submit())
 
-          .getUrl().should.eventually.contain('/0/' + AgeBlockPage.pageName);
-    });
+        .getUrl().should.eventually.contain('/0/' + AgeBlockPage.pageName);
   });
 
   it('Given the number of repeats question has been set to two, when I select shoe size, then I should see a question for shoe size.', function() {
-    return helpers.startQuestionnaire('test_repeating_and_conditional_routing.json').then(() => {
-        return browser
-          .setValue(NoOfRepeatsPage.answer(), 2)
-          .click(NoOfRepeatsPage.submit())
-          .click(RepeatedBlockPage.shoeSizeOnly())
-          .click(RepeatedBlockPage.submit())
+      return browser
+        .setValue(NoOfRepeatsPage.answer(), 2)
+        .click(NoOfRepeatsPage.submit())
+        .click(RepeatedBlockPage.shoeSizeOnly())
+        .click(RepeatedBlockPage.submit())
 
-          .getUrl().should.eventually.contain('/0/' + ShoeSizeBlockPage.pageName);
-    });
+        .getUrl().should.eventually.contain('/0/' + ShoeSizeBlockPage.pageName);
   });
 
   it('Given I have completed the questions to the first of two groups, when I select age and shoe size, then I should see a question for age.', function() {
-    return helpers.startQuestionnaire('test_repeating_and_conditional_routing.json')
-    .then(() => {
-      return completeRepeatingQuestions(2, 1);
-    })
-      .then(() => {
-      return browser
-          .click(RepeatedBlockPage.ageAndShoeSize())
-          .click(RepeatedBlockPage.submit())
-          .getUrl().should.eventually.contain('/1/' + AgeBlockPage.pageName);
-    });
+      return completeRepeatingQuestions(2, 1)
+        .then(() => {
+          return browser
+              .click(RepeatedBlockPage.ageAndShoeSize())
+              .click(RepeatedBlockPage.submit())
+              .getUrl().should.eventually.contain('/1/' + AgeBlockPage.pageName);
+        });
   });
 
   it('Given I have completed the questions to the first of two groups, when I select shoe size, then I should see a question for shoe size.', function() {
     return helpers.startQuestionnaire('test_repeating_and_conditional_routing.json')
-    .then(() => {
-      return completeRepeatingQuestions(2, 1);
-    })
       .then(() => {
-      return browser
+        return completeRepeatingQuestions(2, 1);
+      })
+      .then(() => {
+        return browser
           .click(RepeatedBlockPage.shoeSizeOnly())
           .click(RepeatedBlockPage.submit())
           .getUrl().should.eventually.contain('/1/' + ShoeSizeBlockPage.pageName);
@@ -71,17 +64,29 @@ describe('Repeating Groups', function() {
   });
 
   it('Given I am on the second question in the second group, when I go to the previous page, then I should see the first question for second group.', function() {
-    return helpers.startQuestionnaire('test_repeating_and_conditional_routing.json').then(() => {
-        return browser
-          .setValue(NoOfRepeatsPage.answer(), 2)
-          .click(NoOfRepeatsPage.submit())
-          .click(RepeatedBlockPage.ageAndShoeSize())
-          .click(RepeatedBlockPage.submit())
+      return browser
+        .setValue(NoOfRepeatsPage.answer(), 2)
+        .click(NoOfRepeatsPage.submit())
+        .click(RepeatedBlockPage.ageAndShoeSize())
+        .click(RepeatedBlockPage.submit())
 
-          .click(ShoeSizeBlockPage.previous())
+        .click(ShoeSizeBlockPage.previous())
 
-          .getUrl().should.eventually.contain('/0/' + RepeatedBlockPage.pageName);
-    });
+        .getUrl().should.eventually.contain('/0/' + RepeatedBlockPage.pageName);
+  });
+
+  it('Given I go through the whole survey, I should see a summary of all the repeating groups', function() {
+      return completeRepeatingQuestions(3, 3)
+        .then(() => {
+          return browser
+            .getUrl().should.eventually.contain(SummaryPage.pageName)
+            .getText(SummaryPage.whatIsYourAge(0)).should.eventually.contain(20)
+            .getText(SummaryPage.whatIsYourAge(1)).should.eventually.contain(21)
+            .getText(SummaryPage.whatIsYourAge(2)).should.eventually.contain(22)
+            .getText(SummaryPage.whatIsYourShoeSize(0)).should.eventually.contain(8)
+            .getText(SummaryPage.whatIsYourShoeSize(1)).should.eventually.contain(9)
+            .getText(SummaryPage.whatIsYourShoeSize(2)).should.eventually.contain(10);
+        });
   });
 
   function completeRepeatingQuestions(numberOfRepeats, complete) {
@@ -89,7 +94,7 @@ describe('Repeating Groups', function() {
       .setValue(NoOfRepeatsPage.answer(), numberOfRepeats)
       .click(NoOfRepeatsPage.submit());
 
-    for (var i = 0; i < complete; i++) {
+    for (let i = 0; i < complete; i++) {
       chain = chain.then(() => {
         return browser
           .click(RepeatedBlockPage.ageAndShoeSize())

--- a/tests/functional/spec/repeating_summaries.spec.js
+++ b/tests/functional/spec/repeating_summaries.spec.js
@@ -1,0 +1,149 @@
+const helpers = require('../helpers');
+
+const PrimaryNameBlockPage = require('../pages/surveys/repeating_summaries/primary-name-block.page.js');
+const RepeatingAnyoneElseBlockPage = require('../pages/surveys/repeating_summaries/repeating-anyone-else-block.page.js');
+const RepeatingNameBlockPage = require('../pages/surveys/repeating_summaries/repeating-name-block.page.js');
+const HouseholdSummaryBlockPage = require('../pages/surveys/repeating_summaries/household-summary-block.page.js');
+const FirstNumberBlockPage = require('../pages/surveys/repeating_summaries/first-number-block.page.js');
+const SecondNumberBlockPage = require('../pages/surveys/repeating_summaries/second-number-block.page.js');
+const CurrencyTotalPlaybackPage = require('../pages/surveys/repeating_summaries/currency-total-playback.page.js');
+const MemberSummaryBlockPage = require('../pages/surveys/repeating_summaries/member-summary-block.page.js');
+const SummaryPage = require('../pages/surveys/repeating_summaries/summary.page.js');
+const ThankYouPage = require('../pages/thank-you.page.js');
+
+describe('Repeat Until Summaries', function() {
+
+  before("Launch Survey", function () {
+    return helpers.openQuestionnaire('test_repeat_until_summaries.json');
+  });
+
+  it('Given I complete the Household Section, When I get to see the section summary, Then I should see all answers in that section', function() {
+    return browser
+      .setValue(PrimaryNameBlockPage.answer(), 'Aaa')
+      .click(PrimaryNameBlockPage.submit())
+      .click(RepeatingAnyoneElseBlockPage.yes())
+      .click(RepeatingAnyoneElseBlockPage.submit())
+
+      .setValue(RepeatingNameBlockPage.answer(), 'Bbb')
+      .click(RepeatingNameBlockPage.submit())
+      .click(RepeatingAnyoneElseBlockPage.yes())
+      .click(RepeatingAnyoneElseBlockPage.submit())
+
+      .setValue(RepeatingNameBlockPage.answer(), 'Ccc')
+      .click(RepeatingNameBlockPage.submit())
+      .click(RepeatingAnyoneElseBlockPage.no())
+      .click(RepeatingAnyoneElseBlockPage.submit())
+
+      .getUrl().should.eventually.contain(HouseholdSummaryBlockPage.pageName)
+
+      .then(checkHouseholdSummaryBlockPage)
+      .click(HouseholdSummaryBlockPage.submit());
+  });
+
+  it("Given I complete the First Member group, When I get to see the calculation summary, Then I should see the correct total for the first member", function () {
+    return browser
+
+      .setValue(FirstNumberBlockPage.answer(), '1')
+      .click(FirstNumberBlockPage.submit())
+      .setValue(SecondNumberBlockPage.answer(), '10')
+      .click(SecondNumberBlockPage.submit())
+
+      .getUrl().should.eventually.contain(CurrencyTotalPlaybackPage.pageName)
+
+      .getText(CurrencyTotalPlaybackPage.firstNumberAnswer()).should.eventually.contain("1")
+      .getText(CurrencyTotalPlaybackPage.firstNumberAnswerLabel()).should.eventually.contain("First value for Aaa")
+      .getText(CurrencyTotalPlaybackPage.secondNumberAnswer()).should.eventually.contain("10")
+      .getText(CurrencyTotalPlaybackPage.secondNumberAnswerLabel()).should.eventually.contain("Second value for Aaa")
+      .click(CurrencyTotalPlaybackPage.submit());
+  });
+
+  it("Given I complete the Second Member group, When I get to see the calculation summary, Then I should see the correct total for the second member", function () {
+    return browser
+
+      .setValue(FirstNumberBlockPage.answer(), '2')
+      .click(FirstNumberBlockPage.submit())
+      .setValue(SecondNumberBlockPage.answer(), '20')
+      .click(SecondNumberBlockPage.submit())
+
+      .getUrl().should.eventually.contain(CurrencyTotalPlaybackPage.pageName)
+
+      .getText(CurrencyTotalPlaybackPage.firstNumberAnswer(1)).should.eventually.contain("2")
+      .getText(CurrencyTotalPlaybackPage.firstNumberAnswerLabel(1)).should.eventually.contain("First value for Bbb")
+      .getText(CurrencyTotalPlaybackPage.secondNumberAnswer(1)).should.eventually.contain("20")
+      .getText(CurrencyTotalPlaybackPage.secondNumberAnswerLabel(1)).should.eventually.contain("Second value for Bbb")
+      .click(CurrencyTotalPlaybackPage.submit());
+  });
+
+  it("Given I complete the Third Member group, When I get to see the calculation summary, Then I should see the correct total for the third member", function () {
+    return browser
+
+      .setValue(FirstNumberBlockPage.answer(), '3')
+      .click(FirstNumberBlockPage.submit())
+      .setValue(SecondNumberBlockPage.answer(), '30')
+      .click(SecondNumberBlockPage.submit())
+
+      .getUrl().should.eventually.contain(CurrencyTotalPlaybackPage.pageName)
+
+      .getText(CurrencyTotalPlaybackPage.firstNumberAnswer(2)).should.eventually.contain("3")
+      .getText(CurrencyTotalPlaybackPage.firstNumberAnswerLabel(2)).should.eventually.contain("First value for Ccc")
+      .getText(CurrencyTotalPlaybackPage.secondNumberAnswer(2)).should.eventually.contain("30")
+      .getText(CurrencyTotalPlaybackPage.secondNumberAnswerLabel(2)).should.eventually.contain("Second value for Ccc")
+      .click(CurrencyTotalPlaybackPage.submit());
+
+  });
+
+  it("Given I've completed the Member Section, When I get to see the section summary, Then I should see the correct answers for each member", function () {
+    return browser
+      .getUrl().should.eventually.contain(MemberSummaryBlockPage.pageName)
+      .then(checkMemberSummaryBlockPage)
+      .click(MemberSummaryBlockPage.submit());
+
+  });
+
+  it("Given I've completed all Sections, When I get to see the final summary, Then I should see the correct answers for all questions", function () {
+    return browser
+      .getUrl().should.eventually.contain(SummaryPage.pageName)
+      .then(checkHouseholdSummaryBlockPage)
+      .then(checkMemberSummaryBlockPage);
+  });
+
+  it("Given I've Submitted the survey, When I get to see the answers after submission, Then I should see the correct answers for all questions", function () {
+    return browser
+      .click(SummaryPage.submit())
+      .getUrl().should.eventually.contain(ThankYouPage.pageName)
+      .click(ThankYouPage.viewSubmitted())
+      .getUrl().should.eventually.contain('view-submission')
+      .then(checkHouseholdSummaryBlockPage)
+      .then(checkMemberSummaryBlockPage);
+  });
+});
+
+function checkHouseholdSummaryBlockPage() {
+  return browser
+
+    .getText(HouseholdSummaryBlockPage.primaryName()).should.eventually.contain("Aaa")
+    .getText(HouseholdSummaryBlockPage.repeatingName()).should.eventually.contain("Bbb")
+    .getText(HouseholdSummaryBlockPage.repeatingName(1)).should.eventually.contain("Ccc");
+}
+
+function checkMemberSummaryBlockPage() {
+  return browser
+
+    .getText(MemberSummaryBlockPage.memberGroupTitle()).should.eventually.contain("Aaa")
+    .getText(MemberSummaryBlockPage.firstNumberQuestion()).should.eventually.contain("Aaa")
+    .getText(MemberSummaryBlockPage.firstNumberAnswer()).should.eventually.contain("1")
+    .getText(MemberSummaryBlockPage.secondNumberQuestion()).should.eventually.contain("Aaa")
+    .getText(MemberSummaryBlockPage.secondNumberAnswer()).should.eventually.contain("10")
+
+    .getText(MemberSummaryBlockPage.memberGroupTitle(1)).should.eventually.contain("Bbb")
+    .getText(MemberSummaryBlockPage.firstNumberQuestion(1)).should.eventually.contain("Bbb")
+    .getText(MemberSummaryBlockPage.firstNumberAnswer(1)).should.eventually.contain("2")
+    .getText(MemberSummaryBlockPage.secondNumberQuestion(1)).should.eventually.contain("Bbb")
+    .getText(MemberSummaryBlockPage.secondNumberAnswer(1)).should.eventually.contain("20")
+
+    .getText(MemberSummaryBlockPage.memberGroupTitle(2)).should.eventually.contain("Ccc")
+    .getText(MemberSummaryBlockPage.firstNumberQuestion(2)).should.eventually.contain("Ccc")
+    .getText(MemberSummaryBlockPage.firstNumberAnswer(2)).should.eventually.contain("3")
+    .getText(MemberSummaryBlockPage.secondNumberQuestion(2)).should.eventually.contain("Ccc")
+    .getText(MemberSummaryBlockPage.secondNumberAnswer(2)).should.eventually.contain("30");
+}

--- a/tests/functional/spec/routing_repeat_until.spec.js
+++ b/tests/functional/spec/routing_repeat_until.spec.js
@@ -34,6 +34,13 @@ describe('Routing Repeat Until', function() {
         .click(SexPage.submit())
 
         .getUrl().should.eventually.contain(SummaryPage.pageName)
+
+        .getText(SummaryPage.primaryGroupTitle(0)).should.eventually.contain("Your Details")
+        .getText(SummaryPage.primaryName(0)).should.eventually.contain("Bob")
+
+        .getText(SummaryPage.repeatingGroupTitle(0)).should.eventually.contain("Other Household Members")
+        .getText(SummaryPage.repeatingName(0)).should.eventually.contain("Alice")
+
         .click(SummaryPage.submit());
     });
   });
@@ -74,6 +81,20 @@ describe('Routing Repeat Until', function() {
         .click(SexPage.submit())
 
         .getUrl().should.eventually.contain(SummaryPage.pageName)
+
+        .getText(SummaryPage.primaryGroupTitle(0)).should.eventually.contain("Your Details")
+        .getText(SummaryPage.primaryName(0)).should.eventually.contain("Bob")
+
+        .getText(SummaryPage.repeatingGroupTitle(0)).should.eventually.contain("Other Household Members")
+        .getText(SummaryPage.repeatingName(0)).should.eventually.contain("Alice")
+
+        .getText(SummaryPage.repeatingGroupTitle(0)).should.eventually.contain("Other Household Members")
+        .getText(SummaryPage.repeatingName(1)).should.eventually.contain("John")
+
+        .getText(SummaryPage.sexAnswer(0)).should.eventually.contain("Male")
+        .getText(SummaryPage.sexAnswer(1)).should.eventually.contain("Female")
+        .getText(SummaryPage.sexAnswer(2)).should.eventually.contain("Male")
+
         .click(SummaryPage.submit());
     });
   });

--- a/tests/functional/spec/section_summary.spec.js
+++ b/tests/functional/spec/section_summary.spec.js
@@ -72,13 +72,13 @@ describe('Section Summary', function() {
 
     it('When I click change an answer, Then I should go to that answer', function() {
       return browser
-        .click(FinalSummaryPage.propertyDetailsDropDownButton())
+        .click(FinalSummaryPage.showAllButton())
         .getText(FinalSummaryPage.insuranceTypeAnswer()).should.eventually.contain('Contents')
         .click(FinalSummaryPage.propertyDetailsDropDownChangeLink())
         .getUrl().should.eventually.contain(InsuranceTypePage.pageName)
         .click(InsuranceTypePage.buildings())
         .click(InsuranceTypePage.submit())
-        .getText(PropertyDetailsSummaryPage.insuranceTypeAnswer()).should.eventually.contain('Buildings');
+        .getText(FinalSummaryPage.insuranceTypeAnswer()).should.eventually.contain('Buildings');
     });
   });
 


### PR DESCRIPTION
### What is the context of this PR?
Allows for all answers for each repeating groups to be shown on summary pages. 
On calculated summaries it ensures the answers are from the correct repeat (Fixes #1765).

### How to review 
Test existing schemas with repeating groups. 
New schema `test_repeat_until_summaries.json` includes a repeat until that has section/calculated and final summaries within.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
