### PR TITLE
Stop YYYY validation on invalid YYYY format

### DIFF
--- a/app/validation/validators.py
+++ b/app/validation/validators.py
@@ -216,7 +216,7 @@ class YearCheck:
     def __call__(self, form, field):
         # Must be 4 digits long
         if not re.match(r'\d{4}$', str(form.year.data)):
-            raise validators.ValidationError(self.message)
+            raise validators.StopValidation(self.message)
 
 
 class SingleDatePeriodCheck:

--- a/tests/app/validation/test_year_validator.py
+++ b/tests/app/validation/test_year_validator.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import Mock
-from wtforms.validators import ValidationError
+from wtforms.validators import StopValidation
 
 from app.validation.error_messages import error_messages
 from app.validation.validators import YearCheck
@@ -15,7 +15,7 @@ class TestYearValidator(unittest.TestCase):
 
         mock_field = Mock()
 
-        with self.assertRaises(ValidationError) as ite:
+        with self.assertRaises(StopValidation) as ite:
             validator(mock_form, mock_field)
 
         self.assertEqual(error_messages['INVALID_DATE'], str(ite.exception))
@@ -29,7 +29,7 @@ class TestYearValidator(unittest.TestCase):
 
         mock_field = Mock()
 
-        with self.assertRaises(ValidationError) as ite:
+        with self.assertRaises(StopValidation) as ite:
             validator(mock_form, mock_field)
 
         self.assertEqual(error_messages['INVALID_DATE'], str(ite.exception))
@@ -42,7 +42,7 @@ class TestYearValidator(unittest.TestCase):
 
         mock_field = Mock()
 
-        with self.assertRaises(ValidationError) as ite:
+        with self.assertRaises(StopValidation) as ite:
             validator(mock_form, mock_field)
 
         self.assertEqual(error_messages['INVALID_DATE'], str(ite.exception))
@@ -55,7 +55,7 @@ class TestYearValidator(unittest.TestCase):
 
         mock_field = Mock()
 
-        with self.assertRaises(ValidationError) as ite:
+        with self.assertRaises(StopValidation) as ite:
             validator(mock_form, mock_field)
 
         self.assertEqual(error_messages['INVALID_DATE'], str(ite.exception))
@@ -70,5 +70,5 @@ class TestYearValidator(unittest.TestCase):
 
         try:
             validator(mock_form, mock_field)
-        except ValidationError:
+        except StopValidation:
             self.fail('Valid date raised ValidationError')

--- a/tests/functional/spec/features/validation/date_validation/date-combined-yyyy.spec.js
+++ b/tests/functional/spec/features/validation/date_validation/date-combined-yyyy.spec.js
@@ -36,6 +36,15 @@ describe('Feature: Combined question level and single validation for MM-YYYY dat
          .getText(DateRangePage.errorNumber(1)).should.eventually.contain('Enter a reporting period greater than or equal to 2 years.');
       });
 
+      it('When I enter an invalid year, Then I should see a single validation error', function() {
+        return browser
+         .setValue(DateRangePage.dateRangeFromyear(), 2016)
+         .setValue(DateRangePage.dateRangeToyear(), 20167)
+         .click(DateRangePage.submit())
+         .getText(DateRangePage.errorNumber(1)).should.eventually.contain('Enter a valid date.')
+         .isExisting(DateRangePage.errorNumber(2)).should.eventually.be.false;
+      });
+
       it('When I enter valid dates, Then I should see the summary page', function() {
         return browser
          .setValue(DateRangePage.dateRangeFromyear(), 2016)


### PR DESCRIPTION
### What is the context of this PR?
Issue 1: Entering an invalid date, causes similar issue to month and year field (PR #1821), its not stopping after finding its invalid date field.

Issue 2: When entering characters in year field, you get 500 error.

### How to review 
Issue 1 can be tested with `test_date_validation_yyyy_combined.json`. Enter one of the dates as 5 numbers.

Issue 2 can be tested with `lms_2.json`. Add a person and answer questions getting to `In which country were you born?`. Answer India or similar in order to get the `In which year did you first arrive to live in the UK?`. When typing in characters you should no longer get 500 errors.


### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
