### PR TITLE
Fix translation for units

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
     - pyenv install --skip-existing
     - pyenv rehash
     - pyenv global $(cat .python-version)
-    - pip install -U pip pipenv wheel
+    - pip install -U pip pipenv==2018.5.18 wheel
     - pipenv install --dev --deploy
     - pipenv check -i '36333 '
 cache:

--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -12,7 +12,6 @@ from jinja2.exceptions import UndefinedError
 from babel import units, numbers
 
 from app.questionnaire.rules import convert_to_datetime
-from app.settings import DEFAULT_LOCALE
 
 blueprint = flask.Blueprint('filters', __name__)
 
@@ -20,7 +19,7 @@ blueprint = flask.Blueprint('filters', __name__)
 @blueprint.app_template_filter()
 def format_number(value):
     if value or value == 0:
-        return numbers.format_decimal(value, locale=DEFAULT_LOCALE)
+        return numbers.format_decimal(value, locale=flask_babel.get_locale())
 
     return ''
 
@@ -34,14 +33,14 @@ def format_currency(context, value, currency='GBP'):
 
 def get_formatted_currency(value, currency='GBP'):
     if value or value == 0:
-        return numbers.format_currency(number=value, currency=currency, locale=DEFAULT_LOCALE)
+        return numbers.format_currency(number=value, currency=currency, locale=flask_babel.get_locale())
 
     return ''
 
 
 @blueprint.app_template_filter()
 def get_currency_symbol(currency='GBP'):
-    return numbers.get_currency_symbol(currency, locale=DEFAULT_LOCALE)
+    return numbers.get_currency_symbol(currency, locale=flask_babel.get_locale())
 
 
 @blueprint.app_template_filter()
@@ -83,7 +82,7 @@ def format_address_list(user_entered_address=None, metadata_address=None):
 
 
 def format_unit(unit, value, length='short'):
-    return units.format_unit(value=value, measurement_unit=unit, length=length, locale=DEFAULT_LOCALE)
+    return units.format_unit(value=value, measurement_unit=unit, length=length, locale=flask_babel.get_locale())
 
 
 def format_unit_input_label(unit, unit_length='short'):
