### PR TITLE
Allow for long/short and single/plural labels for answer fields

### DIFF
--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -82,8 +82,21 @@ def format_address_list(user_entered_address=None, metadata_address=None):
     return address_list
 
 
-def format_unit(unit, value=''):
-    return units.format_unit(value=value, measurement_unit=unit, length='short', locale=DEFAULT_LOCALE)
+def format_unit(unit, value, length='short'):
+    return units.format_unit(value=value, measurement_unit=unit, length=length, locale=DEFAULT_LOCALE)
+
+
+def format_unit_input_label(unit, unit_length='short'):
+    """
+    This function is used to only get the unit of measurement text.  If the unit_length
+    is long then only the plural form of the word is returned (e.g., Hours, Years, etc).
+
+    :param (str) unit unit of measurement
+    :param (str) unit_length length of unit text, can be one of short/long/narrow
+    """
+    if unit_length == 'long':
+        return units.format_unit(value=2, measurement_unit=unit, length=unit_length, locale=DEFAULT_LOCALE).replace('2 ', '')
+    return units.format_unit(value='', measurement_unit=unit, length=unit_length, locale=DEFAULT_LOCALE).strip()
 
 
 def format_duration(value):
@@ -471,6 +484,11 @@ def conditional_dates_check():
 @blueprint.app_context_processor
 def format_unit_processor():
     return dict(format_unit=format_unit)
+
+
+@blueprint.app_context_processor
+def format_unit_input_label_processor():
+    return dict(format_unit_input_label=format_unit_input_label)
 
 
 @blueprint.app_context_processor

--- a/app/templates/partials/answers/unit.html
+++ b/app/templates/partials/answers/unit.html
@@ -22,6 +22,6 @@
         'id': answer.id
         } %}
         {% include 'partials/forms/input.html' %}
-        <span class="input-type__type" id="{{answer.id}}-type">{{ format_unit(answer.unit) }}</span>
+        <span class="input-type__type" id="{{answer.id}}-type">{{ format_unit_input_label(answer.unit, unit_length=answer.unit_length) }}</span>
     </div>
 </div>

--- a/data/en/lms_2.json
+++ b/data/en/lms_2.json
@@ -466,7 +466,9 @@
                             "type": "General",
                             "answers": [{
                                 "id": "dob-age-answer",
-                                "type": "Number",
+                                "unit": "duration-year",
+                                "type": "Unit",
+                                "unit_length": "long",
                                 "mandatory": false
                             }]
                         }],
@@ -3255,6 +3257,7 @@
                                 "mandatory": false,
                                 "type": "Unit",
                                 "unit": "duration-hour",
+                                "unit_length": "long",
                                 "label": "Usual hours"
                             }]
                         }],
@@ -3308,6 +3311,7 @@
                                 "mandatory": false,
                                 "type": "Unit",
                                 "unit": "duration-hour",
+                                "unit_length": "long",
                                 "label": "Usual hours"
                             }]
                         }]
@@ -3335,6 +3339,7 @@
                                 "mandatory": false,
                                 "type": "Unit",
                                 "unit": "duration-hour",
+                                "unit_length": "long",
                                 "label": "Usual hours"
                             }]
                         }],
@@ -3390,6 +3395,7 @@
                                 "mandatory": false,
                                 "type": "Unit",
                                 "unit": "duration-hour",
+                                "unit_length": "long",
                                 "label": "Unpaid overtime hours"
                             }]
                         }],
@@ -3440,6 +3446,7 @@
                                 "mandatory": false,
                                 "type": "Unit",
                                 "unit": "duration-hour",
+                                "unit_length": "long",
                                 "label": "Paid overtime hours"
                             }]
                         }]
@@ -3469,6 +3476,7 @@
                                 "mandatory": false,
                                 "type": "Unit",
                                 "unit": "duration-hour",
+                                "unit_length": "long",
                                 "label": "Usual hours"
                             }],
                             "guidance": {
@@ -3518,6 +3526,7 @@
                                 "mandatory": false,
                                 "type": "Unit",
                                 "unit": "duration-hour",
+                                "unit_length": "long",
                                 "label": "Actual hours"
                             }]
                         }],
@@ -3621,7 +3630,9 @@
                                 "label": "Unpaid overtime hours, main job",
                                 "mandatory": false,
                                 "type": "Unit",
-                                "unit": "duration-hour"
+                                "unit": "duration-hour",
+                                "unit_length": "long"
+
                             }]
                         }]
                     },
