### PR TITLE
Ensure not set and set conditions work on empty lists

### DIFF
--- a/app/questionnaire/rules.py
+++ b/app/questionnaire/rules.py
@@ -73,9 +73,9 @@ def evaluate_condition(condition, answer_value, match_value):
     elif condition == 'not contains' and isinstance(answer_value, list) and match_value not in answer_value:
         result = True
     elif condition == 'set':
-        result = answer_value is not None
+        result = answer_value is not None and answer_value != []
     elif condition == 'not set':
-        result = answer_value is None
+        result = answer_value is None or answer_value == []
     elif condition == 'greater than' and answer_and_match and answer_value > match_value:
         result = True
     elif condition == 'less than' and answer_and_match and answer_value < match_value:

--- a/data/en/test_routing_checkbox_set_not_set.json
+++ b/data/en/test_routing_checkbox_set_not_set.json
@@ -1,0 +1,157 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.2",
+    "data_version": "0.0.2",
+    "survey_id": "0",
+    "title": "Other input fields",
+    "theme": "default",
+    "description": "A questionnaire to demo checkbox field Other input.",
+    "metadata": [{
+        "name": "user_id",
+        "validator": "string"
+    }, {
+        "name": "period_id",
+        "validator": "string"
+    }, {
+        "name": "ru_name",
+        "validator": "string"
+    }],
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "blocks": [{
+                    "type": "Question",
+                    "id": "topping-checkbox",
+                    "description": "",
+                    "questions": [{
+                        "answers": [{
+                            "id": "topping-checkbox-answer",
+                            "label": "",
+                            "mandatory": false,
+                            "options": [{
+                                "label": "None",
+                                "value": "None"
+                            }, {
+                                "label": "Cheese",
+                                "value": "Cheese"
+                            }, {
+                                "label": "Ham",
+                                "value": "Ham"
+                            }, {
+                                "label": "Pineapple",
+                                "value": "Pineapple"
+                            }, {
+                                "label": "Tuna",
+                                "value": "Tuna"
+                            }, {
+                                "label": "Pepperoni",
+                                "value": "Pepperoni"
+                            }, {
+                                "label": "Other",
+                                "value": "Other",
+                                "description": "Choose any other topping",
+                                "child_answer_id": "other-answer-topping"
+                            }],
+                            "type": "Checkbox",
+                            "validation": {
+                                "messages": {}
+                            }
+                        }, {
+                            "parent_answer_id": "topping-checkbox-answer",
+                            "mandatory": false,
+                            "id": "other-answer-topping",
+                            "label": "Please specify other",
+                            "type": "TextField"
+                        }],
+                        "description": "",
+                        "id": "topping-checkbox-question",
+                        "title": "What extra toppings would you like?",
+                        "type": "General"
+                    }],
+                    "title": "Topping question",
+                    "routing_rules": []
+                },
+                {
+                    "id": "topping-interstitial-set",
+                    "title": "Topping Interstitial Page",
+                    "description": "You selected a topping",
+                    "type": "Interstitial",
+                    "skip_conditions": [{
+                        "when": [{
+                            "id": "topping-checkbox-answer",
+                            "condition": "not set"
+                        }]
+                    }]
+                },
+                {
+                    "id": "topping-interstitial-not-set",
+                    "title": "Topping Interstitial Page",
+                    "description": "You did not select a topping",
+                    "type": "Interstitial",
+                    "skip_conditions": [{
+                        "when": [{
+                            "id": "topping-checkbox-answer",
+                            "condition": "set"
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "optional-mutually-exclusive",
+                    "questions": [{
+                        "answers": [{
+                            "id": "optional-mutually-exclusive-answer",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Cheddar",
+                                    "value": "Cheddar"
+                                },
+                                {
+                                    "label": "Mozzarella",
+                                    "value": "Mozzarella"
+                                },
+                                {
+                                    "label": "I don't like cheese",
+                                    "value": "No cheese"
+                                }
+                            ],
+                            "type": "MutuallyExclusiveCheckbox"
+                        }],
+                        "id": "optional-mutually-exclusive-question",
+                        "title": "What is your favourite cheese?",
+                        "type": "General"
+                    }],
+                    "title": "Optional question"
+                },
+                {
+                    "id": "cheese-interstitial-set",
+                    "title": "Cheese Interstitial Page",
+                    "description": "You selected an option for the cheese question",
+                    "type": "Interstitial",
+                    "skip_conditions": [{
+                        "when": [{
+                            "id": "optional-mutually-exclusive-answer",
+                            "condition": "not set"
+                        }]
+                    }]
+                }, {
+                    "id": "cheese-interstitial-not-set",
+                    "title": "Cheese Interstitial Page",
+                    "description": "You did not select an option for the cheese question",
+                    "type": "Interstitial",
+                    "skip_conditions": [{
+                        "when": [{
+                            "id": "optional-mutually-exclusive-answer",
+                            "condition": "set"
+                        }]
+                    }]
+                }, {
+                    "type": "Summary",
+                    "id": "summary"
+                }
+            ],
+            "id": "checkboxes",
+            "title": ""
+        }]
+    }]
+}

