### PR TITLE
Add group instance to year field validation

### DIFF
--- a/app/forms/date_form.py
+++ b/app/forms/date_form.py
@@ -36,8 +36,8 @@ class DateField(FormField):
 
 class MonthYearField(FormField):
 
-    def __init__(self, answer_store, metadata, answer, error_messages, **kwargs):
-        form_class = get_month_year_form(answer_store, metadata, answer, error_messages)
+    def __init__(self, answer_store, metadata, answer, error_messages, group_instance=0, **kwargs):
+        form_class = get_month_year_form(answer_store, metadata, answer, error_messages, group_instance=group_instance)
         super(MonthYearField, self).__init__(form_class, **kwargs)
 
     def process(self, formdata, data=None):
@@ -53,8 +53,9 @@ class MonthYearField(FormField):
 
 class YearField(FormField):
 
-    def __init__(self, answer_store, metadata, answer, error_messages, **kwargs):
-        form_class = get_year_form(answer_store, metadata, answer, error_messages, kwargs.get('description'), kwargs.get('label'))
+    def __init__(self, answer_store, metadata, answer, error_messages, group_instance=0, **kwargs):
+        form_class = get_year_form(answer_store, metadata, answer, error_messages, kwargs.get('description'),
+                                   kwargs.get('label'), group_instance=group_instance)
         super(YearField, self).__init__(form_class, **kwargs)
 
     def process(self, formdata, data=None):
@@ -113,7 +114,7 @@ def get_date_form(answer_store, metadata, answer=None, error_messages=None):
     return DateForm
 
 
-def get_month_year_form(answer, answer_store, metadata, error_messages):
+def get_month_year_form(answer, answer_store, metadata, error_messages, group_instance=0):
     """
     Returns a month year form metaclass with appropriate validators. Used in both date and
     date range form creation.
@@ -145,7 +146,7 @@ def get_month_year_form(answer, answer_store, metadata, error_messages):
     validate_with.append(MonthYearCheck(error_message))
 
     if 'minimum' in answer or 'maximum' in answer:
-        min_max_validation = validate_min_max_date(answer, answer_store, metadata, 'yyyy-mm')
+        min_max_validation = validate_min_max_date(answer, answer_store, metadata, 'yyyy-mm', group_instance=group_instance)
         validate_with.append(min_max_validation)
 
     MonthYearDateForm.month = get_month_selection_field(validate_with)
@@ -153,7 +154,7 @@ def get_month_year_form(answer, answer_store, metadata, error_messages):
     return MonthYearDateForm
 
 
-def get_year_form(answer, answer_store, metadata, error_messages, label, guidance):
+def get_year_form(answer, answer_store, metadata, error_messages, label, guidance, group_instance=0):
     """
     Returns a year form metaclass with appropriate validators. Used in both date and
     date range form creation.
