### PR TITLE
Skip shared facilities question if less than 2 members

### DIFF
--- a/data/en/lms_2.json
+++ b/data/en/lms_2.json
@@ -589,6 +589,17 @@
                                 "id": "primary-household-member-address-check-answer",
                                 "condition": "not set"
                             }]
+                        }, {
+                            "when": [{
+                                "answer_ids": [
+                                    "primary-household-member-first-name",
+                                    "other-household-member-first-name",
+                                    "student-household-member-first-name"
+                                ],
+                                "type": "answer_count",
+                                "condition": "less than",
+                                "value": 2
+                            }]
                         }
                     ],
                     "blocks": [{
@@ -655,6 +666,16 @@
                             "when": [{
                                 "id": "primary-household-member-address-check-answer",
                                 "condition": "not set"
+                            }]
+                        }, {
+                            "when": [{
+                                "answer_ids": [
+                                    "other-household-member-first-name-no-primary",
+                                    "student-household-member-first-name-no-primary"
+                                ],
+                                "type": "answer_count",
+                                "condition": "less than",
+                                "value": 2
                             }]
                         }
                     ],


### PR DESCRIPTION
### What is the context of this PR?
Doesn't make sense to ask if the facilities are shared when there is only 1 household member.
This PR adds a skip condition to ensure that these are only asked if there are at least 2 members in the household.

### How to review 
Shared facilities questions should only be asked when you add at least 2 members to the household.
[Slides](https://docs.google.com/presentation/d/1BWjHrAfjxgyR69Jwys4BPahm9JF6eUbz2lIkd1se-TQ/edit#slide=id.g4267003c02_2_29)

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
