### PR TITLE
Add link on answer summary page

### DIFF
--- a/app/templates/partials/summary/answer-summary.html
+++ b/app/templates/partials/summary/answer-summary.html
@@ -2,12 +2,13 @@
   <h2 class="summary__title neptune">{{ content.summary.label }}</h2>
   {%- for group in content.summary.groups -%}
 
-  <div class="summary__block u-mb-l">
+  <div class="summary__block u-mb-xs">
     {%- for answer in group.answers -%}
     <div class="summary__item">
       <div class="grid">
         <div class="grid__col col-8@xs mars {{ 'col-10@m' }}">
-          <div class="summary__label mars" id="{{ answer.id }}-{{ loop.index }}-label" data-qa="{{ answer.id }}-{{ loop.index }}-label">
+          <div class="summary__label mars" id="{{ answer.id }}-{{ loop.index }}-label"
+               data-qa="{{ answer.id }}-{{ loop.index }}-label">
             <p class="icon--{{content.summary.icon}}" data-qa="{{ answer.id }}-{{ loop.index }}">
               {{ answer.label|striptags }}
             </p>
@@ -16,9 +17,9 @@
         <div class="grid__col col-4@xs col-2@m">
           <div class="summary__link mars">
             <a href="{{ answer.block.link }}#{{ answer.id }}" class="summary__edit-link"
-               aria-describedby="{{ answer.id }} {{ answer.id }}-answer" data-qa="{{ answer.id }}-{{ loop.index }}-edit" {{
-               helpers.track('click', 'Summary', 'Edit click') }}>{{ _("Change") }}
-              <span class="u-vh">
+               aria-describedby="{{ answer.id }} {{ answer.id }}-answer" data-qa="{{ answer.id }}-{{ loop.index }}-edit"
+               {{helpers.track('click', 'Summary', 'Edit click') }}>{{ _("Change")}}
+            <span class="u-vh">
                 {{ _("Change your answer for: %(title)s. The current value is: %(value)s",
                 title=answer.label|striptags,
                 value=answer.label|striptags) }}
@@ -31,4 +32,8 @@
     {%- endfor -%}
   </div>
   {%- endfor -%}
+  <a class="page__previous page__previous--bottom u-mb-l u-dib"
+     {{helpers.track('click', 'Navigation', 'Add Person link click', bottom)}}
+  href="{{add_person_location}}" id="add-person-link">{{ _("Add") }} {{ content.summary.label|lower }}
+  </a>
 </div>

--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-10-17 15:30+0100\n"
+"POT-Creation-Date: 2018-10-18 15:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -550,15 +550,19 @@ msgstr ""
 msgid "Selecting this will add a new set of fields to enter another person"
 msgstr ""
 
-#: app/templates/partials/summary/answer-summary.html:20
+#: app/templates/partials/summary/answer-summary.html:21
 #: app/templates/partials/summary/edit-link.html:6
 msgid "Change"
 msgstr ""
 
-#: app/templates/partials/summary/answer-summary.html:22
+#: app/templates/partials/summary/answer-summary.html:23
 #: app/templates/partials/summary/edit-link.html:7
 #, python-format
 msgid "Change your answer for: %(title)s. The current value is: %(value)s"
