### PR TITLE
Don't use answers outside path when routing

### DIFF
--- a/app/data_model/answer_store.py
+++ b/app/data_model/answer_store.py
@@ -89,6 +89,12 @@ class AnswerStore:
         else:
             self.answers.append(answer_to_add)
 
+    def copy(self):
+        """
+        Create a new instance of answer_store with the same values.
+        """
+        return self.__class__(existing_answers=self.answers.copy())
+
     def update(self, answer):
         """
         Update the value of an answer already in the answer store.

--- a/app/questionnaire/path_finder.py
+++ b/app/questionnaire/path_finder.py
@@ -60,7 +60,8 @@ class PathFinder:
                     group_instance_id = get_group_instance_id(self.schema, self.answer_store, Location(group['id'], group_instance, first_block_in_group))
 
                     if evaluate_skip_conditions(group['skip_conditions'], self.schema, self.metadata,
-                                                self.answer_store, group_instance, group_instance_id):
+                                                self.answer_store, group_instance, group_instance_id,
+                                                routing_path=path):
                         continue
 
                 group_blocks = list(self._build_blocks_for_group(group, group_instance))
@@ -83,10 +84,6 @@ class PathFinder:
 
     def _build_blocks_for_group(self, group, instance_idx):
         for block in group['blocks']:
-            skip_conditions = block.get('skip_conditions')
-            if skip_conditions and evaluate_skip_conditions(
-                    skip_conditions, self.schema, self.metadata, self.answer_store, instance_idx):
-                continue
 
             yield {
                 'group_id': group['id'],
@@ -109,10 +106,21 @@ class PathFinder:
             if block_index is None:
                 return path, prev_block_index
 
+            block = blocks[block_index]['block']
+
+            if block.get('skip_conditions') and \
+                    evaluate_skip_conditions(block['skip_conditions'], self.schema, self.metadata,
+                                             self.answer_store, this_location.group_instance, routing_path=path):
+
+                if block_index < len(blocks) - 1:
+                    this_location = Location(blocks[block_index + 1]['group_id'],
+                                             blocks[block_index + 1]['group_instance'],
+                                             blocks[block_index + 1]['block']['id'])
+                    continue
+                return path, block_index
+
             if this_location not in path:
                 path.append(this_location)
-
-            block = blocks[block_index]['block']
 
             # If routing rules exist then a rule must match (i.e. default goto)
             if 'routing_rules' in block and block['routing_rules']:
@@ -140,7 +148,8 @@ class PathFinder:
                                         self.metadata,
                                         self.answer_store,
                                         this_location.group_instance,
-                                        group_instance_id=group_instance_id)
+                                        group_instance_id=group_instance_id,
+                                        routing_path=path)
 
             if should_goto:
                 return self._follow_routing_rule(this_location, rule, blocks, block_index, path)

--- a/app/questionnaire/rules.py
+++ b/app/questionnaire/rules.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
 from app.questionnaire.location import Location
+from app.data_model.answer_store import AnswerStore
 
 MAX_REPEATS = 25
 
@@ -118,7 +119,7 @@ def convert_to_datetime(value):
     return datetime.strptime(value, date_format) if value else None
 
 
-def evaluate_goto(goto_rule, schema, metadata, answer_store, group_instance, group_instance_id=None):
+def evaluate_goto(goto_rule, schema, metadata, answer_store, group_instance, group_instance_id=None, routing_path=None):
     """
     Determine whether a goto rule will be satisfied based on a given answer
     :param goto_rule: goto rule to evaluate
