### PR TITLE
Add routing on the count of multiple answers to when rule

### DIFF
--- a/app/questionnaire/rules.py
+++ b/app/questionnaire/rules.py
@@ -281,8 +281,8 @@ def _get_when_rule_value(when_rule, group_instance, answer_store, schema, metada
         value = get_answer_store_value(when_rule['id'], answer_store, schema, group_instance, group_instance_id, routing_path=routing_path)
     elif 'meta' in when_rule:
         value = get_metadata_value(metadata, when_rule['meta'])
-    elif 'answer_count' in when_rule:
-        value = answer_store.filter(answer_ids=[when_rule['answer_count']]).count()
+    elif when_rule['type'] == 'answer_count':
+        value = answer_store.filter(answer_ids=when_rule['answer_ids']).count()
     else:
         raise Exception('The when rule is invalid')
 

--- a/data/en/test_routing_answer_count.json
+++ b/data/en/test_routing_answer_count.json
@@ -47,7 +47,8 @@
                     "goto": {
                         "group": "group-equal-2",
                         "when": [{
-                            "answer_count": "first-name",
+                            "type": "answer_count",
+                            "answer_ids": ["first-name"],
                             "condition": "equals",
                             "value": 2
                         }]
@@ -56,7 +57,8 @@
                     "goto": {
                         "group": "group-greater-than-2",
                         "when": [{
-                            "answer_count": "first-name",
+                            "type": "answer_count",
+                            "answer_ids": ["first-name"],
                             "condition": "greater than",
                             "value": 2
                         }]

--- a/data/en/test_routing_answer_count_multiple.json
+++ b/data/en/test_routing_answer_count_multiple.json
@@ -1,0 +1,209 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "023",
+    "title": "Test Routing Answer Count",
+    "description": "",
+    "theme": "default",
+    "metadata": [{
+        "name": "user_id",
+        "validator": "string"
+    }, {
+        "name": "period_id",
+        "validator": "string"
+    }, {
+        "name": "ru_name",
+        "validator": "string"
+    }],
+    "sections": [{
+        "id": "intro-section",
+        "title": "Introduction",
+        "groups": [{
+                "id": "primary-group",
+                "title": "Your Details",
+                "blocks": [{
+                    "type": "Question",
+                    "id": "primary-name-block",
+                    "title": "",
+                    "description": "",
+                    "questions": [{
+                        "description": "",
+                        "id": "primary-name-question",
+                        "title": "Please enter your name",
+                        "type": "General",
+                        "answers": [{
+                            "id": "primary-name",
+                            "description": "",
+                            "label": "First Name",
+                            "mandatory": true,
+                            "type": "TextField"
+                        }]
+                    }]
+                }]
+            },
+            {
+                "id": "repeating-group",
+                "title": "Other Household Members",
+                "routing_rules": [{
+                    "repeat": {
+                        "type": "until",
+                        "when": [{
+                            "id": "repeating-anyone-else",
+                            "condition": "equals",
+                            "value": "No"
+                        }]
+                    }
+                }],
+                "blocks": [{
+                        "type": "Question",
+                        "id": "repeating-anyone-else-block",
+                        "questions": [{
+                            "type": "General",
+                            "id": "repeating-anyone-else-question",
+                            "title": "Does anyone else live here?",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "repeating-anyone-else",
+                                "mandatory": true,
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    }
+                                ]
+                            }]
+                        }]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "repeating-name-block",
+                        "title": "",
+                        "description": "",
+                        "questions": [{
+                            "description": "",
+                            "id": "repeating-name-question",
+                            "title": "Who else lives here?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "repeating-name",
+                                "description": "",
+                                "label": "First Name",
+                                "mandatory": true,
+                                "type": "TextField"
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "repeating-anyone-else",
+                                "condition": "equals",
+                                "value": "No"
+                            }]
+                        }]
+                    }
+                ]
+            },
+            {
+                "id": "group-less-than-2",
+                "title": "This is Group 0 - You added less than \"2\" people between both lists",
+                "blocks": [{
+                    "type": "Question",
+                    "id": "group-less-than-2-block",
+                    "description": "",
+                    "title": "This is Group 0 - You added less than \"2\" people between both lists",
+                    "questions": [{
+                        "description": "",
+                        "id": "group-less-than-2-question",
+                        "title": "Did you want Group 0?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "group-less-than-2-answer",
+                            "label": "Why did you choose Group 0?",
+                            "mandatory": true,
+                            "type": "TextArea"
+                        }]
+                    }],
+                    "skip_conditions": [{
+                        "when": [{
+                            "type": "answer_count",
+                            "answer_ids": ["primary-name", "repeating-name"],
+                            "condition": "greater than",
+                            "value": 1
+                        }]
+                    }],
+                    "routing_rules": [{
+                        "goto": {
+                            "group": "summary-group"
+                        }
+                    }]
+                }]
+            }, {
+                "id": "group-equal-2",
+                "title": "This is Group 1 - you added \"2\" people between both lists",
+                "blocks": [{
+                    "type": "Question",
+                    "id": "group-equal-2-block",
+                    "description": "",
+                    "title": "This is Group 1 - you added \"2\" people between both lists",
+                    "questions": [{
+                        "description": "",
+                        "id": "group-equal-2-question",
+                        "title": "Did you want Group 1?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "group-equal-2-answer",
+                            "label": "Why did you choose Group 1?",
+                            "mandatory": true,
+                            "type": "TextArea"
+                        }]
+                    }],
+                    "skip_conditions": [{
+                        "when": [{
+                            "type": "answer_count",
+                            "answer_ids": ["primary-name", "repeating-name"],
+                            "condition": "not equals",
+                            "value": 2
+                        }]
+                    }],
+                    "routing_rules": [{
+                        "goto": {
+                            "group": "summary-group"
+                        }
+                    }]
+                }]
+            }, {
+                "id": "group-greater-than-2",
+                "title": "This is Group 2 - You added greater than \"2\" people between both lists",
+                "blocks": [{
+                    "type": "Question",
+                    "id": "group-greater-than-2-block",
+                    "routing_rules": [],
+                    "description": "",
+                    "title": "This is Group 2 - You added greater than \"2\" people between both lists",
+                    "questions": [{
+                        "description": "",
+                        "id": "group-greater-than-2-question",
+                        "title": "Did you want Group 2?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "group-greater-than-2-answer",
+                            "label": "Why did you choose Group 2?",
+                            "mandatory": true,
+                            "type": "TextArea"
+                        }]
+                    }]
+                }]
+            }, {
+                "blocks": [{
+                    "type": "Summary",
+                    "id": "summary"
+                }],
+                "id": "summary-group",
+                "title": ""
+            }
+        ]
+    }]
+}

