### PR TITLE
Fix helper macros not working as expected

### DIFF
--- a/app/templates/introduction.html
+++ b/app/templates/introduction.html
@@ -32,9 +32,9 @@
 
                 </h2>
 
-                <p class="mars">{{ _("If the company details or structure have changed contact us on %(telephone_number)s or email %(email_address)s",
+                <p class="mars" data-qa="details-changed-title">{{ _("If the company details or structure have changed contact us on %(telephone_number)s or email %(email_address)s",
                         telephone_number = helpers.telephone_number(),
-                        email_address = helpers.email_address('details-changed-title', subject="Change of details reference " + metadata.ru_ref)
+                        email_address = helpers.email_address(aria_describedby='details-changed-title', subject="Change of details reference " + metadata.ru_ref)
                     ) }}
                 </p>
 

--- a/app/templates/layouts/_error.html
+++ b/app/templates/layouts/_error.html
@@ -14,7 +14,7 @@
         {%- endfor -%}
       </ul>
     {%- endif -%}
-    <p class="u-mb-no">{{ _("If the problem continues please call %(tel_num)s", tel_num = helpers.telephone_number('survey-help')) }}</p>
+    <p class="u-mb-no">{{ _("If the problem continues please call %(tel_num)s", tel_num = helpers.telephone_number(aria_describedby='survey-help')) }}</p>
   </div>
 
   {{answer_guidance}}

--- a/app/themes/northernireland/templates/introduction.html
+++ b/app/themes/northernireland/templates/introduction.html
@@ -26,7 +26,7 @@
                         {{ _("You are completing this for <span>%(ru_name)s</span>", ru_name = metadata.ru_name) }}
                     {% endif %}
 
-                <p class="mars">If the company details or structure have changed contact us on {{ helpers.telephone_number() }} or email {{ helpers.email_address('details-changed-title', subject="Change of details reference " + metadata.ru_ref) }}.
+                <p class="mars">If the company details or structure have changed contact us on {{ helpers.telephone_number() }} or email {{ helpers.email_address(aria-describedby='details-changed-title', subject="Change of details reference " + metadata.ru_ref) }}.
                 </p>
 
             </div>

--- a/tests/functional/pages/introduction.page.js
+++ b/tests/functional/pages/introduction.page.js
@@ -34,6 +34,9 @@ class IntroductionPage extends BasePage {
     return '[data-qa="intro-basic-description"]';
   }
 
+  introTitleDescription() {
+    return '[data-qa="details-changed-title"]';
+  }
 }
 
 module.exports = new IntroductionPage();

--- a/tests/functional/spec/introduction.spec.js
+++ b/tests/functional/spec/introduction.spec.js
@@ -13,7 +13,8 @@ describe('Introduction page', function() {
         .getText(IntroductionPage.useOfInformation()).should.eventually.contain('What you need to do next')
         .getText(IntroductionPage.legalResponse()).should.eventually.contain('Your response is legally required')
         .getText(IntroductionPage.legalBasis()).should.eventually.contain('Notice is given under section 999 of the Test Act 2000')
-        .getText(IntroductionPage.introDescription()).should.eventually.contain('To take part, all you need to do is check that you have the information you need to answer the survey questions.');
+        .getText(IntroductionPage.introDescription()).should.eventually.contain('To take part, all you need to do is check that you have the information you need to answer the survey questions.')
+        .getText(IntroductionPage.introTitleDescription()).should.eventually.contain('If the company details or structure have changed contact us on 0300 1234 931 or email surveys@ons.gov.uk');
     });
   });
 });


### PR DESCRIPTION
### What is the context of this PR?
- Added key to macro to display telephone and email correctly on certain pages (introduction / 404 etc)
- [Fixes #1825](https://github.com/ONSdigital/eq-survey-runner/issues/1825)

### How to review 
- Check that the right text is displayed and that they work as expected

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
