### PR TITLE
Repeat rule check if answer instance is on path

### DIFF
--- a/app/questionnaire/navigation.py
+++ b/app/questionnaire/navigation.py
@@ -4,7 +4,7 @@ from structlog import get_logger
 
 from app.questionnaire.completeness import Completeness
 from app.questionnaire.location import Location
-from app.questionnaire.rules import evaluate_repeat, get_answer_ids_on_routing_path
+from app.questionnaire.rules import evaluate_repeat
 
 logger = get_logger()
 
@@ -81,8 +81,7 @@ class Navigation:
 
     def _build_repeating_navigation(self, repeating_rule, section, current_group_id, current_group_instance):
         groups = section['groups']
-        answer_ids_on_path = get_answer_ids_on_routing_path(self.schema, self.routing_path)
-        no_of_repeats = evaluate_repeat(self.schema, repeating_rule, self.answer_store, answer_ids_on_path)
+        no_of_repeats = evaluate_repeat(repeating_rule, self.answer_store, self.schema, self.routing_path)
 
         repeating_nav = []
         if repeating_rule['type'] == 'answer_count':

--- a/tests/app/questionnaire/test_date_rules.py
+++ b/tests/app/questionnaire/test_date_rules.py
@@ -1,0 +1,145 @@
+from unittest.mock import Mock
+from datetime import datetime
+
+from app.data_model.answer_store import AnswerStore, Answer
+from app.questionnaire.questionnaire_schema import QuestionnaireSchema
+from app.questionnaire.rules import evaluate_date_rule, evaluate_goto
+from tests.app.app_context_test_case import AppContextTestCase
+
+
+def get_schema_mock(answer_is_in_repeating_group=False):
+    schema = QuestionnaireSchema({})
+    schema.answer_is_in_repeating_group = Mock(return_value=answer_is_in_repeating_group)
+    return schema
+
+class TestDateRules(AppContextTestCase):
+
+    def test_evaluate_date_rule_equals_with_value_now(self):
+
+        when = {
+            'id': 'date-answer',
+            'condition': 'equals',
+            'date_comparison': {
+                'value': 'now'
+            }
+        }
+
+        answer_value = datetime.utcnow().strftime('%Y-%m-%d')
+        result = evaluate_date_rule(when, None, get_schema_mock(), 0, None, answer_value)
+        self.assertTrue(result)
+
+        answer_value = '2000-01-01'
+        result = evaluate_date_rule(when, None, get_schema_mock(), 0, None, answer_value)
+        self.assertFalse(result)
+
+    def test_evaluate_date_rule_equals_with_with_offset(self):
+
+        when = {
+            'id': 'date-answer',
+            'condition': 'equals',
+            'date_comparison': {
+                'value': '2019-03-31',
+                'offset_by': {
+                    'days': 1,
+                    'months': 1,
+                    'years': 1
+                }
+            }
+        }
+
+        answer_value = '2020-05-01'
+        result = evaluate_date_rule(when, None, get_schema_mock(), 0, None, answer_value)
+        self.assertTrue(result)
+
+        when = {
+            'id': 'date-answer',
+            'condition': 'equals',
+            'date_comparison': {
+                'value': '2021-04-01',
+                'offset_by': {
+                    'days': -1,
+                    'months': -1,
+                    'years': -1
+                }
+            }
+        }
+
+        answer_value = '2020-02-29'
+        result = evaluate_date_rule(when, None, get_schema_mock(), 0, None, answer_value)
+        self.assertTrue(result)
+
+    def test_evaluate_date_rule_not_equals_with_value_year_month(self):
+
+        when = {
+            'id': 'date-answer',
+            'condition': 'not equals',
+            'date_comparison': {
+                'value': '2018-01'
+            }
+        }
+
+        answer_value = '2018-02'
+        result = evaluate_date_rule(when, None, get_schema_mock(), 0, None, answer_value)
+        self.assertTrue(result)
+
+        answer_value = '2018-01'
+        result = evaluate_date_rule(when, None, get_schema_mock(), 0, None, answer_value)
+        self.assertFalse(result)
+
+    def test_evaluate_date_rule_less_than_meta(self):
+
+        metadata = {'return_by': '2016-06-12'}
+        when = {
+            'id': 'date-answer',
+            'condition': 'less than',
+            'date_comparison': {
+                'meta': 'return_by'
+            }
+        }
+
+        answer_value = '2016-06-11'
+        result = evaluate_date_rule(when, None, get_schema_mock(), 0, metadata, answer_value)
+        self.assertTrue(result)
+
+        answer_value = '2016-06-12'
+        result = evaluate_date_rule(when, None, get_schema_mock(), 0, metadata, answer_value)
+        self.assertFalse(result)
+
+    def test_evaluate_date_rule_greater_than_with_id(self):
+
+        when = {
+            'id': 'date-answer',
+            'condition': 'greater than',
+            'date_comparison': {
+                'id': 'compare_date_answer'
+            }
+        }
+
+        answer_store = AnswerStore({})
+        answer_store.add(Answer(answer_id='compare_date_answer', value='2018-02-03'))
+
+        answer_value = '2018-02-04'
+        result = evaluate_date_rule(when, answer_store, get_schema_mock(), 0, None, answer_value)
+        self.assertTrue(result)
+
+        answer_value = '2018-02-03'
+        result = evaluate_date_rule(when, answer_store, get_schema_mock(), 0, None, answer_value)
+        self.assertFalse(result)
+
+    def test_do_not_go_to_next_question_for_date_answer(self):
+
+        goto_rule = {
+            'id': 'next-question',
+            'when': [{
+                'id': 'date-answer',
+                'condition': 'equals',
+                'date_comparison': {
+                    'value': '2018-01'
+                }
+            }]
+        }
+
+        answer_store = AnswerStore({})
+        answer_store.add(Answer(answer_id='date_answer', value='2018-02-01'))
+
+        self.assertFalse(evaluate_goto(goto_rule, get_schema_mock(), {}, answer_store, 0))