--- a/tests/app/questionnaire/test_rules.py
+++ b/tests/app/questionnaire/test_rules.py
@@ -86,6 +86,34 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         self.assertFalse(evaluate_rule(when, ''))
         self.assertFalse(evaluate_rule(when, 'some text'))
 
+    def test_evaluate_rule_not_set_on_empty_list_should_be_true(self):
+        when = {
+            'condition': 'not set'
+        }
+
+        self.assertTrue(evaluate_rule(when, []))
+
+    def test_evaluate_rule_not_set_on_list_with_data_should_be_false(self):
+        when = {
+            'condition': 'not set'
+        }
+
+        self.assertFalse(evaluate_rule(when, ['123']))
+
+    def test_evaluate_rule_set_on_list_with_data_should_be_true(self):
+        when = {
+            'condition': 'set'
+        }
+
+        self.assertTrue(evaluate_rule(when, ['123']))
+
+    def test_evaluate_rule_set_on_empty_list_should_be_false(self):
+        when = {
+            'condition': 'set'
+        }
+
+        self.assertFalse(evaluate_rule(when, []))
+
     def test_evaluate_rule_equals_with_number(self):
         when = {
             'value': 0,

--- a/tests/functional/pages/features/routing/set_not_set/checkbox/cheese-interstitial-not-set.page.js
+++ b/tests/functional/pages/features/routing/set_not_set/checkbox/cheese-interstitial-not-set.page.js
@@ -1,0 +1,11 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../../surveys/question.page');
+
+class CheeseInterstitialNotSetPage extends QuestionPage {
+
+  constructor() {
+    super('cheese-interstitial-not-set');
+  }
+
+}
+module.exports = new CheeseInterstitialNotSetPage();

--- a/tests/functional/pages/features/routing/set_not_set/checkbox/cheese-interstitial-set.page.js
+++ b/tests/functional/pages/features/routing/set_not_set/checkbox/cheese-interstitial-set.page.js
@@ -1,0 +1,11 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../../surveys/question.page');
+
+class CheeseInterstitialSetPage extends QuestionPage {
+
+  constructor() {
+    super('cheese-interstitial-set');
+  }
+
+}
+module.exports = new CheeseInterstitialSetPage();

--- a/tests/functional/pages/features/routing/set_not_set/checkbox/optional-mutually-exclusive.page.js
+++ b/tests/functional/pages/features/routing/set_not_set/checkbox/optional-mutually-exclusive.page.js
@@ -1,0 +1,29 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../../surveys/question.page');
+
+class OptionalMutuallyExclusivePage extends QuestionPage {
+
+  constructor() {
+    super('optional-mutually-exclusive');
+  }
+
+  cheddar() {
+    return '#optional-mutually-exclusive-answer-0';
+  }
+
+  cheddarLabel() { return '#label-optional-mutually-exclusive-answer-0'; }
+
+  mozzarella() {
+    return '#optional-mutually-exclusive-answer-1';
+  }
+
+  mozzarellaLabel() { return '#label-optional-mutually-exclusive-answer-1'; }
+
+  noCheese() {
+    return '#optional-mutually-exclusive-answer-2';
+  }
+
+  noCheeseLabel() { return '#label-optional-mutually-exclusive-answer-2'; }
+
+}
+module.exports = new OptionalMutuallyExclusivePage();

--- a/tests/functional/pages/features/routing/set_not_set/checkbox/summary.page.js
+++ b/tests/functional/pages/features/routing/set_not_set/checkbox/summary.page.js
@@ -1,0 +1,21 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../../surveys/question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  otherAnswerTopping() { return '#other-answer-topping-answer'; }
+
+  otherAnswerToppingEdit() { return '[data-qa="other-answer-topping-edit"]'; }
+
+  optionalMutuallyExclusiveAnswer() { return '#optional-mutually-exclusive-answer-answer'; }
+
+  optionalMutuallyExclusiveAnswerEdit() { return '[data-qa="optional-mutually-exclusive-answer-edit"]'; }
+
+  checkboxesTitle() { return '#checkboxes'; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/pages/features/routing/set_not_set/checkbox/topping-checkbox.page.js
+++ b/tests/functional/pages/features/routing/set_not_set/checkbox/topping-checkbox.page.js
@@ -1,0 +1,57 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../../surveys/question.page');
+
+class ToppingCheckboxPage extends QuestionPage {
+
+  constructor() {
+    super('topping-checkbox');
+  }
+
+  none() {
+    return '#topping-checkbox-answer-0';
+  }
+
+  noneLabel() { return '#label-topping-checkbox-answer-0'; }
+
+  cheese() {
+    return '#topping-checkbox-answer-1';
+  }
+
+  cheeseLabel() { return '#label-topping-checkbox-answer-1'; }
+
+  ham() {
+    return '#topping-checkbox-answer-2';
+  }
+
+  hamLabel() { return '#label-topping-checkbox-answer-2'; }
+
+  pineapple() {
+    return '#topping-checkbox-answer-3';
+  }
+
+  pineappleLabel() { return '#label-topping-checkbox-answer-3'; }
+
+  tuna() {
+    return '#topping-checkbox-answer-4';
+  }
+
+  tunaLabel() { return '#label-topping-checkbox-answer-4'; }
+
+  pepperoni() {
+    return '#topping-checkbox-answer-5';
+  }
+
+  pepperoniLabel() { return '#label-topping-checkbox-answer-5'; }
+
+  other() {
+    return '#topping-checkbox-answer-6';
+  }
+
+  otherLabel() { return '#label-topping-checkbox-answer-6'; }
+
+  otherText() {
+    return '#other-answer-topping';
+  }
+
+}
+module.exports = new ToppingCheckboxPage();

--- a/tests/functional/pages/features/routing/set_not_set/checkbox/topping-interstitial-not-set.page.js
+++ b/tests/functional/pages/features/routing/set_not_set/checkbox/topping-interstitial-not-set.page.js
@@ -1,0 +1,11 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../../surveys/question.page');
+
+class ToppingInterstitialNotSetPage extends QuestionPage {
+
+  constructor() {
+    super('topping-interstitial-not-set');
+  }
+
+}
+module.exports = new ToppingInterstitialNotSetPage();

--- a/tests/functional/pages/features/routing/set_not_set/checkbox/topping-interstitial-set.page.js
+++ b/tests/functional/pages/features/routing/set_not_set/checkbox/topping-interstitial-set.page.js
@@ -1,0 +1,11 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../../surveys/question.page');
+
+class ToppingInterstitialSetPage extends QuestionPage {
+
+  constructor() {
+    super('topping-interstitial-set');
+  }
+
+}
+module.exports = new ToppingInterstitialSetPage();

--- a/tests/functional/spec/features/routing/checkbox_set_not_set_routing.spec.js
+++ b/tests/functional/spec/features/routing/checkbox_set_not_set_routing.spec.js
@@ -1,0 +1,53 @@
+const helpers = require('../../../helpers');
+
+const ToppingCheckboxPage = require('../../../pages/features/routing/set_not_set/checkbox/topping-checkbox.page.js');
+const ToppingInterstitialNotSetPage = require('../../../pages/features/routing/set_not_set/checkbox/topping-interstitial-not-set.page.js');
+const ToppingInterstitialSetPage = require('../../../pages/features/routing/set_not_set/checkbox/topping-interstitial-set.page.js');
+const OptionalMutuallyExclusivePage = require('../../../pages/features/routing/set_not_set/checkbox/optional-mutually-exclusive.page.js');
+const CheeseInterstitialNotSetPage = require('../../../pages/features/routing/set_not_set/checkbox/cheese-interstitial-not-set.page.js');
+const CheeseInterstitialSetPage = require('../../../pages/features/routing/set_not_set/checkbox/cheese-interstitial-set.page.js');
+const SummaryPage = require('../../../pages/features/routing/set_not_set/checkbox/summary.page.js');
+
+describe('Test routing using not set and set conditions on checkboxes', function() {
+
+  beforeEach(function() {
+    return helpers.openQuestionnaire('test_routing_checkbox_set_not_set.json');
+  });
+
+  it('Given a user sets a topping and a cheese, they should see an interstitial for each saying that they were set', function() {
+      return browser
+        .click(ToppingCheckboxPage.cheese())
+        .click(ToppingCheckboxPage.submit())
+
+        .getUrl().should.eventually.contain(ToppingInterstitialSetPage.pageName)
+
+        .click(ToppingInterstitialSetPage.submit())
+
+        .click(OptionalMutuallyExclusivePage.noCheese())
+        .click(OptionalMutuallyExclusivePage.submit())
+
+        .getUrl().should.eventually.contain(CheeseInterstitialSetPage.pageName)
+
+        .click(CheeseInterstitialSetPage.submit())
+
+        .getUrl().should.eventually.contain(SummaryPage.pageName);
+  });
+
+  it('Given a user does not set a topping and does not set a cheese, they should see an interstitial for each saying that they were not set', function() {
+      return browser
+        .click(ToppingCheckboxPage.submit())
+
+        .getUrl().should.eventually.contain(ToppingInterstitialNotSetPage.pageName)
+
+        .click(ToppingInterstitialNotSetPage.submit())
+
+        .click(OptionalMutuallyExclusivePage.submit())
+
+        .getUrl().should.eventually.contain(CheeseInterstitialNotSetPage.pageName)
+
+        .click(CheeseInterstitialNotSetPage.submit())
+
+        .getUrl().should.eventually.contain(SummaryPage.pageName);
+  });
+});
+


### PR DESCRIPTION
### What is the context of this PR?
LMS does routing based on a MutuallyExclusive answer not being set.

MutuallyExclusive uses SelectMultipleField from wtforms, and that will return an empty list if no options are select.

The `not set` and `set` rules currently compare to `None` which won't work for these questions.

We could alternatively override the SelectMultipleField from wtforms, but checking for an empty list seems better for the moment.

### How to review 

test_routing_checkbox_set_not_set will skip interstitials after each question depending on whether you answer the question.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