+msgstr ""
+
+#: app/templates/partials/summary/answer-summary.html:37
+msgid "Add"
 msgstr ""
 
 #: app/templates/partials/summary/answer.html:2

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -738,7 +738,12 @@ def _build_template(current_location, context, template, schema, answer_store, m
     previous_location = path_finder.get_previous_location(current_location)
     previous_url = previous_location.url(metadata) if previous_location is not None else None
 
-    return _render_template(context, current_location, template, front_end_navigation, previous_url, schema, metadata, answer_store)
+    add_person_url = None
+    if routing_path:
+        add_person_location = routing_path[routing_path.index(current_location) - 1]
+        add_person_url = add_person_location.url(metadata) if add_person_location else None
+
+    return _render_template(context, current_location, template, front_end_navigation, previous_url, add_person_url, schema, metadata, answer_store)
 
 
 @with_session_timeout
@@ -746,7 +751,7 @@ def _build_template(current_location, context, template, schema, answer_store, m
 @with_metadata_context
 @with_analytics
 @with_legal_basis
-def _render_template(context, current_location, template, front_end_navigation, previous_url, schema, metadata, answer_store, **kwargs):
+def _render_template(context, current_location, template, front_end_navigation, previous_url, add_person_url, schema, metadata, answer_store, **kwargs):
     page_title = get_page_title_for_location(schema, current_location, metadata, answer_store)
 
     session_store = get_session_store()
@@ -758,6 +763,7 @@ def _render_template(context, current_location, template, front_end_navigation, 
         current_location=current_location,
         navigation=front_end_navigation,
         previous_location=previous_url,
+        add_person_location=add_person_url,
         page_title=page_title,
         metadata=kwargs.pop('metadata_context'),  # `metadata_context` is used as `metadata` in the jinja templates
         language_code=session_data.language_code,

--- a/tests/functional/pages/surveys/answer_summary/household-summary.page.js
+++ b/tests/functional/pages/surveys/answer_summary/household-summary.page.js
@@ -9,11 +9,13 @@ class HouseholdSummaryPage extends QuestionPage {
 
   primaryFirstNameEdit(index = 1) { return '[data-qa="primary-first-name-' + index + '-edit"]'; }
 
-  primaryFirstNameLabel(index = 1) { return '[data-qa="primary-first-name-' + index + '-label"]'; } 
+  primaryFirstNameLabel(index = 1) { return '[data-qa="primary-first-name-' + index + '-label"]'; }
 
   repeatingFirstNameEdit(index = 1) { return '[data-qa="repeating-first-name-' + index + '-edit"]'; }
 
-  repeatingFirstNameLabel(index = 1) { return '[data-qa="repeating-first-name-' + index + '-label"]'; } 
+  repeatingFirstNameLabel(index = 1) { return '[data-qa="repeating-first-name-' + index + '-label"]'; }
+
+  addPersonLink() { return '#add-person-link'; }
 
 }
 module.exports = new HouseholdSummaryPage();

--- a/tests/functional/spec/features/summary/answer_summary.spec.js
+++ b/tests/functional/spec/features/summary/answer_summary.spec.js
@@ -78,5 +78,22 @@ describe('Answer Summary', function () {
           .getUrl().should.eventually.contain(HouseholdSummaryPage.pageName)
           .getText(HouseholdSummaryPage.repeatingFirstNameLabel(3)).should.eventually.contain('Jillian Smith');
       });
+
+      it('When I click add person link, Then I should go to the anyone else page and be able to add additional people', function () {
+        return browser
+          .click(HouseholdSummaryPage.addPersonLink())
+          .getUrl().should.eventually.contain(RepeatingAnyoneElseBlockPage.pageName)
+          .click(RepeatingAnyoneElseBlockPage.yes())
+          .click(RepeatingAnyoneElseBlockPage.submit())
+
+          .setValue(RepeatingNameBlockPage.repeatingFirstName(), 'Dave')
+          .setValue(RepeatingNameBlockPage.repeatingLastName(), 'Smith')
+          .click(RepeatingNameBlockPage.submit())
+          .click(RepeatingAnyoneElseBlockPage.no())
+          .click(RepeatingAnyoneElseBlockPage.submit())
+
+          .getUrl().should.eventually.contain(HouseholdSummaryPage.pageName)
+          .getText(HouseholdSummaryPage.repeatingFirstNameLabel(4)).should.eventually.contain('Dave Smith');
+      });
   });
 });


### PR DESCRIPTION
### What is the context of this PR?
So that people filling out LMS can add an additional person once they get to the summary screen this will take them back to the last page where they selected "No" to adding more people. They will then be able to change that to "Yes" and continue in the add people loop. 

This is not a long term solution but simple throwaway code to solve issues we're currently having for LMS. 

### How to review 
Feature in `test_answer_summary.json` 

### Checklist

* [x] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