--- a/tests/app/questionnaire/test_path_finder.py
+++ b/tests/app/questionnaire/test_path_finder.py
@@ -715,9 +715,9 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         answer_store = AnswerStore()
 
         # Set up some first names
-        answer_store.add(Answer(answer_id='first-name', value='aaa', group_instance=0, group_instance_id='group-1-0'))
-        answer_store.add(Answer(answer_id='first-name', value='bbb', group_instance=1, group_instance_id='group-1-1'))
-        answer_store.add(Answer(answer_id='first-name', value='ccc', group_instance=2, group_instance_id='group-1-2'))
+        answer_store.add(Answer(answer_id='first-name', value='aaa', answer_instance=0, group_instance_id='group-1-0'))
+        answer_store.add(Answer(answer_id='first-name', value='bbb', answer_instance=1, group_instance_id='group-1-1'))
+        answer_store.add(Answer(answer_id='first-name', value='ccc', answer_instance=2, group_instance_id='group-1-2'))
 
         # Set up the independent answer
         answer_store.add(Answer(answer_id='an-independent-answer', value=independent_answer, group_instance=0, group_instance_id='group-1-0'))
@@ -763,10 +763,10 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
 
                 # Set up some first names
 
-                answer_store.add(Answer(answer_id='first-name', value='aaa', group_instance=0, group_instance_id='group-1-0'))
-                answer_store.add(Answer(answer_id='first-name', value='bbb', group_instance=1, group_instance_id='group-1-1'))
-                answer_store.add(Answer(answer_id='first-name', value='ccc', group_instance=2, group_instance_id='group-1-2'))
-                answer_store.add(Answer(answer_id='first-name', value='ddd', group_instance=3, group_instance_id='group-1-3'))
+                answer_store.add(Answer(answer_id='first-name', value='aaa', answer_instance=0, group_instance_id='group-1-0'))
+                answer_store.add(Answer(answer_id='first-name', value='bbb', answer_instance=1, group_instance_id='group-1-1'))
+                answer_store.add(Answer(answer_id='first-name', value='ccc', answer_instance=2, group_instance_id='group-1-2'))
+                answer_store.add(Answer(answer_id='first-name', value='ddd', answer_instance=3, group_instance_id='group-1-3'))
 
                 # Now set a date of birth for the two group instances
 


### PR DESCRIPTION
### What is the context of this PR?
Previously it was only checking if an answer id was on the routing path. Now we check if that instance of an answer is on the path

### How to review 
run `test_routing_repeat_until.json` add 2 additional people then press the browser back and say no additional people to essentially orphan the last person in the answer store.
In the next group it should not ask the sex of the orphaned person.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
