### PR TITLE
Fix month and year field invalid date validation

### DIFF
--- a/app/validation/validators.py
+++ b/app/validation/validators.py
@@ -204,10 +204,9 @@ class MonthYearCheck:
     def __call__(self, form, field):
         try:
             datestr = '{}-{:02d}'.format(int(form.year.data or 0), int(form.month.data or 0))
-
             datetime.strptime(datestr, '%Y-%m')
         except ValueError:
-            raise validators.ValidationError(self.message)
+            raise validators.StopValidation(self.message)
 
 
 class YearCheck:

--- a/tests/app/validation/test_month_year_validator.py
+++ b/tests/app/validation/test_month_year_validator.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import Mock
-from wtforms.validators import ValidationError
+from wtforms.validators import StopValidation
 
 from app.validation.error_messages import error_messages
 from app.validation.validators import MonthYearCheck
@@ -16,7 +16,7 @@ class TestMonthYearValidator(unittest.TestCase):
 
         mock_field = Mock()
 
-        with self.assertRaises(ValidationError) as ite:
+        with self.assertRaises(StopValidation) as ite:
             validator(mock_form, mock_field)
 
         self.assertEqual(error_messages['INVALID_DATE'], str(ite.exception))
@@ -31,7 +31,7 @@ class TestMonthYearValidator(unittest.TestCase):
 
         mock_field = Mock()
 
-        with self.assertRaises(ValidationError) as ite:
+        with self.assertRaises(StopValidation) as ite:
             validator(mock_form, mock_field)
 
         self.assertEqual(error_messages['INVALID_DATE'], str(ite.exception))
@@ -45,7 +45,7 @@ class TestMonthYearValidator(unittest.TestCase):
 
         mock_field = Mock()
 
-        with self.assertRaises(ValidationError) as ite:
+        with self.assertRaises(StopValidation) as ite:
             validator(mock_form, mock_field)
 
         self.assertEqual(error_messages['INVALID_DATE'], str(ite.exception))
@@ -59,7 +59,7 @@ class TestMonthYearValidator(unittest.TestCase):
 
         mock_field = Mock()
 
-        with self.assertRaises(ValidationError) as ite:
+        with self.assertRaises(StopValidation) as ite:
             validator(mock_form, mock_field)
 
         self.assertEqual(error_messages['INVALID_DATE'], str(ite.exception))
@@ -73,7 +73,7 @@ class TestMonthYearValidator(unittest.TestCase):
 
         mock_field = Mock()
 
-        with self.assertRaises(ValidationError) as ite:
+        with self.assertRaises(StopValidation) as ite:
             validator(mock_form, mock_field)
 
         self.assertEqual(error_messages['INVALID_DATE'], str(ite.exception))
@@ -87,7 +87,7 @@ class TestMonthYearValidator(unittest.TestCase):
 
         mock_field = Mock()
 
-        with self.assertRaises(ValidationError) as ite:
+        with self.assertRaises(StopValidation) as ite:
             validator(mock_form, mock_field)
 
         self.assertEqual(error_messages['INVALID_DATE'], str(ite.exception))
@@ -103,5 +103,5 @@ class TestMonthYearValidator(unittest.TestCase):
 
         try:
             validator(mock_form, mock_field)
-        except ValidationError:
-            self.fail('Valid date raised ValidationError')
+        except StopValidation:
+            self.fail('Valid date raised StopValidation')

--- a/tests/functional/spec/features/validation/date_validation/date-combined-mm-yyyy.spec.js
+++ b/tests/functional/spec/features/validation/date_validation/date-combined-mm-yyyy.spec.js
@@ -11,6 +11,53 @@ describe('Feature: Combined question level and single validation for MM-YYYY dat
   describe('Period Validation', function () {
     describe('Given I enter dates', function() {
 
+      it('When I enter a month but no year, Then I should see only a single invalid date error', function() {
+        return browser
+         .setValue(DateRangePage.dateRangeFromyear(), 2018)
+
+         .selectByValue(DateRangePage.dateRangeTomonth(), 4)
+         .setValue(DateRangePage.dateRangeToyear(), 2017)
+         .click(DateRangePage.submit())
+         .getText(DateRangePage.errorNumber(1)).should.eventually.contain('Enter a valid date')
+         .isExisting(DateRangePage.errorNumber(2)).should.eventually.be.false;
+      });
+
+      it('When I enter a year but no month, Then I should see only a single invalid date error', function() {
+        return browser
+         .selectByValue(DateRangePage.dateRangeFrommonth(), 10)
+         .setValue(DateRangePage.dateRangeFromyear(), '')
+
+         .selectByValue(DateRangePage.dateRangeTomonth(), 4)
+         .setValue(DateRangePage.dateRangeToyear(), 2017)
+         .click(DateRangePage.submit())
+         .getText(DateRangePage.errorNumber(1)).should.eventually.contain('Enter a valid date')
+         .isExisting(DateRangePage.errorNumber(2)).should.eventually.be.false;
+      });
+
+      it('When I enter a year of 0, Then I should see only a single invalid date error', function() {
+        return browser
+         .selectByValue(DateRangePage.dateRangeFrommonth(), 10)
+         .setValue(DateRangePage.dateRangeFromyear(), 0)
+
+         .selectByValue(DateRangePage.dateRangeTomonth(), 4)
+         .setValue(DateRangePage.dateRangeToyear(), 2017)
+         .click(DateRangePage.submit())
+         .getText(DateRangePage.errorNumber(1)).should.eventually.contain('Enter a valid date')
+         .isExisting(DateRangePage.errorNumber(2)).should.eventually.be.false;
+      });
+
+      it('When I enter a year that contains more than 4 characters, Then I should see only a single invalid date error', function() {
+        return browser
+         .selectByValue(DateRangePage.dateRangeFrommonth(), 10)
+         .setValue(DateRangePage.dateRangeFromyear(), 10001)
+
+         .selectByValue(DateRangePage.dateRangeTomonth(), 4)
+         .setValue(DateRangePage.dateRangeToyear(), 2017)
+         .click(DateRangePage.submit())
+         .getText(DateRangePage.errorNumber(1)).should.eventually.contain('Enter a valid date')
+         .isExisting(DateRangePage.errorNumber(2)).should.eventually.be.false;
+      });
+
       it('When I enter a single dates that are too early/late, Then I should see a single validation errors', function() {
         return browser
          .selectByValue(DateRangePage.dateRangeFrommonth(), 10)


### PR DESCRIPTION
### What is the context of this PR?
https://trello.com/c/T7WMTEI6/2440-eq-survey-runner-1805-month-and-year-field-invalid-date-validation-not-working-as-expected-issue

Fixes:
https://github.com/ONSdigital/eq-survey-runner/issues/1805
https://github.com/ONSdigital/eq-survey-runner/issues/1749

When an invalid date was provided, it would do ALL the possible validation on the date, even if the date was in a nonsensical format.  This PR stops the validation chain as soon as we realise we don't have a valid date.


### How to review 
Using `test_date_validation_mm_yyyy_combined.json`, fill in the following combinations, they should all only have 1 error message per field:

- Empty month, valid year (eg 2017)
- Empty year, any month
- any month, 0 year
- any month, 5+ character year (eg 12345)


### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