@@ -95,8 +94,8 @@ def format_unit_input_label(unit, unit_length='short'):
     :param (str) unit_length length of unit text, can be one of short/long/narrow
     """
     if unit_length == 'long':
-        return units.format_unit(value=2, measurement_unit=unit, length=unit_length, locale=DEFAULT_LOCALE).replace('2 ', '')
-    return units.format_unit(value='', measurement_unit=unit, length=unit_length, locale=DEFAULT_LOCALE).strip()
+        return units.format_unit(value=2, measurement_unit=unit, length=unit_length, locale=flask_babel.get_locale()).replace('2 ', '')
+    return units.format_unit(value='', measurement_unit=unit, length=unit_length, locale=flask_babel.get_locale()).strip()
 
 
 def format_duration(value):

--- a/app/validation/validators.py
+++ b/app/validation/validators.py
@@ -12,7 +12,6 @@ from wtforms.compat import string_types
 from structlog import get_logger
 
 from app.jinja_filters import format_number, get_formatted_currency
-from app.settings import DEFAULT_LOCALE
 from app.validation.error_messages import error_messages
 from app.questionnaire.rules import convert_to_datetime
 
@@ -28,7 +27,7 @@ class NumberCheck:
 
     def __call__(self, form, field):
         try:
-            Decimal(field.raw_data[0].replace(numbers.get_group_symbol(DEFAULT_LOCALE), ''))
+            Decimal(field.raw_data[0].replace(numbers.get_group_symbol(flask_babel.get_locale()), ''))
         except (ValueError, TypeError, InvalidOperation, AttributeError):
             raise validators.StopValidation(self.message)
 
@@ -131,8 +130,8 @@ class DecimalPlaces:
         self.messages = messages or error_messages
 
     def __call__(self, form, field):
-        data = field.raw_data[0].replace(numbers.get_group_symbol(DEFAULT_LOCALE), '').replace(' ', '')
-        decimal_symbol = numbers.get_decimal_symbol(DEFAULT_LOCALE)
+        data = field.raw_data[0].replace(numbers.get_group_symbol(flask_babel.get_locale()), '').replace(' ', '')
+        decimal_symbol = numbers.get_decimal_symbol(flask_babel.get_locale())
         if data and decimal_symbol in data:
             if self.max_decimals == 0:
                 raise validators.ValidationError(self.messages['INVALID_INTEGER'])

--- a/data/en/test_unit_patterns.json
+++ b/data/en/test_unit_patterns.json
@@ -15,6 +15,9 @@
     }, {
         "name": "ru_name",
         "validator": "string"
+    }, {
+        "name": "language_code",
+        "validator": "string"
     }],
     "sections": [{
         "id": "default-section",

--- a/tests/app/templating/test_summary_context.py
+++ b/tests/app/templating/test_summary_context.py
@@ -1,4 +1,5 @@
 import uuid
+from unittest.mock import Mock, patch
 
 from app.data_model.answer_store import AnswerStore, Answer
 from app.questionnaire.location import Location
@@ -161,6 +162,7 @@ class TestCalculatedSummaryContext(TestStandardSummaryContext):
         }
         self.block_type = 'CalculatedSummary'
 
+    @patch('app.jinja_filters.flask_babel.get_locale', Mock(return_value='en_GB'))
     def test_build_view_context_for_currency_calculated_summary_no_skip(self):
         csrf_token = None
         variables = None
@@ -189,6 +191,7 @@ class TestCalculatedSummaryContext(TestStandardSummaryContext):
         self.assertEqual(context_summary['calculated_question']['answers'][0]['value'], '£27.00')
 
 
+    @patch('app.jinja_filters.flask_babel.get_locale', Mock(return_value='en_GB'))
     def test_build_view_context_for_currency_calculated_summary_with_skip(self):
         csrf_token = None
         variables = None
@@ -218,6 +221,7 @@ class TestCalculatedSummaryContext(TestStandardSummaryContext):
         self.assertEqual(context_summary['calculated_question']['title'], 'Grand total of previous values')
         self.assertEqual(context_summary['calculated_question']['answers'][0]['value'], '£12.00')
 
+    @patch('app.jinja_filters.flask_babel.get_locale', Mock(return_value='en_GB'))
     def test_build_view_context_for_unit_calculated_summary(self):
         csrf_token = None
         variables = None
@@ -270,6 +274,7 @@ class TestCalculatedSummaryContext(TestStandardSummaryContext):
         self.assertEqual(context_summary['calculated_question']['title'], 'Grand total of previous values')
         self.assertEqual(context_summary['calculated_question']['answers'][0]['value'], '20%')
 
+    @patch('app.jinja_filters.flask_babel.get_locale', Mock(return_value='en_GB'))
     def test_build_view_context_for_number_calculated_summary(self):
         csrf_token = None
         variables = None
@@ -377,6 +382,7 @@ class TestRepeatingSummaryContext(TestStandardSummaryContext):
         self.assertEqual(context_summary['groups'][3]['blocks'], [])
 
 
+    @patch('app.jinja_filters.flask_babel.get_locale', Mock(return_value='en_GB'))
     def test_build_view_context_for_calculated_summary_for_repeating_group(self):
         block_type = 'CalculatedSummary'
         schema_context = self.schema_context

--- a/tests/app/test_jinja_filters.py
+++ b/tests/app/test_jinja_filters.py
@@ -27,6 +27,7 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
         self.autoescape_context = Mock(autoescape=True)
         super(TestJinjaFilters, self).setUp()
 
+    @patch('app.jinja_filters.flask_babel.get_locale', Mock(return_value='en_GB'))
     def test_format_currency_for_input(self):
         self.assertEqual(format_currency_for_input('100', 2), '100.00')
         self.assertEqual(format_currency_for_input('100.0', 2), '100.00')
@@ -41,6 +42,7 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
         self.assertEqual(format_currency_for_input(None), '')
         self.assertEqual(format_currency_for_input(Undefined()), '')
 
+    @patch('app.jinja_filters.flask_babel.get_locale', Mock(return_value='en_GB'))
     def test_get_currency_symbol(self):
         self.assertEqual(get_currency_symbol('GBP'), '£')
         self.assertEqual(get_currency_symbol('EUR'), '€')
@@ -48,6 +50,7 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
         self.assertEqual(get_currency_symbol('JPY'), 'JP¥')
         self.assertEqual(get_currency_symbol(''), '')
 
+    @patch('app.jinja_filters.flask_babel.get_locale', Mock(return_value='en_GB'))
     def test_format_currency(self):
         self.assertEqual(format_currency(self.autoescape_context, '11', 'GBP'), "<span class='date'>£11.00</span>")
         self.assertEqual(format_currency(self.autoescape_context, '11.99', 'GBP'), "<span class='date'>£11.99</span>")
@@ -58,6 +61,7 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
         self.assertEqual(format_currency(self.autoescape_context, None), "<span class='date'></span>")
         self.assertEqual(format_currency(self.autoescape_context, Undefined()), "<span class='date'></span>")
 
+    @patch('app.jinja_filters.flask_babel.get_locale', Mock(return_value='en_GB'))
     def test_format_number(self):
         self.assertEqual(format_number(123), '123')
         self.assertEqual(format_number('123.4'), '123.4')
@@ -438,6 +442,7 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
         self.assertEqual(format_number_to_alphabetic_letter(25), 'z')
         self.assertEqual(format_number_to_alphabetic_letter(-1), '')
 
+    @patch('app.jinja_filters.flask_babel.get_locale', Mock(return_value='en_GB'))
     def test_format_unit(self):
         self.assertEqual(format_unit('length-meter', 100), '100 m')
         self.assertEqual(format_unit('length-centimeter', 100), '100 cm')
@@ -458,6 +463,14 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
         self.assertEqual(format_unit('duration-hour', 100, 'long'), '100 hours')
         self.assertEqual(format_unit('duration-year', 100, 'long'), '100 years')
 
+    @patch('app.jinja_filters.flask_babel.get_locale', Mock(return_value='cy'))
+    def test_format_unit_welsh(self):
+        self.assertEqual(format_unit('duration-hour', 100), '100 awr')
+        self.assertEqual(format_unit('duration-year', 100), '100 bl')
+        self.assertEqual(format_unit('duration-hour', 100, 'long'), '100 awr')
+        self.assertEqual(format_unit('duration-year', 100, 'long'), '100 mlynedd')
+
+    @patch('app.jinja_filters.flask_babel.get_locale', Mock(return_value='en_GB'))
     def test_format_unit_input_label(self):
         self.assertEqual(format_unit_input_label('length-meter'), 'm')
         self.assertEqual(format_unit_input_label('length-centimeter'), 'cm')
@@ -478,6 +491,13 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
         self.assertEqual(format_unit_input_label('duration-hour', 'long'), 'hours')
         self.assertEqual(format_unit_input_label('duration-year'), 'yr')
         self.assertEqual(format_unit_input_label('duration-year', 'long'), 'years')
+
+    @patch('app.jinja_filters.flask_babel.get_locale', Mock(return_value='cy'))
+    def test_format_unit_input_label_welsh(self):
+        self.assertEqual(format_unit_input_label('duration-hour'), 'awr')
+        self.assertEqual(format_unit_input_label('duration-hour', 'long'), 'awr')
+        self.assertEqual(format_unit_input_label('duration-year'), 'bl')
+        self.assertEqual(format_unit_input_label('duration-year', 'long'), 'flynedd')
 
 
     def test_format_year_month_duration(self):

--- a/tests/app/validation/test_number_range_validator.py
+++ b/tests/app/validation/test_number_range_validator.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 from wtforms.validators import ValidationError
 
 from app.jinja_filters import format_number
@@ -10,6 +10,7 @@ from app.data_model.answer_store import Answer, AnswerStore
 
 
 # pylint: disable=no-member
+@patch('app.jinja_filters.flask_babel.get_locale', Mock(return_value='en_GB'))
 class TestNumberRangeValidator(unittest.TestCase):
     """
     Number range validator uses the data, which is already known as integer

