### PR TITLE
LMS - Answer summaries and no-primary routing

### DIFF
--- a/app/questionnaire/completeness.py
+++ b/app/questionnaire/completeness.py
@@ -49,6 +49,9 @@ class Completeness:
         def eval_state(state_to_compare):
             return (state == state_to_compare for state in group_states)
 
+        def eval_state_in(state_to_compare):
+            return (state in state_to_compare for state in group_states)
+
         section_state = self.NOT_STARTED
 
         if group_states:
@@ -60,6 +63,9 @@ class Completeness:
 
             elif any(eval_state(self.STARTED)):
                 section_state = self.STARTED
+
+            elif all(eval_state_in((self.SKIPPED, self.INVALID))):
+                section_state = self.SKIPPED
 
             elif all(state in self.COMPLETED_STATES for state in group_states):
                 section_state = self.COMPLETED

--- a/app/questionnaire/navigation.py
+++ b/app/questionnaire/navigation.py
@@ -43,9 +43,10 @@ class Navigation:
         navigation = []
 
         for section in self.schema.sections:
-            non_skipped_groups = self._get_non_skipped_groups(section)
-            if not non_skipped_groups:
+            if self.completeness.get_state_for_section(section) == self.completeness.SKIPPED:
                 continue
+
+            non_skipped_groups = self._get_non_skipped_groups(section)
 
             target_location = self._get_location_for_section(section, non_skipped_groups)
 
@@ -200,7 +201,7 @@ class Navigation:
             # if it's been started then get the first incomplete block within that section
             location = first_incomplete
         else:
-            if completeness_state == Completeness.NOT_STARTED or last_block['type'] != 'SectionSummary':
+            if completeness_state == Completeness.NOT_STARTED or last_block['type'] not in ['SectionSummary', 'AnswerSummary']:
                 # if the section hasn't been started or it is complete but has no section summary
                 # go to the first block
                 target_group, target_block = first_group, first_block

--- a/app/questionnaire/questionnaire_schema.py
+++ b/app/questionnaire/questionnaire_schema.py
@@ -211,6 +211,18 @@ class QuestionnaireSchema:  # pylint: disable=too-many-public-methods
         question = self.get_question(answer['parent_id'])
         return answer.get('type') == 'Checkbox' or question['type'] == 'RepeatingAnswer'
 
+    def block_drives_multiple_groups(self, block_id):
+        driver_count = 0
+
+        for driven_group in self.group_dependencies:
+            if driven_group in ['group_drivers', 'block_drivers']:
+                continue
+
+            if block_id in self.group_dependencies[driven_group]:
+                driver_count += 1
+
+        return driver_count > 1
+
     def answer_is_in_repeating_group(self, answer_id):
         answer = self.get_answer(answer_id)
         question = self.get_question(answer['parent_id'])
@@ -257,6 +269,13 @@ class QuestionnaireSchema:  # pylint: disable=too-many-public-methods
     def get_answer_ids_for_question(self, question_id):
         """ get answer ids associated with a specific question_id """
         return list(self._get_answers_by_id_for_question(question_id).keys())
+
+    def get_block_id_for_answer_id(self, answer_id):
+        answer = self.get_answer(answer_id)
+        question = self.get_question(answer['parent_id'])
+        block = self.get_block(question['parent_id'])
+
+        return block['id']
 
 
 def get_nested_schema_objects(parent_object, list_key):

--- a/app/questionnaire/rules.py
+++ b/app/questionnaire/rules.py
@@ -338,6 +338,10 @@ def get_answer_store_value(answer_id, answer_store, schema, group_instance, grou
     if all([answer.get('group_instance_id') for answer in answers_on_path.answers]) and group_instance_id:
         # If all of the matching answers have a group_instance_id, then we know the answer has this group_instance_id
         group_instance = None
+        answer_block_id = schema.get_block_id_for_answer_id(answer_id)
+        if not schema.answer_is_in_repeating_group(answer_id) and schema.block_drives_multiple_groups(answer_block_id):
+            group_instance_id = None
+
     else:
         # We don't have group_instance_ids everywhere, so filter on the group_instance
         if group_instance > 0 and not schema.answer_is_in_repeating_group(answer_id):

--- a/data/en/lms_2.json
+++ b/data/en/lms_2.json
@@ -51,64 +51,66 @@
     ],
     "sections": [{
             "id": "household-section",
-            "title": "About the household",
+            "title": "Who lives here",
             "groups": [{
                     "id": "primary-household-member-group",
                     "title": "Your Details",
                     "blocks": [{
-                            "type": "Question",
-                            "id": "primary-household-member-block",
-                            "questions": [{
-                                "description": "",
-                                "id": "primary-household-member-question",
-                                "title": "What is your name?",
-                                "type": "General",
-                                "answers": [{
-                                        "id": "primary-household-member-first-name",
-                                        "description": "",
-                                        "label": "My first or given name",
-                                        "mandatory": true,
-                                        "type": "TextField"
+                        "type": "Question",
+                        "id": "primary-household-member-block",
+                        "questions": [{
+                            "description": "",
+                            "id": "primary-household-member-question",
+                            "title": "What is your name?",
+                            "type": "General",
+                            "answers": [{
+                                    "id": "primary-household-member-first-name",
+                                    "description": "",
+                                    "label": "My first or given name",
+                                    "mandatory": true,
+                                    "type": "TextField"
+                                },
+                                {
+                                    "id": "primary-household-member-last-name",
+                                    "description": "",
+                                    "label": "My surname or family name",
+                                    "mandatory": true,
+                                    "type": "TextField"
+                                }
+                            ]
+                        }]
+                    }]
+                },
+                {
+                    "id": "primary-household-member-address-group",
+                    "title": "Your Details",
+                    "blocks": [{
+                        "type": "Question",
+                        "id": "address-check-block",
+                        "questions": [{
+                            "id": "address-check-question",
+                            "title": "Is this address your main residence?",
+                            "description": "",
+                            "type": "General",
+                            "answers": [{
+                                "id": "primary-household-member-address-check-answer",
+                                "mandatory": true,
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes",
+                                        "description": "This is my main residence"
                                     },
                                     {
-                                        "id": "primary-household-member-last-name",
-                                        "description": "",
-                                        "label": "My surname or family name",
-                                        "mandatory": true,
-                                        "type": "TextField"
+                                        "label": "No",
+                                        "value": "No",
+                                        "description": "This address is not my main residence. For example it is my old address, second home, holiday home, business address or is not familiar to me"
                                     }
-                                ]
+                                ],
+                                "type": "Radio"
                             }]
-                        },
-                        {
-                            "type": "Question",
-                            "id": "address-check-block",
-                            "questions": [{
-                                "id": "address-check-question",
-                                "title": "Is this address your main residence?",
-                                "description": "{{ format_address_list ([metadata['address_line1'], metadata['address_line2'], metadata['locality'], metadata['town_name'], metadata['postcode']]) }}",
-                                "type": "General",
-                                "answers": [{
-                                    "id": "primary-household-member-address-check-answer",
-                                    "mandatory": true,
-                                    "options": [{
-                                            "label": "Yes",
-                                            "value": "Yes",
-                                            "description": "This is my main residence"
-                                        },
-                                        {
-                                            "label": "No",
-                                            "value": "No",
-                                            "description": "This address is not my main residence. For example it is my old address, second home, holiday home, business address or is not familiar to me"
-                                        }
-                                    ],
-                                    "type": "Radio"
-                                }]
-                            }]
-                        }
-                    ]
+                        }]
+                    }]
                 },
-
                 {
                     "id": "other-household-member-group",
                     "title": "Other Household Members",
@@ -164,13 +166,13 @@
                                 "type": "General",
                                 "answers": [{
                                         "id": "other-household-member-first-name",
-                                        "label": "First Name",
+                                        "label": "First or given name",
                                         "mandatory": true,
                                         "type": "TextField"
                                     },
                                     {
                                         "id": "other-household-member-last-name",
-                                        "label": "Last Name",
+                                        "label": "Surname or family name",
                                         "mandatory": true,
                                         "type": "TextField"
                                     }
@@ -212,7 +214,7 @@
                             "questions": [{
                                 "type": "General",
                                 "id": "student-household-member-anyone-else-question",
-                                "title": "Apart from anyone already added, is there anyone you need to add who lives in a student halls of residence for part of the year?",
+                                "title": "Apart from anyone already added, is there anyone you need to add, including people who live in a student halls of residence?",
                                 "description": "{{ [[answers['primary-household-member-first-name'], answers['primary-household-member-last-name']], [answers['other-household-member-first-name'], answers['other-household-member-last-name']], [answers['student-household-member-first-name'], answers['student-household-member-last-name']]] | format_repeating_summary }}",
                                 "answers": [{
                                     "type": "Radio",
@@ -240,13 +242,13 @@
                                 "type": "General",
                                 "answers": [{
                                         "id": "student-household-member-first-name",
-                                        "label": "First Name",
+                                        "label": "First or given name",
                                         "mandatory": true,
                                         "type": "TextField"
                                     },
                                     {
                                         "id": "student-household-member-last-name",
-                                        "label": "Last Name",
+                                        "label": "Surname or family name",
                                         "mandatory": true,
                                         "type": "TextField"
                                     }
@@ -258,71 +260,6 @@
                                     "condition": "equals",
                                     "value": "No"
                                 }]
-                            }]
-                        }
-                    ]
-                },
-                {
-                    "id": "share-group",
-                    "title": "",
-                    "skip_conditions": [{
-                        "when": [{
-                            "id": "primary-household-member-address-check-answer",
-                            "condition": "equals",
-                            "value": "No"
-                        }]
-                    }],
-                    "blocks": [{
-                            "type": "Question",
-                            "id": "share-cooking-block",
-                            "questions": [{
-                                "id": "share-cooking-question",
-                                "title": "Do all of these people share cooking facilities?",
-                                "description": "{{ [[answers['primary-household-member-first-name'], answers['primary-household-member-last-name']], [answers['other-household-member-first-name'], answers['other-household-member-last-name']], [answers['student-household-member-first-name'], answers['student-household-member-last-name']]] | format_repeating_summary }}",
-                                "type": "General",
-                                "answers": [{
-                                    "id": "share-cooking-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Yes",
-                                            "value": "Yes"
-                                        },
-                                        {
-                                            "label": "No",
-                                            "value": "No"
-                                        }
-                                    ],
-                                    "type": "Radio"
-                                }]
-                            }]
-                        },
-                        {
-                            "type": "Question",
-                            "id": "share-living-block",
-                            "questions": [{
-                                "id": "share-living-question",
-                                "title": "Do all of these people share a living room or dining room?",
-                                "description": "{{ [[answers['primary-household-member-first-name'], answers['primary-household-member-last-name']], [answers['other-household-member-first-name'], answers['other-household-member-last-name']], [answers['student-household-member-first-name'], answers['student-household-member-last-name']]] | format_repeating_summary }}",
-                                "type": "General",
-                                "answers": [{
-                                    "id": "share-living-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Yes",
-                                            "value": "Yes"
-                                        },
-                                        {
-                                            "label": "No",
-                                            "value": "No"
-                                        }
-                                    ],
-                                    "type": "Radio"
-                                }]
-                            }],
-                            "routing_rules": [{
-                                "goto": {
-                                    "group": "household-relationships-group"
-                                }
                             }]
                         }
                     ]
@@ -419,16 +356,6 @@
                                             "id": "household-check-answer-no-primary",
                                             "condition": "equals",
                                             "value": "Yes"
-                                        }]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "share-group-no-primary",
-                                        "when": [{
-                                            "id": "address-type-answer-no-primary",
-                                            "condition": "equals",
-                                            "value": "Student accommodation rented through a private landlord"
                                         }]
                                     }
                                 },
@@ -545,7 +472,7 @@
                             "questions": [{
                                 "type": "General",
                                 "id": "student-household-member-anyone-else-question-no-primary",
-                                "title": "Apart from anyone already added, is there anyone you need to add who lives in a student halls of residence for part of the year?",
+                                "title": "Apart from anyone already added, is there anyone you need to add, including people who live in a student halls of residence?",
                                 "description": "{{ [[answers['other-household-member-first-name-no-primary'], answers['other-household-member-last-name-no-primary']], [answers['student-household-member-first-name-no-primary'], answers['student-household-member-last-name-no-primary']]] | format_repeating_summary }}",
                                 "answers": [{
                                     "type": "Radio",
@@ -596,7 +523,7 @@
                     ]
                 },
                 {
-                    "id": "share-group-no-primary",
+                    "id": "household-summary-group-no-primary",
                     "title": "",
                     "skip_conditions": [{
                         "when": [{
@@ -605,6 +532,132 @@
                             "value": "Yes"
                         }]
                     }],
+                    "blocks": [{
+                        "type": "AnswerSummary",
+                        "id": "household-summary-no-primary",
+                        "title": "People who live here",
+                        "label": "Household members",
+                        "icon": "person",
+                        "answer_ids": [
+                            "other-household-member-first-name-no-primary",
+                            "student-household-member-first-name-no-primary"
+                        ],
+                        "answer_label": "[answers['other-household-member-first-name-no-primary'], answers['other-household-member-last-name-no-primary'], answers['student-household-member-first-name-no-primary'], answers['student-household-member-last-name-no-primary']] | format_household_name"
+                    }]
+                },
+                {
+                    "id": "household-summary-group",
+                    "title": "",
+                    "skip_conditions": [{
+                        "when": [{
+                            "id": "primary-household-member-address-check-answer",
+                            "condition": "equals",
+                            "value": "No"
+                        }]
+                    }],
+                    "blocks": [{
+                        "type": "AnswerSummary",
+                        "id": "household-summary",
+                        "title": "People who live here",
+                        "label": "Household members",
+                        "icon": "person",
+                        "answer_ids": [
+                            "primary-household-member-first-name",
+                            "other-household-member-first-name",
+                            "student-household-member-first-name"
+                        ],
+                        "answer_label": "[answers['primary-household-member-first-name'], answers['primary-household-member-last-name'], answers['other-household-member-first-name'], answers['other-household-member-last-name'], answers['student-household-member-first-name'], answers['student-household-member-last-name']] | format_household_name"
+                    }]
+                }
+            ]
+        },
+        {
+            "id": "household-section-share",
+            "title": "About the household",
+            "groups": [{
+                    "id": "share-group",
+                    "title": "",
+                    "skip_conditions": [{
+                            "when": [{
+                                "id": "primary-household-member-address-check-answer",
+                                "condition": "equals",
+                                "value": "No"
+                            }]
+                        },
+                        {
+                            "when": [{
+                                "id": "primary-household-member-address-check-answer",
+                                "condition": "not set"
+                            }]
+                        }
+                    ],
+                    "blocks": [{
+                            "type": "Question",
+                            "id": "share-cooking-block",
+                            "questions": [{
+                                "id": "share-cooking-question",
+                                "title": "Do all of these people share cooking facilities?",
+                                "description": "{{ [[answers['primary-household-member-first-name'], answers['primary-household-member-last-name']], [answers['other-household-member-first-name'], answers['other-household-member-last-name']], [answers['student-household-member-first-name'], answers['student-household-member-last-name']]] | format_repeating_summary }}",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "share-cooking-answer",
+                                    "mandatory": false,
+                                    "options": [{
+                                            "label": "Yes",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "No"
+                                        }
+                                    ],
+                                    "type": "Radio"
+                                }]
+                            }]
+                        },
+                        {
+                            "type": "Question",
+                            "id": "share-living-block",
+                            "questions": [{
+                                "id": "share-living-question",
+                                "title": "Do all of these people share a living room or dining room?",
+                                "description": "{{ [[answers['primary-household-member-first-name'], answers['primary-household-member-last-name']], [answers['other-household-member-first-name'], answers['other-household-member-last-name']], [answers['student-household-member-first-name'], answers['student-household-member-last-name']]] | format_repeating_summary }}",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "share-living-answer",
+                                    "mandatory": false,
+                                    "options": [{
+                                            "label": "Yes",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "No"
+                                        }
+                                    ],
+                                    "type": "Radio"
+                                }]
+                            }]
+                        }
+                    ]
+                },
+                {
+                    "id": "share-group-no-primary",
+                    "title": "",
+                    "skip_conditions": [{
+                            "when": [{
+                                "id": "primary-household-member-address-check-answer",
+                                "condition": "equals",
+                                "value": "Yes"
+                            }]
+                        },
+                        {
+                            "when": [{
+                                "id": "primary-household-member-address-check-answer",
+                                "condition": "not set"
+                            }]
+                        }
+                    ],
                     "blocks": [{
                             "type": "Question",
                             "id": "share-cooking-block-no-primary",
@@ -654,6 +707,80 @@
                             }]
                         }
                     ]
+                },
+                {
+                    "id": "household-relationships-group-no-primary",
+                    "title": "Relationships",
+                    "skip_conditions": [{
+                        "when": [{
+                            "id": "primary-household-member-address-check-answer",
+                            "condition": "equals",
+                            "value": "Yes"
+                        }]
+                    }],
+                    "routing_rules": [{
+                        "repeat": {
+                            "type": "answer_count_minus_one",
+                            "answer_ids": [
+                                "other-household-member-first-name-no-primary",
+                                "student-household-member-first-name-no-primary"
+                            ]
+                        }
+                    }],
+                    "blocks": [{
+                        "type": "Question",
+                        "id": "no-primary-household-relationships-block",
+                        "questions": [{
+                            "id": "no-primary-relationship-question",
+                            "title": "How is <em>{{[group_instances[group_instance_id]['primary-household-member-first-name'], group_instances[group_instance_id]['primary-household-member-last-name'], group_instances[group_instance_id]['other-household-member-first-name'], group_instances[group_instance_id]['other-household-member-last-name'], group_instances[group_instance_id]['student-household-member-first-name'], group_instances[group_instance_id]['student-household-member-last-name'], group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> related to the people below?",
+
+                            "type": "Relationship",
+                            "member_label": "answers['primary-household-member-first-name'] | default(answers['other-household-member-first-name']) | default(answers['student-household-member-first-name']) | default(answers['other-household-member-first-name-no-primary']) | default(answers['student-household-member-first-name-no-primary'])",
+                            "answers": [{
+                                "id": "no-primary-who-is-related",
+                                "label": "%(current_person)s is the &hellip; of %(other_person)s",
+                                "mandatory": true,
+                                "type": "Relationship",
+                                "options": [{
+                                        "label": "Husband or wife",
+                                        "value": "Husband or wife"
+                                    },
+                                    {
+                                        "label": "Partner",
+                                        "value": "Partner"
+                                    },
+                                    {
+                                        "label": "Mother or father",
+                                        "value": "Mother or father"
+                                    },
+                                    {
+                                        "label": "Son or daughter",
+                                        "value": "Son or daughter"
+                                    },
+                                    {
+                                        "label": "Brother or sister",
+                                        "value": "Brother or sister"
+                                    },
+                                    {
+                                        "label": "Relation - other",
+                                        "value": "Relation - other"
+                                    },
+                                    {
+                                        "label": "Grandparent",
+                                        "value": "Grandparent"
+                                    },
+                                    {
+                                        "label": "Grandchild",
+                                        "value": "Grandchild"
+                                    },
+                                    {
+                                        "label": "Unrelated",
+                                        "value": "Unrelated"
+                                    }
+                                ]
+                            }]
+                        }]
+                    }]
                 },
                 {
                     "id": "household-relationships-group",
@@ -741,11 +868,7 @@
                 "other-household-member-first-name",
                 "other-household-member-last-name",
                 "student-household-member-first-name",
-                "student-household-member-last-name",
-                "other-household-member-first-name-no-primary",
-                "other-household-member-last-name-no-primary",
-                "student-household-member-first-name-no-primary",
-                "student-household-member-last-name-no-primary"
+                "student-household-member-last-name"
             ],
             "groups": [{
                 "id": "household-member-group",
@@ -756,9 +879,7 @@
                         "answer_ids": [
                             "primary-household-member-first-name",
                             "other-household-member-first-name",
-                            "student-household-member-first-name",
-                            "other-household-member-first-name-no-primary",
-                            "student-household-member-first-name-no-primary"
+                            "student-household-member-first-name"
                         ]
                     }
                 }],
@@ -3716,7 +3837,8 @@
                                     "type": "TextField",
                                     "mandatory": false,
                                     "label": "Please describe"
