### PR TITLE
Enforce expiry on eq_session

### DIFF
--- a/app/data_model/models.py
+++ b/app/data_model/models.py
@@ -2,6 +2,7 @@ import datetime
 
 from flask_sqlalchemy import SQLAlchemy
 from structlog import get_logger
+
 from app.data_model import app_models
 
 logger = get_logger()
@@ -41,21 +42,23 @@ class EQSession(db.Model):
     session_data = db.Column('session_data', db.String)
     created_at = db.Column('created_at', db.DateTime, default=datetime.datetime.utcnow)
     updated_at = db.Column('updated_at', db.DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow)
+    expires_at = db.Column('expires_at', db.DateTime)
 
-    def __init__(self, eq_session_id, user_id, session_data=None):
+    def __init__(self, eq_session_id, user_id, session_data=None, expires_at=None):
         self.eq_session_id = eq_session_id
         self.user_id = user_id
         self.session_data = session_data
+        self.expires_at = expires_at
 
     def to_app_model(self):
-        model = app_models.EQSession(self.eq_session_id, self.user_id, self.session_data)
+        model = app_models.EQSession(self.eq_session_id, self.user_id, self.session_data, self.expires_at)
         model.created_at = self.created_at
         model.updated_at = self.updated_at
         return model
 
     @classmethod
     def from_app_model(cls, model):
-        return cls(model.eq_session_id, model.user_id, model.session_data)
+        return cls(model.eq_session_id, model.user_id, model.session_data, model.expires_at)
 
 
 # pylint: disable=maybe-no-member

--- a/app/helpers/template_helper.py
+++ b/app/helpers/template_helper.py
@@ -5,7 +5,7 @@ from flask_login import current_user
 from flask_themes2 import render_theme_template
 from structlog import get_logger
 
-from app.globals import get_metadata
+from app.globals import get_metadata, get_session_timeout_in_seconds
 from app.templating.metadata_context import build_metadata_context
 from app.templating.template_renderer import TemplateRenderer
 
@@ -15,14 +15,8 @@ logger = get_logger()
 def with_session_timeout(func):
     @wraps(func)
     def session_wrapper(*args, **kwargs):
-        session_timeout = current_app.config['EQ_SESSION_TIMEOUT_SECONDS']
-        schema_session_timeout = g.schema.json.get('session_timeout_in_seconds')
-        if schema_session_timeout is not None and \
-           schema_session_timeout < current_app.config['EQ_SESSION_TIMEOUT_SECONDS']:
-            session_timeout = schema_session_timeout
-
-        session_timeout_prompt = g.schema.json.get('session_prompt_in_seconds') or \
-            current_app.config['EQ_SESSION_TIMEOUT_PROMPT_SECONDS']
+        session_timeout_prompt = g.schema.json.get('session_prompt_in_seconds') or current_app.config['EQ_SESSION_TIMEOUT_PROMPT_SECONDS']
+        session_timeout = get_session_timeout_in_seconds(g.schema, with_grace_period=False)
 
         return func(
             *args,

--- a/app/setup.py
+++ b/app/setup.py
@@ -10,7 +10,7 @@ import boto3
 import sqlalchemy
 import yaml
 from botocore.config import Config
-from flask import Flask, url_for
+from flask import Flask, url_for, session as cookie_session
 from flask_babel import Babel
 from flask_caching import Cache
 from flask_talisman import Talisman
@@ -143,6 +143,11 @@ def create_app(setting_overrides=None):  # noqa: C901  pylint: disable=too-compl
 
     @application.before_request
     def before_request():  # pylint: disable=unused-variable
+
+        # While True the session lives for permanent_session_lifetime seconds
+        # Needed to be able to set the client-side cookie expiration
+        cookie_session.permanent = True
+
         request_id = str(uuid4())
         logger.new(request_id=request_id)
 
@@ -220,6 +225,9 @@ def check_database():
 
     if 'session_data' not in session_table.c:  # pragma: no cover
         raise Exception('Database patch "pr-1391-apply.sql" has not been run')
+
+    if 'expires_at' not in session_table.c:  # pragma: no cover
+        raise Exception('Database patch "pr-1797-apply.sql" has not been run')
 
 
 def setup_dynamodb(application):

--- a/tests/app/authentication/test_authenticator.py
+++ b/tests/app/authentication/test_authenticator.py
@@ -1,10 +1,13 @@
-from flask import session
+from datetime import datetime, timedelta
+
+from dateutil.tz import tzutc
+from flask import session as cookie_session
 from mock import patch
 
-from app.data_model.session_data import SessionData
-from app.settings import USER_IK
 from app.authentication.authenticator import load_user, request_load_user, user_loader
+from app.data_model.session_data import SessionData
 from app.data_model.session_store import SessionStore
+from app.settings import USER_IK
 from tests.app.app_context_test_case import AppContextTestCase
 
 
@@ -24,13 +27,14 @@ class TestAuthenticator(AppContextTestCase): # pylint: disable=too-many-public-m
             case_id='case_id'
         )
         self.session_store = SessionStore('user_ik', 'pepper', 'eq_session_id')