@@ -3648,6 +3659,7 @@
                                 "mandatory": false,
                                 "type": "Unit",
                                 "unit": "duration-hour",
+                                "unit_length": "long",
                                 "label": "Unpaid overtime hours, second job"
                             }]
                         }],
@@ -3691,6 +3703,7 @@
                                 "mandatory": false,
                                 "type": "Unit",
                                 "unit": "duration-hour",
+                                "unit_length": "long",
                                 "label": "Paid overtime hours, main job"
                             }]
                         }]
@@ -3725,6 +3738,7 @@
                                 "mandatory": false,
                                 "type": "Unit",
                                 "unit": "duration-hour",
+                                "unit_length": "long",
                                 "label": "Paid overtime hours, second job"
                             }]
                         }]
@@ -3754,6 +3768,7 @@
                                 "mandatory": false,
                                 "type": "Unit",
                                 "unit": "duration-hour",
+                                "unit_length": "long",
                                 "label": "Usual hours"
                             }],
                             "guidance": {
@@ -3786,6 +3801,7 @@
                                 "mandatory": false,
                                 "type": "Unit",
                                 "unit": "duration-hour",
+                                "unit_length": "long",
                                 "label": "Actual hours main job"
                             }]
                         }],
@@ -3891,6 +3907,7 @@
                                 "mandatory": false,
                                 "type": "Unit",
                                 "unit": "duration-hour",
+                                "unit_length": "long",
                                 "label": "Usual hours"
                             }],
                             "guidance": {
@@ -3923,6 +3940,7 @@
                                 "mandatory": false,
                                 "type": "Unit",
                                 "unit": "duration-hour",
+                                "unit_length": "long",
                                 "label": "Actual hours, second job"
                             }]
                         }],
@@ -4026,6 +4044,7 @@
                                 "mandatory": false,
                                 "type": "Unit",
                                 "unit": "duration-hour",
+                                "unit_length": "long",
                                 "label": "Casual hours"
                             }]
                         }]

--- a/data/en/mbs_0203.json
+++ b/data/en/mbs_0203.json
@@ -151,6 +151,7 @@
                         "mandatory": true,
                         "q_code": "110",
                         "type": "Unit",
+                        "unit_length": "short",
                         "label": "Total volume of potable water that was supplied to customers, in megalitres",
                         "unit": "volume-megaliter"
                     }]

--- a/data/en/mbs_0204.json
+++ b/data/en/mbs_0204.json
@@ -151,6 +151,7 @@
                         "mandatory": true,
                         "q_code": "110",
                         "type": "Unit",
+                        "unit_length": "short",
                         "label": "Total volume of potable water that was supplied to customers, in megalitres",
                         "unit": "volume-megaliter"
                     }]

--- a/data/en/mbs_0253.json
+++ b/data/en/mbs_0253.json
@@ -181,6 +181,7 @@
                         "mandatory": true,
                         "q_code": "110",
                         "type": "Unit",
+                        "unit_length": "short",
                         "label": "Total volume of potable water that was supplied to customers, in megalitres",
                         "unit": "volume-megaliter"
                     }]

--- a/data/en/test_calculated_summary.json
+++ b/data/en/test_calculated_summary.json
@@ -69,6 +69,7 @@
                                 "label": "Second answer label in unit total",
                                 "mandatory": true,
                                 "type": "Unit",
+                                "unit_length": "short",
                                 "unit": "length-centimeter"
                             },
                             {
@@ -109,6 +110,7 @@
                                 "label": "Third answer label in unit total",
                                 "mandatory": true,
                                 "type": "Unit",
+                                "unit_length": "short",
                                 "unit": "length-centimeter"
                             }]
                         }

--- a/data/en/test_summary.json
+++ b/data/en/test_summary.json
@@ -81,6 +81,7 @@
                         "label": "Kilometres Square",
                         "mandatory": false,
                         "type": "Unit",