--- a/tests/app/questionnaire/test_rules.py
+++ b/tests/app/questionnaire/test_rules.py
@@ -778,7 +778,8 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
             correct value is fetched. """
         answer_group_id = 'repeated-answer'
         when = [{
-            'answer_count': answer_group_id,
+            'type': 'answer_count',
+            'answer_ids': [answer_group_id],
             'condition': 'equals',
             'value': 0,
         }]
@@ -835,7 +836,8 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
             correct value is fetched. """
         answer_group_id = 'repeated-answer'
         when = [{
-            'answer_count': answer_group_id,
+            'type': 'answer_count',
+            'answer_ids': [answer_group_id],
             'condition': 'equals',
             'value': 1,
         }]
@@ -854,7 +856,8 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
             value is correctly matched """
         answer_group_id = 'repeated-answer'
         when = [{
-            'answer_count': answer_group_id,
+            'type': 'answer_count',
+            'answer_ids': [answer_group_id],
             'condition': 'equals',
             'value': 2,
         }]
@@ -875,12 +878,13 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
 
         self.assertTrue(evaluate_when_rules(when, get_schema_mock(), {}, answer_store, 0, None))
 
-    def test_answer_count_when_rule_not_equal(self):  # pylint: disable=no-self-use
+    def test_answer_count_when_rule_not_equal(self):
         """Assert that an `answer_count` can be used in a when block and the
             False is returned when the values do not match. """
         answer_group_id = 'repeated-answer'
         when = [{
-            'answer_count': answer_group_id,
+            'type': 'answer_count',
+            'answer_ids': [answer_group_id],
             'condition': 'equals',
             'value': 1,
         }]
@@ -907,6 +911,24 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         ))
 
         self.assertTrue(evaluate_when_rules(when, get_schema_mock(), {}, answer_store, 0, None))
+
+    def test_evaluate_when_rule_raises_exception_if_invalid(self):
+        """If there isn't an id, meta key, or a type with value answer_count when attempting to
+        get the value of the when condition, an exception is thrown"""
+        when = {
+            'when': [
+                {
+                    'type': 'answer_countinvalid',
+                    'answer_ids': ['id'],
+                    'condition': 'equals',
+                    'value': 1,
+                }
+            ]
+        }
+        answer_store = AnswerStore({})
+        with self.assertRaises(Exception) as err:
+            evaluate_when_rules(when['when'], get_schema_mock(), {}, answer_store, 0, None)
+            self.assertEqual('The when rule is invalid', str(err.exception))
 
     def test_evaluate_when_rule_raises_if_bad_when_condition(self):
         when = {

--- a/tests/functional/pages/features/routing/answer_count_multiple/group-equal-2-block.page.js
+++ b/tests/functional/pages/features/routing/answer_count_multiple/group-equal-2-block.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class GroupEqual2BlockPage extends QuestionPage {
+
+  constructor() {
+    super('group-equal-2-block');
+  }
+
+  answer() {
+    return '#group-equal-2-answer';
+  }
+
+  answerLabel() { return '#label-group-equal-2-answer'; }
+
+}
+module.exports = new GroupEqual2BlockPage();

--- a/tests/functional/pages/features/routing/answer_count_multiple/group-greater-than-2-block.page.js
+++ b/tests/functional/pages/features/routing/answer_count_multiple/group-greater-than-2-block.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class GroupGreaterThan2BlockPage extends QuestionPage {
+
+  constructor() {
+    super('group-greater-than-2-block');
+  }
+
+  answer() {
+    return '#group-greater-than-2-answer';
+  }
+
+  answerLabel() { return '#label-group-greater-than-2-answer'; }
+
+}
+module.exports = new GroupGreaterThan2BlockPage();

--- a/tests/functional/pages/features/routing/answer_count_multiple/group-less-than-2-block.page.js
+++ b/tests/functional/pages/features/routing/answer_count_multiple/group-less-than-2-block.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class GroupLessThan2BlockPage extends QuestionPage {
+
+  constructor() {
+    super('group-less-than-2-block');
+  }
+
+  answer() {
+    return '#group-less-than-2-answer';
+  }
+
+  answerLabel() { return '#label-group-less-than-2-answer'; }
+
+}
+module.exports = new GroupLessThan2BlockPage();

--- a/tests/functional/pages/features/routing/answer_count_multiple/primary-name-block.page.js
+++ b/tests/functional/pages/features/routing/answer_count_multiple/primary-name-block.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class PrimaryNameBlockPage extends QuestionPage {
+
+  constructor() {
+    super('primary-name-block');
+  }
+
+  answer() {
+    return '#primary-name';
+  }
+
+  answerLabel() { return '#label-primary-name'; }
+
+}
+module.exports = new PrimaryNameBlockPage();

--- a/tests/functional/pages/features/routing/answer_count_multiple/repeating-anyone-else-block.page.js
+++ b/tests/functional/pages/features/routing/answer_count_multiple/repeating-anyone-else-block.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class RepeatingAnyoneElseBlockPage extends QuestionPage {
+
+  constructor() {
+    super('repeating-anyone-else-block');
+  }
+
+  yes() {
+    return '#repeating-anyone-else-0';
+  }
+
+  yesLabel() { return '#label-repeating-anyone-else-0'; }
+
+  no() {
+    return '#repeating-anyone-else-1';
+  }
+
+  noLabel() { return '#label-repeating-anyone-else-1'; }
+
+}
+module.exports = new RepeatingAnyoneElseBlockPage();

--- a/tests/functional/pages/features/routing/answer_count_multiple/repeating-name-block.page.js
+++ b/tests/functional/pages/features/routing/answer_count_multiple/repeating-name-block.page.js
@@ -1,0 +1,17 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class RepeatingNameBlockPage extends QuestionPage {
+
+  constructor() {
+    super('repeating-name-block');
+  }
+
+  answer() {
+    return '#repeating-name';
+  }
+
+  answerLabel() { return '#label-repeating-name'; }
+
+}
+module.exports = new RepeatingNameBlockPage();

--- a/tests/functional/pages/features/routing/answer_count_multiple/summary.page.js
+++ b/tests/functional/pages/features/routing/answer_count_multiple/summary.page.js
@@ -1,0 +1,59 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../../../surveys/question.page');
+
+class SummaryPage extends QuestionPage {
+
+  constructor() {
+    super('summary');
+  }
+
+  primaryName(index = 0) { return '#primary-name-' + index + '-answer'; }
+
+  primaryNameEdit(index = 0) { return '[data-qa="primary-name-' + index + '-edit"]'; }
+
+  primaryNameQuestion(index = 0) { return '#primary-name-question-' + index; }
+
+  primaryGroupTitle(index = 0) { return '#primary-group-' + index; }
+
+  repeatingAnyoneElse(index = 0) { return '#repeating-anyone-else-' + index + '-answer'; }
+
+  repeatingAnyoneElseEdit(index = 0) { return '[data-qa="repeating-anyone-else-' + index + '-edit"]'; }
+
+  repeatingAnyoneElseQuestion(index = 0) { return '#repeating-anyone-else-question-' + index; }
+
+  repeatingName(index = 0) { return '#repeating-name-' + index + '-answer'; }
+
+  repeatingNameEdit(index = 0) { return '[data-qa="repeating-name-' + index + '-edit"]'; }
+
+  repeatingNameQuestion(index = 0) { return '#repeating-name-question-' + index; }
+
+  repeatingGroupTitle(index = 0) { return '#repeating-group-' + index; }
+
+  groupLessThan2Answer(index = 0) { return '#group-less-than-2-answer-' + index + '-answer'; }
+
+  groupLessThan2AnswerEdit(index = 0) { return '[data-qa="group-less-than-2-answer-' + index + '-edit"]'; }
+
+  groupLessThan2Question(index = 0) { return '#group-less-than-2-question-' + index; }
+
+  groupLessThan2Title(index = 0) { return '#group-less-than-2-' + index; }
+
+  groupEqual2Answer(index = 0) { return '#group-equal-2-answer-' + index + '-answer'; }
+
+  groupEqual2AnswerEdit(index = 0) { return '[data-qa="group-equal-2-answer-' + index + '-edit"]'; }
+
+  groupEqual2Question(index = 0) { return '#group-equal-2-question-' + index; }
+
+  groupEqual2Title(index = 0) { return '#group-equal-2-' + index; }
+
+  groupGreaterThan2Answer(index = 0) { return '#group-greater-than-2-answer-' + index + '-answer'; }
+
+  groupGreaterThan2AnswerEdit(index = 0) { return '[data-qa="group-greater-than-2-answer-' + index + '-edit"]'; }
+
+  groupGreaterThan2Question(index = 0) { return '#group-greater-than-2-question-' + index; }
+
+  groupGreaterThan2Title(index = 0) { return '#group-greater-than-2-' + index; }
+
+  summaryGroupTitle(index = 0) { return '#summary-group-' + index; }
+
+}
+module.exports = new SummaryPage();

--- a/tests/functional/spec/features/routing/answer_count_multiple.spec.js
+++ b/tests/functional/spec/features/routing/answer_count_multiple.spec.js
@@ -1,0 +1,58 @@
+const helpers = require('../../../helpers');
+
+const PrimaryNamePage = require('../../../pages/features/routing/answer_count_multiple/primary-name-block.page.js');
+const AnyoneElsePage = require('../../../pages/features/routing/answer_count_multiple/repeating-anyone-else-block.page.js');
+const RepeatingNamePage = require('../../../pages/features/routing/answer_count_multiple/repeating-name-block.page.js');
+const GroupLessThan2 = require('../../../pages/features/routing/answer_count_multiple/group-less-than-2-block.page.js');
+const GroupEqual2 = require('../../../pages/features/routing/answer_count_multiple/group-equal-2-block.page.js');
+const GroupGreaterThan2 = require('../../../pages/features/routing/answer_count_multiple/group-greater-than-2-block.page.js');
+
+const test_questionnaire_name = 'test_routing_answer_count_multiple.json';
+
+describe('Feature: Routing on answer count', function() {
+
+  it('Given I have a household with one member, When I enter the household member, Then I am routed to the less than 2 Group page', function () {
+    return helpers.openQuestionnaire(test_questionnaire_name).then(() => {
+      return browser
+        .setValue(PrimaryNamePage.answer(), 'Alpha')
+        .click(PrimaryNamePage.submit())
+        .click(AnyoneElsePage.no())
+        .click(AnyoneElsePage.submit())
+        .getUrl().should.eventually.contain(GroupLessThan2.pageName);
+    });
+  });
+
+  it('Given I have a household with two members, When I enter the household members, Then I am routed to the equals 2 Group page', function () {
+    return helpers.openQuestionnaire(test_questionnaire_name).then(() => {
+      return browser
+        .setValue(PrimaryNamePage.answer(), 'Alpha')
+        .click(PrimaryNamePage.submit())
+        .click(AnyoneElsePage.yes())
+        .click(AnyoneElsePage.submit())
+        .setValue(RepeatingNamePage.answer(), 'Beta')
+        .click(RepeatingNamePage.submit())
+        .click(AnyoneElsePage.no())
+        .click(AnyoneElsePage.submit())
+        .getUrl().should.eventually.contain(GroupEqual2.pageName);
+    });
+  });
+
+  it('Given I have a household with three members, When I enter the household members, Then I am routed to the greater than 2 Group page', function () {
+    return helpers.openQuestionnaire(test_questionnaire_name).then(() => {
+      return browser
+        .setValue(PrimaryNamePage.answer(), 'Alpha')
+        .click(PrimaryNamePage.submit())
+        .click(AnyoneElsePage.yes())
+        .click(AnyoneElsePage.submit())
+        .setValue(RepeatingNamePage.answer(), 'Beta')
+        .click(RepeatingNamePage.submit())
+        .click(AnyoneElsePage.yes())
+        .click(AnyoneElsePage.submit())
+        .setValue(RepeatingNamePage.answer(), 'Charlie')
+        .click(RepeatingNamePage.submit())
+        .click(AnyoneElsePage.no())
+        .click(AnyoneElsePage.submit())
+        .getUrl().should.eventually.contain(GroupGreaterThan2.pageName);
+    });
+  });
+});


### PR DESCRIPTION
### What is the context of this PR?
https://trello.com/c/sBtFoRAQ/2482-add-routing-on-the-count-of-multiple-answers-to-when-rule-s

Allow routing and skip conditions to be done using an answer count (before, only repeats were using answer count).  This allows us to skip pages if multiple separate answers have been answered in a certain way.

### How to review 
Open the `test_routing_answer_count_multiple.json` schema, and test it by supplying 1/2/3+ people to get separate pages.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