+        self.expires_at = datetime.now(tzutc()) + timedelta(seconds=5)
 
     def test_check_session_with_user_id_in_session(self):
         with self.app_request_context('/status'):
             with patch('app.authentication.authenticator.get_session_store', return_value=self.session_store):
                 # Given
-                self.session_store.create('eq_session_id', 'user_id', self.session_data)
-                session[USER_IK] = 'user_ik'
+                self.session_store.create('eq_session_id', 'user_id', self.session_data, self.expires_at)
+                cookie_session[USER_IK] = 'user_ik'
 
                 # When
                 user = load_user()
@@ -52,8 +56,8 @@ class TestAuthenticator(AppContextTestCase): # pylint: disable=too-many-public-m
         with self.app_request_context('/status'):
             with patch('app.authentication.authenticator.get_session_store', return_value=self.session_store):
                 # Given
-                self.session_store.create('eq_session_id', 'user_id', self.session_data)
-                session[USER_IK] = 'user_ik'
+                self.session_store.create('eq_session_id', 'user_id', self.session_data, self.expires_at)
+                cookie_session[USER_IK] = 'user_ik'
 
                 # When
                 user = user_loader(None)
@@ -66,8 +70,8 @@ class TestAuthenticator(AppContextTestCase): # pylint: disable=too-many-public-m
         with self.app_request_context('/status'):
             with patch('app.authentication.authenticator.get_session_store', return_value=self.session_store):
                 # Given
-                self.session_store.create('eq_session_id', 'user_id', self.session_data)
-                session[USER_IK] = 'user_ik'
+                self.session_store.create('eq_session_id', 'user_id', self.session_data, self.expires_at)
+                cookie_session[USER_IK] = 'user_ik'
 
                 # When
                 user = request_load_user(None)
@@ -75,3 +79,52 @@ class TestAuthenticator(AppContextTestCase): # pylint: disable=too-many-public-m
                 # Then
                 self.assertEqual(user.user_id, 'user_id')
                 self.assertEqual(user.user_ik, 'user_ik')
+
+    def test_no_user_when_session_has_expired(self):
+        with self.app_request_context('/status'):
+            with patch('app.authentication.authenticator.get_session_store', return_value=self.session_store):
+                # Given
+                self.session_store.create('eq_session_id', 'user_id', self.session_data, expires_at=datetime.now(tzutc()))
+                cookie_session[USER_IK] = 'user_ik'
+
+                # When
+                user = user_loader(None)
+
+                # Then
+                self.assertIsNone(user)
+                self.assertIsNone(cookie_session.get(USER_IK))
+
+
+    def test_valid_user_extends_session_expiry(self):
+        with self.app_request_context('/status'):
+            with patch('app.authentication.authenticator.get_session_store', return_value=self.session_store):
+                # Given
+                self.session_store.create('eq_session_id', 'user_id', self.session_data, self.expires_at)
+                cookie_session[USER_IK] = 'user_ik'
+                cookie_session['expires_in'] = 5
+
+                # When
+                user = user_loader(None)
+
+                # Then
+                self.assertEqual(user.user_id, 'user_id')
+                self.assertEqual(user.user_ik, 'user_ik')
+                self.assertEqual(user.is_authenticated, True)
+                self.assertGreater(self.session_store.expiration_time, self.expires_at)
+
+
+    def test_session_still_valid_without_expiration_time(self):
+        with self.app_request_context('/status'):
+            with patch('app.authentication.authenticator.get_session_store', return_value=self.session_store):
+                # Given
+                self.session_store.create('eq_session_id', 'user_id', self.session_data)  # expires_at = None
+                cookie_session[USER_IK] = 'user_ik'
+
+                # When
+                user = user_loader(None)
+
+                # Then
+                self.assertEqual(user.user_id, 'user_id')
+                self.assertEqual(user.user_ik, 'user_ik')
+                self.assertEqual(user.is_authenticated, True)
+                self.assertIsNone(self.session_store.expiration_time)

