### PR TITLE
Fix summary alignment with empty title

### DIFF
--- a/app/templates/partials/summary/summary.html
+++ b/app/templates/partials/summary/summary.html
@@ -6,6 +6,8 @@
             {%- if group.title -%}
                 <h2 class="summary__title neptune" id="{{ group.id }}">{{ group.title }}</h2>
                 <div class="summary__block u-mb-l">
+            {%- elif loop.first -%}
+                <div class="summary__block u-mb-l">
             {%- endif -%}
 
                 {%- for block in group.blocks -%}


### PR DESCRIPTION
### What is the context of this PR?
Alignment of button on summary with no group title was on the wrong side. 

This change matches the closing if statement with the opening one in the summary template to ensure we always have matching `<div>` and `</div>`

### How to review 

checkbox_mutually_exclusive is an easy test to ensure the buttons are on the left side.
Should also check repeat_until_summaries to ensure nothing has been broken.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
