### PR TITLE
Remove language_code metadata

### DIFF
--- a/data/en/test_unit_patterns.json
+++ b/data/en/test_unit_patterns.json
@@ -15,9 +15,6 @@
     }, {
         "name": "ru_name",
         "validator": "string"
-    }, {
-        "name": "language_code",
-        "validator": "string"
     }],
     "sections": [{
         "id": "default-section",


### PR DESCRIPTION


### What is the context of this PR?
language_code shouldn't have been added to metadata, it is overriding the language_code we set elsewhere

### How to review 
Check that setting the language under 'Runner Settings' in go launcher changes the language of the units on test_unit_patterns.
### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
