### PR TITLE
Fix no primary routing around EVEROT

### DIFF
--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -316,11 +316,12 @@ def format_household_member_name(names):
 @blueprint.app_template_filter()
 def format_household_member_name_possessive(names):
     name = format_household_member_name(names)
-    last_char = name[-1:]
-    if last_char.lower() == 's':
-        return name + '’'
+    if name:
+        last_char = name[-1:]
+        if last_char.lower() == 's':
+            return name + '’'
 
-    return name + '’s'
+        return name + '’s'
 
 
 @blueprint.app_template_filter()

--- a/data/en/lms_2.json
+++ b/data/en/lms_2.json
@@ -4591,10 +4591,6 @@
                                             "condition": "not set"
                                         },
                                         {
-                                            "id": "working-days-answer-exclusive",
-                                            "condition": "not set"
-                                        },
-                                        {
                                             "id": "one-job-emp-status-emp-or-self-answer",
                                             "condition": "equals",
                                             "value": "employee"
@@ -4607,10 +4603,6 @@
                                     "block": "reason-why-fewer-hours-than-usual-employee-w14-emp",
                                     "when": [{
                                             "id": "working-days-answer",
-                                            "condition": "not set"
-                                        },
-                                        {
-                                            "id": "working-days-answer-exclusive",
                                             "condition": "not set"
                                         },
                                         {
@@ -11758,6 +11750,10 @@
                                             "value": "No"
                                         },
                                         {
+                                            "id": "no-primary-working-days-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
                                             "id": "no-primary-working-days-answer-exclusive",
                                             "condition": "not set"
                                         }
@@ -12218,6 +12214,10 @@
                                 "goto": {
                                     "block": "no-primary-reason-why-fewer-hours-than-usual-employee-w14-emp",
                                     "when": [{
+                                            "id": "no-primary-working-days-answer",
+                                            "condition": "not set"
+                                        },
+                                        {
                                             "id": "no-primary-working-days-answer-exclusive",
                                             "condition": "not set"
                                         },

--- a/tests/app/test_jinja_filters.py
+++ b/tests/app/test_jinja_filters.py
@@ -395,6 +395,15 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
 
         self.assertEqual(format_value, 'John Doe\u2019s')
 
+    def test_format_household_member_name_possessive_with_no_names(self):
+        # Given
+        name = [Undefined(), Undefined()]
+
+        # When
+        format_value = format_household_member_name_possessive(name)
+
+        self.assertIsNone(format_value)
+
     def test_format_household_member_name_possessive_trailing_s(self):
         # Given
         name = ['John', 'Does']


### PR DESCRIPTION
### What is the context of this PR?
Mebin discovered that on no primary, the routing for one job / paid overtime was going to USHR instead of POT. This was due to a missing routing rule in the duplicated 'no-primary' section.

Also fixes missing route to actual hours on no primary

Also fixes format_household_name_possessive to ensure we can handle names being None.

### How to review 
- No primary person
- One job
- Paid / Unpaid / Paid and Unpaid Overtime

Goes to paid / unpaid overtime, not usual hours.

- No primary, one job, employed, no overtime routes through actual hours

- No primary, ensure why-uk does not 500.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