--- a/tests/app/validation/test_number_validator.py
+++ b/tests/app/validation/test_number_validator.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 from wtforms.validators import StopValidation, ValidationError
 
 from app.validation.error_messages import error_messages
@@ -9,6 +9,7 @@ from app.data_model.answer_store import AnswerStore
 
 
 # pylint: disable=no-member
+@patch('app.jinja_filters.flask_babel.get_locale', Mock(return_value='en_GB'))
 class TestNumberValidator(unittest.TestCase):
     """
     Number validator uses the raw data from the input, which is in a list

--- a/tests/app/validation/test_sum_check_validator.py
+++ b/tests/app/validation/test_sum_check_validator.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from wtforms.validators import ValidationError
 
@@ -7,6 +7,7 @@ from app.validation.error_messages import error_messages
 from app.validation.validators import SumCheck, format_playback_value
 
 
+@patch('app.jinja_filters.flask_babel.get_locale', Mock(return_value='en_GB'))
 class TestSumCheckValidator(unittest.TestCase):
     """
     Sum check validator evaluates a calculated total against a target total, given a condition

--- a/tests/functional/generate_pages.py
+++ b/tests/functional/generate_pages.py
@@ -73,6 +73,12 @@ ANSWER_GETTER = Template(r"""  ${answerName}() {
 
 """)
 