+                        "unit_length": "short",
                         "unit": "area-square-kilometer"
                     }, {
                         "id": "test-decimal",

--- a/data/en/test_unit_patterns.json
+++ b/data/en/test_unit_patterns.json
@@ -30,28 +30,32 @@
                         "label": "Centimetres",
                         "mandatory": false,
                         "type": "Unit",
-                        "unit": "length-centimeter"
+                        "unit": "length-centimeter",
+                        "unit_length": "short"
                     }, {
                         "id": "metres",
                         "description": "",
                         "label": "Metres",
                         "mandatory": false,
                         "type": "Unit",
-                        "unit": "length-meter"
+                        "unit": "length-meter",
+                        "unit_length": "short"
                     }, {
                         "id": "kilometres",
                         "description": "",
                         "label": "Kilometres",
                         "mandatory": false,
                         "type": "Unit",
-                        "unit": "length-kilometer"
+                        "unit": "length-kilometer",
+                        "unit_length": "short"
                     }, {
                         "id": "miles",
                         "description": "",
                         "label": "Miles",
                         "mandatory": false,
                         "type": "Unit",
-                        "unit": "length-mile"
+                        "unit": "length-mile",
+                        "unit_length": "short"
                     }],
                     "description": "",
                     "id": "set-length-units-question",
@@ -59,6 +63,36 @@
                     "type": "General"
                 }],
                 "title": "Length Units"
+            }, {
+                "type": "Question",
+                "id": "set-duration-units-block",
+                "description": "",
+                "questions": [{
+                    "answers": [{
+                            "id": "duration-hour",
+                            "description": "",
+                            "label": "Hour",
+                            "mandatory": false,
+                            "type": "Unit",
+                            "unit": "duration-hour",
+                            "unit_length": "long"
+                        },
+                        {
+                            "id": "duration-year",
+                            "description": "",
+                            "label": "Years",
+                            "mandatory": false,
+                            "type": "Unit",
+                            "unit": "duration-year",
+                            "unit_length": "long"
+                        }
+                    ],
+                    "description": "",
+                    "id": "set-duration-units-question",
+                    "title": "Duration Units",
+                    "type": "General"
+                }],
+                "title": "Duration Units"
             }, {
                 "type": "Question",
                 "id": "set-area-units-block",
@@ -70,42 +104,48 @@
                         "label": "Centimetres Square",
                         "mandatory": false,
                         "type": "Unit",
-                        "unit": "area-square-centimeter"
+                        "unit": "area-square-centimeter",
+                        "unit_length": "short"
                     }, {
                         "id": "square-metres",
                         "description": "",
                         "label": "Metres Square",
                         "mandatory": false,
                         "type": "Unit",
-                        "unit": "area-square-meter"
+                        "unit": "area-square-meter",
+                        "unit_length": "short"
                     }, {
                         "id": "square-kilometres",
                         "description": "",
                         "label": "Kilometres Square",
                         "mandatory": false,
                         "type": "Unit",
-                        "unit": "area-square-kilometer"
+                        "unit": "area-square-kilometer",
+                        "unit_length": "short"
                     }, {
                         "id": "square-miles",
                         "description": "",
                         "label": "Miles Square",
                         "mandatory": false,
                         "type": "Unit",
-                        "unit": "area-square-mile"
+                        "unit": "area-square-mile",
+                        "unit_length": "short"
                     }, {
                         "id": "acres",
                         "description": "",
                         "label": "Acres",
                         "mandatory": false,
                         "type": "Unit",
-                        "unit": "area-acre"
+                        "unit": "area-acre",
+                        "unit_length": "short"
                     }, {
                         "id": "hectares",
                         "description": "",
                         "label": "Hectares",
                         "mandatory": false,
                         "type": "Unit",
-                        "unit": "area-hectare"
+                        "unit": "area-hectare",
+                        "unit_length": "short"
                     }],
                     "description": "",
                     "id": "set-area-unit-questions",
@@ -124,35 +164,40 @@
                         "label": "Cubic Centimetres",
                         "mandatory": false,
                         "type": "Unit",
-                        "unit": "volume-cubic-centimeter"
+                        "unit": "volume-cubic-centimeter",
+                        "unit_length": "short"
                     }, {
                         "id": "cubic-metres",
                         "description": "",
                         "label": "Cubic Metres",
                         "mandatory": false,
                         "type": "Unit",
-                        "unit": "volume-cubic-meter"
+                        "unit": "volume-cubic-meter",
+                        "unit_length": "short"
                     }, {
                         "id": "litres",
                         "description": "",
                         "label": "Litres",
                         "mandatory": false,
                         "type": "Unit",
-                        "unit": "volume-liter"
+                        "unit": "volume-liter",
+                        "unit_length": "short"
                     }, {
                         "id": "hectolitres",
                         "description": "",
                         "label": "Hectolitres",
                         "mandatory": false,
                         "type": "Unit",
-                        "unit": "volume-hectoliter"
+                        "unit": "volume-hectoliter",
+                        "unit_length": "short"
                     }, {
                         "id": "megalitres",
                         "description": "",
                         "label": "Megalitres",
                         "mandatory": false,
                         "type": "Unit",
-                        "unit": "volume-megaliter"
+                        "unit": "volume-megaliter",
+                        "unit_length": "short"
                     }],
                     "description": "",
                     "id": "set-volume-unit-questions",