@@ -130,7 +131,15 @@ def evaluate_goto(goto_rule, schema, metadata, answer_store, group_instance, gro
     :return: True if the when condition has been met otherwise False
     """
     if 'when' in goto_rule:
-        return evaluate_when_rules(goto_rule['when'], schema, metadata, answer_store, group_instance, group_instance_id)
+        return evaluate_when_rules(
+            goto_rule['when'],
+            schema,
+            metadata,
+            answer_store,
+            group_instance,
+            group_instance_id=group_instance_id,
+            routing_path=routing_path
+        )
     return True
 
 
@@ -140,13 +149,16 @@ def evaluate_repeat(repeat_rule, answer_store, schema, routing_path):
     """
     if repeat_rule['type'] == 'until':
         when = repeat_rule['when']
-        answers = list(answer_store.filter(answer_ids=[when[0]['id']]))
+        when_ids = [rule['id'] for rule in when]
+
+        answers = list(answer_store.filter(answer_ids=when_ids))
 
         no_of_repeats = 1
 
         for answer in answers:
             group_instance = answer['group_instance']
-            if evaluate_when_rules(when, schema, {}, answer_store, group_instance, None):
+            if evaluate_when_rules(when, schema, {}, answer_store, group_instance,
+                                   group_instance_id=(answer['group_instance_id'] or None)):
                 break
 
             no_of_repeats = no_of_repeats + 1
@@ -157,7 +169,7 @@ def evaluate_repeat(repeat_rule, answer_store, schema, routing_path):
             'answer_count_minus_one': _get_answer_count_minus_one,
         }
 
-        answers = _get_answers_on_routing_path(schema, routing_path, answer_store, repeat_rule)
+        answers = _get_answers_on_routing_path_with_repeats(schema, routing_path, answer_store, repeat_rule)
 
         repeat_function = repeat_functions[repeat_rule['type']]
         no_of_repeats = repeat_function(answers)
@@ -169,7 +181,7 @@ def evaluate_repeat(repeat_rule, answer_store, schema, routing_path):
     return no_of_repeats
 
 