+ANSWER_UNIT_TYPE_GETTER = Template(r"""  ${answerName}Unit() {
+    return '#${answerId}-type';
+  }
+
+""")
+
 RELATIONSHIP_ANSWER_GETTER = Template(r"""  ${answerName}(instance) {
     return '[name="${answerId}-' + instance + '"]';
   }
@@ -243,6 +249,9 @@ def process_answer(question_type, answer, page_spec, long_names, page_name):
             page_spec.write(ANSWER_GETTER.substitute(answer_context))
             page_spec.write(ANSWER_LABEL_GETTER.substitute(answer_context))
 
+        if answer['type'] == 'Unit':
+            page_spec.write(ANSWER_UNIT_TYPE_GETTER.substitute(answer_context))
+
     else:
         raise Exception('Answer type {} not configured'.format(answer['type']))
 
@@ -313,9 +322,11 @@ def process_summary(schema_data, page_spec):
                         if block['type'] == 'SectionSummary':
                             page_spec.write(SECTION_SUMMARY_ANSWER_GETTER.substitute(answer_context))
                             page_spec.write(SECTION_SUMMARY_ANSWER_EDIT_GETTER.substitute(answer_context))
+
+                        page_spec.write(SUMMARY_ANSWER_GETTER.substitute(answer_context))
+                        page_spec.write(SUMMARY_ANSWER_EDIT_GETTER.substitute(answer_context))
+
                     page_spec.write(SUMMARY_QUESTION_GETTER.substitute(question_context))
-                    page_spec.write(SUMMARY_ANSWER_GETTER.substitute(answer_context))
-                    page_spec.write(SUMMARY_ANSWER_EDIT_GETTER.substitute(answer_context))
 
             group_context = {
                 'group_id_camel': camel_case(generate_pascal_case_from_id(group['id'])),

--- a/tests/functional/pages/features/units/set-area-units-block.page.js
+++ b/tests/functional/pages/features/units/set-area-units-block.page.js
@@ -1,0 +1,71 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class SetAreaUnitsBlockPage extends QuestionPage {
+
+  constructor() {
+    super('set-area-units-block');
+  }
+
+  squareCentimetres() {
+    return '#square-centimetres';
+  }
+
+  squareCentimetresLabel() { return '#label-square-centimetres'; }
+
+  squareCentimetresUnit() {
+    return '#square-centimetres-type';
+  }
+
+  squareMetres() {
+    return '#square-metres';
+  }
+
+  squareMetresLabel() { return '#label-square-metres'; }
+
+  squareMetresUnit() {
+    return '#square-metres-type';
+  }
+
+  squareKilometres() {
+    return '#square-kilometres';
+  }
+
+  squareKilometresLabel() { return '#label-square-kilometres'; }
+
+  squareKilometresUnit() {
+    return '#square-kilometres-type';
+  }
+
+  squareMiles() {
+    return '#square-miles';
+  }
+
+  squareMilesLabel() { return '#label-square-miles'; }
+
+  squareMilesUnit() {
+    return '#square-miles-type';
+  }
+
+  acres() {
+    return '#acres';
+  }
+
+  acresLabel() { return '#label-acres'; }
+
+  acresUnit() {
+    return '#acres-type';
+  }
+
+  hectares() {
+    return '#hectares';
+  }
+
+  hectaresLabel() { return '#label-hectares'; }
+
+  hectaresUnit() {
+    return '#hectares-type';
+  }
+
+}
+module.exports = new SetAreaUnitsBlockPage();

--- a/tests/functional/pages/features/units/set-duration-units-block.page.js
+++ b/tests/functional/pages/features/units/set-duration-units-block.page.js
@@ -1,0 +1,31 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class SetDurationUnitsBlockPage extends QuestionPage {
+
+  constructor() {
+    super('set-duration-units-block');
+  }
+
+  durationHour() {
+    return '#duration-hour';
+  }
+
+  durationHourLabel() { return '#label-duration-hour'; }
+
+  durationHourUnit() {
+    return '#duration-hour-type';
+  }
+
+  durationYear() {
+    return '#duration-year';
+  }
+
+  durationYearLabel() { return '#label-duration-year'; }
+
+  durationYearUnit() {
+    return '#duration-year-type';
+  }
+
+}
+module.exports = new SetDurationUnitsBlockPage();

--- a/tests/functional/pages/features/units/set-length-units-block.page.js
+++ b/tests/functional/pages/features/units/set-length-units-block.page.js
@@ -1,0 +1,51 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class SetLengthUnitsBlockPage extends QuestionPage {
+
+  constructor() {
+    super('set-length-units-block');
+  }
+
+  centimetres() {
+    return '#centimetres';
+  }
+
+  centimetresLabel() { return '#label-centimetres'; }
+
+  centimetresUnit() {
+    return '#centimetres-type';
+  }
+
+  metres() {
+    return '#metres';
+  }
+
+  metresLabel() { return '#label-metres'; }
+
+  metresUnit() {
+    return '#metres-type';
+  }
+
+  kilometres() {
+    return '#kilometres';
+  }
+
+  kilometresLabel() { return '#label-kilometres'; }
+
+  kilometresUnit() {
+    return '#kilometres-type';
+  }
+
+  miles() {
+    return '#miles';
+  }
+
+  milesLabel() { return '#label-miles'; }
+
+  milesUnit() {
+    return '#miles-type';
+  }
+
+}
+module.exports = new SetLengthUnitsBlockPage();

--- a/tests/functional/pages/features/units/set-volume-units-block.page.js
+++ b/tests/functional/pages/features/units/set-volume-units-block.page.js
@@ -1,0 +1,61 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class SetVolumeUnitsBlockPage extends QuestionPage {
+
+  constructor() {
+    super('set-volume-units-block');
+  }
+
+  cubicCentimetres() {
+    return '#cubic-centimetres';
+  }
+
+  cubicCentimetresLabel() { return '#label-cubic-centimetres'; }
+
+  cubicCentimetresUnit() {
+    return '#cubic-centimetres-type';
+  }
+
+  cubicMetres() {
+    return '#cubic-metres';
+  }
+
+  cubicMetresLabel() { return '#label-cubic-metres'; }
+
+  cubicMetresUnit() {
+    return '#cubic-metres-type';
+  }
+
+  litres() {
+    return '#litres';
+  }
+
+  litresLabel() { return '#label-litres'; }
+
+  litresUnit() {
+    return '#litres-type';
+  }
+
+  hectolitres() {
+    return '#hectolitres';
+  }
+
+  hectolitresLabel() { return '#label-hectolitres'; }
+
+  hectolitresUnit() {
+    return '#hectolitres-type';
+  }
+
+  megalitres() {
+    return '#megalitres';
+  }
+
+  megalitresLabel() { return '#label-megalitres'; }
+
+  megalitresUnit() {
+    return '#megalitres-type';
+  }
+
+}
+module.exports = new SetVolumeUnitsBlockPage();

--- a/tests/functional/pages/features/units/summary.page.js
+++ b/tests/functional/pages/features/units/summary.page.js
@@ -1,0 +1,91 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../surveys/question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  centimetres(index = 0) { return '#centimetres-' + index + '-answer'; }
+
+  centimetresEdit(index = 0) { return '[data-qa="centimetres-' + index + '-edit"]'; }
+
+  metres(index = 0) { return '#metres-' + index + '-answer'; }
+
+  metresEdit(index = 0) { return '[data-qa="metres-' + index + '-edit"]'; }
+
+  kilometres(index = 0) { return '#kilometres-' + index + '-answer'; }
+
+  kilometresEdit(index = 0) { return '[data-qa="kilometres-' + index + '-edit"]'; }
+
+  miles(index = 0) { return '#miles-' + index + '-answer'; }
+
+  milesEdit(index = 0) { return '[data-qa="miles-' + index + '-edit"]'; }
+
+  setLengthUnitsQuestion(index = 0) { return '#set-length-units-question-' + index; }
+
+  durationHour(index = 0) { return '#duration-hour-' + index + '-answer'; }
+
+  durationHourEdit(index = 0) { return '[data-qa="duration-hour-' + index + '-edit"]'; }
+
+  durationYear(index = 0) { return '#duration-year-' + index + '-answer'; }
+
+  durationYearEdit(index = 0) { return '[data-qa="duration-year-' + index + '-edit"]'; }
+
+  setDurationUnitsQuestion(index = 0) { return '#set-duration-units-question-' + index; }
+
+  squareCentimetres(index = 0) { return '#square-centimetres-' + index + '-answer'; }
+
+  squareCentimetresEdit(index = 0) { return '[data-qa="square-centimetres-' + index + '-edit"]'; }
+
+  squareMetres(index = 0) { return '#square-metres-' + index + '-answer'; }
+
+  squareMetresEdit(index = 0) { return '[data-qa="square-metres-' + index + '-edit"]'; }
+
+  squareKilometres(index = 0) { return '#square-kilometres-' + index + '-answer'; }
+
+  squareKilometresEdit(index = 0) { return '[data-qa="square-kilometres-' + index + '-edit"]'; }
+
+  squareMiles(index = 0) { return '#square-miles-' + index + '-answer'; }
+
+  squareMilesEdit(index = 0) { return '[data-qa="square-miles-' + index + '-edit"]'; }
+
+  acres(index = 0) { return '#acres-' + index + '-answer'; }
+
+  acresEdit(index = 0) { return '[data-qa="acres-' + index + '-edit"]'; }
+
+  hectares(index = 0) { return '#hectares-' + index + '-answer'; }
+
+  hectaresEdit(index = 0) { return '[data-qa="hectares-' + index + '-edit"]'; }
+
+  setAreaUnitQuestions(index = 0) { return '#set-area-unit-questions-' + index; }
+
+  cubicCentimetres(index = 0) { return '#cubic-centimetres-' + index + '-answer'; }
+
+  cubicCentimetresEdit(index = 0) { return '[data-qa="cubic-centimetres-' + index + '-edit"]'; }
+
+  cubicMetres(index = 0) { return '#cubic-metres-' + index + '-answer'; }
+
+  cubicMetresEdit(index = 0) { return '[data-qa="cubic-metres-' + index + '-edit"]'; }
+
+  litres(index = 0) { return '#litres-' + index + '-answer'; }
+
+  litresEdit(index = 0) { return '[data-qa="litres-' + index + '-edit"]'; }
+
+  hectolitres(index = 0) { return '#hectolitres-' + index + '-answer'; }
+
+  hectolitresEdit(index = 0) { return '[data-qa="hectolitres-' + index + '-edit"]'; }
+
+  megalitres(index = 0) { return '#megalitres-' + index + '-answer'; }
+
+  megalitresEdit(index = 0) { return '[data-qa="megalitres-' + index + '-edit"]'; }
+
+  setVolumeUnitQuestions(index = 0) { return '#set-volume-unit-questions-' + index; }
+
+  testTitle(index = 0) { return '#test-' + index; }
+
+  summaryGroupTitle(index = 0) { return '#summary-group-' + index; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/spec/features/units.js
+++ b/tests/functional/spec/features/units.js
@@ -1,0 +1,44 @@
+const helpers = require('../../helpers');
+
+const SetLengthUnitsBlockPage = require('../../pages/features/units/set-length-units-block.page.js');
+const SetDurationUnitsBlockPage = require('../../pages/features/units/set-duration-units-block.page.js');
+const SetAreaUnitsBlockPage = require('../../pages/features/units/set-area-units-block.page.js');
+const SetVolumeUnitsBlockPage = require('../../pages/features/units/set-volume-units-block.page.js');
+const SummaryPage = require('../../pages/features/units/summary.page.js');
+
+describe('Units', function() {
+
+  it('Given we do not set a language code and run the questionnaire, when we enter values for durations, they should be displayed on the summary with their units.', function() {
+    //return helpers.openQuestionnaire('test_unit_patterns.json').then(() => {
+    return helpers.openQuestionnaire('test_unit_patterns.json', helpers.getRandomString(10), helpers.getRandomString(10), '201605', 'May 2016', 'GB-ENG', 'en').then(() => {
+        return browser
+          .click(SetLengthUnitsBlockPage.submit())
+          .getText(SetDurationUnitsBlockPage.durationHourUnit()).should.eventually.equal('hours')
+          .getText(SetDurationUnitsBlockPage.durationYearUnit()).should.eventually.equal('years')
+          .setValue(SetDurationUnitsBlockPage.durationHour(), 123)
+          .setValue(SetDurationUnitsBlockPage.durationYear(), 321)
+          .click(SetDurationUnitsBlockPage.submit())
+          .click(SetAreaUnitsBlockPage.submit())
+          .click(SetVolumeUnitsBlockPage.submit())
+          .getText(SummaryPage.durationHour()).should.eventually.equal('123 hours')
+          .getText(SummaryPage.durationYear()).should.eventually.equal('321 years');
+        });
+    });
+
+  it('Given we set a language code for welsh and run the questionnaire, when we enter values for durations, they should be displayed on the summary with their units.', function() {
+    return helpers.openQuestionnaire('test_unit_patterns.json', helpers.getRandomString(10), helpers.getRandomString(10), '201605', 'May 2016', 'GB-ENG', 'cy').then(() => {
+        return browser
+          .click(SetLengthUnitsBlockPage.submit())
+          .getText(SetDurationUnitsBlockPage.durationHourUnit()).should.eventually.equal('awr')
+          .getText(SetDurationUnitsBlockPage.durationYearUnit()).should.eventually.equal('flynedd')
+          .setValue(SetDurationUnitsBlockPage.durationHour(), 123)
+          .setValue(SetDurationUnitsBlockPage.durationYear(), 321)
+          .click(SetDurationUnitsBlockPage.submit())
+          .click(SetAreaUnitsBlockPage.submit())
+          .click(SetVolumeUnitsBlockPage.submit())
+          .getText(SummaryPage.durationHour()).should.eventually.equal('123 awr')
+          .getText(SummaryPage.durationYear()).should.eventually.equal('321 mlynedd');
+        });
+    });
+});
+


### PR DESCRIPTION
### What is the context of this PR?
[trello](https://trello.com/c/HWYJdleY/2431-fix-translation-for-units-s)

Remove the hardcoded 'en_GB' locale from calls to babel in jinja filters. Since the flask_babel locale is set in `setup.py` we can use `get_locale` getter to retrieve it.

I've added a functional test for the unit_patterns schema. This required some changes to generate pages to support multiple answers in summaries and to support input unit labels.

### How to review 
You can test this by doing the same thing as the functional tests (running test_unit_patterns.json and changing language_code to `cy`).

Please could someone who speaks welsh ensure that the different versions of 'years' that are shown are actually correct?

This does raise an issue with the pattern library I think in that the `type` shown in the input unit label does not scale with the length of the unit. This becomes apparent with the Welsh word for 'years'.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