@@ -183,7 +184,7 @@ def get_year_form(answer, answer_store, metadata, error_messages, label, guidanc
     validate_with.append(YearCheck(error_message))
 
     if 'minimum' in answer or 'maximum' in answer:
-        min_max_validation = validate_min_max_date(answer, answer_store, metadata, 'yyyy')
+        min_max_validation = validate_min_max_date(answer, answer_store, metadata, 'yyyy', group_instance=group_instance)
         validate_with.append(min_max_validation)
 
     YearDateForm.year = CustomIntegerField(
@@ -216,11 +217,11 @@ def get_month_selection_field(validate_with):
     return SelectField(choices=month_choices, default='', validators=validate_with)
 
 
-def validate_min_max_date(answer, answer_store, metadata, date_format):
+def validate_min_max_date(answer, answer_store, metadata, date_format, group_instance=0):
     messages = None
     if 'validation' in answer:
         messages = answer['validation'].get('messages')
-    minimum_date, maximum_date = get_dates_for_single_date_period_validation(answer, answer_store, metadata)
+    minimum_date, maximum_date = get_dates_for_single_date_period_validation(answer, answer_store, metadata, group_instance=group_instance)
 
     display_format = 'd MMMM YYYY'
     if date_format == 'yyyy-mm':
@@ -235,7 +236,7 @@ def validate_min_max_date(answer, answer_store, metadata, date_format):
     return SingleDatePeriodCheck(messages=messages, date_format=display_format, minimum_date=minimum_date, maximum_date=maximum_date)
 
 
-def get_dates_for_single_date_period_validation(answer, answer_store, metadata):
+def get_dates_for_single_date_period_validation(answer, answer_store, metadata, group_instance=0):
     """
     Gets attributes within a minimum or maximum of a date field and validates that the entered date
     is valid.
@@ -248,9 +249,9 @@ def get_dates_for_single_date_period_validation(answer, answer_store, metadata):
     minimum_referenced_date, maximum_referenced_date = None, None
 
     if 'minimum' in answer:
-        minimum_referenced_date = get_referenced_offset_value(answer['minimum'], answer_store, metadata)
+        minimum_referenced_date = get_referenced_offset_value(answer['minimum'], answer_store, metadata, group_instance=group_instance)
     if 'maximum' in answer:
-        maximum_referenced_date = get_referenced_offset_value(answer['maximum'], answer_store, metadata)
+        maximum_referenced_date = get_referenced_offset_value(answer['maximum'], answer_store, metadata, group_instance=group_instance)
 
     # Extra runtime validation that will catch invalid schemas
     # Similar validation in schema validator
@@ -261,7 +262,7 @@ def get_dates_for_single_date_period_validation(answer, answer_store, metadata):
     return minimum_referenced_date, maximum_referenced_date
 
 
-def get_referenced_offset_value(answer_min_or_max, answer_store, metadata):
+def get_referenced_offset_value(answer_min_or_max, answer_store, metadata, group_instance=0):
     """
     Gets value of the referenced date type, whether it is a value,
     id of an answer or a meta date. Then adds/subtracts offset from that value and returns
@@ -284,7 +285,7 @@ def get_referenced_offset_value(answer_min_or_max, answer_store, metadata):
         value = get_metadata_value(metadata, answer_min_or_max['meta'])
     elif 'answer_id' in answer_min_or_max:
         schema = load_schema_from_metadata(metadata)
-        value = get_answer_store_value(answer_min_or_max['answer_id'], answer_store, schema, group_instance=0)
+        value = get_answer_store_value(answer_min_or_max['answer_id'], answer_store, schema, group_instance=group_instance)
 
     value = convert_to_datetime(value)
 

--- a/app/forms/fields.py
+++ b/app/forms/fields.py
@@ -17,7 +17,7 @@ MAX_DECIMAL_PLACES = 6
 logger = get_logger()
 
 
-def get_field(answer, label, error_messages, answer_store, metadata):
+def get_field(answer, label, error_messages, answer_store, metadata, group_instance=0):
     guidance = answer.get('guidance', '')
 
     if answer['type'] in ['Number', 'Currency', 'Percentage', 'Unit']:
@@ -25,9 +25,9 @@ def get_field(answer, label, error_messages, answer_store, metadata):
     elif answer['type'] == 'Date':
         field = get_date_field(answer, label, guidance, error_messages, answer_store, metadata)
     elif answer['type'] == 'MonthYearDate':
-        field = get_month_year_field(answer, label, guidance, error_messages, answer_store, metadata)
+        field = get_month_year_field(answer, label, guidance, error_messages, answer_store, metadata, group_instance=group_instance)
     elif answer['type'] == 'YearDate':
-        field = get_year_field(answer, label, guidance, error_messages, answer_store, metadata)
+        field = get_year_field(answer, label, guidance, error_messages, answer_store, metadata, group_instance=group_instance)
     elif answer['type'] == 'Checkbox':
         field = get_select_multiple_field(answer, label, guidance, error_messages)
     else:
@@ -119,7 +119,7 @@ def get_date_field(answer, label, guidance, error_messages, answer_store, metada
     )
 
 
-def get_month_year_field(answer, label, guidance, error_messages, answer_store, metadata):
+def get_month_year_field(answer, label, guidance, error_messages, answer_store, metadata, group_instance=0):
     return MonthYearField(
         answer,
         answer_store,
@@ -127,10 +127,11 @@ def get_month_year_field(answer, label, guidance, error_messages, answer_store, 
         error_messages,
         label=label,
         description=guidance,
+        group_instance=group_instance,
     )
 
 
-def get_year_field(answer, label, guidance, error_messages, answer_store, metadata):
+def get_year_field(answer, label, guidance, error_messages, answer_store, metadata, group_instance=0):
     return YearField(
         answer,
         answer_store,
@@ -138,6 +139,7 @@ def get_year_field(answer, label, guidance, error_messages, answer_store, metada
         error_messages,
         label=label,
         description=guidance,
+        group_instance=group_instance,
     )
 
 

--- a/app/forms/questionnaire_form.py
+++ b/app/forms/questionnaire_form.py
@@ -279,7 +279,7 @@ def get_answer_fields(question, data, error_messages, schema, answer_store, meta
                 next(a['mandatory'] for a in question['answers'] if a['id'] == answer['parent_answer_id'])
 
         name = answer.get('label') or get_question_title(question, answer_store, schema, metadata, group_instance, group_instance_id)
-        answer_fields[answer['id']] = get_field(answer, name, error_messages, answer_store, metadata)
+        answer_fields[answer['id']] = get_field(answer, name, error_messages, answer_store, metadata, group_instance=group_instance)
     return answer_fields
 
 


### PR DESCRIPTION
### What is the context of this PR?
LMS was using 'minimum' validation on two questions, which validated against dates from other answers.

Since the date validation used a group_instance of 0, we were always getting the value from the first repeat not the current repeat.

The same logic needs to be added to all of the fields when we have time. ([trello](https://trello.com/c/3zgV8Aod/2503-make-form-validation-repeating-group-aware))

### How to review 
- Add two people, first person born in 2016, born outside uk.
- Check the `first-arrive-in-uk` question (When did you most recently arrive in the UK) only lets you say you arrived after 2015.
- Second born in e.g. 1980.
- born outside UK
- ensure `first-arrive-in-uk` allows you to enter a date after 1980 e.g. 1981 

- Check that `camyr2` question behaves the same way.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
