### PR TITLE
Add missing routing to lms

### DIFF
--- a/data/en/lms_2.json
+++ b/data/en/lms_2.json
@@ -3710,31 +3710,27 @@
                                 "goto": {
                                     "block": "two-jobs-j1-usual-hours-w12-1",
                                     "when": [{
-                                            "id": "second-job-answer",
-                                            "condition": "equals",
-                                            "value": "yes"
-                                        },
-                                        {
-                                            "id": "working-days-answer",
-                                            "condition": "contains",
-                                            "value": "did not work this week"
-                                        }
-                                    ]
+                                        "id": "second-job-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }, {
+                                        "id": "working-days-answer",
+                                        "condition": "contains",
+                                        "value": "Did not work this week"
+                                    }]
                                 }
                             },
                             {
                                 "goto": {
                                     "block": "two-jobs-j1-usual-hours-w12-1",
                                     "when": [{
-                                            "id": "second-job-answer",
-                                            "condition": "equals",
-                                            "value": "yes"
-                                        },
-                                        {
-                                            "id": "working-days-answer",
-                                            "condition": "not set"
-                                        }
-                                    ]
+                                        "id": "second-job-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }, {
+                                        "id": "working-days-answer",
+                                        "condition": "not set"
+                                    }]
                                 }
                             },
                             {
@@ -5776,7 +5772,31 @@
                                 "unit_length": "long",
                                 "label": "Usual hours, main job"
                             }]
-                        }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "two-jobs-j2-usual-hours-w12-2",
+                                    "when": [{
+                                        "id": "working-days-answer",
+                                        "condition": "not set"
+                                    }]
+                                }
+                            }, {
+                                "goto": {
+                                    "block": "two-jobs-j2-usual-hours-w12-2",
+                                    "when": [{
+                                        "id": "working-days-answer",
+                                        "condition": "contains",
+                                        "value": "Did not work this week"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "two-jobs-j1-actual-hours-w12-1-1"
+                                }
+                            }
+                        ]
                     },
                     {
                         "id": "two-jobs-j1-actual-hours-w12-1-1",
@@ -5907,7 +5927,92 @@
                                 "unit_length": "long",
                                 "label": "Usual hours, second job"
                             }]
-                        }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "one-job-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "working-days-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "one-job-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "working-days-answer",
+                                            "condition": "contains",
+                                            "value": "did not work this week"
+                                        }
+                                    ]
+                                }
+                            }, {
+                                "goto": {
+                                    "block": "reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "working-days-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "id": "one-job-emp-status-emp-or-self-proxy-answer",
+                                            "condition": "equals",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "working-days-answer",
+                                            "condition": "contains",
+                                            "value": "did not work this week"
+                                        }
+                                    ]
+                                }
+                            }, {
+                                "goto": {
+                                    "block": "reason-why-fewer-hours-than-usual-self-employed-w14-semp",
+                                    "when": [{
+                                        "id": "working-days-answer",
+                                        "condition": "not set"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "reason-why-fewer-hours-than-usual-self-employed-w14-semp",
+                                    "when": [{
+                                        "id": "working-days-answer",
+                                        "condition": "contains",
+                                        "value": "Did not work this week"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "two-jobs-j2-actual-hours-w12-22"
+                                }
+                            }
+                        ]
                     },
                     {
                         "id": "two-jobs-j2-actual-hours-w12-22",


### PR DESCRIPTION
### What is the context of this PR?
[trello](https://trello.com/c/WDSyaNzC/2452-add-missing-routing-to-lms)

### How to review 
My test plan was:
```
Scenario 1
---

1 job, employed, did not work this week, some overtime (of any kind):
    - Go from overtime question to usual hours.
1 job, self-employed, did not work this week, some overtime (of any kind):
    - Go from overtime question to usual hours.

2 jobs, employed, did not work this week, some overtime (of any kind):
    - Go from overtime question to usual hours.
2 jobs, self-employed, did not work this week, some overtime (of any kind):
    - Go from overtime question to usual hours.

Scenario 2
---

1 job, employed in main job, did not work this week:
    - Ask main job usual hours -> why fewer hours than usual (Never ask actual hours)
2 jobs, employed in main job, did not work this week
    - Ask main job usual hours -> second job usual hours -> why fewer hours than usual (Never ask actual hours)

1 job, self-employed in main job, did not work this week:
    - Ask main job usual hours -> why fewer hours than usual (Never ask actual hours)
2 jobs, self-employed in main job, did not work this week
    - Ask main job usual hours -> second job usual hours -> why fewer hours than usual (Never ask actual hours)

Each of the above should probably be checked with proxy set.
```
### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