--- a/tests/app/data_model/test_app_models.py
+++ b/tests/app/data_model/test_app_models.py
@@ -6,7 +6,6 @@ from app.data_model.app_models import EQSession, QuestionnaireState, UsedJtiClai
 from app.storage.data_access import TABLE_CONFIG
 from tests.app.app_context_test_case import AppContextTestCase
 
-
 NOW = datetime.datetime.now(tz=tzutc()).replace(microsecond=0)
 
 
@@ -16,14 +15,17 @@ class TestAppModels(AppContextTestCase):
         self._test_model(SubmittedResponse('txid', 'somedata', NOW))
 
     def test_questionnaire_state(self):
-        new = self._test_model(QuestionnaireState('someuser', 'somedata', 1))
-        self.assertGreaterEqual(new.created_at, NOW)
-        self.assertGreaterEqual(new.updated_at, NOW)
+        new_model = self._test_model(QuestionnaireState('someuser', 'somedata', 1))
+
+        self.assertGreaterEqual(new_model.created_at, NOW)
+        self.assertGreaterEqual(new_model.updated_at, NOW)
 
     def test_eq_session(self):
-        new = self._test_model(EQSession('sessionid', 'someuser', 'somedata'))
-        self.assertGreaterEqual(new.created_at, NOW)
-        self.assertGreaterEqual(new.updated_at, NOW)
+        new_model = self._test_model(EQSession('sessionid', 'someuser', 'somedata', NOW))
+
+        self.assertGreaterEqual(new_model.created_at, NOW)
+        self.assertGreaterEqual(new_model.updated_at, NOW)
+        self.assertGreaterEqual(new_model.expires_at, NOW)
 
     def test_used_jti_claim(self):
         self._test_model(UsedJtiClaim('claimid', NOW, NOW))
@@ -33,6 +35,8 @@ class TestAppModels(AppContextTestCase):
         schema = config['schema'](strict=True)
 
         item, _ = schema.dump(orig)
-        new, _ = schema.load(item)
-        self.assertEqual(orig.__dict__, new.__dict__)
-        return new
+        new_model, _ = schema.load(item)
+
+        self.assertEqual(orig.__dict__, new_model.__dict__)
+
+        return new_model

--- a/tests/app/data_model/test_models.py
+++ b/tests/app/data_model/test_models.py
@@ -1,4 +1,6 @@
-import datetime
+from datetime import datetime, timedelta
+
+from dateutil.tz import tzutc
 
 from app.data_model.models import EQSession, QuestionnaireState, UsedJtiClaim
 from tests.app.app_context_test_case import AppContextTestCase
@@ -7,19 +9,28 @@ from tests.app.app_context_test_case import AppContextTestCase
 class TestModels(AppContextTestCase):
 
     def test_questionnaire_state(self):
-        self._test_model(QuestionnaireState, ['someuser', 'somedata', 1])
+        original, new = self._make_models(QuestionnaireState, ['someuser', 'somedata', 1])
+
+        self.assertEqual(original, new)
 
     def test_eq_session(self):
-        self._test_model(EQSession, ['sessionid', 'someuser', 'somedata'])
+        expires_at = datetime.now(tz=tzutc()) + timedelta(seconds=5)
+        original, new = self._make_models(EQSession, ['sessionid', 'someuser', 'somedata', expires_at])
+
+        self.assertEqual(original, new)
 
     def test_used_jti_claim(self):
-        self._test_model(UsedJtiClaim, ['claimid', datetime.datetime.now()])
+        original, new = self._make_models(UsedJtiClaim, ['claimid', datetime.now()])
 
-    def _test_model(self, model_type, args):
+        self.assertEqual(original, new)
+
+    @staticmethod
+    def _make_models(model_type, args):
         orig = model_type(*args)
         new = model_type.from_app_model(orig.to_app_model())
         orig_dict = orig.__dict__
         del orig_dict['_sa_instance_state']
         new_dict = new.__dict__
         del new_dict['_sa_instance_state']
-        self.assertEqual(orig_dict, new_dict)
+
+        return orig_dict, new_dict

--- a/tests/integration/session/test_timeout.py
+++ b/tests/integration/session/test_timeout.py
@@ -7,7 +7,7 @@ from tests.integration.integration_test_case import IntegrationTestCase
 class TestTimeout(IntegrationTestCase):
 
     def setUp(self):
-        settings.EQ_SESSION_TIMEOUT_SECONDS = 1
+        settings.EQ_SESSION_TIMEOUT_SECONDS = 2
         settings.EQ_SESSION_TIMEOUT_GRACE_PERIOD_SECONDS = 0
         super().setUp()
 
