### PR TITLE
Fix 500 on NI theme intro page

### DIFF
--- a/app/themes/northernireland/templates/introduction.html
+++ b/app/themes/northernireland/templates/introduction.html
@@ -25,8 +25,12 @@
                     {% else %}
                         {{ _("You are completing this for <span>%(ru_name)s</span>", ru_name = metadata.ru_name) }}
                     {% endif %}
+                </h2>
 
-                <p class="mars">If the company details or structure have changed contact us on {{ helpers.telephone_number() }} or email {{ helpers.email_address(aria-describedby='details-changed-title', subject="Change of details reference " + metadata.ru_ref) }}.
+                <p class="mars" data-qa="details-changed-title">{{ _("If the company details or structure have changed contact us on %(telephone_number)s or email %(email_address)s",
+                        telephone_number = helpers.telephone_number(),
+                        email_address = helpers.email_address(aria_describedby='details-changed-title', subject="Change of details reference " + metadata.ru_ref)
+                    ) }}
                 </p>
 
             </div>


### PR DESCRIPTION
### What is the context of this PR?
NI theme intro pages are returning a 500 error because of a template issue.
This PR addresses this.

### How to review 
Ensure you can launch any NI schema `(qcas_0019)` successfully.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