-def _get_answers_on_routing_path(schema, routing_path, answer_store, repeat_rule):
+def _get_answers_on_routing_path_with_repeats(schema, routing_path, answer_store, repeat_rule):
     repeat_indexes = []
 
     answer_ids_on_path = get_answer_ids_on_routing_path(
@@ -185,18 +197,26 @@ def _get_answers_on_routing_path(schema, routing_path, answer_store, repeat_rule
             if answer_id in answer_ids_on_path:
                 repeat_indexes.append(answer_id)
 
-    answers = list(answer_store.filter(answer_ids=repeat_indexes))
+    answers = answer_store.filter(answer_ids=repeat_indexes)
 
     # Exclude answers that are not on the routing path from repeat function
-    answers_to_remove = []
-    for answer in answers:
-        if not _is_answer_on_path(schema, answer, routing_path):
-            answers_to_remove.append(answer)
+    answers_on_path = _get_answers_on_path(answers, schema, routing_path)
+
+    return answers_on_path
+
+
+def _get_answers_on_path(answers, schema, routing_path) -> AnswerStore:
+    """
+    Get any answers that are on the routing path and return an answer store.
+    """
+    answers_to_remove = [answer for answer in answers if not _is_answer_on_path(schema, answer, routing_path)]
+
+    answers_on_path = answers.copy()
 
     for answer in answers_to_remove:
-        answers.remove(answer)
+        answers_on_path.answers.remove(answer)
 
-    return answers
+    return answers_on_path
 
 
 def _is_answer_on_path(schema, answer, routing_path):
@@ -227,7 +247,7 @@ def _get_comparison_id_value(when_rule, answer_store, schema, group_instance, gr
     return get_answer_store_value(answer_id, answer_store, schema, group_instance=group_instance, group_instance_id=group_instance_id)
 
 
-def evaluate_skip_conditions(skip_conditions, schema, metadata, answer_store, group_instance=0, group_instance_id=None):
+def evaluate_skip_conditions(skip_conditions, schema, metadata, answer_store, group_instance=0, group_instance_id=None, routing_path=None):
     """
     Determine whether a skip condition will be satisfied based on a given answer
     :param skip_conditions: skip_conditions rule to evaluate
@@ -244,20 +264,21 @@ def evaluate_skip_conditions(skip_conditions, schema, metadata, answer_store, gr
         return False
 
     for when in skip_conditions:
-        condition = evaluate_when_rules(when['when'], schema, metadata, answer_store, group_instance, group_instance_id)
+        condition = evaluate_when_rules(when['when'], schema, metadata, answer_store,
+                                        group_instance, group_instance_id, routing_path)
         if condition is True:
             return True
     return False
 
 
-def _get_when_rule_value(when_rule, group_instance, answer_store, schema, metadata, group_instance_id=None):
+def _get_when_rule_value(when_rule, group_instance, answer_store, schema, metadata, group_instance_id=None, routing_path=None):
     """
     Get the value from a when rule.
     :raises: Exception if none of `id`, `meta`, or `answer_count` are provided.
     :return: The value to use in a when rule
     """
     if 'id' in when_rule:
-        value = get_answer_store_value(when_rule['id'], answer_store, schema, group_instance, group_instance_id)
+        value = get_answer_store_value(when_rule['id'], answer_store, schema, group_instance, group_instance_id, routing_path=routing_path)
     elif 'meta' in when_rule:
         value = get_metadata_value(metadata, when_rule['meta'])
     elif 'answer_count' in when_rule:
@@ -268,7 +289,7 @@ def _get_when_rule_value(when_rule, group_instance, answer_store, schema, metada
     return value
 
 
-def evaluate_when_rules(when_rules, schema, metadata, answer_store, group_instance, group_instance_id=None):
+def evaluate_when_rules(when_rules, schema, metadata, answer_store, group_instance, group_instance_id=None, routing_path=None):
     """
     Whether the skip condition has been met.
     :param when_rules: when rules to evaluate
@@ -280,13 +301,12 @@ def evaluate_when_rules(when_rules, schema, metadata, answer_store, group_instan
     :param group_instance_id: The group instance ID to filter results by
     :return: True if the when condition has been met otherwise False
     """
-
     for when_rule in when_rules:
         if 'id' in when_rule:
             if group_instance > 0 and not schema.answer_is_in_repeating_group(when_rule['id']):
                 group_instance = 0
 
-        value = _get_when_rule_value(when_rule, group_instance, answer_store, schema, metadata, group_instance_id)
+        value = _get_when_rule_value(when_rule, group_instance, answer_store, schema, metadata, group_instance_id, routing_path=routing_path)
 
         if 'date_comparison' in when_rule:
             if not evaluate_date_rule(when_rule, answer_store, schema, group_instance, metadata, value):
@@ -301,14 +321,19 @@ def evaluate_when_rules(when_rules, schema, metadata, answer_store, group_instan
 
     return True
 
+def get_answer_store_value(answer_id, answer_store, schema, group_instance, group_instance_id=None, routing_path=None):
 
-def get_answer_store_value(answer_id, answer_store, schema, group_instance, group_instance_id=None):
     filtered = answer_store.filter(answer_ids=[answer_id])
 
-    if not filtered.count():
+    if routing_path:
+        answers_on_path = _get_answers_on_path(filtered, schema, routing_path)
+    else:
+        answers_on_path = filtered
+
+    if not answers_on_path.count():
         return None
 
-    if all([answer.get('group_instance_id') for answer in filtered.answers]) and group_instance_id:
+    if all([answer.get('group_instance_id') for answer in answers_on_path.answers]) and group_instance_id:
         # If all of the matching answers have a group_instance_id, then we know the answer has this group_instance_id
         group_instance = None
     else:

--- a/data/en/test_routing_not_affected_by_answers_not_on_path.json
+++ b/data/en/test_routing_not_affected_by_answers_not_on_path.json
@@ -1,0 +1,140 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "001",
+    "title": "Test routing not affected by invalid answers",
+    "theme": "default",
+    "description": "A test survey to make sure previous answers that are not on the routing path do not affect routing",
+    "metadata": [{
+        "name": "user_id",
+        "validator": "string"
+    }, {
+        "name": "period_id",
+        "validator": "string"
+    }, {
+        "name": "ru_name",
+        "validator": "string"
+    }],
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "blocks": [{
+                "type": "Question",
+                "id": "initial-choice",
+                "questions": [{
+                    "type": "General",
+                    "id": "initial-choice-question",
+                    "title": "Answer First, then, after answering a quesiton, go back to this question and answer Second",
+                    "answers": [{
+                        "type": "Radio",
+                        "id": "initial-choice-answer",
+                        "mandatory": true,
+                        "options": [{
+                            "label": "Go here first",
+                            "value": "First"
+                        }, {
+                            "label": "Go here second",
+                            "value": "Second"
+                        }]
+                    }]
+                }],
+                "routing_rules": [{
+                        "goto": {
+                            "block": "valid-path",
+                            "when": [{
+                                "id": "initial-choice-answer",
+                                "condition": "equals",
+                                "value": "Second"
+                            }]
+                        }
+                    },
+                    {
+                        "goto": {
+                            "block": "invalid-path"
+                        }
+                    }
+                ]
+            }, {
+                "type": "Question",
+                "id": "invalid-path",
+                "title": "",
+                "description": "Enter an answer and continue",
+                "questions": [{
+                    "answers": [{
+                        "id": "invalid-path-answer",
+                        "mandatory": true,
+                        "type": "Number"
+                    }],
+                    "id": "invalid-path-question",
+                    "title": "Enter a number",
+                    "type": "General"
+                }]
+            }, {
+                "type": "Interstitial",
+                "id": "invalid-path-interstitial",
+                "title": "You now have an answer that could be invalid in the store.",
+                "description": "Go back to the first question and choose the second path.",
+                "routing_rules": [{
+                    "goto": {
+                        "block": "summary"
+                    }
+                }]
+            }, {
+                "type": "Question",
+                "id": "valid-path",
+                "title": "Route page",
+                "description": "This page should take you to the valid page. If it takes you to the invalid page then routing is using an answer that isn't on the routing path",
+                "questions": [{
+                    "answers": [{
+                        "id": "valid-path-answer",
+                        "mandatory": true,
+                        "type": "Number"
+                    }],
+                    "id": "valid-path-question",
+                    "title": "Enter a number and continue",
+                    "type": "General"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "block": "invalid-final-interstitial",
+                        "when": [{
+                            "id": "invalid-path-answer",
+                            "condition": "set"
+                        }]
+                    }
+                }, {
+                    "goto": {
+                        "block": "valid-skipped-interstitial"
+                    }
+                }]
+            }, {
+                "type": "Interstitial",
+                "id": "valid-skipped-interstitial",
+                "title": "This page should have been skipped!",
+                "description": "",
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "invalid-path-answer",
+                        "condition": "not set"
+                    }]
+                }]
+            }, {
+                "type": "Interstitial",
+                "id": "valid-final-interstitial",
+                "title": "You were routed correctly!",
+                "description": ""
+            }, {
+                "type": "Interstitial",
+                "id": "invalid-final-interstitial",
+                "title": "You were routed incorrectly.",
+                "description": ""
+            }, {
+                "type": "Summary",
+                "id": "summary"
+            }],
+            "id": "group",
+            "title": ""
+        }]
+    }]
+}

--- a/tests/app/questionnaire/test_rules.py
+++ b/tests/app/questionnaire/test_rules.py
@@ -1024,3 +1024,29 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         number_of_repeats = evaluate_repeat(repeat, answer_store, schema, routing_path)
 
         self.assertEqual(number_of_repeats, 2)
+
+    def test_routing_ignores_answers_not_on_path(self):
+        when = {
+            'when': [
+                {
+                    'id': 'some-answer',
+                    'condition': 'equals',
+                    'value': 'some value'
+                }
+            ]
+        }
+        answer_store = AnswerStore({})
+        answer_store.add(Answer(
+            answer_id='some-answer',
+            value='some value',
+            group_instance=0,
+        ))
+
+        routing_path = [
+            Location('test', 0, 'test_block_id')
+        ]
+        with patch('app.questionnaire.rules._get_answers_on_path', return_value=answer_store):
+            self.assertTrue(evaluate_when_rules(when['when'], get_schema_mock(), {}, answer_store, 0, None))
+
+        with patch('app.questionnaire.rules._is_answer_on_path', return_value=False):
+            self.assertFalse(evaluate_when_rules(when['when'], get_schema_mock(), {}, answer_store, 0, None, routing_path=routing_path))

--- a/tests/functional/pages/features/routing/answer_value_off_path/initial-choice.page.js
+++ b/tests/functional/pages/features/routing/answer_value_off_path/initial-choice.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class InitialChoicePage extends QuestionPage {
+
+  constructor() {
+    super('initial-choice');
+  }
+
+  first() {
+    return '#initial-choice-answer-0';
+  }
+
+  firstLabel() { return '#label-initial-choice-answer-0'; }
+
+  second() {
+    return '#initial-choice-answer-1';
+  }
+
+  secondLabel() { return '#label-initial-choice-answer-1'; }
+
+}
+module.exports = new InitialChoicePage();

--- a/tests/functional/pages/features/routing/answer_value_off_path/invalid-final-interstitial.page.js
+++ b/tests/functional/pages/features/routing/answer_value_off_path/invalid-final-interstitial.page.js
@@ -1,0 +1,11 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class InvalidFinalInterstitialPage extends QuestionPage {
+
+  constructor() {
+    super('invalid-final-interstitial');
+  }
+
+}
+module.exports = new InvalidFinalInterstitialPage();

--- a/tests/functional/pages/features/routing/answer_value_off_path/invalid-path-interstitial.page.js
+++ b/tests/functional/pages/features/routing/answer_value_off_path/invalid-path-interstitial.page.js
@@ -1,0 +1,11 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class InvalidPathInterstitialPage extends QuestionPage {
+
+  constructor() {
+    super('invalid-path-interstitial');
+  }
+
+}
+module.exports = new InvalidPathInterstitialPage();

--- a/tests/functional/pages/features/routing/answer_value_off_path/invalid-path.page.js
+++ b/tests/functional/pages/features/routing/answer_value_off_path/invalid-path.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class InvalidPathPage extends QuestionPage {
+
+  constructor() {
+    super('invalid-path');
+  }
+
+  answer() {
+    return '#invalid-path-answer';
+  }
+
+  answerLabel() { return '#label-invalid-path-answer'; }
+
+}
+module.exports = new InvalidPathPage();

--- a/tests/functional/pages/features/routing/answer_value_off_path/radio-mandatory.page.js
+++ b/tests/functional/pages/features/routing/answer_value_off_path/radio-mandatory.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class RadioMandatoryPage extends QuestionPage {
+
+  constructor() {
+    super('radio-mandatory');
+  }
+
+  first() {
+    return '#radio-mandatory-answer-0';
+  }
+
+  firstLabel() { return '#label-radio-mandatory-answer-0'; }
+
+  second() {
+    return '#radio-mandatory-answer-1';
+  }
+
+  secondLabel() { return '#label-radio-mandatory-answer-1'; }
+
+}
+module.exports = new RadioMandatoryPage();

--- a/tests/functional/pages/features/routing/answer_value_off_path/summary.page.js
+++ b/tests/functional/pages/features/routing/answer_value_off_path/summary.page.js
@@ -1,0 +1,31 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  initialChoiceAnswer(index = 0) { return '#initial-choice-answer-' + index + '-answer'; }
+
+  initialChoiceAnswerEdit(index = 0) { return '[data-qa="initial-choice-answer-' + index + '-edit"]'; }
+
+  initialChoiceQuestion(index = 0) { return '#initial-choice-question-' + index; }
+
+  invalidPathAnswer(index = 0) { return '#invalid-path-answer-' + index + '-answer'; }
+
+  invalidPathAnswerEdit(index = 0) { return '[data-qa="invalid-path-answer-' + index + '-edit"]'; }
+
+  invalidPathQuestion(index = 0) { return '#invalid-path-question-' + index; }
+
+  validPathAnswer(index = 0) { return '#valid-path-answer-' + index + '-answer'; }
+
+  validPathAnswerEdit(index = 0) { return '[data-qa="valid-path-answer-' + index + '-edit"]'; }
+
+  validPathQuestion(index = 0) { return '#valid-path-question-' + index; }
+
+  groupTitle(index = 0) { return '#group-' + index; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/pages/features/routing/answer_value_off_path/valid-final-interstitial.page.js
+++ b/tests/functional/pages/features/routing/answer_value_off_path/valid-final-interstitial.page.js
@@ -1,0 +1,11 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class ValidFinalInterstitialPage extends QuestionPage {
+
+  constructor() {
+    super('valid-final-interstitial');
+  }
+
+}
+module.exports = new ValidFinalInterstitialPage();

--- a/tests/functional/pages/features/routing/answer_value_off_path/valid-path.page.js
+++ b/tests/functional/pages/features/routing/answer_value_off_path/valid-path.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class ValidPathPage extends QuestionPage {
+
+  constructor() {
+    super('valid-path');
+  }
+
+  answer() {
+    return '#valid-path-answer';
+  }
+
+  answerLabel() { return '#label-valid-path-answer'; }
+
+}
+module.exports = new ValidPathPage();

--- a/tests/functional/spec/features/routing/answer_not_on_path.spec.js
+++ b/tests/functional/spec/features/routing/answer_not_on_path.spec.js
@@ -1,0 +1,43 @@
+const helpers = require('../../../helpers');
+
+const InitialChoicePage = require('../../../pages/features/routing/answer_value_off_path/initial-choice.page.js');
+const InvalidPathPage = require('../../../pages/features/routing/answer_value_off_path/invalid-path.page.js');
+const InvalidPathInterstitialPage = require('../../../pages/features/routing/answer_value_off_path/invalid-path-interstitial.page.js');
+const ValidPathPage = require('../../../pages/features/routing/answer_value_off_path/valid-path.page.js');
+const ValidFinalInterstitialPage = require('../../../pages/features/routing/answer_value_off_path/valid-final-interstitial.page.js');
+const InvalidFinalInterstitialPage = require('../../../pages/features/routing/answer_value_off_path/invalid-final-interstitial.page.js');
+
+describe('Answers not on path are not considered when routing', function() {
+
+  beforeEach(function() {
+    return helpers.openQuestionnaire('test_routing_not_affected_by_answers_not_on_path.json');
+  });
+
+  it('Given the user enters an answer on the first path, when they return to the second path, they should be routed to the valid path interstitial', function() {
+    return browser
+      .click(InitialChoicePage.first())
+      .click(InitialChoicePage.submit())
+
+      .getUrl().should.eventually.contain(InvalidPathPage.pageName)
+      .setValue(InvalidPathPage.answer(), 123)
+      .click(InvalidPathPage.submit())
+
+      // We now have an answer in the store on the 'invalid' path
+
+      .getUrl().should.eventually.contain(InvalidPathInterstitialPage.pageName)
+      .click(InvalidPathInterstitialPage.previous())
+      .click(InvalidPathPage.previous())
+
+      // Take the second route
+
+      .click(InitialChoicePage.second())
+      .click(InitialChoicePage.submit())
+
+      .setValue(ValidPathPage.answer(), 321)
+      .click(ValidPathPage.submit())
+
+      // We should be routed to the valid interstitial page since the invalid path answer should not be considered whilst routing.
+      .getUrl().should.eventually.contain(ValidFinalInterstitialPage.pageName);
+  });
+});
+


### PR DESCRIPTION
### What is the context of this PR?

[trello](https://trello.com/c/FD4aiOuW/2439-question-should-we-modify-answer-store-filter-to-only-return-answers-on-the-routing-path)

Currently, we use the full answer store when checking routing rules / skip conditions. This means that if you navigate backwards, change your path, and then encounter a routing rule which evaluates a (now invalid) answer value, it will still route you according to the invalid answer. 

The original proposal to fix this was to filter the answer store based on the routing path. This proved problematic since path_finder uses the answer store to build the path. The relationship between answer store and routing path probably needs to be discussed at a higher level, see [trello](https://trello.com/c/kanSjZJf/2479-discuss-interplay-between-routing-path-path-finder-and-answer-store). Given this, I haven't attempted to make any changes to the answer_store.

The scope of this card was then limited to fixing the evaluation of routing in `rules.py`. We discussed eventually using some representation of answer_id / group_instance stored with the routing_path to improve the performance of comparisons. I haven't implemented this yet, since it's likely better done as part of refactoring the routing path.

I ended up copying the answer_store in the `_get_answers_on_path` function. I think we could get away with mutating it, but that would be a potential source of issues down the line.

I had to refactor the path_finder a little to allow skip conditions to take the routing_path into account.

### How to review 
- Run `test_routing_not_affected_by_answers_not_on_path`. Follow the instructions to generate an invalid path and make sure you are routed correctly on the second path.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