@@ -16,22 +16,28 @@ class TestTimeout(IntegrationTestCase):
         settings.EQ_SESSION_TIMEOUT_GRACE_PERIOD_SECONDS = 30
         super().tearDown()
 
-    def test_timeout_continue_returns_200(self):
+    def test_timeout_continue_valid_session_returns_200(self):
         self.launchSurvey('test', 'timeout')
         self.get('/timeout-continue')
         self.assertStatusOK()
 
+    def test_timeout_continue_invalid_session_returns_401(self):
+        self.launchSurvey('test', 'timeout')
+        time.sleep(3)
+        self.get('/timeout-continue')
+        self.assertStatusUnauthorised()
+
     def test_when_session_times_out_server_side_401_is_returned(self):
         self.launchSurvey('test', 'timeout')
-        time.sleep(2)
+        time.sleep(3)
         self.get(self.last_url)
         self.assertStatusUnauthorised()
 
     def test_schema_defined_timeout_is_used(self):
-        self.launchSurvey('test', 'timeout')
-        self.assertInPage('window.__EQ_SESSION_TIMEOUT__ = 1')
-
-    def test_schema_defined_timeout_cant_be_higher_than_server(self):
         self._application.config['EQ_SESSION_TIMEOUT_SECONDS'] = 10
         self.launchSurvey('test', 'timeout')
         self.assertInPage('window.__EQ_SESSION_TIMEOUT__ = 6')
+
+    def test_schema_defined_timeout_cant_be_higher_than_server(self):
+        self.launchSurvey('test', 'timeout')
+        self.assertInPage('window.__EQ_SESSION_TIMEOUT__ = 2')


### PR DESCRIPTION
### What is the context of this PR?
We do not need to keep all the session data in DynamoDB. If a session hasn't been updated for a set period the session is no longer valid and can be deleted from our table. Currently session is not updated per request hence all users are signed out after the preset 45 minutes.

Issues being addressed:
- `updated_at` time not being updated hence session times out after 45 minutes (current timeout length), regardless of whether you were active or not.
- browser cookie never expires - current expiry time `(1969-12-31T23:59:59.000Z)`

This PR introduces a new column `expires_at` which is used to determine whether a user has a valid session. This column has been introduced to both Postgres and Dynamo to keep the data consistent. For Postgres, a DB migration is required, which will be done through another PR. 

Once the `expires_at` time has passed, the user will be signed out when making the next request, or automatically via the timeout modal (JS) feature. This value is also used to configure [TTL](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html) within DynamoDB, which will delete the data within 48hrs of expiry.

---

To test DynamoDB, provision Dynamo using eq-terraform using the branch `eq-session-ttl-enabled`. Make sure you change the env variable in runner to match your environment eg 
`dev-eq-session` - > `<name>-eq-session`
For context here are my current env settings: https://gist.github.com/MebinAbraham/11160b4daa9163aec1b65ee9cdc46d9f
Toggle: `EQ_SESSION_DYNAMO_WRITE=True` to test between Dynamo/SQLite

To test the changes for Postgres (SQLite locally), you need to alter the table manually. Use contents from PR #1797 to add a new column in SQLite.
`cat database-scripts/pr-1797-apply.sql | sqlite3 /tmp/questionnaire.db`
or just remove the tmp db. `rm /tmp/questionnaire.db`

You can test the expiry by using the `test_timeout.json` schema or by changing these in `settings.py`:
```
EQ_SESSION_TIMEOUT_SECONDS = int(os.getenv('EQ_SESSION_TIMEOUT_SECONDS', str(45 * 60)))
EQ_SESSION_TIMEOUT_GRACE_PERIOD_SECONDS = int(os.getenv('EQ_SESSION_TIMEOUT_GRACE_PERIOD_SECONDS', '5'))
EQ_SESSION_TIMEOUT_PROMPT_SECONDS = int(os.getenv('EQ_SESSION_TIMEOUT_PROMPT_SECONDS', '5'))
```

### How to review 
Test all scenarios that you can think of.
- Ensure user is signed out when their session has expired.
- Ensure the `updated_at` and `expires_at` time is modified with each request.
- Use chrome dev tool to inspect the session cookie to ensure the expiry time is as expected. `(Inspect Element > Application > Cookies > http://localhost:5000 > session > Expires/Max-Age)`

### Expected behaviour
- All new sessions are given an expiration time.
- Once the expiration time has passed, the user is signed out.
- In-flight sessions will not be given an expiration time. (This can be discussed, currently, it won't since the `expires_at` is retrieved from the cookie).
- All requests should be backwards compatible.

Note: I have still have some test to write for the different scenarios but wanted to get some eyes on this.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