-                                }, {
+                                },
+                                {
                                     "id": "working-hours-answer-exclusive",
                                     "mandatory": false,
                                     "type": "Checkbox",
@@ -3787,47 +3909,49 @@
                             "type": "MutuallyExclusive",
                             "mandatory": false,
                             "answers": [{
-                                "id": "working-days-answer",
-                                "mandatory": false,
-                                "type": "Checkbox",
-                                "options": [{
-                                        "label": "{{calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'MO') | format_date_custom('EEEE dd MMMM') }}",
-                                        "value": "Monday"
-                                    },
-                                    {
-                                        "label": "{{calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'TU') | format_date_custom('EEEE dd MMMM') }}",
-                                        "value": "Tuesday"
-                                    },
-                                    {
-                                        "label": "{{calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'WE') | format_date_custom('EEEE dd MMMM') }}",
-                                        "value": "Wednesday"
-                                    },
-                                    {
-                                        "label": "{{calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'TH') | format_date_custom('EEEE dd MMMM') }}",
-                                        "value": "Thursday"
-                                    },
-                                    {
-                                        "label": "{{calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'FR') | format_date_custom('EEEE dd MMMM') }}",
-                                        "value": "Friday"
-                                    },
-                                    {
-                                        "label": "{{calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SA') | format_date_custom('EEEE dd MMMM') }}",
-                                        "value": "Saturday"
-                                    },
-                                    {
-                                        "label": "{{calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU') | format_date_custom('EEEE dd MMMM') }}",
-                                        "value": "Sunday"
-                                    }
-                                ]
-                            }, {
-                                "id": "working-days-answer-exclusive",
-                                "mandatory": false,
-                                "type": "Checkbox",
-                                "options": [{
-                                    "label": "Did not work this week",
-                                    "value": "Did not work this week"
-                                }]
-                            }]
+                                    "id": "working-days-answer",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "options": [{
+                                            "label": "{{calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'MO') | format_date_custom('EEEE dd MMMM') }}",
+                                            "value": "Monday"
+                                        },
+                                        {
+                                            "label": "{{calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'TU') | format_date_custom('EEEE dd MMMM') }}",
+                                            "value": "Tuesday"
+                                        },
+                                        {
+                                            "label": "{{calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'WE') | format_date_custom('EEEE dd MMMM') }}",
+                                            "value": "Wednesday"
+                                        },
+                                        {
+                                            "label": "{{calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'TH') | format_date_custom('EEEE dd MMMM') }}",
+                                            "value": "Thursday"
+                                        },
+                                        {
+                                            "label": "{{calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'FR') | format_date_custom('EEEE dd MMMM') }}",
+                                            "value": "Friday"
+                                        },
+                                        {
+                                            "label": "{{calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SA') | format_date_custom('EEEE dd MMMM') }}",
+                                            "value": "Saturday"
+                                        },
+                                        {
+                                            "label": "{{calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU') | format_date_custom('EEEE dd MMMM') }}",
+                                            "value": "Sunday"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "working-days-answer-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "options": [{
+                                        "label": "Did not work this week",
+                                        "value": "Did not work this week"
+                                    }]
+                                }
+                            ]
                         }]
                     },
                     {
@@ -4009,30 +4133,35 @@
                                 "goto": {
                                     "block": "two-jobs-j1-usual-hours-w12-1",
                                     "when": [{
-                                        "id": "second-job-answer",
-                                        "condition": "equals",
-                                        "value": "Yes"
-                                    }, {
-                                        "id": "working-days-answer-exclusive",
-                                        "condition": "contains",
-                                        "value": "Did not work this week"
-                                    }]
+                                            "id": "second-job-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "id": "working-days-answer-exclusive",
+                                            "condition": "contains",
+                                            "value": "Did not work this week"
+                                        }
+                                    ]
                                 }
                             },
                             {
                                 "goto": {
                                     "block": "two-jobs-j1-usual-hours-w12-1",
                                     "when": [{
-                                        "id": "second-job-answer",
-                                        "condition": "equals",
-                                        "value": "Yes"
-                                    }, {
-                                        "id": "working-days-answer",
-                                        "condition": "not set"
-                                    }, {
-                                        "id": "working-days-answer-exclusive",
-                                        "condition": "not set"
-                                    }]
+                                            "id": "second-job-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "id": "working-days-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "working-days-answer-exclusive",
+                                            "condition": "not set"
+                                        }
+                                    ]
                                 }
                             },
                             {
@@ -4071,14 +4200,16 @@
                                 "goto": {
                                     "block": "two-jobs-j1-unpaid-overtime-w-10-1",
                                     "when": [{
-                                        "id": "second-job-answer",
-                                        "condition": "equals",
-                                        "value": "Yes"
-                                    }, {
-                                        "id": "overtime-answer",
-                                        "condition": "equals",
-                                        "value": "Unpaid overtime"
-                                    }]
+                                            "id": "second-job-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "id": "overtime-answer",
+                                            "condition": "equals",
+                                            "value": "Unpaid overtime"
+                                        }
+                                    ]
                                 }
                             },
                             {
@@ -4460,6 +4591,10 @@
                                             "condition": "not set"
                                         },
                                         {
+                                            "id": "working-days-answer-exclusive",
+                                            "condition": "not set"
+                                        },
+                                        {
                                             "id": "one-job-emp-status-emp-or-self-answer",
                                             "condition": "equals",
                                             "value": "employee"
@@ -4472,6 +4607,10 @@
                                     "block": "reason-why-fewer-hours-than-usual-employee-w14-emp",
                                     "when": [{
                                             "id": "working-days-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "working-days-answer-exclusive",
                                             "condition": "not set"
                                         },
                                         {
@@ -6126,14 +6265,17 @@
                                 "goto": {
                                     "block": "two-jobs-j2-usual-hours-w12-2",
                                     "when": [{
-                                        "id": "working-days-answer",
-                                        "condition": "not set"
-                                    }, {
-                                        "id": "working-days-answer-exclusive",
-                                        "condition": "not set"
-                                    }]
+                                            "id": "working-days-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "working-days-answer-exclusive",
+                                            "condition": "not set"
+                                        }
+                                    ]
                                 }
-                            }, {
+                            },
+                            {
                                 "goto": {
                                     "block": "two-jobs-j2-usual-hours-w12-2",
                                     "when": [{
@@ -6297,7 +6439,8 @@
                                         {
                                             "id": "working-days-answer",
                                             "condition": "not set"
-                                        }, {
+                                        },
+                                        {
                                             "id": "working-days-answer-exclusive",
                                             "condition": "not set"
                                         }
@@ -6319,7 +6462,8 @@
                                         }
                                     ]
                                 }
-                            }, {
+                            },
+                            {
                                 "goto": {
                                     "block": "reason-why-fewer-hours-than-usual-employee-w14-emp",
                                     "when": [{
@@ -6330,7 +6474,8 @@
                                         {
                                             "id": "working-days-answer",
                                             "condition": "not set"
-                                        }, {
+                                        },
+                                        {
                                             "id": "working-days-answer-exclusive",
                                             "condition": "not set"
                                         }
@@ -6352,16 +6497,19 @@
                                         }
                                     ]
                                 }
-                            }, {
+                            },
+                            {
                                 "goto": {
                                     "block": "reason-why-fewer-hours-than-usual-self-employed-w14-semp",
                                     "when": [{
-                                        "id": "working-days-answer",
-                                        "condition": "not set"
-                                    }, {
-                                        "id": "working-days-answer-exclusive",
-                                        "condition": "not set"
-                                    }]
+                                            "id": "working-days-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "working-days-answer-exclusive",
+                                            "condition": "not set"
+                                        }
+                                    ]
                                 }
                             },
                             {
@@ -7995,31 +8143,33 @@
                             "type": "MutuallyExclusive",
                             "mandatory": false,
                             "answers": [{
-                                "id": "unpaid-or-voluntary-work-answer",
-                                "mandatory": false,
-                                "type": "Checkbox",
-                                "options": [{
-                                        "label": "Yes, for a family-owned business",
-                                        "value": "Yes, for a family-owned business"
-                                    },
-                                    {
-                                        "label": "Yes, for a voluntary cause or charity",
-                                        "value": "Yes, for a voluntary cause or charity"
-                                    },
-                                    {
-                                        "label": "Yes, for an internship",
-                                        "value": "Yes, for an internship"
-                                    }
-                                ]
-                            }, {
-                                "id": "unpaid-or-voluntary-work-answer-exclusive",
-                                "mandatory": false,
-                                "type": "Checkbox",
-                                "options": [{
-                                    "label": "No",
-                                    "value": "No"
-                                }]
-                            }]
+                                    "id": "unpaid-or-voluntary-work-answer",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "options": [{
+                                            "label": "Yes, for a family-owned business",
+                                            "value": "Yes, for a family-owned business"
+                                        },
+                                        {
+                                            "label": "Yes, for a voluntary cause or charity",
+                                            "value": "Yes, for a voluntary cause or charity"
+                                        },
+                                        {
+                                            "label": "Yes, for an internship",
+                                            "value": "Yes, for an internship"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "unpaid-or-voluntary-work-answer-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "options": [{
+                                        "label": "No",
+                                        "value": "No"
+                                    }]
+                                }
+                            ]
                         }]
                     },
                     {
@@ -8346,6 +8496,7627 @@
                     {
                         "id": "household-member-completed",
                         "title": "There are no more questions for {{[group_instances[group_instance_id]['primary-household-member-first-name'], group_instances[group_instance_id]['primary-household-member-last-name'], group_instances[group_instance_id]['other-household-member-first-name'], group_instances[group_instance_id]['other-household-member-last-name'], group_instances[group_instance_id]['student-household-member-first-name'], group_instances[group_instance_id]['student-household-member-last-name'], group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}",
+                        "description": "",
+                        "type": "Interstitial"
+                    }
+                ]
+            }]
+        },
+        {
+            "id": "household-members-new",
+            "title_from_answers": [
+                "other-household-member-first-name-no-primary",
+                "other-household-member-last-name-no-primary",
+                "student-household-member-first-name-no-primary",
+                "student-household-member-last-name-no-primary"
+            ],
+            "groups": [{
+                "id": "no-primary-household-member-group",
+                "title": "Household Member Details",
+                "routing_rules": [{
+                    "repeat": {
+                        "type": "answer_count",
+                        "answer_ids": [
+                            "other-household-member-first-name-no-primary",
+                            "student-household-member-first-name-no-primary"
+                        ]
+                    }
+                }],
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "primary-household-member-address-check-answer",
+                        "condition": "equals",
+                        "value": "Yes"
+                    }]
+                }],
+                "blocks": [{
+                        "type": "Interstitial",
+                        "id": "no-primary-household-member-begin",
+                        "title": "{{[group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}",
+                        "description": "In this section, we’re going to ask questions about <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em>.",
+                        "content": [{
+                            "title": "Information you need",
+                            "list": [
+                                "Personal details such as date of birth, nationality, country of birth",
+                                "How long <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> has lived in the UK",
+                                "Their national identity, ethnicity and religion"
+                            ]
+                        }]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "no-primary-proxy-check",
+                        "questions": [{
+                            "id": "no-primary-proxy-check-question",
+                            "title": "Are you <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em>?",
+                            "type": "General",
+                            "guidance": {
+                                "content": [{
+                                    "description": "An adult should answer on behalf of anyone aged 15 or younger."
+                                }]
+                            },
+                            "answers": [{
+                                "id": "no-primary-proxy-check-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Yes, I am",
+                                        "value": "no proxy"
+                                    },
+                                    {
+                                        "label": "No, I am answering on their behalf",
+                                        "value": "proxy"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                            "goto": {
+                                "block": "no-primary-alternative-address"
+                            }
+                        }]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "no-primary-alternative-address",
+                        "questions": [{
+                            "id": "no-primary-alternative-address-question",
+                            "titles": [{
+                                    "value": "Does <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> currently live at any other addresses for part of the year?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "Do you currently live at any other addresses for part of the year?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-alternative-address-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-alternative-address-type",
+                                    "when": [{
+                                        "id": "no-primary-alternative-address-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-sex"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "no-primary-alternative-address-type",
+                        "questions": [{
+                            "id": "no-primary-alternative-address-type-question",
+                            "titles": [{
+                                    "value": "What type of property is <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name_possessive}}</em> other address?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "What type of property is your other address?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-alternative-address-type-answer",
+                                "mandatory": false,
+                                "type": "Checkbox",
+                                "options": [{
+                                        "label": "A student halls of residence",
+                                        "value": "A student halls of residence"
+                                    },
+                                    {
+                                        "label": "Student accomodation rented through a private landlord",
+                                        "value": "Student accomodation rented through a private landlord"
+                                    },
+                                    {
+                                        "label": "A family or parental home",
+                                        "value": "A family or parental home"
+                                    },
+                                    {
+                                        "label": "A second home",
+                                        "value": "A second home",
+                                        "description": "For example, a place where you stay whilst working away from your main residence"
+                                    },
+                                    {
+                                        "label": "A holiday home",
+                                        "value": "A holiday home",
+                                        "description": "For example, somewhere you stay whilst on holiday or travelling, either in the UK or abroad"
+                                    },
+                                    {
+                                        "label": "Another type of address",
+                                        "value": "Another type of address"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-household-member-completed",
+                                    "when": [{
+                                        "id": "no-primary-alternative-address-type-answer",
+                                        "condition": "contains",
+                                        "value": "Student accomodation rented through a private landlord"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-sex",
+                                    "when": [{
+                                        "id": "no-primary-alternative-address-type-answer",
+                                        "condition": "contains",
+                                        "value": "A student halls of residence"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-time-away"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "no-primary-time-away",
+                        "questions": [{
+                            "id": "no-primary-time-away-question",
+                            "titles": [{
+                                    "value": "Is <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> currently away from {{ metadata['display_address'] }} for a continuous period of 6 months or more?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "Are you currently away from {{ metadata['display_address'] }} for a continuous period of 6 months or more?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-time-away-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-household-member-completed",
+                                    "when": [{
+                                        "id": "no-primary-time-away-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-sex"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "no-primary-sex",
+                        "questions": [{
+                            "id": "no-primary-sex-question",
+                            "titles": [{
+                                    "value": "What is <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name_possessive}}</em> sex?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "What is your sex?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-sex-answer",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Male",
+                                        "value": "Male"
+                                    },
+                                    {
+                                        "label": "Female",
+                                        "value": "Female"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                            "goto": {
+                                "block": "no-primary-date-of-birth"
+                            }
+                        }]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "no-primary-date-of-birth",
+                        "questions": [{
+                            "id": "no-primary-date-of-birth-question",
+                            "titles": [{
+                                    "value": "What is <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name_possessive}}</em> date of birth?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "What is your date of birth?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-date-of-birth-answer",
+                                "mandatory": false,
+                                "type": "Date",
+                                "maximum": {
+                                    "value": "now"
+                                },
+                                "minimum": {
+                                    "value": "1900-01-01"
+                                }
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-date-of-birth-age",
+                                    "when": [{
+                                        "id": "no-primary-date-of-birth-answer",
+                                        "condition": "not set"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-nationality",
+                                    "when": [{
+                                        "id": "no-primary-date-of-birth-answer",
+                                        "condition": "greater than",
+                                        "date_comparison": {
+                                            "value": "now",
+                                            "offset_by": {
+                                                "years": -16
+                                            }
+                                        }
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-marital-status"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "ConfirmationQuestion",
+                        "id": "no-primary-date-of-birth-age",
+                        "questions": [{
+                            "id": "no-primary-dob-age-question",
+                            "titles": [{
+                                    "value": "What is <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name_possessive}}</em> age?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "What is your age?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-dob-age-answer",
+                                "unit": "duration-year",
+                                "type": "Unit",
+                                "unit_length": "long",
+                                "mandatory": false,
+                                "max_value": {
+                                    "value": 118
+                                }
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-nationality",
+                                    "when": [{
+                                        "id": "no-primary-dob-age-answer",
+                                        "condition": "not set"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-nationality",
+                                    "when": [{
+                                        "id": "no-primary-dob-age-answer",
+                                        "condition": "less than",
+                                        "value": 16
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-marital-status",
+                                    "when": [{
+                                        "id": "no-primary-dob-age-answer",
+                                        "condition": "greater than",
+                                        "value": 16
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-marital-status",
+                                    "when": [{
+                                        "id": "no-primary-dob-age-answer",
+                                        "condition": "equals",
+                                        "value": 16
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-marital-status"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "no-primary-marital-status",
+                        "questions": [{
+                            "id": "no-primary-marital-status-question",
+                            "titles": [{
+                                    "value": "What is <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name_possessive}}</em> legal marital status?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "What is your legal marital status?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-marital-status-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Never married",
+                                        "value": "Never married"
+                                    },
+                                    {
+                                        "label": "Married",
+                                        "value": "Married"
+                                    },
+                                    {
+                                        "label": "In a registered same-sex civil partnership",
+                                        "value": "In a registered same-sex civil partnership"
+                                    },
+                                    {
+                                        "label": "Separated, but still legally married",
+                                        "value": "Separated, but still legally married"
+                                    },
+                                    {
+                                        "label": "Separated, but still legally in a same-sex civil partnership",
+                                        "value": "Separated, but still legally in a same-sex civil partnership"
+                                    },
+                                    {
+                                        "label": "Divorced",
+                                        "value": "Divorced"
+                                    },
+                                    {
+                                        "label": "Formerly in a same-sex civil partnership which is now legally dissolved",
+                                        "value": "Formerly in a same-sex civil partnership which is now legally dissolved"
+                                    },
+                                    {
+                                        "label": "Widowed",
+                                        "value": "Widowed"
+                                    },
+                                    {
+                                        "label": "Surviving member of a same-sex civil partnership",
+                                        "value": "Surviving member of a same-sex civil partnership"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                            "goto": {
+                                "block": "no-primary-nationality"
+                            }
+                        }]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "no-primary-nationality",
+                        "questions": [{
+                            "id": "no-primary-nationality-question",
+                            "type": "General",
+                            "titles": [{
+                                    "value": "What is <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name_possessive}}</em> nationality?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "What is your nationality?"
+                                }
+                            ],
+                            "answers": [{
+                                    "id": "no-primary-nationality-answer",
+                                    "mandatory": false,
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "British",
+                                            "value": "British"
+                                        },
+                                        {
+                                            "label": "Irish",
+                                            "value": "Irish"
+                                        },
+                                        {
+                                            "label": "Indian",
+                                            "value": "Indian"
+                                        },
+                                        {
+                                            "label": "Pakistani",
+                                            "value": "Pakistani"
+                                        },
+                                        {
+                                            "label": "Polish",
+                                            "value": "Polish"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "child_answer_id": "no-primary-nationality-answer-other"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "no-primary-nationality-answer-other",
+                                    "parent_answer_id": "no-primary-nationality-answer",
+                                    "type": "TextField",
+                                    "mandatory": false,
+                                    "label": "Please enter nationality"
+                                }
+                            ]
+                        }]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "no-primary-country-of-birth-wales",
+                        "skip_conditions": [{
+                            "when": [{
+                                "meta": "country",
+                                "condition": "not equals",
+                                "value": "W"
+                            }]
+                        }],
+                        "questions": [{
+                            "id": "no-primary-country-of-birth-wales-question",
+                            "titles": [{
+                                    "value": "In which country was <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> born?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "In which country were you born?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                    "id": "no-primary-country-of-birth-wales-answer",
+                                    "mandatory": false,
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "Wales",
+                                            "value": "Wales"
+                                        },
+                                        {
+                                            "label": "England",
+                                            "value": "England"
+                                        },
+                                        {
+                                            "label": "Scotland",
+                                            "value": "Scotland"
+                                        },
+                                        {
+                                            "label": "Northern Ireland",
+                                            "value": "Northern Ireland"
+                                        },
+                                        {
+                                            "label": "Republic of Ireland",
+                                            "value": "Republic of Ireland"
+                                        },
+                                        {
+                                            "label": "Isle of Man or Channel Islands",
+                                            "value": "Isle of Man or Channel Islands"
+                                        },
+                                        {
+                                            "label": "India",
+                                            "value": "India"
+                                        },
+                                        {
+                                            "label": "Pakistan",
+                                            "value": "Pakistan"
+                                        },
+                                        {
+                                            "label": "Poland",
+                                            "value": "Poland"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "child_answer_id": "no-primary-country-of-birth-wales-answer-other"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "no-primary-country-of-birth-wales-answer-other",
+                                    "parent_answer_id": "no-primary-country-of-birth-wales-answer",
+                                    "type": "TextField",
+                                    "mandatory": false,
+                                    "label": "Please enter country of birth"
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-national-identity",
+                                    "when": [{
+                                        "id": "no-primary-country-of-birth-wales-answer",
+                                        "condition": "equals",
+                                        "value": "England"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-national-identity",
+                                    "when": [{
+                                        "id": "no-primary-country-of-birth-wales-answer",
+                                        "condition": "equals",
+                                        "value": "Wales"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-national-identity",
+                                    "when": [{
+                                        "id": "no-primary-country-of-birth-wales-answer",
+                                        "condition": "equals",
+                                        "value": "Scotland"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-national-identity",
+                                    "when": [{
+                                        "id": "no-primary-country-of-birth-wales-answer",
+                                        "condition": "equals",
+                                        "value": "Northern Ireland"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-national-identity",
+                                    "when": [{
+                                        "id": "no-primary-country-of-birth-wales-answer",
+                                        "condition": "not set"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-first-arrive-in-uk"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "no-primary-country-of-birth-scotland",
+                        "skip_conditions": [{
+                            "when": [{
+                                    "meta": "country",
+                                    "condition": "not equals",
+                                    "value": "N"
+                                },
+                                {
+                                    "meta": "country",
+                                    "condition": "not equals",
+                                    "value": "S"
+                                }
+                            ]
+                        }],
+                        "questions": [{
+                            "id": "no-primary-country-of-birth-scotland-question",
+                            "titles": [{
+                                    "value": "In which country was <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> born?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "In which country were you born?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                    "id": "no-primary-country-of-birth-scotland-answer",
+                                    "mandatory": false,
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "Scotland",
+                                            "value": "Scotland"
+                                        },
+                                        {
+                                            "label": "England",
+                                            "value": "England"
+                                        },
+                                        {
+                                            "label": "Wales",
+                                            "value": "Wales"
+                                        },
+                                        {
+                                            "label": "Northern Ireland",
+                                            "value": "Northern Ireland"
+                                        },
+                                        {
+                                            "label": "Republic of Ireland",
+                                            "value": "Republic of Ireland"
+                                        },
+                                        {
+                                            "label": "Isle of Man or Channel Islands",
+                                            "value": "Isle of Man or Channel Islands"
+                                        },
+                                        {
+                                            "label": "India",
+                                            "value": "India"
+                                        },
+                                        {
+                                            "label": "Pakistan",
+                                            "value": "Pakistan"
+                                        },
+                                        {
+                                            "label": "Poland",
+                                            "value": "Poland"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "child_answer_id": "no-primary-country-of-birth-scotland-answer-other"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "no-primary-country-of-birth-scotland-answer-other",
+                                    "parent_answer_id": "no-primary-country-of-birth-scotland-answer",
+                                    "type": "TextField",
+                                    "mandatory": false,
+                                    "label": "Please enter country of birth"
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-national-identity",
+                                    "when": [{
+                                        "id": "no-primary-country-of-birth-scotland-answer",
+                                        "condition": "equals",
+                                        "value": "England"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-national-identity",
+                                    "when": [{
+                                        "id": "no-primary-country-of-birth-scotland-answer",
+                                        "condition": "equals",
+                                        "value": "Wales"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-national-identity",
+                                    "when": [{
+                                        "id": "no-primary-country-of-birth-scotland-answer",
+                                        "condition": "equals",
+                                        "value": "Scotland"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-national-identity",
+                                    "when": [{
+                                        "id": "no-primary-country-of-birth-scotland-answer",
+                                        "condition": "equals",
+                                        "value": "Northern Ireland"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-national-identity",
+                                    "when": [{
+                                        "id": "no-primary-country-of-birth-scotland-answer",
+                                        "condition": "not set"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-first-arrive-in-uk"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "no-primary-country-of-birth-england",
+                        "skip_conditions": [{
+                            "when": [{
+                                "meta": "country",
+                                "condition": "not equals",
+                                "value": "E"
+                            }]
+                        }],
+                        "questions": [{
+                            "id": "no-primary-country-of-birth-england-question",
+                            "titles": [{
+                                    "value": "In which country was <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> born?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "In which country were you born?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                    "id": "no-primary-country-of-birth-england-answer",
+                                    "mandatory": false,
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "England",
+                                            "value": "England"
+                                        },
+                                        {
+                                            "label": "Wales",
+                                            "value": "Wales"
+                                        },
+                                        {
+                                            "label": "Scotland",
+                                            "value": "Scotland"
+                                        },
+                                        {
+                                            "label": "Northern Ireland",
+                                            "value": "Northern Ireland"
+                                        },
+                                        {
+                                            "label": "Republic of Ireland",
+                                            "value": "Republic of Ireland"
+                                        },
+                                        {
+                                            "label": "Isle of Man or Channel Islands",
+                                            "value": "Isle of Man or Channel Islands"
+                                        },
+                                        {
+                                            "label": "India",
+                                            "value": "India"
+                                        },
+                                        {
+                                            "label": "Pakistan",
+                                            "value": "Pakistan"
+                                        },
+                                        {
+                                            "label": "Poland",
+                                            "value": "Poland"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "child_answer_id": "no-primary-country-of-birth-england-answer-other"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "no-primary-country-of-birth-england-answer-other",
+                                    "parent_answer_id": "no-primary-country-of-birth-england-answer",
+                                    "type": "TextField",
+                                    "mandatory": false,
+                                    "label": "Please enter country of birth"
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-national-identity",
+                                    "when": [{
+                                        "id": "no-primary-country-of-birth-england-answer",
+                                        "condition": "equals",
+                                        "value": "England"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-national-identity",
+                                    "when": [{
+                                        "id": "no-primary-country-of-birth-england-answer",
+                                        "condition": "equals",
+                                        "value": "Wales"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-national-identity",
+                                    "when": [{
+                                        "id": "no-primary-country-of-birth-england-answer",
+                                        "condition": "equals",
+                                        "value": "Scotland"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-national-identity",
+                                    "when": [{
+                                        "id": "no-primary-country-of-birth-england-answer",
+                                        "condition": "equals",
+                                        "value": "Northern Ireland"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-national-identity",
+                                    "when": [{
+                                        "id": "no-primary-country-of-birth-england-answer",
+                                        "condition": "not set"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-first-arrive-in-uk"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "no-primary-first-arrive-in-uk",
+                        "questions": [{
+                            "id": "no-primary-first-arrive-in-uk-question",
+                            "titles": [{
+                                    "value": "In which year did <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> first arrive to live in the UK?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "In which year did you first arrive to live in the UK?"
+                                }
+                            ],
+                            "description": "Please exclude holidays and short visits to the UK",
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-first-arrive-in-uk-answer",
+                                "mandatory": false,
+                                "type": "YearDate",
+                                "maximum": {
+                                    "value": "now"
+                                },
+                                "minimum": {
+                                    "answer_id": "no-primary-date-of-birth-answer"
+                                }
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-national-identity",
+                                    "when": [{
+                                        "id": "no-primary-first-arrive-in-uk-answer",
+                                        "condition": "not set"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-continuous-in-uk"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "no-primary-continuous-in-uk",
+                        "questions": [{
+                            "id": "no-primary-continuous-in-uk-question",
+                            "titles": [{
+                                    "value": "Apart from holidays and short visits abroad, has <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> lived in the UK continuously since {{ answers['no-primary-first-arrive-in-uk-answer'][group_instance]|format_date }}?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "Apart from holidays and short visits abroad, have you lived in the UK continuously since {{ answers['no-primary-first-arrive-in-uk-answer'][group_instance]|format_date }}?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-continuous-in-uk-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-national-identity",
+                                    "when": [{
+                                            "id": "no-primary-continuous-in-uk-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "id": "no-primary-date-of-birth-answer",
+                                            "condition": "greater than",
+                                            "date_comparison": {
+                                                "value": "now",
+                                                "offset_by": {
+                                                    "years": -16
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-national-identity",
+                                    "when": [{
+                                            "id": "no-primary-continuous-in-uk-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "id": "no-primary-dob-age-answer",
+                                            "condition": "less than",
+                                            "value": 16
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-why-uk",
+                                    "when": [{
+                                            "id": "no-primary-continuous-in-uk-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "id": "no-primary-dob-age-answer",
+                                            "condition": "greater than",
+                                            "value": 15
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-why-uk",
+                                    "when": [{
+                                            "id": "no-primary-continuous-in-uk-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "id": "no-primary-date-of-birth-answer",
+                                            "condition": "less than",
+                                            "date_comparison": {
+                                                "value": "now",
+                                                "offset_by": {
+                                                    "years": -16
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-national-identity",
+                                    "when": [{
+                                            "id": "no-primary-continuous-in-uk-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "id": "no-primary-date-of-birth-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-dob-age-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-camyr2-block",
+                                    "when": [{
+                                        "id": "no-primary-continuous-in-uk-answer",
+                                        "condition": "equals",
+                                        "value": "No"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-national-identity"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "no-primary-camyr2-block",
+                        "questions": [{
+                            "id": "no-primary-camyr2-question",
+                            "titles": [{
+                                    "value": "When did {{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} <em>most recently</em> arrive in the UK?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "When did you <em>most recently</em> arrive in the UK?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-last-arrive-in-uk-answer",
+                                "mandatory": false,
+                                "type": "MonthYearDate",
+                                "maximum": {
+                                    "value": "now"
+                                },
+                                "minimum": {
+                                    "answer_id": "no-primary-first-arrive-in-uk-answer"
+                                }
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-national-identity",
+                                    "when": [{
+                                        "id": "no-primary-last-arrive-in-uk-answer",
+                                        "condition": "not set"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-why-uk-continuous",
+                                    "when": [{
+                                        "id": "no-primary-date-of-birth-answer",
+                                        "condition": "less than",
+                                        "date_comparison": {
+                                            "value": "now",
+                                            "offset_by": {
+                                                "years": -16
+                                            }
+                                        }
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-why-uk-continuous",
+                                    "when": [{
+                                        "id": "no-primary-dob-age-answer",
+                                        "condition": "greater than",
+                                        "value": 15
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-national-identity",
+                                    "when": [{
+                                        "id": "no-primary-dob-age-answer",
+                                        "condition": "less than",
+                                        "value": 16
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-national-identity",
+                                    "when": [{
+                                        "id": "no-primary-date-of-birth-answer",
+                                        "condition": "not set"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-national-identity",
+                                    "when": [{
+                                        "id": "no-primary-dob-age-answer",
+                                        "condition": "not set"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-national-identity"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "no-primary-why-uk",
+                        "questions": [{
+                            "id": "no-primary-why-uk-question",
+                            "titles": [{
+                                    "value": "What was <em>{{ [answers['primary-household-member-first-name'][group_instance], answers['primary-household-member-last-name'][group_instance]] | format_household_name_possessive}}</em> main reason for coming to the UK in {{ answers['no-primary-first-arrive-in-uk-answer'][group_instance]|format_date }} ?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "What was your main reason for coming to the UK in {{ answers['no-primary-first-arrive-in-uk-answer'][group_instance]|format_date }}?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                    "id": "no-primary-why-uk-answer",
+                                    "mandatory": false,
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "For employment",
+                                            "value": "For employment"
+                                        },
+                                        {
+                                            "label": "For study",
+                                            "value": "For study"
+                                        },
+                                        {
+                                            "label": "As a spouse or dependent of a UK citizen or settled person",
+                                            "value": "As a spouse or dependent of a UK citizen or settled person"
+                                        },
+                                        {
+                                            "label": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons",
+                                            "value": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons"
+                                        },
+                                        {
+                                            "label": "To get married or form a civil partnership in the UK with a non-UK citizen",
+                                            "value": "To get married or form a civil partnership in the UK with a non-UK citizen"
+                                        },
+                                        {
+                                            "label": "Seeking asylum",
+                                            "value": "Seeking asylum"
+                                        },
+                                        {
+                                            "label": "As a visitor",
+                                            "value": "As a visitor"
+                                        },
+                                        {
+                                            "label": "Another reason",
+                                            "value": "Another reason",
+                                            "child_answer_id": "no-primary-why-uk-answer-other"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "no-primary-why-uk-answer-other",
+                                    "parent_answer_id": "no-primary-why-uk-answer",
+                                    "type": "TextField",
+                                    "mandatory": false,
+                                    "label": "Please describe"
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                            "goto": {
+                                "block": "no-primary-national-identity"
+                            }
+                        }]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "no-primary-why-uk-continuous",
+                        "questions": [{
+                            "id": "no-primary-why-uk-continuous-question",
+                            "titles": [{
+                                    "value": "What was <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name_possessive}}</em> main reason for coming to the UK in {{ answers['no-primary-last-arrive-in-uk-answer'][group_instance]|format_date }}?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "What was your main reason for coming to the UK in {{ answers['no-primary-last-arrive-in-uk-answer'][group_instance]|format_date }}?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                    "id": "no-primary-why-uk-continuous-answer",
+                                    "mandatory": false,
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "For employment",
+                                            "value": "For employment"
+                                        },
+                                        {
+                                            "label": "For study",
+                                            "value": "For study"
+                                        },
+                                        {
+                                            "label": "As a spouse or dependent of a UK citizen or settled person",
+                                            "value": "As a spouse or dependent of a UK citizen or settled person"
+                                        },
+                                        {
+                                            "label": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons",
+                                            "value": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons"
+                                        },
+                                        {
+                                            "label": "To get married or form a civil partnership in the UK with a non-UK citizen",
+                                            "value": "To get married or form a civil partnership in the UK with a non-UK citizen"
+                                        },
+                                        {
+                                            "label": "Seeking asylum",
+                                            "value": "Seeking asylum"
+                                        },
+                                        {
+                                            "label": "As a visitor",
+                                            "value": "As a visitor"
+                                        },
+                                        {
+                                            "label": "Another reason",
+                                            "value": "Another reason",
+                                            "child_answer_id": "no-primary-why-uk-continuous-answer-other"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "no-primary-why-uk-continuous-answer-other",
+                                    "parent_answer_id": "no-primary-why-uk-continuous-answer",
+                                    "type": "TextField",
+                                    "mandatory": false,
+                                    "label": "Please describe"
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                            "goto": {
+                                "block": "no-primary-national-identity"
+                            }
+                        }]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "no-primary-national-identity",
+                        "questions": [{
+                                "id": "no-primary-national-identity-england-question",
+                                "titles": [{
+                                        "value": "What does <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> consider their national identity to be?",
+                                        "when": [{
+                                            "id": "no-primary-proxy-check-answer",
+                                            "condition": "equals",
+                                            "value": "proxy"
+                                        }]
+                                    },
+                                    {
+                                        "value": "What do you consider your national identity to be?"
+                                    }
+                                ],
+                                "type": "General",
+                                "answers": [{
+                                        "id": "no-primary-national-identity-england-answer",
+                                        "mandatory": false,
+                                        "type": "Checkbox",
+                                        "options": [{
+                                                "label": "English",
+                                                "value": "English"
+                                            },
+                                            {
+                                                "label": "Welsh",
+                                                "value": "Welsh"
+                                            },
+                                            {
+                                                "label": "Scottish",
+                                                "value": "Scottish"
+                                            },
+                                            {
+                                                "label": "Northern Irish",
+                                                "value": "Northern Irish"
+                                            },
+                                            {
+                                                "label": "British",
+                                                "value": "British"
+                                            },
+                                            {
+                                                "label": "Other",
+                                                "value": "Other",
+                                                "child_answer_id": "no-primary-national-identity-england-answer-other"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "id": "no-primary-national-identity-england-answer-other",
+                                        "parent_answer_id": "no-primary-national-identity-england-answer",
+                                        "type": "TextField",
+                                        "mandatory": false,
+                                        "label": "Please enter national identity"
+                                    }
+                                ],
+                                "skip_conditions": [{
+                                    "when": [{
+                                        "meta": "country",
+                                        "condition": "not equals",
+                                        "value": "E"
+                                    }]
+                                }]
+                            },
+                            {
+                                "id": "no-primary-national-identity-wales-question",
+                                "titles": [{
+                                        "value": "What does <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> consider their national identity to be?",
+                                        "when": [{
+                                            "id": "no-primary-proxy-check-answer",
+                                            "condition": "equals",
+                                            "value": "proxy"
+                                        }]
+                                    },
+                                    {
+                                        "value": "What do you consider your national identity to be?"
+                                    }
+                                ],
+                                "type": "General",
+                                "answers": [{
+                                        "id": "no-primary-national-identity-wales-answer",
+                                        "mandatory": false,
+                                        "type": "Checkbox",
+                                        "options": [{
+                                                "label": "Welsh",
+                                                "value": "Welsh"
+                                            },
+                                            {
+                                                "label": "English",
+                                                "value": "English"
+                                            },
+                                            {
+                                                "label": "Scottish",
+                                                "value": "Scottish"
+                                            },
+                                            {
+                                                "label": "Northern Irish",
+                                                "value": "Northern Irish"
+                                            },
+                                            {
+                                                "label": "British",
+                                                "value": "British"
+                                            },
+                                            {
+                                                "label": "Other",
+                                                "value": "Other",
+                                                "child_answer_id": "no-primary-national-identity-wales-answer-other"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "id": "no-primary-national-identity-wales-answer-other",
+                                        "parent_answer_id": "no-primary-national-identity-wales-answer",
+                                        "type": "TextField",
+                                        "mandatory": false,
+                                        "label": "Please enter national identity"
+                                    }
+                                ],
+                                "skip_conditions": [{
+                                    "when": [{
+                                        "meta": "country",
+                                        "condition": "not equals",
+                                        "value": "W"
+                                    }]
+                                }]
+                            },
+                            {
+                                "id": "no-primary-national-identity-scotland-question",
+                                "titles": [{
+                                        "value": "What does <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> consider their national identity to be?",
+                                        "when": [{
+                                            "id": "no-primary-proxy-check-answer",
+                                            "condition": "equals",
+                                            "value": "proxy"
+                                        }]
+                                    },
+                                    {
+                                        "value": "What do you consider your national identity to be?"
+                                    }
+                                ],
+                                "type": "General",
+                                "answers": [{
+                                        "id": "no-primary-national-identity-scotland-answer",
+                                        "mandatory": false,
+                                        "type": "Checkbox",
+                                        "options": [{
+                                                "label": "Scottish",
+                                                "value": "Scottish"
+                                            },
+                                            {
+                                                "label": "English",
+                                                "value": "English"
+                                            },
+                                            {
+                                                "label": "Welsh",
+                                                "value": "Welsh"
+                                            },
+                                            {
+                                                "label": "Northern Irish",
+                                                "value": "Northern Irish"
+                                            },
+                                            {
+                                                "label": "British",
+                                                "value": "British"
+                                            },
+                                            {
+                                                "label": "Other",
+                                                "value": "Other",
+                                                "child_answer_id": "no-primary-national-identity-scotland-answer-other"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "id": "no-primary-national-identity-scotland-answer-other",
+                                        "parent_answer_id": "no-primary-national-identity-scotland-answer",
+                                        "type": "TextField",
+                                        "mandatory": false,
+                                        "label": "Please enter national identity"
+                                    }
+                                ],
+                                "skip_conditions": [{
+                                    "when": [{
+                                            "meta": "country",
+                                            "condition": "not equals",
+                                            "value": "S"
+                                        },
+                                        {
+                                            "meta": "country",
+                                            "condition": "not equals",
+                                            "value": "N"
+                                        }
+                                    ]
+                                }]
+                            }
+                        ],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-understand-welsh",
+                                    "when": [{
+                                        "meta": "country",
+                                        "condition": "equals",
+                                        "value": "W"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-ethnic-group"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "no-primary-understand-welsh",
+                        "questions": [{
+                            "id": "no-primary-understand-welsh-question",
+                            "titles": [{
+                                    "value": "Can <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> understand, speak, read or write Welsh?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "Can you understand, speak, read or write Welsh?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-understand-welsh-answer",
+                                "mandatory": false,
+                                "type": "Checkbox",
+                                "options": [{
+                                        "label": "Understand spoken Welsh",
+                                        "value": "Understand spoken Welsh"
+                                    },
+                                    {
+                                        "label": "Read Welsh",
+                                        "value": "Read Welsh"
+                                    },
+                                    {
+                                        "label": "Write in Welsh",
+                                        "value": "Write in Welsh"
+                                    },
+                                    {
+                                        "label": "Speak Welsh",
+                                        "value": "Speak Welsh"
+                                    },
+                                    {
+                                        "label": "None of these",
+                                        "value": "None of these"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-welsh-frequency",
+                                    "when": [{
+                                        "id": "no-primary-understand-welsh-answer",
+                                        "condition": "contains",
+                                        "value": "Speak Welsh"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-ethnic-group"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "no-primary-welsh-frequency",
+                        "questions": [{
+                            "id": "no-primary-welsh-frequency-question",
+                            "titles": [{
+                                    "value": "How often does <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> speak Welsh?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "How often do you speak Welsh?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-welsh-frequency-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Daily",
+                                        "value": "Daily"
+                                    },
+                                    {
+                                        "label": "Weekly",
+                                        "value": "Weekly"
+                                    },
+                                    {
+                                        "label": "Less often",
+                                        "value": "Less often"
+                                    },
+                                    {
+                                        "label": "Never",
+                                        "value": "Never"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                            "goto": {
+                                "block": "no-primary-ethnic-group"
+                            }
+                        }]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "no-primary-ethnic-group",
+                        "questions": [{
+                            "id": "no-primary-ethnic-group-question",
+                            "titles": [{
+                                    "value": "What is <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name_possessive}}</em> ethnic group?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "What is your ethnic group?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-ethnic-group-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "White",
+                                        "value": "White",
+                                        "description": "Includes any White background"
+                                    },
+                                    {
+                                        "label": "Mixed or Multiple ethnic groups",
+                                        "value": "Mixed or Multiple ethnic groups",
+                                        "description": "Includes White and Black Caribbean, White and Black African, White and Asian or any other Mixed ethnic group"
+                                    },
+                                    {
+                                        "label": "Asian or Asian British",
+                                        "value": "Asian or Asian British",
+                                        "description": "Includes Indian, Pakistani, Bangladeshi, Chinese or any other Asian background"
+                                    },
+                                    {
+                                        "label": "Black, African, Caribbean or Black British",
+                                        "value": "Black, African, Caribbean or Black British",
+                                        "description": "Includes African, Caribbean or any other Black background"
+                                    },
+                                    {
+                                        "label": "Other",
+                                        "value": "Other",
+                                        "description": "For example Arab or any other background"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-white-ethnic-group",
+                                    "when": [{
+                                        "id": "no-primary-ethnic-group-answer",
+                                        "condition": "equals",
+                                        "value": "White"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-mixed-ethnic-group",
+                                    "when": [{
+                                        "id": "no-primary-ethnic-group-answer",
+                                        "condition": "equals",
+                                        "value": "Mixed or Multiple ethnic groups"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-asian-ethnic-group",
+                                    "when": [{
+                                        "id": "no-primary-ethnic-group-answer",
+                                        "condition": "equals",
+                                        "value": "Asian or Asian British"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-black-ethnic-group",
+                                    "when": [{
+                                        "id": "no-primary-ethnic-group-answer",
+                                        "condition": "equals",
+                                        "value": "Black, African, Caribbean or Black British"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-other-ethnic-group",
+                                    "when": [{
+                                        "id": "no-primary-ethnic-group-answer",
+                                        "condition": "equals",
+                                        "value": "Other"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-household-member-completed",
+                                    "when": [{
+                                        "id": "no-primary-date-of-birth-answer",
+                                        "condition": "greater than",
+                                        "date_comparison": {
+                                            "value": "now",
+                                            "offset_by": {
+                                                "years": -16
+                                            }
+                                        }
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-household-member-completed",
+                                    "when": [{
+                                        "id": "no-primary-dob-age-answer",
+                                        "condition": "less than",
+                                        "value": 16
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-household-member-completed",
+                                    "when": [{
+                                            "id": "no-primary-dob-age-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-date-of-birth-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-religion",
+                                    "when": [{
+                                        "id": "no-primary-date-of-birth-answer",
+                                        "condition": "less than",
+                                        "date_comparison": {
+                                            "value": "now",
+                                            "offset_by": {
+                                                "years": -16
+                                            }
+                                        }
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-religion",
+                                    "when": [{
+                                        "id": "no-primary-dob-age-answer",
+                                        "condition": "greater than",
+                                        "value": 15
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-religion"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "no-primary-white-ethnic-group",
+                        "questions": [{
+                            "id": "no-primary-white-ethnic-group-question",
+                            "titles": [{
+                                    "value": "Which one best describes <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name_possessive}}</em> White ethnic group or background?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "Which one best describes your White ethnic group or background?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                    "id": "no-primary-white-ethnic-group-answer",
+                                    "mandatory": false,
+                                    "options": [{
+                                            "label": "English, Welsh, Scottish, Northern Irish or British",
+                                            "value": "English, Welsh, Scottish, Northern Irish or British"
+                                        },
+                                        {
+                                            "label": "Irish",
+                                            "value": "Irish"
+                                        },
+                                        {
+                                            "label": "Gypsy or Irish Traveller",
+                                            "value": "Gypsy or Irish Traveller"
+                                        },
+                                        {
+                                            "label": "Any other White background",
+                                            "value": "Other",
+                                            "child_answer_id": "no-primary-white-ethnic-group-answer-other"
+                                        }
+                                    ],
+                                    "type": "Radio"
+                                },
+                                {
+                                    "id": "no-primary-white-ethnic-group-answer-other",
+                                    "parent_answer_id": "no-primary-white-ethnic-group-answer",
+                                    "type": "TextField",
+                                    "mandatory": false,
+                                    "label": "Please enter ethnic background"
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-household-member-completed",
+                                    "when": [{
+                                        "id": "no-primary-date-of-birth-answer",
+                                        "condition": "greater than",
+                                        "date_comparison": {
+                                            "value": "now",
+                                            "offset_by": {
+                                                "years": -16
+                                            }
+                                        }
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-household-member-completed",
+                                    "when": [{
+                                        "id": "no-primary-dob-age-answer",
+                                        "condition": "less than",
+                                        "value": 16
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-household-member-completed",
+                                    "when": [{
+                                            "id": "no-primary-dob-age-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-date-of-birth-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-religion"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "no-primary-mixed-ethnic-group",
+                        "questions": [{
+                            "id": "no-primary-mixed-ethnic-group-question",
+                            "titles": [{
+                                    "value": "Which one best describes <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name_possessive}}</em> Mixed or Multiple ethnic group or background?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "Which one best describes your Mixed or Multiple ethnic group or background?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                    "id": "no-primary-mixed-ethnic-group-answer",
+                                    "mandatory": false,
+                                    "options": [{
+                                            "label": "White and Black Caribbean",
+                                            "value": "White and Black Caribbean"
+                                        },
+                                        {
+                                            "label": "White and Black African",
+                                            "value": "White and Black African"
+                                        },
+                                        {
+                                            "label": "White and Asian",
+                                            "value": "White and Asian"
+                                        },
+                                        {
+                                            "label": "Any other Mixed or Multiple ethnic background",
+                                            "value": "Other",
+                                            "child_answer_id": "no-primary-mixed-ethnic-group-answer-other"
+                                        }
+                                    ],
+                                    "type": "Radio"
+                                },
+                                {
+                                    "id": "no-primary-mixed-ethnic-group-answer-other",
+                                    "parent_answer_id": "no-primary-mixed-ethnic-group-answer",
+                                    "type": "TextField",
+                                    "mandatory": false,
+                                    "label": "Please enter ethnic background"
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-household-member-completed",
+                                    "when": [{
+                                        "id": "no-primary-date-of-birth-answer",
+                                        "condition": "greater than",
+                                        "date_comparison": {
+                                            "value": "now",
+                                            "offset_by": {
+                                                "years": -16
+                                            }
+                                        }
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-household-member-completed",
+                                    "when": [{
+                                        "id": "no-primary-dob-age-answer",
+                                        "condition": "less than",
+                                        "value": 16
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-household-member-completed",
+                                    "when": [{
+                                            "id": "no-primary-dob-age-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-date-of-birth-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-religion"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "no-primary-asian-ethnic-group",
+                        "questions": [{
+                            "id": "no-primary-asian-ethnic-group-question",
+                            "titles": [{
+                                    "value": "Which one best describes <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name_possessive}}</em> Asian or Asian British ethnic group or background?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "Which one best describes your Asian or Asian British ethnic group or background?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                    "id": "no-primary-asian-ethnic-group-answer",
+                                    "mandatory": false,
+                                    "options": [{
+                                            "label": "Indian",
+                                            "value": "Indian"
+                                        },
+                                        {
+                                            "label": "Pakistani",
+                                            "value": "Pakistani"
+                                        },
+                                        {
+                                            "label": "Bangladeshi",
+                                            "value": "Bangladeshi"
+                                        },
+                                        {
+                                            "label": "Chinese",
+                                            "value": "Chinese"
+                                        },
+                                        {
+                                            "label": "Any other Asian background",
+                                            "value": "Other",
+                                            "child_answer_id": "no-primary-asian-ethnic-group-answer-other"
+                                        }
+                                    ],
+                                    "type": "Radio"
+                                },
+                                {
+                                    "id": "no-primary-asian-ethnic-group-answer-other",
+                                    "parent_answer_id": "no-primary-asian-ethnic-group-answer",
+                                    "type": "TextField",
+                                    "mandatory": false,
+                                    "label": "Please enter ethnic background"
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-household-member-completed",
+                                    "when": [{
+                                        "id": "no-primary-date-of-birth-answer",
+                                        "condition": "greater than",
+                                        "date_comparison": {
+                                            "value": "now",
+                                            "offset_by": {
+                                                "years": -16
+                                            }
+                                        }
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-household-member-completed",
+                                    "when": [{
+                                        "id": "no-primary-dob-age-answer",
+                                        "condition": "less than",
+                                        "value": 16
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-household-member-completed",
+                                    "when": [{
+                                            "id": "no-primary-dob-age-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-date-of-birth-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-religion"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "no-primary-black-ethnic-group",
+                        "questions": [{
+                            "id": "no-primary-black-ethnic-group-question",
+                            "titles": [{
+                                    "value": "Which one best describes <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name_possessive}}</em> Black, African, Caribbean or Black British ethnic group or background?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "Which one best describes your Black, African, Caribbean or Black British ethnic group or background?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                    "id": "no-primary-black-ethnic-group-answer",
+                                    "mandatory": false,
+                                    "options": [{
+                                            "label": "African",
+                                            "value": "African"
+                                        },
+                                        {
+                                            "label": "Caribbean",
+                                            "value": "Caribbean"
+                                        },
+                                        {
+                                            "label": "Any other Black, African or Caribbean background",
+                                            "value": "Other",
+                                            "child_answer_id": "no-primary-black-ethnic-group-answer-other"
+                                        }
+                                    ],
+                                    "type": "Radio"
+                                },
+                                {
+                                    "id": "no-primary-black-ethnic-group-answer-other",
+                                    "parent_answer_id": "no-primary-black-ethnic-group-answer",
+                                    "type": "TextField",
+                                    "mandatory": false,
+                                    "label": "Please enter ethnic background"
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-household-member-completed",
+                                    "when": [{
+                                        "id": "no-primary-date-of-birth-answer",
+                                        "condition": "greater than",
+                                        "date_comparison": {
+                                            "value": "now",
+                                            "offset_by": {
+                                                "years": -16
+                                            }
+                                        }
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-household-member-completed",
+                                    "when": [{
+                                        "id": "no-primary-dob-age-answer",
+                                        "condition": "less than",
+                                        "value": 16
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-household-member-completed",
+                                    "when": [{
+                                            "id": "no-primary-dob-age-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-date-of-birth-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-religion"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "no-primary-other-ethnic-group",
+                        "questions": [{
+                            "id": "no-primary-other-ethnic-group-question",
+                            "titles": [{
+                                    "value": "Which one best describes <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name_possessive}}</em> Other ethnic group or background?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "Which one best describes your Other ethnic group or background?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                    "id": "no-primary-other-ethnic-group-answer",
+                                    "mandatory": false,
+                                    "options": [{
+                                            "label": "Arab",
+                                            "value": "Arab"
+                                        },
+                                        {
+                                            "label": "Any other ethnic group",
+                                            "value": "Other",
+                                            "child_answer_id": "no-primary-other-ethnic-group-answer-other"
+                                        }
+                                    ],
+                                    "type": "Radio"
+                                },
+                                {
+                                    "id": "no-primary-other-ethnic-group-answer-other",
+                                    "parent_answer_id": "no-primary-other-ethnic-group-answer",
+                                    "type": "TextField",
+                                    "mandatory": false,
+                                    "label": "Please enter ethnic background"
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-household-member-completed",
+                                    "when": [{
+                                        "id": "no-primary-date-of-birth-answer",
+                                        "condition": "greater than",
+                                        "date_comparison": {
+                                            "value": "now",
+                                            "offset_by": {
+                                                "years": -16
+                                            }
+                                        }
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-household-member-completed",
+                                    "when": [{
+                                        "id": "no-primary-dob-age-answer",
+                                        "condition": "less than",
+                                        "value": 16
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-household-member-completed",
+                                    "when": [{
+                                            "id": "no-primary-dob-age-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-date-of-birth-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-religion"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "no-primary-religion",
+                        "questions": [{
+                            "id": "no-primary-religion-question",
+                            "titles": [{
+                                    "value": "What is <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name_possessive}}</em> religion?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "What is your religion?"
+                                }
+                            ],
+                            "description": "",
+                            "type": "General",
+                            "answers": [{
+                                    "id": "no-primary-religion-answer",
+                                    "mandatory": false,
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "No religion",
+                                            "value": "No religion"
+                                        },
+                                        {
+                                            "label": "Christian",
+                                            "value": "Christian",
+                                            "description": "Including Church of England, Catholic, Protestant and other Christian denominations"
+                                        },
+                                        {
+                                            "label": "Buddhist",
+                                            "value": "Buddhist"
+                                        },
+                                        {
+                                            "label": "Hindu",
+                                            "value": "Hindu"
+                                        },
+                                        {
+                                            "label": "Jewish",
+                                            "value": "Jewish"
+                                        },
+                                        {
+                                            "label": "Muslim",
+                                            "value": "Muslim"
+                                        },
+                                        {
+                                            "label": "Sikh",
+                                            "value": "Sikh"
+                                        },
+                                        {
+                                            "label": "Other religion",
+                                            "value": "Other",
+                                            "child_answer_id": "no-primary-religion-answer-other"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "no-primary-religion-answer-other",
+                                    "parent_answer_id": "no-primary-religion-answer",
+                                    "type": "TextField",
+                                    "mandatory": false,
+                                    "label": "Please enter religion"
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-household-member-completed",
+                                    "when": [{
+                                        "id": "no-primary-date-of-birth-answer",
+                                        "condition": "greater than",
+                                        "date_comparison": {
+                                            "value": "now",
+                                            "offset_by": {
+                                                "years": -16
+                                            }
+                                        }
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-paid-job-q1"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-paid-job-q1",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-paid-job-question",
+                            "titles": [{
+                                    "value": "Did <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> have a paid job, either as an employee or self-employed, in the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "Did you have a paid job, either as an employee or self-employed, in the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-paid-job-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-second-job-w2",
+                                    "when": [{
+                                        "id": "no-primary-paid-job-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-not-working-casual-work-nw-2"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-second-job-w2",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-second-job-question",
+                            "titles": [{
+                                    "value": "Did {{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} have a <em>second</em> paid job or business?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "Did you have a <em>second</em> paid job or business?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-second-job-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-two-jobs-j1-emp-status-w3-1",
+                                    "when": [{
+                                            "id": "no-primary-second-job-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "id": "no-primary-proxy-check-answer",
+                                            "condition": "equals",
+                                            "value": "no proxy"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-two-jobs-j1-emp-status-w3-1-proxy",
+                                    "when": [{
+                                        "id": "no-primary-second-job-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-one-job-emp-status-w3",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "no proxy"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-one-job-emp-status-w3-proxy"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-two-jobs-j1-emp-status-w3-1",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-two-jobs-j1-emp-status-question",
+                            "titles": [{
+                                "value": "Employment status in <em>main</em> job"
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                    "id": "no-primary-two-jobs-j1-emp-status-emp-or-self-answer",
+                                    "mandatory": false,
+                                    "label": "In your <em>main</em> job are you an employee or self-employed?",
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "An employee",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "label": "Self-employed",
+                                            "value": "Self-employed"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "no-primary-two-jobs-j1-emp-status-full-or-part-time-answer",
+                                    "mandatory": false,
+                                    "label": "Is that job full-time or part-time?",
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "Full-time",
+                                            "value": "Full-time"
+                                        },
+                                        {
+                                            "label": "Part-time",
+                                            "value": "Part-time"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }]
+                    },
+                    {
+                        "id": "no-primary-two-jobs-j2-emp-status-w3-2",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-two-jobs-j2-emp-status-question",
+                            "titles": [{
+                                "value": "Employment status in <em>second</em> job"
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                    "id": "no-primary-two-jobs-j2-emp-status-emp-or-self-answer",
+                                    "mandatory": false,
+                                    "label": "In your <em>second</em> job, are you an employee or self-employed?",
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "An employee",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "label": "Self-employed",
+                                            "value": "Self-employed"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "no-primary-two-jobs-j2-emp-status-full-or-part-time-answer",
+                                    "mandatory": false,
+                                    "label": "Is that job full-time or part-time?",
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "Full-time",
+                                            "value": "Full-time"
+                                        },
+                                        {
+                                            "label": "Part-time",
+                                            "value": "Part-time"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                            "goto": {
+                                "block": "no-primary-working-hours-flex10"
+                            }
+                        }]
+                    },
+                    {
+                        "id": "no-primary-two-jobs-j1-emp-status-w3-1-proxy",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-two-jobs-j1-emp-status-emp-or-self-proxy-question",
+                            "titles": [{
+                                "value": "{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name_possessive}} employment status in <em>main</em> job"
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                    "id": "no-primary-two-jobs-j1-emp-status-emp-or-self-proxy-answer",
+                                    "mandatory": false,
+                                    "label": "In their <em>main</em> job are they an employee or self-employed?",
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "An employee",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "label": "Self-employed",
+                                            "value": "Self-employed"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "no-primary-two-jobs-j1-emp-status-full-or-part-time-proxy-answer",
+                                    "mandatory": false,
+                                    "label": "Is that job full-time or part-time?",
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "Full-time",
+                                            "value": "Full-time"
+                                        },
+                                        {
+                                            "label": "Part-time",
+                                            "value": "Part-time"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }]
+                    },
+                    {
+                        "id": "no-primary-two-jobs-j2-emp-status-w3-2-proxy",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-two-jobs-j2-emp-status-proxy-question",
+                            "titles": [{
+                                "value": "{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name_possessive}} employment status in <em>second</em> job"
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                    "id": "no-primary-two-jobs-j2-emp-status-emp-or-self-proxy-answer",
+                                    "mandatory": false,
+                                    "label": "In their <em>second</em> job are they an employee or self-employed?",
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "An employee",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "label": "Self-employed",
+                                            "value": "Self-employed"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "no-primary-two-jobs-j2-emp-status-full-or-part-time-proxy-answer",
+                                    "mandatory": false,
+                                    "label": "Is that job full-time or part-time?",
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "Full-time",
+                                            "value": "Full-time"
+                                        },
+                                        {
+                                            "label": "Part-time",
+                                            "value": "Part-time"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                            "goto": {
+                                "block": "no-primary-working-hours-flex10"
+                            }
+                        }]
+                    },
+                    {
+                        "id": "no-primary-one-job-emp-status-w3",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-one-job-emp-status-question",
+                            "titles": [{
+                                "value": "Employment status"
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                    "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                    "mandatory": false,
+                                    "label": "Are you an employee or self-employed?",
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "An employee",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "label": "Self-employed",
+                                            "value": "Self-employed"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "no-primary-one-job-emp-status-full-or-part-time-answer",
+                                    "mandatory": false,
+                                    "label": "Is your job full-time or part-time?",
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "Full-time",
+                                            "value": "Full-time"
+                                        },
+                                        {
+                                            "label": "Part-time",
+                                            "value": "Part-time"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                            "goto": {
+                                "block": "no-primary-working-hours-flex10"
+                            }
+                        }]
+                    },
+                    {
+                        "id": "no-primary-one-job-emp-status-w3-proxy",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-one-job-emp-status-proxy-question",
+                            "titles": [{
+                                "value": "<em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name_possessive}}</em> employment status"
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                    "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                    "mandatory": false,
+                                    "label": "Are they an employee or self-employed?",
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "An employee",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "label": "Self-employed",
+                                            "value": "Self-employed"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "no-primary-one-job-emp-status-full-or-part-time-proxy-answer",
+                                    "mandatory": false,
+                                    "label": "Is their job full-time or part-time?",
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "Full-time",
+                                            "value": "Full-time"
+                                        },
+                                        {
+                                            "label": "Part-time",
+                                            "value": "Part-time"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                            "goto": {
+                                "block": "no-primary-working-hours-flex10"
+                            }
+                        }]
+                    },
+                    {
+                        "id": "no-primary-not-working-casual-work-nw-2",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-not-working-casual-work-question",
+                            "titles": [{
+                                    "value": "Did they do any casual work for payment, even for an hour, in the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "Did you do any casual work for payment, even for an hour, in the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-working-casual-work-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-working-hours-flex10",
+                                    "when": [{
+                                        "id": "no-primary-working-casual-work-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-did-you-look-for-paid-work-nw3"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-working-hours-flex10",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-working-hours-question",
+                            "titles": [{
+                                    "value": "These are specific working arrangements that only apply to some people. Does <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> have any of the following?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "These are specific working arrangements that only apply to some people. Do you have any of the following?"
+                                }
+                            ],
+                            "type": "MutuallyExclusive",
+                            "mandatory": false,
+                            "answers": [{
+                                    "id": "no-primary-working-hours-answer",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "options": [{
+                                            "label": "Flexi-time",
+                                            "value": "Flexi-time"
+                                        },
+                                        {
+                                            "label": "Optional start and finish times",
+                                            "value": "Optional start and finish times"
+                                        },
+                                        {
+                                            "label": "Zero hours contract",
+                                            "value": "Zero hours contract"
+                                        },
+                                        {
+                                            "label": "An annualised hours contract",
+                                            "value": "An annualised hours contract"
+                                        },
+                                        {
+                                            "label": "Term-time working",
+                                            "value": "Term-time working"
+                                        },
+                                        {
+                                            "label": "Job sharing",
+                                            "value": "Job sharing"
+                                        },
+                                        {
+                                            "label": "On-call working",
+                                            "value": "On-call working"
+                                        },
+                                        {
+                                            "label": "Working from home",
+                                            "value": "Working from home"
+                                        },
+                                        {
+                                            "label": "Some other arrangement",
+                                            "value": "Some other arrangement",
+                                            "child_answer_id": "no-primary-working-hours-answer-other"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "no-primary-working-hours-answer-other",
+                                    "parent_answer_id": "no-primary-working-hours-answer",
+                                    "type": "TextField",
+                                    "mandatory": false,
+                                    "label": "Please describe"
+                                },
+                                {
+                                    "id": "no-primary-working-hours-answer-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "options": [{
+                                        "label": "None of these",
+                                        "value": "None of these"
+                                    }]
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                            "goto": {
+                                "block": "no-primary-working-days-w5"
+                            }
+                        }]
+                    },
+                    {
+                        "id": "no-primary-working-days-w5",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-working-days-question",
+                            "titles": [{
+                                    "value": "On which of the following days did <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> do any work in their paid jobs or businesses?",
+                                    "when": [{
+                                            "id": "no-primary-proxy-check-answer",
+                                            "condition": "equals",
+                                            "value": "proxy"
+                                        },
+                                        {
+                                            "id": "no-primary-second-job-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "value": "On which of the following days did you do any work in your paid jobs or businesses?",
+                                    "when": [{
+                                            "id": "no-primary-proxy-check-answer",
+                                            "condition": "equals",
+                                            "value": "no proxy"
+                                        },
+                                        {
+                                            "id": "no-primary-second-job-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "value": "On which of the following days did <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> do any work in their paid job or business?",
+                                    "when": [{
+                                            "id": "no-primary-proxy-check-answer",
+                                            "condition": "equals",
+                                            "value": "proxy"
+                                        },
+                                        {
+                                            "id": "no-primary-second-job-answer",
+                                            "condition": "equals",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "value": "On which of the following days did you do any work in your paid job or business?"
+                                }
+                            ],
+                            "type": "MutuallyExclusive",
+                            "mandatory": false,
+                            "answers": [{
+                                    "id": "no-primary-working-days-answer",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "options": [{
+                                            "label": "{{calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'MO') | format_date_custom('EEEE dd MMMM') }}",
+                                            "value": "Monday"
+                                        },
+                                        {
+                                            "label": "{{calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'TU') | format_date_custom('EEEE dd MMMM') }}",
+                                            "value": "Tuesday"
+                                        },
+                                        {
+                                            "label": "{{calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'WE') | format_date_custom('EEEE dd MMMM') }}",
+                                            "value": "Wednesday"
+                                        },
+                                        {
+                                            "label": "{{calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'TH') | format_date_custom('EEEE dd MMMM') }}",
+                                            "value": "Thursday"
+                                        },
+                                        {
+                                            "label": "{{calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'FR') | format_date_custom('EEEE dd MMMM') }}",
+                                            "value": "Friday"
+                                        },
+                                        {
+                                            "label": "{{calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SA') | format_date_custom('EEEE dd MMMM') }}",
+                                            "value": "Saturday"
+                                        },
+                                        {
+                                            "label": "{{calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU') | format_date_custom('EEEE dd MMMM') }}",
+                                            "value": "Sunday"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "no-primary-working-days-answer-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "options": [{
+                                        "label": "Did not work this week",
+                                        "value": "Did not work this week"
+                                    }]
+                                }
+                            ]
+                        }]
+                    },
+                    {
+                        "id": "no-primary-overtime-w6",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-overtime-question",
+                            "titles": [{
+                                    "value": "Does <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> ever do any work which they would consider as overtime?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "Do you ever do work which you would consider as overtime?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-overtime-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Work paid overtime",
+                                        "value": "Paid overtime"
+                                    },
+                                    {
+                                        "label": "Work unpaid overtime",
+                                        "value": "Unpaid overtime"
+                                    },
+                                    {
+                                        "label": "Work both paid and unpaid overtime",
+                                        "value": "Paid and unpaid overtime"
+                                    },
+                                    {
+                                        "label": "Do not work overtime",
+                                        "value": "No overtime"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "id": "no-primary-working-casual-work-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "id": "no-primary-working-days-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-working-days-answer-exclusive",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "id": "no-primary-working-casual-work-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "id": "no-primary-working-days-answer-exclusive",
+                                            "condition": "contains",
+                                            "value": "Did not work this week"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-unpaid-overtime-w10",
+                                    "when": [{
+                                            "id": "no-primary-working-casual-work-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "Unpaid overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-unpaid-overtime-w10",
+                                    "when": [{
+                                            "id": "no-primary-working-casual-work-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "Paid and unpaid overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-paid-overtime-w-11",
+                                    "when": [{
+                                            "id": "no-primary-working-casual-work-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "Paid overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-casual-hours-worked-casac",
+                                    "when": [{
+                                            "id": "no-primary-working-casual-work-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-one-job-usual-hours-w12",
+                                    "when": [{
+                                            "id": "no-primary-second-job-answer",
+                                            "condition": "equals",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "id": "no-primary-working-days-answer-exclusive",
+                                            "condition": "contains",
+                                            "value": "Did not work this week"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-one-job-usual-hours-w12",
+                                    "when": [{
+                                            "id": "no-primary-second-job-answer",
+                                            "condition": "equals",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "id": "no-primary-working-days-answer-exclusive",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-two-jobs-j1-usual-hours-w12-1",
+                                    "when": [{
+                                            "id": "no-primary-second-job-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "id": "no-primary-working-days-answer-exclusive",
+                                            "condition": "contains",
+                                            "value": "Did not work this week"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-two-jobs-j1-usual-hours-w12-1",
+                                    "when": [{
+                                            "id": "no-primary-second-job-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "id": "no-primary-working-days-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-working-days-answer-exclusive",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-unpaid-overtime-w10",
+                                    "when": [{
+                                            "id": "no-primary-second-job-answer",
+                                            "condition": "equals",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "Unpaid overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-unpaid-overtime-w10",
+                                    "when": [{
+                                            "id": "no-primary-second-job-answer",
+                                            "condition": "equals",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "Paid and unpaid overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-two-jobs-j1-unpaid-overtime-w-10-1",
+                                    "when": [{
+                                            "id": "no-primary-second-job-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "Unpaid overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-two-jobs-j1-unpaid-overtime-w-10-1",
+                                    "when": [{
+                                            "id": "no-primary-second-job-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "Paid and unpaid overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-paid-overtime-w-11",
+                                    "when": [{
+                                            "id": "no-primary-second-job-answer",
+                                            "condition": "equals",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "Paid overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-two-jobs-j1-paid-overtime-w-11-1",
+                                    "when": [{
+                                            "id": "no-primary-second-job-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "Paid overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-one-job-usual-hours-w12",
+                                    "when": [{
+                                            "id": "no-primary-second-job-answer",
+                                            "condition": "equals",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-two-jobs-j1-usual-hours-w12-1",
+                                    "when": [{
+                                            "id": "no-primary-second-job-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-one-job-usual-hours-w12",
+                                    "when": [{
+                                            "id": "no-primary-second-job-answer",
+                                            "condition": "equals",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-two-jobs-j1-usual-hours-w12-1",
+                                    "when": [{
+                                            "id": "no-primary-second-job-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-one-job-usual-hours-w12",
+                                    "when": [{
+                                        "id": "no-primary-second-job-answer",
+                                        "condition": "equals",
+                                        "value": "No"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-two-jobs-j1-usual-hours-w12-1",
+                                    "when": [{
+                                        "id": "no-primary-second-job-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-one-job-usual-hours-w12"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-unpaid-overtime-w10",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-unpaid-overtime-question",
+                            "titles": [{
+                                    "value": "How many hours of <em>unpaid</em> overtime did {{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} <em>actually</em> work in that week?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "How many hours of <em>unpaid</em> overtime did you <em>actually</em> work in that week?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-unpaid-overtime-answer",
+                                "mandatory": false,
+                                "type": "Unit",
+                                "unit": "duration-hour",
+                                "unit_length": "long",
+                                "label": "Unpaid overtime hours",
+                                "max_value": {
+                                    "value": 168
+                                }
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-paid-overtime-w-11",
+                                    "when": [{
+                                        "id": "no-primary-overtime-answer",
+                                        "condition": "equals",
+                                        "value": "Paid and unpaid overtime"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-casual-hours-worked-casac",
+                                    "when": [{
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "unpaid overtime"
+                                        },
+                                        {
+                                            "id": "no-primary-working-casual-work-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-one-job-usual-hours-w12"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-paid-overtime-w-11",
+                        "type": "Question",
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "no-primary-overtime-answer",
+                                "condition": "equals",
+                                "value": "Unpaid overtime"
+                            }]
+                        }],
+                        "questions": [{
+                            "id": "no-primary-paid-overtime-question",
+                            "titles": [{
+                                    "value": "How many hours of <em>paid</em> overtime did {{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} <em>actually</em> work in that week?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "How many hours of <em>paid</em> overtime did you <em>actually</em> work in that week?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-paid-overtime-answer",
+                                "mandatory": false,
+                                "type": "Unit",
+                                "unit": "duration-hour",
+                                "unit_length": "long",
+                                "label": "Paid overtime hours",
+                                "max_value": {
+                                    "value": 168
+                                }
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-casual-hours-worked-casac",
+                                    "when": [{
+                                        "id": "no-primary-working-casual-work-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-one-job-usual-hours-w12"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-one-job-usual-hours-w12",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-one-job-usual-hours-question",
+                            "titles": [{
+                                    "value": "Many jobs or businesses have usual hours. Not including their overtime, how many hours does {{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} <em>usually</em> work a week in their job or business?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "Many jobs or businesses have usual hours. Not including your overtime, how many hours do you <em>usually</em> work in your job or business?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-one-job-usual-hours-answer",
+                                "mandatory": false,
+                                "type": "Unit",
+                                "unit": "duration-hour",
+                                "unit_length": "long",
+                                "label": "Usual hours",
+                                "max_value": {
+                                    "value": 168
+                                }
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "id": "no-primary-working-days-answer-exclusive",
+                                            "condition": "contains",
+                                            "value": "Did not work this week"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "condition": "equals",
+                                            "value": "employee"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "id": "no-primary-working-days-answer-exclusive",
+                                            "condition": "contains",
+                                            "value": "Did not work this week"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "id": "no-primary-working-days-answer-exclusive",
+                                            "condition": "contains",
+                                            "value": "Did not work this week"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "condition": "equals",
+                                            "value": "employee"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-self-employed-w14-semp",
+                                    "when": [{
+                                            "id": "no-primary-working-days-answer-exclusive",
+                                            "condition": "contains",
+                                            "value": "Did not work this week"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "condition": "equals",
+                                            "value": "Self-employed"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-self-employed-w14-semp",
+                                    "when": [{
+                                            "id": "no-primary-working-days-answer-exclusive",
+                                            "condition": "contains",
+                                            "value": "Did not work this week"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "condition": "equals",
+                                            "value": "Self-employed"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "id": "no-primary-working-days-answer-exclusive",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "condition": "equals",
+                                            "value": "employee"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "id": "no-primary-working-days-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-working-days-answer-exclusive",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "condition": "equals",
+                                            "value": "employee"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "id": "no-primary-working-days-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-working-days-answer-exclusive",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-self-employed-w14-semp",
+                                    "when": [{
+                                            "id": "no-primary-working-days-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-working-days-answer-exclusive",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "condition": "equals",
+                                            "value": "Self-employed"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-self-employed-w14-semp",
+                                    "when": [{
+                                            "id": "no-primary-working-days-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-working-days-answer-exclusive",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "condition": "equals",
+                                            "value": "Self-employed"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-one-job-actual-hours-w12"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-one-job-actual-hours-w12",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-one-job-actual-hours-question",
+                            "titles": [{
+                                    "value": "{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} usually works {{answers['no-primary-one-job-usual-hours-answer'][group_instance]}} hours in their job. In the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}, how many hours did {{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} <em>actually</em> work, excluding overtime?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "You usually work {{answers['no-primary-one-job-usual-hours-answer'][group_instance]}} hours in your job. In the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}, how many hours did you <em>actually</em> work, excluding overtime?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-one-job-actual-hours-answer",
+                                "mandatory": false,
+                                "type": "Unit",
+                                "unit": "duration-hour",
+                                "unit_length": "long",
+                                "label": "Actual hours",
+                                "max_value": {
+                                    "value": 168
+                                }
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-one-job-actual-hours-confirmation-w12-1",
+                                    "when": [{
+                                        "id": "no-primary-one-job-actual-hours-answer",
+                                        "condition": "not set"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-one-job-actual-hours-confirmation-w12-1",
+                                    "when": [{
+                                        "id": "no-primary-one-job-actual-hours-answer",
+                                        "condition": "equals",
+                                        "value": 0
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                        "id": "no-primary-working-casual-work-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-self-employed-w14-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-self-employed-w14-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "condition": "not set",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer"
+                                        },
+                                        {
+                                            "condition": "not set",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-self-employed-w14-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-self-employed-w14-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-one-job-hours-totalized-w13"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-one-job-actual-hours-confirmation-w12-1",
+                        "type": "ConfirmationQuestion",
+                        "questions": [{
+                            "id": "no-primary-one-job-actual-hours-confirmation-question",
+                            "titles": [{
+                                    "value": "In the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY')}}, you entered that <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> worked zero hours, excluding overtime.",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "In the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}, you entered that you worked zero hours, excluding overtime."
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "no-primary-one-job-actual-hours-confirmation-answer",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-one-job-actual-hours-w12",
+                                    "when": [{
+                                        "id": "no-primary-one-job-actual-hours-confirmation-answer",
+                                        "condition": "equals",
+                                        "value": "No"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                        "id": "no-primary-working-casual-work-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "no overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "no overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-self-employed-w14-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-self-employed-w14-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "equals",
+                                            "value": "No overtime"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-self-employed-w14-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-self-employed-w14-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        },
+                                        {
+                                            "id": "no-primary-overtime-answer",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-one-job-hours-totalized-w13"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-two-jobs-j1-unpaid-overtime-w-10-1",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-two-jobs-j1-unpaid-overtime-question",
+                            "titles": [{
+                                    "value": "In their <em>main</em> job, how many hours of <em>unpaid</em> overtime did {{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} actually work in that week?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "In your <em>main</em> job, how many hours of <em>unpaid</em> overtime did you actually work in that week?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-two-jobs-j1-unpaid-overtime-answer",
+                                "label": "Unpaid overtime hours, main job",
+                                "mandatory": false,
+                                "type": "Unit",
+                                "unit": "duration-hour",
+                                "unit_length": "long",
+                                "max_value": {
+                                    "value": 168
+                                }
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "no-primary-two-jobs-j2-unpaid-overtime-w-10-2",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-two-jobs-j2-unpaid-overtime-question",
+                            "titles": [{
+                                    "value": "In their <em>second</em> job, how many hours of <em>unpaid</em> overtime did {{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} actually work in that week?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "In your <em>second</em> job, how many hours of <em>unpaid</em> overtime did you actually work in that week?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-two-jobs-j2-unpaid-overtime-answer",
+                                "mandatory": false,
+                                "type": "Unit",
+                                "unit": "duration-hour",
+                                "unit_length": "long",
+                                "label": "Unpaid overtime hours, second job",
+                                "max_value": {
+                                    "value": 168
+                                }
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-two-jobs-j1-paid-overtime-w-11-1",
+                                    "when": [{
+                                        "id": "no-primary-overtime-answer",
+                                        "condition": "equals",
+                                        "value": "Paid and unpaid overtime"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-two-jobs-j1-usual-hours-w12-1"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-two-jobs-j1-paid-overtime-w-11-1",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-two-jobs-j1-paid-overtime-question",
+                            "titles": [{
+                                    "value": "In their <em>main</em> job, how many hours of <em>paid</em> overtime did {{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} actually work in that week?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "In your <em>main</em> job, how many hours of <em>paid</em> overtime did you actually work in that week?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-two-jobs-j1-paid-overtime-answer",
+                                "mandatory": false,
+                                "type": "Unit",
+                                "unit": "duration-hour",
+                                "unit_length": "long",
+                                "label": "Paid overtime hours, main job",
+                                "max_value": {
+                                    "value": 168
+                                }
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "no-primary-two-jobs-j2-paid-overtime-w-11-2",
+                        "type": "Question",
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "no-primary-second-job-answer",
+                                "condition": "equals",
+                                "value": "No"
+                            }]
+                        }],
+                        "questions": [{
+                            "id": "no-primary-two-jobs-j2-paid-overtime-question",
+                            "titles": [{
+                                    "value": "In their <em>second</em> job, how many hours of <em>paid</em> overtime did {{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} actually work in that week?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "In your <em>second</em> job, how many hours of <em>paid</em> overtime did you actually work in that week?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-two-jobs-j2-paid-overtime-answer",
+                                "mandatory": false,
+                                "type": "Unit",
+                                "unit": "duration-hour",
+                                "unit_length": "long",
+                                "label": "Paid overtime hours, second job",
+                                "max_value": {
+                                    "value": 168
+                                }
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "no-primary-two-jobs-j1-usual-hours-w12-1",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-two-jobs-j1-usual-hours-question",
+                            "titles": [{
+                                    "value": "Many jobs or businesses have usual hours. Not including their overtime, how many hours does {{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} <em>usually</em> work a week in their <em>main</em> job or business?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "Many jobs or businesses have usual hours. Not including your overtime, how many hours do you <em>usually</em> work a week in your <em>main</em> job or business?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-two-jobs-j1-usual-hours-answer",
+                                "mandatory": false,
+                                "type": "Unit",
+                                "unit": "duration-hour",
+                                "unit_length": "long",
+                                "label": "Usual hours, main job",
+                                "max_value": {
+                                    "value": 168
+                                }
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-two-jobs-j2-usual-hours-w12-2",
+                                    "when": [{
+                                            "id": "no-primary-working-days-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-working-days-answer-exclusive",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-two-jobs-j2-usual-hours-w12-2",
+                                    "when": [{
+                                        "id": "no-primary-working-days-answer-exclusive",
+                                        "condition": "contains",
+                                        "value": "Did not work this week"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-two-jobs-j1-actual-hours-w12-1-1"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-two-jobs-j1-actual-hours-w12-1-1",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-two-jobs-j1-actual-hours-question",
+                            "titles": [{
+                                    "value": "{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} usually works {{answers['no-primary-two-jobs-j1-usual-hours-answer'][group_instance]}} in their main job. In the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}, how many hours did they <em>actually</em> work in their <em>main</em> job, excluding overtime?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "You usually work {{answers['no-primary-two-jobs-j1-usual-hours-answer'][group_instance]}} hours in your main job. In the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}, how many hours did you <em>actually</em> work in your <em>main</em> job, excluding overtime?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-two-jobs-j1-actual-hours-answer",
+                                "mandatory": false,
+                                "type": "Unit",
+                                "unit": "duration-hour",
+                                "unit_length": "long",
+                                "label": "Actual hours, main job",
+                                "max_value": {
+                                    "value": 168
+                                }
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-two-jobs-j1-actual-hours-confirmation-w12-1-1",
+                                    "when": [{
+                                        "id": "no-primary-two-jobs-j1-actual-hours-answer",
+                                        "condition": "not set"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-two-jobs-j1-actual-hours-confirmation-w12-1-1",
+                                    "when": [{
+                                        "id": "no-primary-two-jobs-j1-actual-hours-answer",
+                                        "condition": "equals",
+                                        "value": 0
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-two-jobs-j2-usual-hours-w12-2"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-two-jobs-j1-actual-hours-confirmation-w12-1-1",
+                        "type": "ConfirmationQuestion",
+                        "questions": [{
+                            "id": "no-primary-two-jobs-j1-actual-hours-confirmation-question",
+                            "titles": [{
+                                    "value": "In the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}, you entered that {{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} worked zero hours in their <em>main</em> job, excluding overtime.",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "In the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}, you entered that you worked zero hours in your <em>main</em> job, excluding overtime."
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "no-primary-two-jobs-j1-actual-hours-confirmation-answer",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-two-jobs-j1-actual-hours-w12-1-1",
+                                    "when": [{
+                                        "id": "no-primary-two-jobs-j1-actual-hours-confirmation-answer",
+                                        "condition": "equals",
+                                        "value": "No"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-two-jobs-j2-usual-hours-w12-2"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-two-jobs-j2-usual-hours-w12-2",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-two-jobs-j2-usual-hours-question",
+                            "titles": [{
+                                    "value": "Many jobs or businesses have usual hours. Not including their overtime, how many hours does {{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} <em>usually</em> work a week in their <em>second</em> job or business?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "Many jobs or businesses have usual hours. Not including your overtime, how many hours do you <em>usually</em> work a week in your <em>second</em> job or business?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-two-jobs-j2-usual-hours-answer",
+                                "mandatory": false,
+                                "type": "Unit",
+                                "unit": "duration-hour",
+                                "unit_length": "long",
+                                "label": "Usual hours, second job",
+                                "max_value": {
+                                    "value": 168
+                                }
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-working-days-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-working-days-answer-exclusive",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-working-days-answer-exclusive",
+                                            "condition": "contains",
+                                            "value": "Did not work this week"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-working-days-answer",
+                                            "condition": "not set"
+                                        }, {
+                                            "id": "no-primary-working-days-answer-exclusive",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "condition": "equals",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-working-days-answer-exclusive",
+                                            "condition": "contains",
+                                            "value": "Did not work this week"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-self-employed-w14-semp",
+                                    "when": [{
+                                            "id": "no-primary-working-days-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-working-days-answer-exclusive",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-self-employed-w14-semp",
+                                    "when": [{
+                                        "id": "no-primary-working-days-answer-exclusive",
+                                        "condition": "contains",
+                                        "value": "Did not work this week"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-two-jobs-j2-actual-hours-w12-22"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-two-jobs-j2-actual-hours-w12-22",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-two-jobs-j2-actual-hours-question",
+                            "titles": [{
+                                    "value": "{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} usually works {{answers['no-primary-two-jobs-j2-usual-hours-answer'][group_instance]}} hours in their second job. In the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}, how many hours did they <em>actually</em> work in their <em>second</em> job, excluding overtime?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "You usually work {{answers['no-primary-two-jobs-j2-usual-hours-answer'][group_instance]}} hours in your second job. In the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}, how many hours did you <em>actually</em> work in your <em>second</em> job, excluding overtime?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-two-jobs-j2-actual-hours-answer",
+                                "mandatory": false,
+                                "type": "Unit",
+                                "unit": "duration-hour",
+                                "unit_length": "long",
+                                "label": "Actual hours, second job",
+                                "max_value": {
+                                    "value": 168
+                                }
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-two-jobs-j2-actual-hours-confirmation-w12-22-1",
+                                    "when": [{
+                                        "id": "no-primary-two-jobs-j2-actual-hours-answer",
+                                        "condition": "not set"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-two-jobs-j2-actual-hours-confirmation-w12-22-1",
+                                    "when": [{
+                                        "id": "no-primary-two-jobs-j2-actual-hours-answer",
+                                        "condition": "equals",
+                                        "value": 0
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-two-jobs-hours-totalized-w13-1"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-two-jobs-j2-actual-hours-confirmation-w12-22-1",
+                        "type": "ConfirmationQuestion",
+                        "questions": [{
+                            "id": "no-primary-two-jobs-j2-actual-hours-confirmation-question",
+                            "titles": [{
+                                    "value": "In the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}, you entered that {{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} worked <em>zero hours</em> in their second job, excluding overtime.",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "In the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}, you entered that you worked <em>zero hours</em> in your second job, excluding overtime."
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "no-primary-two-jobs-j2-actual-hours-confirmation-answer",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-two-jobs-j2-actual-hours-w12-22",
+                                    "when": [{
+                                        "id": "no-primary-two-jobs-j2-actual-hours-confirmation-answer",
+                                        "condition": "equals",
+                                        "value": "No"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-two-jobs-hours-totalized-w13-1"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-casual-hours-worked-casac",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-casual-hours-question",
+                            "titles": [{
+                                    "value": "In the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}, how many hours did {{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} <em>actually</em> work, excluding overtime?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "In the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}, how many hours did you <em>actually</em> work, excluding overtime?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-casual-hours-answer",
+                                "mandatory": false,
+                                "type": "Unit",
+                                "unit": "duration-hour",
+                                "unit_length": "long",
+                                "label": "Actual hours",
+                                "max_value": {
+                                    "value": 168
+                                }
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "no-primary-one-job-hours-totalized-w13",
+                        "type": "CalculatedSummary",
+                        "titles": [{
+                                "value": "We calculate the total number of hours that <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> worked in their job, including overtime, to be %(total)s for the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}. Is this correct? ",
+                                "when": [{
+                                    "id": "no-primary-proxy-check-answer",
+                                    "condition": "equals",
+                                    "value": "proxy"
+                                }]
+                            },
+                            {
+                                "value": "We calculate the total number of hours that you worked in your job, including overtime, to be %(total)s for the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}. Is this correct? "
+                            }
+                        ],
+                        "calculation": {
+                            "calculation_type": "sum",
+                            "answers_to_calculate": [
+                                "no-primary-one-job-actual-hours-answer",
+                                "no-primary-paid-overtime-answer",
+                                "no-primary-unpaid-overtime-answer",
+                                "no-primary-casual-hours-answer"
+                            ],
+                            "titles": [{
+                                "value": "Total hours worked"
+                            }]
+                        },
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                        "id": "no-primary-working-casual-work-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-self-employed-w14-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-self-employed-w14-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-one-job-emp-status-emp-or-self-proxy-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-one-job-usual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-one-job-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-self-employed-w14-semp"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-two-jobs-hours-totalized-w13-1",
+                        "type": "CalculatedSummary",
+                        "titles": [{
+                                "value": "We calculate the total number of hours that <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> worked in their main and second jobs, including overtime, to be %(total)s for the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}. Is this correct? ",
+                                "when": [{
+                                    "id": "no-primary-proxy-check-answer",
+                                    "condition": "equals",
+                                    "value": "proxy"
+                                }]
+                            },
+                            {
+                                "value": "We calculate the total number of hours that you worked in your main and second jobs, including overtime, to be %(total)s for the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}. Is this correct? "
+                            }
+                        ],
+                        "calculation": {
+                            "calculation_type": "sum",
+                            "answers_to_calculate": [
+                                "no-primary-two-jobs-j1-actual-hours-answer",
+                                "no-primary-two-jobs-j2-actual-hours-answer",
+                                "no-primary-two-jobs-j1-paid-overtime-answer",
+                                "no-primary-two-jobs-j2-paid-overtime-answer",
+                                "no-primary-two-jobs-j1-unpaid-overtime-answer",
+                                "no-primary-two-jobs-j2-unpaid-overtime-answer"
+                            ],
+                            "titles": [{
+                                "value": "Total hours worked"
+                            }]
+                        },
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-two-jobs-j1-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-two-jobs-j1-actual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-two-jobs-j1-usual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-two-jobs-j1-emp-status-emp-or-self-proxy-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-two-jobs-j1-actual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-two-jobs-j1-usual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "id": "no-primary-two-jobs-j1-emp-status-emp-or-self-proxy-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-two-jobs-j1-emp-status-emp-or-self-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-two-jobs-j1-actual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-two-jobs-j1-usual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-two-jobs-j1-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-two-jobs-j1-actual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-two-jobs-j1-usual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-two-jobs-j1-emp-status-emp-or-self-proxy-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-two-jobs-j1-actual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-two-jobs-j1-usual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                                    "when": [{
+                                            "id": "no-primary-two-jobs-j1-emp-status-emp-or-self-proxy-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-two-jobs-j1-emp-status-emp-or-self-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-two-jobs-j1-actual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-two-jobs-j1-usual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-two-jobs-j1-emp-status-emp-or-self-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-two-jobs-j1-actual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-two-jobs-j1-usual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-two-jobs-j1-emp-status-emp-or-self-proxy-answer",
+                                            "value": "employee"
+                                        },
+                                        {
+                                            "id": "no-primary-two-jobs-j1-actual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-two-jobs-j1-usual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                                    "when": [{
+                                            "id": "no-primary-two-jobs-j1-emp-status-emp-or-self-proxy-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-two-jobs-j1-emp-status-emp-or-self-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
+                                            "id": "no-primary-two-jobs-j1-actual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-two-jobs-j1-usual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-two-jobs-j1-emp-status-emp-or-self-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-two-jobs-j1-actual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-two-jobs-j1-usual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-two-jobs-j1-emp-status-emp-or-self-proxy-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-two-jobs-j1-actual-hours-answer",
+                                            "condition": "greater than",
+                                            "comparison_id": "no-primary-two-jobs-j1-usual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-two-jobs-j1-emp-status-emp-or-self-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-two-jobs-j1-actual-hours-answer",
+                                            "condition": "equals",
+                                            "comparison_id": "no-primary-two-jobs-j1-usual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-when-start-working-current-business-red6-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-two-jobs-j1-emp-status-emp-or-self-proxy-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "comparison_id": "no-primary-two-jobs-j1-usual-hours-answer",
+                                            "condition": "equals",
+                                            "id": "no-primary-two-jobs-j1-actual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-self-employed-w14-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-two-jobs-j1-emp-status-emp-or-self-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-two-jobs-j1-actual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-two-jobs-j1-usual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-self-employed-w14-semp",
+                                    "when": [{
+                                            "condition": "equals",
+                                            "id": "no-primary-two-jobs-j1-emp-status-emp-or-self-proxy-answer",
+                                            "value": "Self-employed"
+                                        },
+                                        {
+                                            "id": "no-primary-two-jobs-j1-actual-hours-answer",
+                                            "condition": "less than",
+                                            "comparison_id": "no-primary-two-jobs-j1-usual-hours-answer"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-reason-why-fewer-hours-than-usual-self-employed-w14-semp"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-reason-why-fewer-hours-than-usual-self-employed-w14-semp",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-reason-why-fewer-hours-than-usual-self-employed-question",
+                            "titles": [{
+                                    "value": "What was the main reason <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> worked fewer hours or days than usual in the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "What was the main reason you worked fewer hours or days than usual in the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                    "id": "no-primary-reason-why-fewer-hours-than-usual-self-employed-answer",
+                                    "mandatory": false,
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "On leave",
+                                            "value": "On leave"
+                                        },
+                                        {
+                                            "label": "Illness or injury expected to last fewer than 4 weeks",
+                                            "value": "Illness or injury expected to last fewer than 4 weeks"
+                                        },
+                                        {
+                                            "label": "Illness or disability expected to last for 4 weeks or longer",
+                                            "value": "Illness or disability expected to last for 4 weeks or longer"
+                                        },
+                                        {
+                                            "label": "Maternity or paternity leave",
+                                            "value": "Maternity or paternity leave"
+                                        },
+                                        {
+                                            "label": "Business not set up yet",
+                                            "value": "Business not set up yet"
+                                        },
+                                        {
+                                            "label": "No client or customer that week",
+                                            "value": "No client or customer that week"
+                                        },
+                                        {
+                                            "label": "Temporary interruption to work",
+                                            "value": "Temporary interruption to work ",
+                                            "description": "Including bad weather"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "child_answer_id": "no-primary-reason-why-fewer-hours-than-usual-self-employed-answer-other"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "no-primary-reason-why-fewer-hours-than-usual-self-employed-answer-other",
+                                    "parent_answer_id": "no-primary-reason-why-fewer-hours-than-usual-self-employed-answer",
+                                    "type": "TextField",
+                                    "mandatory": false,
+                                    "label": "Please describe"
+                                }
+                            ]
+                        }]
+                    },
+                    {
+                        "id": "no-primary-when-start-working-current-business-red6-semp",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-when-start-working-current-business-question",
+                            "titles": [{
+                                    "value": "When did <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> start working continuously as a self-employed person?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "When did you start working continuously as a self-employed person?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-when-start-working-current-business-answer",
+                                "type": "MonthYearDate",
+                                "mandatory": false,
+                                "maximum": {
+                                    "value": "now"
+                                }
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-made-redundant-red5",
+                                    "when": [{
+                                        "id": "no-primary-when-start-working-current-business-answer",
+                                        "condition": "less than",
+                                        "date_comparison": {
+                                            "offset_by": {
+                                                "months": -4
+                                            },
+                                            "value": "now"
+                                        }
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-left-paid-job-red3"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-reason-why-fewer-hours-than-usual-employee-question",
+                            "titles": [{
+                                    "value": "What was the main reason <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> worked fewer hours or days than usual in the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "What was the main reason you worked fewer hours or days than usual in the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                    "id": "no-primary-reason-why-fewer-hours-than-usual-employee-answer",
+                                    "mandatory": false,
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "On leave",
+                                            "value": "On leave",
+                                            "description": "paid or unpaid"
+                                        },
+                                        {
+                                            "label": "Illness or injury expected to last fewer than 4 weeks",
+                                            "value": "Illness or injury expected to last fewer than 4 weeks"
+                                        },
+                                        {
+                                            "label": "Illness or disability expected to last for 4 weeks or longer",
+                                            "value": "Illness or disability expected to last for 4 weeks or longer"
+                                        },
+                                        {
+                                            "label": "Maternity or paternity leave",
+                                            "value": "Maternity or paternity leave"
+                                        },
+                                        {
+                                            "label": "Parental leave",
+                                            "value": "Parental leave"
+                                        },
+                                        {
+                                            "label": "Waiting to start a new job",
+                                            "value": "Waiting to start a new job"
+                                        },
+                                        {
+                                            "label": "Hours can vary",
+                                            "value": "Hours can vary"
+                                        },
+                                        {
+                                            "label": "Temporary interruption to work",
+                                            "value": "Temporary interruption to work",
+                                            "description": "Including bad weather, labour disputes"
+                                        },
+                                        {
+                                            "label": "Job is casual",
+                                            "value": "Job is casual"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "child_answer_id": "no-primary-reason-why-fewer-hours-than-usual-employee-answer-other"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "no-primary-reason-why-fewer-hours-than-usual-employee-answer-other",
+                                    "parent_answer_id": "no-primary-reason-why-fewer-hours-than-usual-employee-answer",
+                                    "type": "TextField",
+                                    "mandatory": false,
+                                    "label": "Please describe"
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-receiving-half-salary-w15-proxy",
+                                    "when": [{
+                                            "id": "no-primary-reason-why-fewer-hours-than-usual-employee-answer",
+                                            "condition": "equals",
+                                            "value": "Illness or disability expected to last for 4 weeks or longer"
+                                        },
+                                        {
+                                            "id": "no-primary-proxy-check-answer",
+                                            "condition": "equals",
+                                            "value": "proxy"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-receiving-half-salary-w15-proxy",
+                                    "when": [{
+                                            "id": "no-primary-reason-why-fewer-hours-than-usual-employee-answer",
+                                            "condition": "equals",
+                                            "value": "Maternity or paternity leave"
+                                        },
+                                        {
+                                            "id": "no-primary-proxy-check-answer",
+                                            "condition": "equals",
+                                            "value": "proxy"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-receiving-half-salary-w15-proxy",
+                                    "when": [{
+                                            "id": "no-primary-reason-why-fewer-hours-than-usual-employee-answer",
+                                            "condition": "equals",
+                                            "value": "Parental leave"
+                                        },
+                                        {
+                                            "id": "no-primary-proxy-check-answer",
+                                            "condition": "equals",
+                                            "value": "proxy"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-receiving-half-salary-w15",
+                                    "when": [{
+                                        "id": "no-primary-reason-why-fewer-hours-than-usual-employee-answer",
+                                        "condition": "equals",
+                                        "value": "Illness or disability expected to last for 4 weeks or longer"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-receiving-half-salary-w15",
+                                    "when": [{
+                                        "id": "no-primary-reason-why-fewer-hours-than-usual-employee-answer",
+                                        "condition": "equals",
+                                        "value": "Maternity or paternity leave"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-receiving-half-salary-w15",
+                                    "when": [{
+                                        "id": "no-primary-reason-why-fewer-hours-than-usual-employee-answer",
+                                        "condition": "equals",
+                                        "value": "Parental leave"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-how-long-have-you-been-looking-before-start-dur2",
+                                    "when": [{
+                                        "id": "no-primary-reason-why-fewer-hours-than-usual-employee-answer",
+                                        "condition": "equals",
+                                        "value": "Waiting to start a new job"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-receiving-half-salary-w15",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-receiving-half-salary-question",
+                            "title": "About your absence",
+                            "type": "General",
+                            "answers": [{
+                                    "id": "no-primary-receiving-half-salary-answer",
+                                    "mandatory": false,
+                                    "label": "Are you receiving half of your salary or more while you are away?",
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "Yes",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "no-primary-will-return-to-work-answer",
+                                    "mandatory": false,
+                                    "label": "Have you agreed with your employer that you will return to work?",
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "Yes",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "No"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-did-you-look-for-paid-work-nw3",
+                                    "when": [{
+                                        "id": "no-primary-will-return-to-work-answer",
+                                        "condition": "equals",
+                                        "value": "No"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-receiving-half-salary-w15-proxy",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-receiving-half-salary-proxy-question",
+                            "title": "About {{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} absence",
+                            "type": "General",
+                            "answers": [{
+                                    "id": "no-primary-receiving-half-salary-proxy-answer",
+                                    "mandatory": false,
+                                    "label": "Is <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> receiving half of their salary or more while they are away?",
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "Yes",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "no-primary-will-return-to-work-proxy-answer",
+                                    "mandatory": false,
+                                    "label": "Has <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> agreed with their employer that they will return to work?",
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "Yes",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "No"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-did-you-look-for-paid-work-nw3",
+                                    "when": [{
+                                        "id": "no-primary-will-return-to-work-proxy-answer",
+                                        "condition": "equals",
+                                        "value": "No"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-main-job-when-start-working-current-business-red6-emp"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-main-job-when-start-working-current-business-red6-emp",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-main-job-when-start-working-current-business-question",
+                            "titles": [{
+                                    "value": "In their <em>main</em> job, when did {{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} start working for their current employer?",
+                                    "when": [{
+                                            "id": "no-primary-proxy-check-answer",
+                                            "condition": "equals",
+                                            "value": "proxy"
+                                        },
+                                        {
+                                            "id": "no-primary-second-job-answer",
+                                            "condition": "equals",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "value": "In your <em>main</em> job, when did you start working for your current employer?",
+                                    "when": [{
+                                        "id": "no-primary-second-job-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }]
+                                },
+                                {
+                                    "value": "When did <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> start working for their current employer?",
+                                    "when": [{
+                                            "id": "no-primary-second-job-answer",
+                                            "condition": "equals",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "id": "no-primary-proxy-check-answer",
+                                            "condition": "equals",
+                                            "value": "proxy"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "value": "When did <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> start working for their current employer?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "When did you start working for your current employer?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-main-job-when-start-working-current-business-answer",
+                                "type": "MonthYearDate",
+                                "mandatory": false,
+                                "maximum": {
+                                    "value": "now"
+                                }
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-made-redundant-red5",
+                                    "when": [{
+                                        "id": "no-primary-main-job-when-start-working-current-business-answer",
+                                        "condition": "less than",
+                                        "date_comparison": {
+                                            "offset_by": {
+                                                "months": -4
+                                            },
+                                            "value": "now"
+                                        }
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-left-paid-job-red3"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-left-paid-job-red3",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-left-paid-job-question",
+                            "titles": [{
+                                    "value": "Has <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> left any paid job in the last three months?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "Have you left any paid job in the last three months?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-left-paid-job-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-reason-leaving-paid-job-red4",
+                                    "when": [{
+                                        "id": "no-primary-left-paid-job-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-made-redundant-red5"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-did-you-look-for-paid-work-nw3",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-did-you-look-for-work-question",
+                            "titles": [{
+                                    "value": "In the 4 weeks between {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {'weeks': -3}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }} did <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> look for any paid work?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "In the 4 weeks between {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {'weeks': -3}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }} did you look for any paid work?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-did-you-look-for-paid-work-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-how-long-have-you-been-looking-dur1",
+                                    "when": [{
+                                        "id": "no-primary-did-you-look-for-paid-work-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-not-looking-for-work-reason-nw4"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-how-long-have-you-been-looking-dur1",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-how-long-have-you-been-looking-question",
+                            "titles": [{
+                                    "value": "How long has <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> been looking for paid work?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "How long have you been looking for paid work?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-how-long-have-you-been-looking-answer",
+                                "mandatory": false,
+                                "units": [
+                                    "years",
+                                    "months"
+                                ],
+                                "type": "Duration"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "no-primary-if-offered-would-start-nw5",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-if-offered-would-start-question",
+                            "titles": [{
+                                    "value": "If <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> had been offered a job in the week starting {{ calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}) | format_date_custom( 'EEEE d MMMM' ) }} would they be able to start before {{ calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {'weeks':2}) | format_date_custom( 'EEEE d MMMM' ) }}?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "If you had been offered a job in the week starting {{ calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}) | format_date_custom( 'EEEE d MMMM' ) }} would you be able to start before {{ calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {'weeks':2}) | format_date_custom( 'EEEE d MMMM' ) }}?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-if-offered-would-start-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-unpaid-or-voluntary-work-nw7",
+                                    "when": [{
+                                        "id": "no-primary-if-offered-would-start-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-not-be-able-to-start-reason-nw6"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-not-be-able-to-start-reason-nw6",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-not-be-able-to-start-question",
+                            "titles": [{
+                                    "value": "Why would <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> not have been able to start?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "Why would you not have been able to start?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                    "id": "no-primary-not-be-able-to-start-answer",
+                                    "mandatory": false,
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "In education",
+                                            "value": "In education"
+                                        },
+                                        {
+                                            "label": "Looking after the family or home",
+                                            "value": "Looking after the family or home"
+                                        },
+                                        {
+                                            "label": "Childcare too expensive",
+                                            "value": "Childcare too expensive"
+                                        },
+                                        {
+                                            "label": "Caring responsibilities for adults",
+                                            "value": "Caring responsibilities for adults"
+                                        },
+                                        {
+                                            "label": "Illness or injury expecting to last fewer than 4 weeks",
+                                            "value": "Illness or injury expecting to last fewer than 4 weeks"
+                                        },
+                                        {
+                                            "label": "Illness or disability expecting to last for 4 weeks or longer",
+                                            "value": "Illness or disability expecting to last for 4 weeks or longer"
+                                        },
+                                        {
+                                            "label": "Waiting to start a job recently accepted",
+                                            "value": "Waiting to start a job recently accepted"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "child_answer_id": "no-primary-not-be-able-to-start-answer-other"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "no-primary-not-be-able-to-start-answer-other",
+                                    "parent_answer_id": "no-primary-not-be-able-to-start-answer",
+                                    "type": "TextField",
+                                    "mandatory": false,
+                                    "label": "Please describe"
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-how-long-have-you-been-looking-before-start-dur2",
+                                    "when": [{
+                                        "id": "no-primary-not-be-able-to-start-answer",
+                                        "condition": "equals",
+                                        "value": "Waiting to start a job recently accepted"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-unpaid-or-voluntary-work-nw7"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-not-looking-for-work-reason-nw4",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-not-looking-for-work-reason-question",
+                            "titles": [{
+                                    "value": "What was the main reason they did not look for work in this period?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "What was the main reason you did not look for work in this period?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                    "id": "no-primary-not-looking-for-work-reason-answer",
+                                    "mandatory": false,
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "Retired from paid work",
+                                            "value": "Retired from paid work"
+                                        },
+                                        {
+                                            "label": "Studying",
+                                            "value": "Studying"
+                                        },
+                                        {
+                                            "label": "Looking after the family or home",
+                                            "value": "Looking after the family or home"
+                                        },
+                                        {
+                                            "label": "Childcare is too expensive",
+                                            "value": "Childcare is too expensive"
+                                        },
+                                        {
+                                            "label": "Caring responsibilities for adults",
+                                            "value": "Caring responsibilities for adults"
+                                        },
+                                        {
+                                            "label": "Illness or disability expecting to last for 4 weeks or longer",
+                                            "value": "Illness or disability expecting to last for 4 weeks or longer"
+                                        },
+                                        {
+                                            "label": "Illness or injury expected to last fewer than 4 weeks",
+                                            "value": "Illness or injury expected to last fewer than 4 weeks"
+                                        },
+                                        {
+                                            "label": "Waiting to start a job recently accepted",
+                                            "value": "Waiting to start a job recently accepted"
+                                        },
+                                        {
+                                            "label": "Waiting for the result of a job application",
+                                            "value": "Waiting for the result of a job application"
+                                        },
+                                        {
+                                            "label": "No suitable jobs were available",
+                                            "value": "No suitable jobs were available"
+                                        },
+                                        {
+                                            "label": "Not yet started looking",
+                                            "value": "Not yet started looking"
+                                        },
+                                        {
+                                            "label": "Did not need employment",
+                                            "value": "Did not need employment"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "child_answer_id": "no-primary-not-looking-for-work-reason-answer-other"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "no-primary-not-looking-for-work-reason-answer-other",
+                                    "parent_answer_id": "no-primary-not-looking-for-work-reason-answer",
+                                    "type": "TextField",
+                                    "mandatory": false,
+                                    "label": "Please describe"
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-how-long-have-you-been-looking-before-start-dur2",
+                                    "when": [{
+                                        "id": "no-primary-not-looking-for-work-reason-answer",
+                                        "condition": "equals",
+                                        "value": "Waiting to start a job recently accepted"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-unpaid-or-voluntary-work-nw7"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-how-long-have-you-been-looking-before-start-dur2",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-how-long-have-you-been-looking-before-start-question",
+                            "titles": [{
+                                    "value": "How long were they looking for a paid job before they found one?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "How long were you looking for a paid job before you found one?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-how-long-have-you-been-looking-before-start-answer",
+                                "mandatory": false,
+                                "units": [
+                                    "years",
+                                    "months"
+                                ],
+                                "type": "Duration"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "no-primary-unpaid-or-voluntary-work-nw7",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-unpaid-or-voluntary-work-question",
+                            "titles": [{
+                                    "value": "Did <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> do any unpaid or voluntary work in the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "Did you do any unpaid or voluntary work in the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}) , calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                    "id": "no-primary-unpaid-or-voluntary-work-answer",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "options": [{
+                                            "label": "Yes, for a family-owned business",
+                                            "value": "Yes, for a family-owned business"
+                                        },
+                                        {
+                                            "label": "Yes, for a voluntary cause or charity",
+                                            "value": "Yes, for a voluntary cause or charity"
+                                        },
+                                        {
+                                            "label": "Yes, for an internship",
+                                            "value": "Yes, for an internship"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "no-primary-unpaid-or-voluntary-work-answer-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "options": [{
+                                        "label": "No",
+                                        "value": "No"
+                                    }]
+                                }
+                            ]
+                        }]
+                    },
+                    {
+                        "id": "no-primary-ever-had-a-paid-job-red-1",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-ever-had-a-paid-job-question",
+                            "titles": [{
+                                    "value": "Has <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> ever had a paid job?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "Have you ever had a paid job?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-ever-had-a-paid-job-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-when-left-last-paid-job-red-1-1",
+                                    "when": [{
+                                        "id": "no-primary-ever-had-a-paid-job-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-enrolled-education-course-qe1"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-when-left-last-paid-job-red-1-1",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-when-left-last-paid-job-question",
+                            "titles": [{
+                                    "value": "When did <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> leave their last paid job?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "When did you leave your last paid job?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-when-left-last-paid-job-answer",
+                                "type": "MonthYearDate",
+                                "mandatory": false,
+                                "maximum": {
+                                    "value": "now"
+                                }
+                            }]
+                        }],
+                        "routing_rules": [{
+                            "goto": {
+                                "block": "no-primary-reason-leaving-paid-job-red4"
+                            }
+                        }]
+                    },
+                    {
+                        "id": "no-primary-reason-leaving-paid-job-red4",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-reason-leaving-paid-job-question",
+                            "titles": [{
+                                    "value": "Why did <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> leave their last paid job?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "Why did you leave your last paid job?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-reason-leaving-paid-job-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Dismissed",
+                                        "value": "Dismissed"
+                                    },
+                                    {
+                                        "label": "Made redundant",
+                                        "value": "Made redundant"
+                                    },
+                                    {
+                                        "label": "Voluntary redundancy",
+                                        "value": "Voluntary redundancy"
+                                    },
+                                    {
+                                        "label": "A temporary job which came to an end",
+                                        "value": "A temporary job which came to an end"
+                                    },
+                                    {
+                                        "label": "Resigned",
+                                        "value": "Resigned"
+                                    },
+                                    {
+                                        "label": "Health reasons",
+                                        "value": "Health reasons"
+                                    },
+                                    {
+                                        "label": "Early retirement",
+                                        "value": "Early retirement"
+                                    },
+                                    {
+                                        "label": "Retired",
+                                        "value": "Retired",
+                                        "description": "At or after State Pension age"
+                                    },
+                                    {
+                                        "label": "Family or personal reasons",
+                                        "value": "Family or personal reasons"
+                                    },
+                                    {
+                                        "label": "For education or training",
+                                        "value": "For education or training"
+                                    },
+                                    {
+                                        "label": "Left for some other reason",
+                                        "value": "Left for some other reason"
+                                    }
+                                ]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "no-primary-made-redundant-red5",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-made-redundant-question",
+                            "titles": [{
+                                    "value": "Has <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> been made redundant from any other jobs in the last three months?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "Have you been made redundant from any other jobs in the last three months?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-made-redundant-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    }
+                                ]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "no-primary-enrolled-education-course-qe1",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-enrolled-education-course-question",
+                            "titles": [{
+                                    "value": "Is <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> currently enrolled on any formal education courses?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "Are you currently enrolled on any formal education courses?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-enrolled-education-course-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "no-primary-course-type-qe2",
+                                    "when": [{
+                                        "id": "no-primary-enrolled-education-course-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "no-primary-household-member-completed"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "no-primary-course-type-qe2",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-course-type-question",
+                            "titles": [{
+                                "value": "What kind of course is it?"
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-course-type-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "At school",
+                                        "value": "At school"
+                                    },
+                                    {
+                                        "label": "A full-time course at university, or college including 6th Form college",
+                                        "value": "A full-time course at university, or college including 6th Form college"
+                                    },
+                                    {
+                                        "label": "A part-time course at university, or college, including day release and block release",
+                                        "value": "A part-time course at university, or college, including day release and block release"
+                                    },
+                                    {
+                                        "label": "Training for a qualification in nursing, physiotherapy or a similar medical practice",
+                                        "value": "Training for a qualification in nursing, physiotherapy or a similar medical practice"
+                                    },
+                                    {
+                                        "label": "An Open college or Open University course",
+                                        "value": "An Open college or Open University course"
+                                    },
+                                    {
+                                        "label": "A sandwich course",
+                                        "value": "A sandwich course"
+                                    },
+                                    {
+                                        "label": "Any other correspondence course or open learning method",
+                                        "value": "Any other correspondence course or open learning method"
+                                    }
+                                ]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "no-primary-attend18",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "no-primary-attend18-question",
+                            "titles": [{
+                                    "value": "Is <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> attending this course?",
+                                    "when": [{
+                                        "id": "no-primary-proxy-check-answer",
+                                        "condition": "equals",
+                                        "value": "proxy"
+                                    }]
+                                },
+                                {
+                                    "value": "Are you attending this course?"
+                                }
+                            ],
+                            "type": "General",
+                            "answers": [{
+                                "id": "no-primary-attend18-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Still attending",
+                                        "value": "Still attending"
+                                    },
+                                    {
+                                        "label": "Waiting for term to (re)start",
+                                        "value": "Waiting for term to (re)start"
+                                    },
+                                    {
+                                        "label": "Stopped attending",
+                                        "value": "Stopped attending"
+                                    }
+                                ]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "no-primary-household-member-completed",
+                        "title": "There are no more questions for {{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}",
                         "description": "",
                         "type": "Interstitial"
                     }

--- a/data/en/test_navigation.json
+++ b/data/en/test_navigation.json
@@ -10,497 +10,637 @@
         "visible": true
     },
     "metadata": [{
-        "name": "user_id",
-        "validator": "string"
-    }, {
-        "name": "period_id",
-        "validator": "string"
-    }, {
-        "name": "ru_name",
-        "validator": "string"
-    }],
+            "name": "user_id",
+            "validator": "string"
+        },
+        {
+            "name": "period_id",
+            "validator": "string"
+        },
+        {
+            "name": "ru_name",
+            "validator": "string"
+        }
+    ],
     "sections": [{
-        "id": "property-details-section",
-        "title": "Property Details",
-        "groups": [{
-            "blocks": [{
-                "type": "Question",
-                "id": "insurance-type",
-                "description": "",
-                "questions": [{
-                    "answers": [{
-                        "id": "insurance-type-answer",
-                        "label": "",
-                        "mandatory": false,
-                        "options": [{
-                            "label": "Buildings",
-                            "value": "Buildings"
-                        }, {
-                            "label": "Contents",
-                            "value": "Contents"
-                        }, {
-                            "label": "Both",
-                            "value": "Both"
+            "id": "property-details-section",
+            "title": "Property Details",
+            "groups": [{
+                "blocks": [{
+                        "type": "Question",
+                        "id": "insurance-type",
+                        "description": "",
+                        "questions": [{
+                            "answers": [{
+                                "id": "insurance-type-answer",
+                                "label": "",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Buildings",
+                                        "value": "Buildings"
+                                    },
+                                    {
+                                        "label": "Contents",
+                                        "value": "Contents"
+                                    },
+                                    {
+                                        "label": "Both",
+                                        "value": "Both"
+                                    }
+                                ],
+                                "q_code": "1",
+                                "type": "Radio"
+                            }],
+                            "description": "",
+                            "id": "insurance-type-question",
+                            "title": "What kind of insurance would you like?",
+                            "type": "General"
                         }],
-                        "q_code": "1",
-                        "type": "Radio"
-                    }],
-                    "description": "",
-                    "id": "insurance-type-question",
-                    "title": "What kind of insurance would you like?",
-                    "type": "General"
-                }],
+                        "title": "Property Details"
+                    },
+                    {
+                        "type": "Question",
+                        "id": "insurance-address",
+                        "description": "",
+                        "questions": [{
+                            "answers": [{
+                                "id": "insurance-address-answer",
+                                "label": "",
+                                "mandatory": false,
+                                "q_code": "2",
+                                "type": "TextArea"
+                            }],
+                            "description": "",
+                            "id": "insurance-address-question",
+                            "title": "What is the address you would like to insure?",
+                            "type": "General"
+                        }],
+                        "title": "Property Details"
+                    }
+                ],
+                "id": "property-details",
                 "title": "Property Details"
-            }, {
-                "type": "Question",
-                "id": "insurance-address",
-                "description": "",
-                "questions": [{
-                    "answers": [{
-                        "id": "insurance-address-answer",
-                        "label": "",
-                        "mandatory": false,
-                        "q_code": "2",
-                        "type": "TextArea"
-                    }],
+            }]
+        },
+        {
+            "id": "house-details-section",
+            "title": "House Details",
+            "groups": [{
+                "blocks": [{
+                    "type": "Question",
+                    "id": "house-type",
+                    "skip_conditions": [{
+                            "when": [{
+                                "id": "insurance-type-answer",
+                                "condition": "equals",
+                                "value": "Contents"
+                            }]
+                        },
+                        {
+                            "when": [{
+                                "id": "insurance-type-answer",
+                                "condition": "not set"
+                            }]
+                        }
+                    ],
                     "description": "",
-                    "id": "insurance-address-question",
-                    "title": "What is the address you would like to insure?",
-                    "type": "General"
+                    "questions": [{
+                        "answers": [{
+                            "id": "house-type-answer",
+                            "label": "",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "Detached",
+                                    "value": "Detached"
+                                },
+                                {
+                                    "label": "Semi-detached",
+                                    "value": "Semi-detached"
+                                },
+                                {
+                                    "label": "Terrace",
+                                    "value": "Terrace"
+                                }
+                            ],
+                            "q_code": "12",
+                            "type": "Radio"
+                        }],
+                        "description": "",
+                        "id": "house-type-question",
+                        "title": "What kind of house is it?",
+                        "type": "General"
+                    }],
+                    "title": "House Details"
                 }],
-                "title": "Property Details"
-            }],
-            "id": "property-details",
-            "title": "Property Details"
-        }]
-    }, {
-        "id": "house-details-section",
-        "title": "House Details",
-        "groups": [{
-            "blocks": [{
-                "type": "Question",
-                "id": "house-type",
+                "id": "house-details",
+                "title": "House Details"
+            }]
+        },
+        {
+            "id": "property-interstitial-section",
+            "title": "Property Interstitial",
+            "groups": [{
+                "blocks": [{
+                    "type": "Interstitial",
+                    "id": "property-interstitial",
+                    "description": "",
+                    "questions": [{
+                        "description": "You have successfully completed the Property Details section. No need to answer House Type questions for contents only.",
+                        "id": "property-interstitial-question",
+                        "title": "Property Details",
+                        "type": "Content"
+                    }],
+                    "title": ""
+                }],
+                "id": "property-interstitial-group",
+                "title": "Property Interstitial",
                 "skip_conditions": [{
                     "when": [{
                         "id": "insurance-type-answer",
-                        "condition": "equals",
+                        "condition": "not equals",
                         "value": "Contents"
                     }]
-                }, {
-                    "when": [{
-                        "id": "insurance-type-answer",
-                        "condition": "not set"
-                    }]
-                }],
-                "description": "",
-                "questions": [{
-                    "answers": [{
-                        "id": "house-type-answer",
-                        "label": "",
-                        "mandatory": false,
-                        "options": [{
-                            "label": "Detached",
-                            "value": "Detached"
-                        }, {
-                            "label": "Semi-detached",
-                            "value": "Semi-detached"
-                        }, {
-                            "label": "Terrace",
-                            "value": "Terrace"
-                        }],
-                        "q_code": "12",
-                        "type": "Radio"
-                    }],
-                    "description": "",
-                    "id": "house-type-question",
-                    "title": "What kind of house is it?",
-                    "type": "General"
-                }],
-                "title": "House Details"
-            }],
-            "id": "house-details",
-            "title": "House Details"
-        }]
-    }, {
-        "id": "property-interstitial-section",
-        "title": "Property Interstitial",
-        "groups": [{
-            "blocks": [{
-                "type": "Interstitial",
-                "id": "property-interstitial",
-                "description": "",
-                "questions": [{
-                    "description": "You have successfully completed the Property Details section. No need to answer House Type questions for contents only.",
-                    "id": "property-interstitial-question",
-                    "title": "Property Details",
-                    "type": "Content"
-                }],
-                "title": ""
-            }],
-            "id": "property-interstitial-group",
-            "title": "Property Interstitial",
-            "skip_conditions": [{
-                "when": [{
-                    "id": "insurance-type-answer",
-                    "condition": "not equals",
-                    "value": "Contents"
                 }]
             }]
-        }]
-    }, {
-        "id": "household-composition-section",
-        "title": "Household Composition",
-        "groups": [{
-            "blocks": [{
-                "type": "Question",
-                "id": "household-composition",
-                "questions": [{
-                    "id": "household-composition-question",
-                    "title": "List the names of everyone  who lives here.",
-                    "number": "2",
-                    "guidance": {
-                        "content": [{
-                            "title": "Include",
-                            "list": ["Yourself, if this is your permanent or family home", "Family members including partners, children and babies born on or before 9 April 2017", "Students and, or school children who live away from home during term time", "Housemates tenants or lodgers"]
+        },
+        {
+            "id": "household-composition-section",
+            "title": "Household Composition",
+            "groups": [{
+                "blocks": [{
+                    "type": "Question",
+                    "id": "household-composition",
+                    "questions": [{
+                        "id": "household-composition-question",
+                        "title": "List the names of everyone  who lives here.",
+                        "number": "2",
+                        "guidance": {
+                            "content": [{
+                                "title": "Include",
+                                "list": [
+                                    "Yourself, if this is your permanent or family home",
+                                    "Family members including partners, children and babies born on or before 9 April 2017",
+                                    "Students and, or school children who live away from home during term time",
+                                    "Housemates tenants or lodgers"
+                                ]
+                            }]
+                        },
+                        "type": "RepeatingAnswer",
+                        "answers": [{
+                                "id": "first-name",
+                                "label": "First name",
+                                "mandatory": true,
+                                "type": "TextField",
+                                "validation": {
+                                    "messages": {
+                                        "MANDATORY_TEXTFIELD": "Please enter a name or remove the person to continue"
+                                    }
+                                }
+                            },
+                            {
+                                "id": "last-name",
+                                "label": "Last name",
+                                "mandatory": false,
+                                "type": "TextField"
+                            }
+                        ]
+                    }],
+                    "title": "Household Details"
+                }],
+                "id": "multiple-questions-group",
+                "title": "Household Details"
+            }]
+        },
+        {
+            "id": "household-full-names-section",
+            "title_from_answers": [
+                "first-name",
+                "last-name"
+            ],
+            "groups": [{
+                "blocks": [{
+                        "type": "Question",
+                        "id": "repeating-block-1",
+                        "title": "{{answers['first-name'][group_instance]}} {{answers['last-name'][group_instance]}}",
+                        "description": "",
+                        "questions": [{
+                            "id": "over-16-question",
+                            "title": "Is the person above over 16?",
+                            "description": "",
+                            "type": "General",
+                            "answers": [{
+                                "id": "what-is-your-age",
+                                "label": "",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    }
+                                ],
+                                "q_code": "5",
+                                "type": "Radio"
+                            }]
                         }]
                     },
-                    "type": "RepeatingAnswer",
-                    "answers": [{
-                        "id": "first-name",
-                        "label": "First name",
-                        "mandatory": true,
-                        "type": "TextField",
-                        "validation": {
-                            "messages": {
-                                "MANDATORY_TEXTFIELD": "Please enter a name or remove the person to continue"
-                            }
-                        }
-                    }, {
-                        "id": "last-name",
-                        "label": "Last name",
-                        "mandatory": false,
-                        "type": "TextField"
-                    }]
-                }],
-                "title": "Household Details"
-            }],
-            "id": "multiple-questions-group",
-            "title": "Household Details"
-        }]
-    }, {
-        "id": "household-full-names-section",
-        "title_from_answers": ["first-name", "last-name"],
-        "groups": [{
-            "blocks": [{
-                "type": "Question",
-                "id": "repeating-block-1",
-                "title": "{{answers['first-name'][group_instance]}} {{answers['last-name'][group_instance]}}",
-                "description": "",
-                "questions": [{
-                    "id": "over-16-question",
-                    "title": "Is the person above over 16?",
-                    "description": "",
-                    "type": "General",
-                    "answers": [{
-                        "id": "what-is-your-age",
-                        "label": "",
-                        "mandatory": false,
-                        "options": [{
-                            "label": "Yes",
-                            "value": "Yes"
-                        }, {
-                            "label": "No",
-                            "value": "No"
-                        }],
-                        "q_code": "5",
-                        "type": "Radio"
-                    }]
+                    {
+                        "type": "Question",
+                        "id": "repeating-block-2",
+                        "title": "{{answers['first-name'][group_instance]}} {{answers['last-name'][group_instance]}}",
+                        "description": "",
+                        "questions": [{
+                            "id": "working-status-question",
+                            "title": "",
+                            "description": "What is the working status of this person?",
+                            "type": "General",
+                            "answers": [{
+                                "q_code": "6",
+                                "id": "what-is-your-shoe-size",
+                                "label": "",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Full time student",
+                                        "value": "Full time student"
+                                    },
+                                    {
+                                        "label": "Employed",
+                                        "value": "Employed"
+                                    },
+                                    {
+                                        "label": "Self employed",
+                                        "value": "Self employed"
+                                    },
+                                    {
+                                        "label": "Unemployed",
+                                        "value": "Unmployed"
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
+                        }]
+                    }
+                ],
+                "id": "repeating-group",
+                "title": "Person ",
+                "routing_rules": [{
+                    "repeat": {
+                        "type": "answer_count",
+                        "answer_id": "first-name"
+                    }
                 }]
-            }, {
-                "type": "Question",
-                "id": "repeating-block-2",
-                "title": "{{answers['first-name'][group_instance]}} {{answers['last-name'][group_instance]}}",
-                "description": "",
-                "questions": [{
-                    "id": "working-status-question",
-                    "title": "",
-                    "description": "What is the working status of this person?",
-                    "type": "General",
-                    "answers": [{
-                        "q_code": "6",
-                        "id": "what-is-your-shoe-size",
-                        "label": "",
-                        "mandatory": false,
-                        "options": [{
-                            "label": "Full time student",
-                            "value": "Full time student"
-                        }, {
-                            "label": "Employed",
-                            "value": "Employed"
-                        }, {
-                            "label": "Self employed",
-                            "value": "Self employed"
-                        }, {
-                            "label": "Unemployed",
-                            "value": "Unmployed"
-                        }],
-                        "type": "Radio"
-                    }]
-                }]
-            }],
-            "id": "repeating-group",
-            "title": "Person ",
-            "routing_rules": [{
-                "repeat": {
-                    "type": "answer_count",
-                    "answer_id": "first-name"
-                }
             }]
-        }]
-    }, {
-        "id": "extra-cover-section",
-        "title": "Extra Cover",
-        "groups": [{
-            "blocks": [{
-                "type": "Question",
-                "id": "extra-cover-block",
-                "description": "",
-                "questions": [{
-                    "answers": [{
-                        "id": "extra-cover-answer",
-                        "label": "",
-                        "mandatory": true,
-                        "q_code": "7",
-                        "type": "Number",
-                        "validation": {
-                            "messages": {
-                                "NUMBER_TOO_LARGE": "Thats hotter then the sun, Jar Jar Binks you must be",
-                                "NUMBER_TOO_SMALL": "How can it be negative?"
-                            }
-                        }
-                    }],
+        },
+        {
+            "id": "extra-cover-section",
+            "title": "Extra Cover",
+            "groups": [{
+                "blocks": [{
+                    "type": "Question",
+                    "id": "extra-cover-block",
                     "description": "",
-                    "id": "extra-cover-question",
-                    "title": "Please list any special items you have",
-                    "type": "General"
+                    "questions": [{
+                        "answers": [{
+                            "id": "extra-cover-answer",
+                            "label": "",
+                            "mandatory": true,
+                            "q_code": "7",
+                            "type": "Number",
+                            "validation": {
+                                "messages": {
+                                    "NUMBER_TOO_LARGE": "Thats hotter then the sun, Jar Jar Binks you must be",
+                                    "NUMBER_TOO_SMALL": "How can it be negative?"
+                                }
+                            }
+                        }],
+                        "description": "",
+                        "id": "extra-cover-question",
+                        "title": "Please list any special items you have",
+                        "type": "General"
+                    }],
+                    "title": "Extra Cover"
                 }],
+                "id": "extra-cover",
                 "title": "Extra Cover"
-            }],
-            "id": "extra-cover",
-            "title": "Extra Cover"
-        }]
-    }, {
-        "id": "extra-cover-items-section",
-        "title": "Extra Cover Items",
-        "groups": [{
-            "id": "extra-cover-items-group",
+            }]
+        },
+        {
+            "id": "extra-cover-items-section",
             "title": "Extra Cover Items",
-            "routing_rules": [{
-                "repeat": {
-                    "type": "answer_value",
-                    "answer_id": "extra-cover-answer"
+            "groups": [{
+                "id": "extra-cover-items-group",
+                "title": "Extra Cover Items",
+                "routing_rules": [{
+                    "repeat": {
+                        "type": "answer_value",
+                        "answer_id": "extra-cover-answer"
+                    }
+                }],
+                "blocks": [{
+                        "type": "Question",
+                        "id": "extra-cover-items",
+                        "title": "Extra Cover {{group_instance + 1}}",
+                        "questions": [{
+                            "id": "extra-cover-items-question",
+                            "title": "What is the item you want to insure {{group_instance + 1}}?",
+                            "number": "1",
+                            "type": "General",
+                            "answers": [{
+                                "id": "extra-cover-items-answer",
+                                "label": "Item",
+                                "mandatory": false,
+                                "type": "TextField",
+                                "q_code": "8"
+                            }]
+                        }]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "extra-cover-items-radio",
+                        "title": "Continue to next",
+                        "description": "",
+                        "questions": [{
+                            "id": "extra-cover-items-radio-question",
+                            "title": "Tick either?",
+                            "description": "",
+                            "type": "General",
+                            "answers": [{
+                                "id": "extra-cover-items-radio-answer",
+                                "label": "",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    }
+                                ],
+                                "q_code": "9",
+                                "type": "Radio"
+                            }]
+                        }]
+                    }
+                ]
+            }]
+        },
+        {
+            "id": "payment-details-section",
+            "title": "Payment Details",
+            "groups": [{
+                    "id": "skip-payment-group",
+                    "title": "Are you ready for payment?",
+                    "blocks": [{
+                        "type": "Question",
+                        "id": "skip-payment",
+                        "title": "Skip Payent",
+                        "description": "",
+                        "questions": [{
+                            "id": "skip-payment-question",
+                            "title": "Would you like to skip the payment collection?",
+                            "description": "",
+                            "type": "General",
+                            "answers": [{
+                                "id": "skip-payment-answer",
+                                "label": "",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    }
+                                ],
+                                "q_code": "10",
+                                "type": "Radio"
+                            }]
+                        }]
+                    }]
+                },
+                {
+                    "skip_conditions": [{
+                            "when": [{
+                                "id": "skip-payment-answer",
+                                "condition": "equals",
+                                "value": "Yes"
+                            }]
+                        },
+                        {
+                            "when": [{
+                                "id": "skip-payment-answer",
+                                "condition": "not set"
+                            }]
+                        }
+                    ],
+                    "blocks": [{
+                            "type": "Question",
+                            "id": "credit-card",
+                            "description": "",
+                            "questions": [{
+                                "answers": [{
+                                    "id": "credit-card-answer",
+                                    "label": "",
+                                    "mandatory": true,
+                                    "q_code": "11",
+                                    "type": "Number"
+                                }],
+                                "description": "The long one in the middle of the card please",
+                                "id": "credit-card-question",
+                                "title": "What is your credit card number?",
+                                "type": "General"
+                            }],
+                            "title": "Payment Details"
+                        },
+                        {
+                            "type": "Question",
+                            "id": "expiry-date",
+                            "description": "",
+                            "questions": [{
+                                "answers": [{
+                                    "id": "expiry-date-answer",
+                                    "label": "",
+                                    "mandatory": true,
+                                    "q_code": "12",
+                                    "type": "TextField"
+                                }],
+                                "description": "",
+                                "id": "expiry-date-question",
+                                "title": "What is the expiry date?",
+                                "type": "General"
+                            }],
+                            "title": "Payment Details"
+                        },
+                        {
+                            "type": "Question",
+                            "id": "security-code",
+                            "description": "",
+                            "questions": [{
+                                "answers": [{
+                                    "id": "security-code-answer",
+                                    "label": "",
+                                    "mandatory": true,
+                                    "q_code": "13",
+                                    "type": "TextField"
+                                }],
+                                "description": "Its the last 3 numbers",
+                                "id": "security-code-question",
+                                "title": "What is the security code on the back?",
+                                "type": "General"
+                            }],
+                            "title": "Payment Details"
+                        },
+                        {
+                            "type": "Question",
+                            "id": "skip-interstitial",
+                            "title": "Skip Interstitial",
+                            "description": "",
+                            "questions": [{
+                                "id": "skip-interstitial-question",
+                                "title": "Would you like to skip the interstitial page?",
+                                "description": "",
+                                "type": "General",
+                                "answers": [{
+                                    "q_code": "14",
+                                    "id": "skip-interstitial-answer",
+                                    "label": "",
+                                    "mandatory": false,
+                                    "options": [{
+                                            "label": "Yes",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "No"
+                                        }
+                                    ],
+                                    "type": "Radio"
+                                }]
+                            }]
+                        },
+                        {
+                            "type": "Interstitial",
+                            "id": "security-code-interstitial",
+                            "title": "Payment Details Interstitial Page",
+                            "description": "",
+                            "questions": [{
+                                "description": "You have successfully completed the payment section, thank you.",
+                                "id": "security-code-interstitial-question",
+                                "title": "Payment",
+                                "type": "Content"
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "skip-interstitial-answer",
+                                    "condition": "equals",
+                                    "value": "Yes"
+                                }]
+                            }]
+                        }
+                    ],
+                    "id": "payment-details",
+                    "title": "Payment Details"
                 }
-            }],
-            "blocks": [{
-                "type": "Question",
-                "id": "extra-cover-items",
-                "title": "Extra Cover {{group_instance + 1}}",
-                "questions": [{
-                    "id": "extra-cover-items-question",
-                    "title": "What is the item you want to insure {{group_instance + 1}}?",
-                    "number": "1",
-                    "type": "General",
-                    "answers": [{
-                        "id": "extra-cover-items-answer",
-                        "label": "Item",
-                        "mandatory": false,
-                        "type": "TextField",
-                        "q_code": "8"
-                    }]
-                }]
-            }, {
-                "type": "Question",
-                "id": "extra-cover-items-radio",
-                "title": "Continue to next",
-                "description": "",
-                "questions": [{
-                    "id": "extra-cover-items-radio-question",
-                    "title": "Tick either?",
+            ]
+        },
+        {
+            "id": "final-section",
+            "title": "Final section",
+            "groups": [{
+                "id": "final-section-routed-group",
+                "title": "",
+                "blocks": [{
+                    "type": "Interstitial",
+                    "id": "final-interstitial",
+                    "title": "Final section page",
                     "description": "",
-                    "type": "General",
-                    "answers": [{
-                        "id": "extra-cover-items-radio-answer",
-                        "label": "",
-                        "mandatory": false,
-                        "options": [{
-                            "label": "Yes",
-                            "value": "Yes"
-                        }, {
-                            "label": "No",
-                            "value": "No"
-                        }],
-                        "q_code": "9",
-                        "type": "Radio"
+                    "questions": [{
+                        "description": "This is the last page in the section",
+                        "id": "final-interstitial-question",
+                        "title": "Final",
+                        "type": "Content"
+                    }],
+                    "routing_rules": [{
+                        "goto": {
+                            "group": "summary-group"
+                        }
                     }]
                 }]
             }]
-        }]
-    }, {
-        "id": "payment-details-section",
-        "title": "Payment Details",
-        "groups": [{
-            "id": "skip-payment-group",
-            "title": "Are you ready for payment?",
-            "blocks": [{
-                "type": "Question",
-                "id": "skip-payment",
-                "title": "Skip Payent",
-                "description": "",
-                "questions": [{
-                    "id": "skip-payment-question",
-                    "title": "Would you like to skip the payment collection?",
-                    "description": "",
-                    "type": "General",
-                    "answers": [{
-                        "id": "skip-payment-answer",
-                        "label": "",
-                        "mandatory": false,
-                        "options": [{
-                            "label": "Yes",
-                            "value": "Yes"
-                        }, {
-                            "label": "No",
-                            "value": "No"
-                        }],
-                        "q_code": "10",
-                        "type": "Radio"
+        },
+        {
+            "id": "impossible-section",
+            "title": "Impossible section",
+            "groups": [{
+                    "id": "impossible-section-routed-group",
+                    "title": "",
+                    "blocks": [{
+                        "type": "Interstitial",
+                        "id": "impossible-block",
+                        "title": "This block should be routed around",
+                        "description": "You should never see this.",
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "impossible-skip-answer",
+                                "condition": "not set"
+                            }]
+                        }]
                     }]
-                }]
+                },
+                {
+                    "id": "impossible-section-skipped-group",
+                    "title": "Impossible",
+                    "blocks": [{
+                        "type": "Question",
+                        "id": "impossible-skipped-block",
+                        "title": "Payment details last page",
+                        "description": "",
+                        "questions": [{
+                            "description": "This question should have been routed around",
+                            "id": "impossible-skip-question",
+                            "title": "Impossible",
+                            "type": "General",
+                            "answers": [{
+                                "id": "impossible-skip-answer",
+                                "label": "",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "impossible-skip-answer",
+                                "condition": "not set"
+                            }]
+                        }]
+                    }]
+                }
+            ]
+        },
+        {
+            "id": "summary-section",
+            "title": "Summary",
+            "groups": [{
+                "blocks": [{
+                    "type": "Summary",
+                    "id": "summary"
+                }],
+                "id": "summary-group",
+                "title": "Summary"
             }]
-        }, {
-            "skip_conditions": [{
-                "when": [{
-                    "id": "skip-payment-answer",
-                    "condition": "equals",
-                    "value": "Yes"
-                }]
-            }, {
-                "when": [{
-                    "id": "skip-payment-answer",
-                    "condition": "not set"
-                }]
-            }],
-            "blocks": [{
-                "type": "Question",
-                "id": "credit-card",
-                "description": "",
-                "questions": [{
-                    "answers": [{
-                        "id": "credit-card-answer",
-                        "label": "",
-                        "mandatory": true,
-                        "q_code": "11",
-                        "type": "Number"
-                    }],
-                    "description": "The long one in the middle of the card please",
-                    "id": "credit-card-question",
-                    "title": "What is your credit card number?",
-                    "type": "General"
-                }],
-                "title": "Payment Details"
-            }, {
-                "type": "Question",
-                "id": "expiry-date",
-                "description": "",
-                "questions": [{
-                    "answers": [{
-                        "id": "expiry-date-answer",
-                        "label": "",
-                        "mandatory": true,
-                        "q_code": "12",
-                        "type": "TextField"
-                    }],
-                    "description": "",
-                    "id": "expiry-date-question",
-                    "title": "What is the expiry date?",
-                    "type": "General"
-                }],
-                "title": "Payment Details"
-            }, {
-                "type": "Question",
-                "id": "security-code",
-                "description": "",
-                "questions": [{
-                    "answers": [{
-                        "id": "security-code-answer",
-                        "label": "",
-                        "mandatory": true,
-                        "q_code": "13",
-                        "type": "TextField"
-                    }],
-                    "description": "Its the last 3 numbers",
-                    "id": "security-code-question",
-                    "title": "What is the security code on the back?",
-                    "type": "General"
-                }],
-                "title": "Payment Details"
-            }, {
-                "type": "Question",
-                "id": "skip-interstitial",
-                "title": "Skip Interstitial",
-                "description": "",
-                "questions": [{
-                    "id": "skip-interstitial-question",
-                    "title": "Would you like to skip the interstitial page?",
-                    "description": "",
-                    "type": "General",
-                    "answers": [{
-                        "q_code": "14",
-                        "id": "skip-interstitial-answer",
-                        "label": "",
-                        "mandatory": false,
-                        "options": [{
-                            "label": "Yes",
-                            "value": "Yes"
-                        }, {
-                            "label": "No",
-                            "value": "No"
-                        }],
-                        "type": "Radio"
-                    }]
-                }]
-            }, {
-                "type": "Interstitial",
-                "id": "security-code-interstitial",
-                "title": "Payment Details Interstitial Page",
-                "description": "",
-                "questions": [{
-                    "description": "You have successfully completed the payment section, thank you.",
-                    "id": "security-code-interstitial-question",
-                    "title": "Payment",
-                    "type": "Content"
-                }],
-                "skip_conditions": [{
-                    "when": [{
-                        "id": "skip-interstitial-answer",
-                        "condition": "equals",
-                        "value": "Yes"
-                    }]
-                }]
-            }],
-            "id": "payment-details",
-            "title": "Payment Details"
-        }]
-    }, {
-        "id": "summary-section",
-        "title": "Summary",
-        "groups": [{
-            "blocks": [{
-                "type": "Summary",
-                "id": "summary"
-            }],
-            "id": "summary-group",
-            "title": "Summary"
-        }]
-    }]
+        }
+    ]
 }

--- a/data/en/test_routing_on_answer_from_driving_repeating_group.json
+++ b/data/en/test_routing_on_answer_from_driving_repeating_group.json
@@ -134,6 +134,81 @@
                 ]
             },
             {
+                "id": "household-relationships-no-primary",
+                "title": "Relationships",
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "primary-live-here",
+                        "condition": "equals",
+                        "value": "Yes"
+                    }]
+                }],
+                "routing_rules": [{
+                    "repeat": {
+                        "type": "answer_count_minus_one",
+                        "answer_ids": [
+                            "repeating-name"
+                        ]
+                    }
+                }],
+                "blocks": [{
+                    "type": "Question",
+                    "id": "relationships-no-primary",
+                    "title": "Who lives here?",
+                    "questions": [{
+                        "id": "relationship-no-primary-question",
+                        "title": "Describe how this person is related to the others",
+                        "description": "If members are not related, select the \u2018unrelated\u2019 option, including foster parents and foster children.",
+                        "type": "Relationship",
+                        "member_label": "answers['repeating-name']",
+                        "answers": [{
+                            "id": "who-is-related-no-primary",
+                            "label": "%(current_person)s is the &hellip; of %(other_person)s",
+                            "mandatory": false,
+                            "q_code": "2",
+                            "type": "Relationship",
+                            "options": [{
+                                    "label": "Husband or wife",
+                                    "value": "Husband or wife"
+                                },
+                                {
+                                    "label": "Partner",
+                                    "value": "Partner"
+                                },
+                                {
+                                    "label": "Mother or father",
+                                    "value": "Mother or father"
+                                },
+                                {
+                                    "label": "Son or daughter",
+                                    "value": "Son or daughter"
+                                },
+                                {
+                                    "label": "Brother or sister",
+                                    "value": "Brother or sister"
+                                },
+                                {
+                                    "label": "Relation - other",
+                                    "value": "Relation - other"
+                                },
+                                {
+                                    "label": "Grandparent",
+                                    "value": "Grandparent"
+                                },
+                                {
+                                    "label": "Grandchild",
+                                    "value": "Grandchild"
+                                },
+                                {
+                                    "label": "Unrelated",
+                                    "value": "Unrelated"
+                                }
+                            ]
+                        }]
+                    }]
+                }]
+            },
+            {
                 "id": "household-relationships",
                 "title": "Relationships",
                 "skip_conditions": [{
@@ -203,6 +278,48 @@
                                 {
                                     "label": "Unrelated",
                                     "value": "Unrelated"
+                                }
+                            ]
+                        }]
+                    }]
+                }]
+            },
+            {
+                "id": "sex-group-no-primary",
+                "title": "Household Member Details",
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "primary-live-here",
+                        "condition": "equals",
+                        "value": "Yes"
+                    }]
+                }],
+                "routing_rules": [{
+                    "repeat": {
+                        "type": "answer_count",
+                        "answer_ids": [
+                            "repeating-name"
+                        ]
+                    }
+                }],
+                "blocks": [{
+                    "type": "Question",
+                    "id": "sex-block-no-primary",
+                    "questions": [{
+                        "id": "sex-question-no-primary",
+                        "title": "What is {{ group_instances[group_instance_id]['repeating-name'] }}'s sex?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "sex-answer-no-primary",
+                            "mandatory": true,
+                            "type": "Radio",
+                            "options": [{
+                                    "label": "Male",
+                                    "value": "Male"
+                                },
+                                {
+                                    "label": "Female",
+                                    "value": "Female"
                                 }
                             ]
                         }]

--- a/tests/app/questionnaire/test_completeness.py
+++ b/tests/app/questionnaire/test_completeness.py
@@ -489,3 +489,13 @@ class TestCompleteness(AppContextTestCase): # pylint: disable=too-many-public-me
             schema, AnswerStore(), completed_blocks, routing_path, metadata={})
         with patch('app.questionnaire.path_finder.evaluate_goto', return_value=False):
             self.assertFalse(progress.get_first_incomplete_location_in_survey())
+
+    def test_get_state_for_section(self):
+        """
+        This is a bad test that is really only for coverage.
+        The test navigation schema should be changed to include a situation where all groups
+        in a section are 'invalid' AND 'skipped'
+        """
+        with patch('app.questionnaire.completeness.Completeness.get_state_for_group', side_effect=['SKIPPED', 'INVALID']):
+            completeness = Completeness([], [], [], [], [])
+            self.assertEqual(completeness.get_state_for_section({'groups': [1, 1]}), 'SKIPPED')

--- a/tests/app/questionnaire/test_navigation.py
+++ b/tests/app/questionnaire/test_navigation.py
@@ -9,6 +9,15 @@ from app.utilities.schema import load_schema_from_params
 
 from tests.app.app_context_test_case import AppContextTestCase
 
+standard_routing_path = [
+    Location('property-details', 0, 'insurance-type'),
+    Location('property-details', 0, 'insurance-address'),
+    Location('multiple-questions-group', 0, 'household-composition'),
+    Location('extra-cover', 0, 'extra-cover-block'),
+    Location('skip-payment-group', 0, 'skip-payment'),
+    Location('final-section-routed-group', 0, 'final-interstitial'),
+    Location('summary-group', 0, 'summary')
+]
 
 # pylint: disable=R0904,C0302
 class TestNavigation(AppContextTestCase):
@@ -22,7 +31,8 @@ class TestNavigation(AppContextTestCase):
             'form_type': 'some_form'
         }
 
-        navigation = _create_navigation(schema, AnswerStore(), metadata, [], [])
+
+        navigation = _create_navigation(schema, AnswerStore(), metadata, [], standard_routing_path)
 
         user_navigation = [
             {
@@ -52,6 +62,13 @@ class TestNavigation(AppContextTestCase):
                 'repeating': False,
                 'completed': False,
                 'link_url': Location('skip-payment-group', 0, 'skip-payment').url(metadata)
+            },
+            {
+                'link_name': 'Final section',
+                'highlight': False,
+                'repeating': False,
+                'completed': False,
+                'link_url': Location('final-section-routed-group', 0, 'final-interstitial').url(metadata)
             }
         ]
         self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
@@ -124,6 +141,13 @@ class TestNavigation(AppContextTestCase):
                 'repeating': False,
                 'completed': False,
                 'link_url': Location('skip-payment-group', 0, 'skip-payment').url(metadata)
+            },
+            {
+                'link_name': 'Final section',
+                'highlight': False,
+                'repeating': False,
+                'completed': False,
+                'link_url': Location('final-section-routed-group', 0, 'final-interstitial').url(metadata)
             }
 
         ]
@@ -249,6 +273,13 @@ class TestNavigation(AppContextTestCase):
                 'completed': False,
                 'highlight': False,
                 'link_url': Location('skip-payment-group', 0, 'skip-payment').url(metadata)
+            },
+            {
+                'link_name': 'Final section',
+                'highlight': False,
+                'repeating': False,
+                'completed': False,
+                'link_url': Location('final-section-routed-group', 0, 'final-interstitial').url(metadata)
             }
         ]
         self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
@@ -358,6 +389,13 @@ class TestNavigation(AppContextTestCase):
                 'repeating': False,
                 'link_name': 'Payment Details',
                 'link_url': Location('skip-payment-group', 0, 'skip-payment').url(metadata),
+            },
+            {
+                'link_name': 'Final section',
+                'highlight': False,
+                'repeating': False,
+                'completed': False,
+                'link_url': Location('final-section-routed-group', 0, 'final-interstitial').url(metadata)
             }
         ]
 
@@ -473,6 +511,13 @@ class TestNavigation(AppContextTestCase):
                 'completed': False,
                 'link_name': 'Payment Details',
                 'link_url': Location('skip-payment-group', 0, 'skip-payment').url(metadata)
+            },
+            {
+                'link_name': 'Final section',
+                'highlight': False,
+                'repeating': False,
+                'completed': False,
+                'link_url': Location('final-section-routed-group', 0, 'final-interstitial').url(metadata)
             }
         ]
 
@@ -581,6 +626,13 @@ class TestNavigation(AppContextTestCase):
                 'repeating': False,
                 'completed': False,
                 'link_url': Location('skip-payment-group', 0, 'skip-payment').url(metadata)
+            },
+            {
+                'link_name': 'Final section',
+                'highlight': False,
+                'repeating': False,
+                'completed': False,
+                'link_url': Location('final-section-routed-group', 0, 'final-interstitial').url(metadata)
             }
         ]
 
@@ -774,7 +826,7 @@ class TestNavigation(AppContextTestCase):
             Location('multiple-questions-group', 0, 'household-composition'),
         ]
 
-        navigation = _create_navigation(schema, AnswerStore(), metadata, completed_blocks, [])
+        navigation = _create_navigation(schema, AnswerStore(), metadata, completed_blocks, standard_routing_path)
 
         confirmation_link = {
             'link_name': 'Summary',
@@ -786,7 +838,7 @@ class TestNavigation(AppContextTestCase):
 
         navigation_links = navigation.build_navigation('property-details', 0)
         self.assertNotIn(confirmation_link, navigation_links)
-        self.assertEqual(len(navigation_links), 4)
+        self.assertEqual(len(navigation_links), 5)
 
     def test_build_navigation_summary_link_visible_when_all_sections_complete(self):
         schema = load_schema_from_params('test', 'navigation')
@@ -849,7 +901,7 @@ class TestNavigation(AppContextTestCase):
 
         navigation_links = navigation.build_navigation('property-details', 0)
         self.assertIn(confirmation_link, navigation_links)
-        self.assertEqual(len(navigation_links), 5)
+        self.assertEqual(len(navigation_links), 6)
 
     def test_build_navigation_submit_answers_link_not_visible_for_survey_with_summary(self):
         schema = load_schema_from_params('test', 'navigation')
@@ -878,7 +930,7 @@ class TestNavigation(AppContextTestCase):
             Location('extra-cover-items-group', 0, 'extra-cover-items'),
         ]
 
-        navigation = _create_navigation(schema, AnswerStore(), metadata, completed_blocks, [])
+        navigation = _create_navigation(schema, AnswerStore(), metadata, completed_blocks, standard_routing_path)
 
         confirmation_link = {
             'link_name': 'Submit answers',
@@ -890,7 +942,7 @@ class TestNavigation(AppContextTestCase):
 
         navigation_links = navigation.build_navigation('property-details', 0)
         self.assertNotIn(confirmation_link, navigation_links)
-        self.assertEqual(len(navigation_links), 4)
+        self.assertEqual(len(navigation_links), 5)
 
     def test_build_navigation_submit_answers_link_hidden_when_no_sections_completed(self):
         schema = load_schema_from_params('test', 'navigation_confirmation')
@@ -1057,9 +1109,8 @@ class TestNavigation(AppContextTestCase):
         }
 
         completed_blocks = []
-        routing_path = []
 
-        navigation = _create_navigation(schema, AnswerStore(), metadata, completed_blocks, routing_path)
+        navigation = _create_navigation(schema, AnswerStore(), metadata, completed_blocks, standard_routing_path)
 
         confirmation_link = {
             'link_name': 'Summary',
@@ -1071,7 +1122,7 @@ class TestNavigation(AppContextTestCase):
 
         navigation_links = navigation.build_navigation('property-details', 0)
         self.assertNotIn(confirmation_link, navigation_links)
-        self.assertEqual(len(navigation_links), 4)
+        self.assertEqual(len(navigation_links), 5)
 
     def test_build_navigation_summary_link_hidden_when_not_on_routing_path(self):
         schema = load_schema_from_params('test', 'navigation')
@@ -1130,7 +1181,7 @@ class TestNavigation(AppContextTestCase):
 
         navigation_links = navigation.build_navigation('property-details', 0)
         self.assertNotIn(confirmation_link, navigation_links)
-        self.assertEqual(len(navigation_links), 4)
+        self.assertEqual(len(navigation_links), 5)
 
     def test_build_navigation_summary_link_shown_when_invalid_section_present(self):
         schema = load_schema_from_params('test', 'navigation')
@@ -1184,7 +1235,7 @@ class TestNavigation(AppContextTestCase):
         navigation_links = navigation.build_navigation('skip-payment', 0)
 
         self.assertIn(confirmation_link, navigation_links)
-        self.assertEqual(len(navigation_links), 6)
+        self.assertEqual(len(navigation_links), 7)
 
     def test_build_navigation_repeated_blocks_independent_completeness(self):
         schema = load_schema_from_params('test', 'navigation')
@@ -1296,6 +1347,13 @@ class TestNavigation(AppContextTestCase):
                 'repeating': False,
                 'link_name': 'Payment Details',
                 'link_url': Location('skip-payment-group', 0, 'skip-payment').url(metadata),
+            },
+            {
+                'link_name': 'Final section',
+                'highlight': False,
+                'repeating': False,
+                'completed': False,
+                'link_url': Location('final-section-routed-group', 0, 'final-interstitial').url(metadata)
             }
         ]
 
@@ -1376,6 +1434,13 @@ class TestNavigation(AppContextTestCase):
                 'repeating': False,
                 'link_name': 'Payment Details',
                 'link_url': Location('skip-payment-group', 0, 'skip-payment').url(metadata),
+            },
+            {
+                'link_name': 'Final section',
+                'highlight': False,
+                'repeating': False,
+                'completed': False,
+                'link_url': Location('final-section-routed-group', 0, 'final-interstitial').url(metadata)
             }
         ]
         self.assertEqual(navigation.build_navigation(
@@ -1459,6 +1524,13 @@ class TestNavigation(AppContextTestCase):
                 'repeating': False,
                 'link_name': 'Payment Details',
                 'link_url': Location('skip-payment-group', 0, 'skip-payment').url(metadata),
+            },
+            {
+                'link_name': 'Final section',
+                'highlight': False,
+                'repeating': False,
+                'completed': False,
+                'link_url': Location('final-section-routed-group', 0, 'final-interstitial').url(metadata)
             }
         ]
 

--- a/tests/app/questionnaire/test_path_finder.py
+++ b/tests/app/questionnaire/test_path_finder.py
@@ -846,7 +846,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
             Location('repeating-group', 1, 'repeating-name-block'),
             Location('repeating-group', 2, 'repeating-anyone-else-block'),
         ]
-        expected_next_location = Location('household-relationships', 1, 'relationships')
+        expected_next_location = Location('household-relationships-no-primary', 0, 'relationships-no-primary')
 
         path_finder = PathFinder(schema, answer_store, metadata={}, completed_blocks=completed_blocks)
 

--- a/tests/app/questionnaire/test_rules.py
+++ b/tests/app/questionnaire/test_rules.py
@@ -13,6 +13,7 @@ from tests.app.app_context_test_case import AppContextTestCase
 def get_schema_mock(answer_is_in_repeating_group=False):
     schema = QuestionnaireSchema({})
     schema.answer_is_in_repeating_group = Mock(return_value=answer_is_in_repeating_group)
+    schema.get_block_id_for_answer_id = Mock(return_value='answer_block')
     return schema
 
 class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods

--- a/tests/functional/pages/surveys/navigation/final-interstitial.page.js
+++ b/tests/functional/pages/surveys/navigation/final-interstitial.page.js
@@ -1,0 +1,11 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class FinalInterstitialPage extends QuestionPage {
+
+  constructor() {
+    super('final-interstitial');
+  }
+
+}
+module.exports = new FinalInterstitialPage();

--- a/tests/functional/pages/surveys/navigation/household-composition.page.js
+++ b/tests/functional/pages/surveys/navigation/household-composition.page.js
@@ -11,11 +11,14 @@ class HouseholdCompositionPage extends QuestionPage {
     return 'button[name="action[add_answer]"]';
   }
 
-  removePerson(index=1) {
+  removePerson(index = 1) {
     return 'button[value="' + index + '"]';
     // Have to check whether it's visible in test code
   }
 
+  personLegend(index = 1) {
+    return 'div.question__answer:nth-child(' + index + ') > fieldset > legend';
+  }
   firstName(index = '') {
     return '#household-0-first-name' + index;
   }

--- a/tests/functional/pages/surveys/navigation/summary.page.js
+++ b/tests/functional/pages/surveys/navigation/summary.page.js
@@ -7,5 +7,131 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
+  insuranceTypeAnswer(index = 0) { return '#insurance-type-answer-' + index + '-answer'; }
+
+  insuranceTypeAnswerEdit(index = 0) { return '[data-qa="insurance-type-answer-' + index + '-edit"]'; }
+
+  insuranceTypeQuestion(index = 0) { return '#insurance-type-question-' + index; }
+
+  insuranceAddressAnswer(index = 0) { return '#insurance-address-answer-' + index + '-answer'; }
+
+  insuranceAddressAnswerEdit(index = 0) { return '[data-qa="insurance-address-answer-' + index + '-edit"]'; }
+
+  insuranceAddressQuestion(index = 0) { return '#insurance-address-question-' + index; }
+
+  propertyDetailsTitle(index = 0) { return '#property-details-' + index; }
+
+  houseTypeAnswer(index = 0) { return '#house-type-answer-' + index + '-answer'; }
+
+  houseTypeAnswerEdit(index = 0) { return '[data-qa="house-type-answer-' + index + '-edit"]'; }
+
+  houseTypeQuestion(index = 0) { return '#house-type-question-' + index; }
+
+  houseDetailsTitle(index = 0) { return '#house-details-' + index; }
+
+  propertyInterstitialGroupTitle(index = 0) { return '#property-interstitial-group-' + index; }
+
+  firstName(index = 0) { return '#first-name-' + index + '-answer'; }
+
+  firstNameEdit(index = 0) { return '[data-qa="first-name-' + index + '-edit"]'; }
+
+  lastName(index = 0) { return '#last-name-' + index + '-answer'; }
+
+  lastNameEdit(index = 0) { return '[data-qa="last-name-' + index + '-edit"]'; }
+
+  householdCompositionQuestion(index = 0) { return '#household-composition-question-' + index; }
+
+  multipleQuestionsGroupTitle(index = 0) { return '#multiple-questions-group-' + index; }
+
+  whatIsYourAge(index = 0) { return '#what-is-your-age-' + index + '-answer'; }
+
+  whatIsYourAgeEdit(index = 0) { return '[data-qa="what-is-your-age-' + index + '-edit"]'; }
+
+  over16Question(index = 0) { return '#over-16-question-' + index; }
+
+  whatIsYourShoeSize(index = 0) { return '#what-is-your-shoe-size-' + index + '-answer'; }
+
+  whatIsYourShoeSizeEdit(index = 0) { return '[data-qa="what-is-your-shoe-size-' + index + '-edit"]'; }
+
+  workingStatusQuestion(index = 0) { return '#working-status-question-' + index; }
+
+  repeatingGroupTitle(index = 0) { return '#repeating-group-' + index; }
+
+  extraCoverAnswer(index = 0) { return '#extra-cover-answer-' + index + '-answer'; }
+
+  extraCoverAnswerEdit(index = 0) { return '[data-qa="extra-cover-answer-' + index + '-edit"]'; }
+
+  extraCoverQuestion(index = 0) { return '#extra-cover-question-' + index; }
+
+  extraCoverTitle(index = 0) { return '#extra-cover-' + index; }
+
+  extraCoverItemsAnswer(index = 0) { return '#extra-cover-items-answer-' + index + '-answer'; }
+
+  extraCoverItemsAnswerEdit(index = 0) { return '[data-qa="extra-cover-items-answer-' + index + '-edit"]'; }
+
+  extraCoverItemsQuestion(index = 0) { return '#extra-cover-items-question-' + index; }
+
+  extraCoverItemsRadioAnswer(index = 0) { return '#extra-cover-items-radio-answer-' + index + '-answer'; }
+
+  extraCoverItemsRadioAnswerEdit(index = 0) { return '[data-qa="extra-cover-items-radio-answer-' + index + '-edit"]'; }
+
+  extraCoverItemsRadioQuestion(index = 0) { return '#extra-cover-items-radio-question-' + index; }
+
+  extraCoverItemsGroupTitle(index = 0) { return '#extra-cover-items-group-' + index; }
+
+  skipPaymentAnswer(index = 0) { return '#skip-payment-answer-' + index + '-answer'; }
+
+  skipPaymentAnswerEdit(index = 0) { return '[data-qa="skip-payment-answer-' + index + '-edit"]'; }
+
+  skipPaymentQuestion(index = 0) { return '#skip-payment-question-' + index; }
+
+  skipPaymentGroupTitle(index = 0) { return '#skip-payment-group-' + index; }
+
+  creditCardAnswer(index = 0) { return '#credit-card-answer-' + index + '-answer'; }
+
+  creditCardAnswerEdit(index = 0) { return '[data-qa="credit-card-answer-' + index + '-edit"]'; }
+
+  creditCardQuestion(index = 0) { return '#credit-card-question-' + index; }
+
+  expiryDateAnswer(index = 0) { return '#expiry-date-answer-' + index + '-answer'; }
+
+  expiryDateAnswerEdit(index = 0) { return '[data-qa="expiry-date-answer-' + index + '-edit"]'; }
+
+  expiryDateQuestion(index = 0) { return '#expiry-date-question-' + index; }
+
+  securityCodeAnswer(index = 0) { return '#security-code-answer-' + index + '-answer'; }
+
+  securityCodeAnswerEdit(index = 0) { return '[data-qa="security-code-answer-' + index + '-edit"]'; }
+
+  securityCodeQuestion(index = 0) { return '#security-code-question-' + index; }
+
+  skipInterstitialAnswer(index = 0) { return '#skip-interstitial-answer-' + index + '-answer'; }
+
+  skipInterstitialAnswerEdit(index = 0) { return '[data-qa="skip-interstitial-answer-' + index + '-edit"]'; }
+
+  skipInterstitialQuestion(index = 0) { return '#skip-interstitial-question-' + index; }
+
+  paymentDetailsTitle(index = 0) { return '#payment-details-' + index; }
+
+  finalSectionRoutedGroupTitle(index = 0) { return '#final-section-routed-group-' + index; }
+
+  impossibleAnswer(index = 0) { return '#impossible-answer-' + index + '-answer'; }
+
+  impossibleAnswerEdit(index = 0) { return '[data-qa="impossible-answer-' + index + '-edit"]'; }
+
+  impossibleQuestion(index = 0) { return '#impossible-question-' + index; }
+
+  impossibleSectionRoutedGroupTitle(index = 0) { return '#impossible-section-routed-group-' + index; }
+
+  impossibleSkipAnswer(index = 0) { return '#impossible-skip-answer-' + index + '-answer'; }
+
+  impossibleSkipAnswerEdit(index = 0) { return '[data-qa="impossible-skip-answer-' + index + '-edit"]'; }
+
+  impossibleSkipQuestion(index = 0) { return '#impossible-skip-question-' + index; }
+
+  impossibleSectionSkippedGroupTitle(index = 0) { return '#impossible-section-skipped-group-' + index; }
+
+  summaryGroupTitle(index = 0) { return '#summary-group-' + index; }
+
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/surveys/routing_on_answer_from_driving_repeating_group/relationships-no-primary.page.js
+++ b/tests/functional/pages/surveys/routing_on_answer_from_driving_repeating_group/relationships-no-primary.page.js
@@ -1,0 +1,21 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class RelationshipsNoPrimaryPage extends QuestionPage {
+
+  constructor() {
+    super('relationships-no-primary');
+  }
+
+  answer(instance) {
+    return '[name="who-is-related-no-primary-' + instance + '"]';
+  }
+
+  relationship(instance, answer) {
+    return '#who-is-related-no-primary-' + instance + ' > [value="' + answer + '"]';
+  }
+
+  answerLabel() { return '#label-who-is-related-no-primary'; }
+
+}
+module.exports = new RelationshipsNoPrimaryPage();

--- a/tests/functional/pages/surveys/routing_on_answer_from_driving_repeating_group/sex-block-no-primary.page.js
+++ b/tests/functional/pages/surveys/routing_on_answer_from_driving_repeating_group/sex-block-no-primary.page.js
@@ -1,0 +1,23 @@
+// >>> WARNING THIS PAGE WAS AUTO-GENERATED - DO NOT EDIT!!! <<<
+const QuestionPage = require('../question.page');
+
+class SexBlockNoPrimaryPage extends QuestionPage {
+
+  constructor() {
+    super('sex-block-no-primary');
+  }
+
+  male() {
+    return '#sex-answer-no-primary-0';
+  }
+
+  maleLabel() { return '#label-sex-answer-no-primary-0'; }
+
+  female() {
+    return '#sex-answer-no-primary-1';
+  }
+
+  femaleLabel() { return '#label-sex-answer-no-primary-1'; }
+
+}
+module.exports = new SexBlockNoPrimaryPage();

--- a/tests/functional/pages/surveys/routing_on_answer_from_driving_repeating_group/summary.page.js
+++ b/tests/functional/pages/surveys/routing_on_answer_from_driving_repeating_group/summary.page.js
@@ -7,13 +7,17 @@ class SummaryPage extends QuestionPage {
     super('summary');
   }
 
-  primaryName(index = 0) { return '#primary-name-' + index + 'answer'; }
+  primaryName(index = 0) { return '#primary-name-' + index + '-answer'; }
 
   primaryNameEdit(index = 0) { return '[data-qa="primary-name-' + index + '-edit"]'; }
+
+  primaryNameQuestion(index = 0) { return '#primary-name-question-' + index; }
 
   primaryLiveHere(index = 0) { return '#primary-live-here-' + index + '-answer'; }
 
   primaryLiveHereEdit(index = 0) { return '[data-qa="primary-live-here-' + index + '-edit"]'; }
+
+  primaryLiveHereQuestion(index = 0) { return '#primary-live-here-question-' + index; }
 
   primaryGroupTitle(index = 0) { return '#primary-group-' + index; }
 
@@ -21,21 +25,45 @@ class SummaryPage extends QuestionPage {
 
   repeatingAnyoneElseEdit(index = 0) { return '[data-qa="repeating-anyone-else-' + index + '-edit"]'; }
 
+  repeatingAnyoneElseQuestion(index = 0) { return '#repeating-anyone-else-question-' + index; }
+
   repeatingName(index = 0) { return '#repeating-name-' + index + '-answer'; }
 
   repeatingNameEdit(index = 0) { return '[data-qa="repeating-name-' + index + '-edit"]'; }
 
+  repeatingNameQuestion(index = 0) { return '#repeating-name-question-' + index; }
+
   repeatingGroupTitle(index = 0) { return '#repeating-group-' + index; }
+
+  whoIsRelatedNoPrimary(index = 0) { return '#who-is-related-no-primary-' + index + '-answer'; }
+
+  whoIsRelatedNoPrimaryEdit(index = 0) { return '[data-qa="who-is-related-no-primary-' + index + '-edit"]'; }
+
+  relationshipNoPrimaryQuestion(index = 0) { return '#relationship-no-primary-question-' + index; }
+
+  householdRelationshipsNoPrimaryTitle(index = 0) { return '#household-relationships-no-primary-' + index; }
 
   whoIsRelated(index = 0) { return '#who-is-related-' + index + '-answer'; }
 
   whoIsRelatedEdit(index = 0) { return '[data-qa="who-is-related-' + index + '-edit"]'; }
 
+  relationshipQuestion(index = 0) { return '#relationship-question-' + index; }
+
   householdRelationshipsTitle(index = 0) { return '#household-relationships-' + index; }
 
-  sexAnswer(index = 0) { return '#sex-answer-answer-' + index; }
+  sexAnswerNoPrimary(index = 0) { return '#sex-answer-no-primary-' + index + '-answer'; }
+
+  sexAnswerNoPrimaryEdit(index = 0) { return '[data-qa="sex-answer-no-primary-' + index + '-edit"]'; }
+
+  sexQuestionNoPrimary(index = 0) { return '#sex-question-no-primary-' + index; }
+
+  sexGroupNoPrimaryTitle(index = 0) { return '#sex-group-no-primary-' + index; }
+
+  sexAnswer(index = 0) { return '#sex-answer-' + index + '-answer'; }
 
   sexAnswerEdit(index = 0) { return '[data-qa="sex-answer-' + index + '-edit"]'; }
+
+  sexQuestion(index = 0) { return '#sex-question-' + index; }
 
   sexGroupTitle(index = 0) { return '#sex-group-' + index; }
 

--- a/tests/functional/spec/navigation.spec.js
+++ b/tests/functional/spec/navigation.spec.js
@@ -15,6 +15,7 @@ const SecurityCodeInterstitialPage = require('../pages/surveys/navigation/securi
 const SkipInterstitialPage = require('../pages/surveys/navigation/skip-interstitial.page.js');
 const SkipPaymentPage = require('../pages/surveys/navigation/skip-payment.page.js');
 const SummaryPage = require('../pages/surveys/navigation/summary.page.js');
+const FinalInterstitial = require('../pages/surveys/navigation/final-interstitial.page.js');
 const GenericPage = require('../pages/surveys/generic.page.js');
 
 const CoffeePage = require('../pages/surveys/navigation/completeness/coffee.page.js');
@@ -201,6 +202,7 @@ describe('Navigation', function() {
     .click(SkipInterstitialPage.no())
     .click(SkipInterstitialPage.submit())
     .click(SecurityCodeInterstitialPage.submit())
+    .click(FinalInterstitial.submit())
     .then(helpers.isSectionComplete('Payment Details')).should.eventually.be.true;
   }
 

--- a/tests/functional/spec/routing_on_answer_from_repeat.spec.js
+++ b/tests/functional/spec/routing_on_answer_from_repeat.spec.js
@@ -5,7 +5,9 @@ const PrimaryLiveHereBlockPage = require('../pages/surveys/routing_on_answer_fro
 const RepeatingNamePage = require('../pages/surveys/routing_on_answer_from_driving_repeating_group/repeating-name-block.page.js');
 const RepeatingAnyoneElsePage = require('../pages/surveys/routing_on_answer_from_driving_repeating_group/repeating-anyone-else-block.page.js');
 const SexPage = require('../pages/surveys/routing_on_answer_from_driving_repeating_group/sex-block.page.js');
+const SexNoPrimaryPage = require('../pages/surveys/routing_on_answer_from_driving_repeating_group/sex-block-no-primary.page.js');
 const RelationshipsPage = require('../pages/surveys/routing_on_answer_from_driving_repeating_group/relationships.page.js');
+const RelationshipsNoPrimaryPage = require('../pages/surveys/routing_on_answer_from_driving_repeating_group/relationships-no-primary.page.js');
 const SummaryPage = require('../pages/surveys/routing_on_answer_from_driving_repeating_group/summary.page.js');
 
 describe('Routing on Answer from repeat', function() {
@@ -36,16 +38,16 @@ describe('Routing on Answer from repeat', function() {
         .click(RepeatingAnyoneElsePage.no())
         .click(RepeatingAnyoneElsePage.submit())
 
-        .click(RelationshipsPage.relationship(0, 'Husband or wife'))
-        .click(RelationshipsPage.submit())
+        .click(RelationshipsNoPrimaryPage.relationship(0, 'Husband or wife'))
+        .click(RelationshipsNoPrimaryPage.submit())
 
-        .getText(SexPage.questionText()).should.eventually.contain('Alice')
-        .click(SexPage.female())
-        .click(SexPage.submit())
+        .getText(SexNoPrimaryPage.questionText()).should.eventually.contain('Alice')
+        .click(SexNoPrimaryPage.female())
+        .click(SexNoPrimaryPage.submit())
 
-        .getText(SexPage.questionText()).should.eventually.contain('Jamie')
-        .click(SexPage.male())
-        .click(SexPage.submit())
+        .getText(SexNoPrimaryPage.questionText()).should.eventually.contain('Jamie')
+        .click(SexNoPrimaryPage.male())
+        .click(SexNoPrimaryPage.submit())
 
         .getUrl().should.eventually.contain(SummaryPage.pageName)
         .click(SummaryPage.submit());


### PR DESCRIPTION
### What is the context of this PR?

This change includes:

- Duplicate the schema for LMS to allow for inclusion of the primary person.
  The new section has ids of `no-primary-...`.

- There is a fix for navigation to AnswerSummaries

- A fix for skip conditions to skip properly when the driving question has a group-instance-id and isn't in a repeating group.

- Add AnswerSummary to who lives here.

- Skip section in navigation if all groups are skipped or invalid (fixes bug with 'about-the-household')

- Content fix for LMS
### How to review 
Check that who lives here in LMS works as expected.

Known Issues:
- Navigation for who lives here will show 'About the household' as completed when it isn't

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
