### PR TITLE
Fix relationship defaulting to first choice when mandatory

### DIFF
--- a/app/forms/household_relationship_form.py
+++ b/app/forms/household_relationship_form.py
@@ -125,6 +125,7 @@ def generate_relationship_form(schema, block_json, relationship_choices, data, g
     field = FieldList(RelationshipSelectField(
         label=labels,
         choices=choices,
+        default='',
         validators=get_mandatory_validator(answer, schema.error_messages, 'MANDATORY_TEXTFIELD'),
     ), min_entries=len(relationship_choices))
 


### PR DESCRIPTION
### What is the context of this PR?
Fixes Relationship type defaulting to the first choice when the answer is mandatory.

### How to review 
Check LMS and make sure when the Relationship answer is mandatory, `Select a relationship` is displayed and not `Husband or wife`

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
