### PR TITLE
Match long/short units for answer labels and summary screen

### DIFF
--- a/app/templates/partials/summary/unit.html
+++ b/app/templates/partials/summary/unit.html
@@ -1,1 +1,1 @@
-{{ format_unit(answer.unit, answer.value) }}
+{{ format_unit(answer.unit, answer.value, answer.unit_length) }}

--- a/app/templating/summary/answer.py
+++ b/app/templating/summary/answer.py
@@ -6,6 +6,7 @@ class Answer:
         self.value = answer
         self.type = answer_schema['type'].lower()
         self.unit = answer_schema.get('unit')
+        self.unit_length = answer_schema.get('unit_length')
         self.parent_answer_id = answer_schema.get('parent_answer_id')
         self.child_answer_value = child_answer_value
         self.currency = answer_schema.get('currency')
@@ -17,6 +18,7 @@ class Answer:
             'value': self.value,
             'type': self.type,
             'unit': self.unit,
+            'unit_length': self.unit_length,
             'parent_answer_id': self.parent_answer_id,
             'child_answer_value': self.child_answer_value,
             'currency': self.currency,

--- a/app/templating/view_context.py
+++ b/app/templating/view_context.py
@@ -287,6 +287,7 @@ def _get_formatted_total(groups):
                         answer_format = {
                             'type': answer['type'],
                             'unit': answer.get('unit'),
+                            'unit_length': answer.get('unit_length'),
                             'currency': answer.get('currency'),
                         }
                     answer_value = answer.get('value') or 0
@@ -296,7 +297,7 @@ def _get_formatted_total(groups):
         return get_formatted_currency(calculated_total, answer_format['currency'])
 
     if answer_format['type'] == 'unit':
-        return format_unit(answer_format['unit'], calculated_total)
+        return format_unit(answer_format['unit'], calculated_total, answer_format['unit_length'])
 
     if answer_format['type'] == 'percentage':
         return format_percentage(calculated_total)

--- a/data/en/lms_2.json
+++ b/data/en/lms_2.json
@@ -4034,7 +4034,7 @@
                         "id": "one-job-hours-totalized-w13",
                         "type": "CalculatedSummary",
                         "titles": [{
-                                "value": "We calculate the total number of hours that <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}</em> worked in their job, including overtime, to be %(total)s hours for the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}. Is this correct? ",
+                                "value": "We calculate the total number of hours that <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}</em> worked in their job, including overtime, to be %(total)s for the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}. Is this correct? ",
                                 "when": [{
                                     "id": "proxy-check-answer",
                                     "condition": "equals",
@@ -4042,7 +4042,7 @@
                                 }]
                             },
                             {
-                                "value": "We calculate the total number of hours that you worked in your job, including overtime, to be %(total)s hours for the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}. Is this correct? "
+                                "value": "We calculate the total number of hours that you worked in your job, including overtime, to be %(total)s for the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}. Is this correct? "
                             }
                         ],
                         "calculation": {


### PR DESCRIPTION
### What is the context of this PR?
https://trello.com/c/s5ItB4Z9/2430-display-hours-instead-of-hrs-in-lms-summary-page

The answer labels were showing 'Hours' but the summary page was showing 'Hrs'.  This PR makes all of them show the long form.
Additionally, the text on the summary was showing '100 hours hours' in the question as the total is the formatted version of the total now that hours is a unit instead of a number.  I updated the schema to tidy this up also and raised another card to look into it as this issue makes translation more difficult.

The 'unit_length' was added to the answer because the summary uses answers for population, and it doesn't know about the unit length defined in the schema.

This change affects all surveys with a unit type in it, though only `lms_2.json` has units that in long form, all the others are short.  Regardless, it would be prudent to check them to ensure that both the answer label and summary screen text is both correct and consistent

### How to review 
Fill out the `lms_2.json` schema up until the calculated summary page for the work/jobs section.  Every answer field that asks for hours should be 'Hours' and every field in the summary should read 'Hours' also.
Additionally, test other surveys that have a unit type.  Only duration-hour and duration-year have long unit lengths, everything else should still have short labels for both their answer label and summary text.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