--- a/data/en/test_view_submitted_response.json
+++ b/data/en/test_view_submitted_response.json
@@ -85,6 +85,7 @@
                         "label": "Kilometres Square",
                         "mandatory": false,
                         "type": "Unit",
+                        "unit_length": "short",
                         "unit": "area-square-kilometer"
                     }, {
                         "id": "test-decimal",

--- a/tests/app/test_jinja_filters.py
+++ b/tests/app/test_jinja_filters.py
@@ -13,7 +13,7 @@ from app.jinja_filters import (
     format_multilined_string, format_percentage, format_date_range,
     format_household_member_name, format_datetime,
     format_number_to_alphabetic_letter, format_unit, format_currency_for_input,
-    format_number, format_unordered_list,
+    format_number, format_unordered_list, format_unit_input_label,
     format_household_member_name_possessive, concatenated_list,
     calculate_years_difference, get_current_date, as_london_tz, max_value,
     min_value, get_question_title, get_answer_label,
@@ -455,6 +455,30 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
         self.assertEqual(format_unit('volume-hectoliter', 100), '100 hl')
         self.assertEqual(format_unit('volume-megaliter', 100), '100 Ml')
         self.assertEqual(format_unit('duration-hour', 100), '100 hrs')
+        self.assertEqual(format_unit('duration-hour', 100, 'long'), '100 hours')
+        self.assertEqual(format_unit('duration-year', 100, 'long'), '100 years')
+
+    def test_format_unit_input_label(self):
+        self.assertEqual(format_unit_input_label('length-meter'), 'm')
+        self.assertEqual(format_unit_input_label('length-centimeter'), 'cm')
+        self.assertEqual(format_unit_input_label('length-mile'), 'mi')
+        self.assertEqual(format_unit_input_label('length-kilometer'), 'km')
+        self.assertEqual(format_unit_input_label('area-square-meter'), 'm²')
+        self.assertEqual(format_unit_input_label('area-square-centimeter'), 'cm²')
+        self.assertEqual(format_unit_input_label('area-square-kilometer'), 'km²')
+        self.assertEqual(format_unit_input_label('area-square-mile'), 'sq mi')
+        self.assertEqual(format_unit_input_label('area-hectare'), 'ha')
+        self.assertEqual(format_unit_input_label('area-acre'), 'ac')
+        self.assertEqual(format_unit_input_label('volume-cubic-meter'), 'm³')
+        self.assertEqual(format_unit_input_label('volume-cubic-centimeter'), 'cm³')
+        self.assertEqual(format_unit_input_label('volume-liter'), 'l')
+        self.assertEqual(format_unit_input_label('volume-hectoliter'), 'hl')
+        self.assertEqual(format_unit_input_label('volume-megaliter'), 'Ml')
+        self.assertEqual(format_unit_input_label('duration-hour'), 'hr')
+        self.assertEqual(format_unit_input_label('duration-hour', 'long'), 'hours')
+        self.assertEqual(format_unit_input_label('duration-year'), 'yr')
+        self.assertEqual(format_unit_input_label('duration-year', 'long'), 'years')
+
 
     def test_format_year_month_duration(self):
         with self.app_request_context('/'):


### PR DESCRIPTION
### What is the context of this PR?
https://trello.com/c/KYe8MSnc/2415-hours-unit-for-lms-should-be-hours-not-hrs

The 'hrs' field in LMS needs to be 'hours'.  In order to do this, we had to add extra metadata to the unit type so that length and plurality could be specified.

### How to review 
All the `test_unit_patterns.json` measurements. They should all be in short form apart from the time one, which should be long form (hours).

The time entry fields in `lms_2.json` have 'hours' in the label.
Test any/all of the following that they look as expected (short, singular form units)
`mbs_0203.json`
`mbs_0204.json`
`mbs_0253.json`
`test_calculated_summary.json`
`test_summary.json`
`test_view_submitted_response.json`

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
