### PR TITLE
Correct footer in social static pages

### DIFF
--- a/app/themes/social/templates/static/contact-us.html
+++ b/app/themes/social/templates/static/contact-us.html
@@ -66,5 +66,5 @@
 </div>
 
 {% block footer %}
-{% include 'partials/footer.html' %}
+{% include theme('partials/footer-transactional.html') %}
 {% endblock %}

--- a/app/themes/social/templates/static/cookies-privacy.html
+++ b/app/themes/social/templates/static/cookies-privacy.html
@@ -321,5 +321,5 @@
 
 
 {% block footer %}
-{% include 'partials/footer.html' %}
+{% include theme('partials/footer-transactional.html') %}
 {% endblock %}


### PR DESCRIPTION
### What is the context of this PR?
"Contact us" and "Cookies and privacy" pages in the social theme had the wrong footer.

### How to review 
Do they now have the smaller footer consistent with the rest of the theme?