### PR TITLE
Fix summary context repeating groups

### DIFF
--- a/app/templates/partials/summary/summary.html
+++ b/app/templates/partials/summary/summary.html
@@ -2,7 +2,7 @@
     {%- if content.summary.collapsible -%}
         {%- include 'partials/summary/collapsible-summary.html' -%}
     {%- else -%}
-        {%- for group in content.summary.groups -%}
+        {%- for group in content.summary.groups if group.blocks -%}
             {%- if group.title -%}
                 <h2 class="summary__title neptune" id="{{ group.id }}">{{ group.title }}</h2>
                 <div class="summary__block u-mb-l">
@@ -26,7 +26,7 @@
                 {%- if content.summary.summary_type == 'CalculatedSummary' -%}
                     {%- include theme(['partials/summary/calculated-summary-answer.html']) -%}
                 {%- endif -%}
-            {%- if loop.last or loop.nextitem.title-%}
+            {%- if loop.last or loop.nextitem.title -%}
                 </div>
             {%- endif -%}
         {%- endfor -%}

--- a/app/templating/summary_context.py
+++ b/app/templating/summary_context.py
@@ -31,8 +31,7 @@ def build_summary_rendering_context(schema, sections, answer_store, metadata, sc
             repeating_groups = []
             for instance_idx in range(0, no_of_repeats):
                 summary_group = Group(group, path, answer_store, metadata, schema, instance_idx, schema_context).serialize()
-                if summary_group['blocks']:
-                    repeating_groups.extend([summary_group])
+                repeating_groups.append(summary_group)
             groups.extend(repeating_groups)
 
     return groups

--- a/tests/app/templating/test_summary_context.py
+++ b/tests/app/templating/test_summary_context.py
@@ -363,16 +363,18 @@ class TestRepeatingSummaryContext(TestStandardSummaryContext):
 
         context_summary = context['summary']
 
-        self.assertEqual(len(context_summary['groups']), 3)
+        self.assertEqual(len(context_summary['groups']), 4)
         self.assertTrue('title' in context_summary)
 
         self.assertEqual(context_summary['groups'][0]['title'], 'Your Details')
         self.assertEqual(context_summary['groups'][1]['title'], 'Other Household Members')
         self.assertIsNone(context_summary['groups'][2]['title'])
+        self.assertIsNone(context_summary['groups'][3]['title'])
 
         self.assertEqual(context_summary['groups'][0]['blocks'][0]['questions'][0]['answers'][0]['value'], 'Aaa')
         self.assertEqual(context_summary['groups'][1]['blocks'][0]['questions'][0]['answers'][0]['value'], 'Bbb')
         self.assertEqual(context_summary['groups'][2]['blocks'][0]['questions'][0]['answers'][0]['value'], 'Ccc')
+        self.assertEqual(context_summary['groups'][3]['blocks'], [])
 
 
     def test_build_view_context_for_calculated_summary_for_repeating_group(self):
@@ -405,29 +407,30 @@ class TestRepeatingSummaryContext(TestStandardSummaryContext):
 
         context_summary = context['summary']
 
-        self.assertEqual(len(context_summary['groups']), 6)
+        self.assertEqual(len(context_summary['groups']), 7)
 
         self.assertEqual(context_summary['groups'][0]['title'], 'Your Details')
         self.assertEqual(context_summary['groups'][1]['title'], 'Other Household Members')
         self.assertIsNone(context_summary['groups'][2]['title'])
-        self.assertEqual(context_summary['groups'][3]['title'], 'Aaa')
-        self.assertEqual(context_summary['groups'][4]['title'], 'Bbb')
-        self.assertEqual(context_summary['groups'][5]['title'], 'Ccc')
+        self.assertIsNone(context_summary['groups'][3]['title'])
+        self.assertEqual(context_summary['groups'][4]['title'], 'Aaa')
+        self.assertEqual(context_summary['groups'][5]['title'], 'Bbb')
+        self.assertEqual(context_summary['groups'][6]['title'], 'Ccc')
 
         self.assertEqual(context_summary['groups'][0]['blocks'][0]['questions'][0]['answers'][0]['value'], 'Aaa')
         self.assertEqual(context_summary['groups'][1]['blocks'][0]['questions'][0]['answers'][0]['value'], 'Bbb')
         self.assertEqual(context_summary['groups'][2]['blocks'][0]['questions'][0]['answers'][0]['value'], 'Ccc')
 
-        self.assertEqual(context_summary['groups'][3]['blocks'][0]['questions'][0]['title'].endswith('Aaa'), True)
-        self.assertEqual(context_summary['groups'][4]['blocks'][0]['questions'][0]['title'].endswith('Bbb'), True)
-        self.assertEqual(context_summary['groups'][5]['blocks'][0]['questions'][0]['title'].endswith('Ccc'), True)
+        self.assertEqual(context_summary['groups'][4]['blocks'][0]['questions'][0]['title'].endswith('Aaa'), True)
+        self.assertEqual(context_summary['groups'][5]['blocks'][0]['questions'][0]['title'].endswith('Bbb'), True)
+        self.assertEqual(context_summary['groups'][6]['blocks'][0]['questions'][0]['title'].endswith('Ccc'), True)
 
-        self.assertEqual(context_summary['groups'][3]['blocks'][0]['questions'][0]['answers'][0]['value'], 1)
-        self.assertEqual(context_summary['groups'][3]['blocks'][1]['questions'][0]['answers'][0]['value'], 11)
-        self.assertEqual(context_summary['groups'][4]['blocks'][0]['questions'][0]['answers'][0]['value'], 2)
-        self.assertEqual(context_summary['groups'][4]['blocks'][1]['questions'][0]['answers'][0]['value'], 22)
-        self.assertEqual(context_summary['groups'][5]['blocks'][0]['questions'][0]['answers'][0]['value'], 3)
-        self.assertEqual(context_summary['groups'][5]['blocks'][1]['questions'][0]['answers'][0]['value'], 33)
+        self.assertEqual(context_summary['groups'][4]['blocks'][0]['questions'][0]['answers'][0]['value'], 1)
+        self.assertEqual(context_summary['groups'][4]['blocks'][1]['questions'][0]['answers'][0]['value'], 11)
+        self.assertEqual(context_summary['groups'][5]['blocks'][0]['questions'][0]['answers'][0]['value'], 2)
+        self.assertEqual(context_summary['groups'][5]['blocks'][1]['questions'][0]['answers'][0]['value'], 22)
+        self.assertEqual(context_summary['groups'][6]['blocks'][0]['questions'][0]['answers'][0]['value'], 3)
+        self.assertEqual(context_summary['groups'][6]['blocks'][1]['questions'][0]['answers'][0]['value'], 33)
 
 
 class TestAnswerSummaryContext(TestStandardSummaryContext):


### PR DESCRIPTION
### What is the context of this PR?
We currently don't add any group to the summary context if it doesn't have any blocks in it. 

This was to avoid showing and empty group on the summary. e.g if you only add one person on test_repeat_until_summaries.json. it would show the `Other Household Members` title without any content.

Not adding groups to the summary context causes issues in LMS for instance, when we have one person with 1 job and another with 2 jobs, the first group would not be added to the context (since they don't have any of the `two-job` questions, yet we still reference the context by the group_instance. So in this case there would only be one item in context['summary']['groups'], but we're trying to reference it as if there were 2 items.

I've added a condition to the summary template to avoid showing anything if there are no blocks in the group. 

### How to review 
Check test_repeat_until_summaries does not include any extra titles etc.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
