### PR TITLE
Ensure all schemas have default routing rules

### DIFF
--- a/data/en/0_rogue_one.json
+++ b/data/en/0_rogue_one.json
@@ -86,12 +86,7 @@
                     }
                 }, {
                     "goto": {
-                        "block": "orson-krennic-like-this-page",
-                        "when": [{
-                            "id": "character-answer",
-                            "condition": "equals",
-                            "value": "Orson Krennic"
-                        }]
+                        "block": "orson-krennic-like-this-page"
                     }
                 }]
             }, {

--- a/data/en/0_star_wars.json
+++ b/data/en/0_star_wars.json
@@ -165,12 +165,7 @@
                     }
                 }, {
                     "goto": {
-                        "block": "star-wars-trivia",
-                        "when": [{
-                            "id": "light-side-pick-ship-answer",
-                            "condition": "equals",
-                            "value": "No"
-                        }]
+                        "block": "star-wars-trivia"
                     }
                 }]
             }, {
@@ -235,21 +230,16 @@
                     }
                 }, {
                     "goto": {
-                        "block": "star-wars-trivia",
-                        "when": [{
-                            "id": "dark-side-pick-ship-answer",
-                            "condition": "equals",
-                            "value": "No"
-                        }]
-                    }
-                }, {
-                    "goto": {
                         "block": "light-side-ship-type",
                         "when": [{
                             "id": "dark-side-pick-ship-answer",
                             "condition": "equals",
                             "value": "Can I be a pain and have a goodies ship"
                         }]
+                    }
+                }, {
+                    "goto": {
+                        "block": "star-wars-trivia"
                     }
                 }]
             }, {

--- a/data/en/1_0005.json
+++ b/data/en/1_0005.json
@@ -440,12 +440,7 @@
                     }
                 }, {
                     "goto": {
-                        "group": "weekly-pay-summary-group",
-                        "when": [{
-                            "id": "weekly-pay-significant-changes-paid-employees-answer",
-                            "condition": "equals",
-                            "value": "No"
-                        }]
+                        "group": "weekly-pay-summary-group"
                     }
                 }]
             }, {
@@ -816,12 +811,7 @@
                     }
                 }, {
                     "goto": {
-                        "group": "fortnightly-pay-summary-group",
-                        "when": [{
-                            "id": "fortnightly-pay-significant-changes-paid-employees-answer",
-                            "condition": "equals",
-                            "value": "No"
-                        }]
+                        "group": "fortnightly-pay-summary-group"
                     }
                 }]
             }, {
@@ -1180,12 +1170,7 @@
                     }
                 }, {
                     "goto": {
-                        "group": "calendar-monthly-pay-summary-group",
-                        "when": [{
-                            "id": "calendar-monthly-pay-significant-changes-paid-employees-answer",
-                            "condition": "equals",
-                            "value": "No"
-                        }]
+                        "group": "calendar-monthly-pay-summary-group"
                     }
                 }]
             }, {
@@ -1545,12 +1530,7 @@
                     }
                 }, {
                     "goto": {
-                        "group": "four-weekly-pay-summary-group",
-                        "when": [{
-                            "id": "four-weekly-pay-significant-changes-paid-employees-answer",
-                            "condition": "equals",
-                            "value": "No"
-                        }]
+                        "group": "four-weekly-pay-summary-group"
                     }
                 }]
             }, {
@@ -1910,12 +1890,7 @@
                     }
                 }, {
                     "goto": {
-                        "group": "five-weekly-pay-summary-group",
-                        "when": [{
-                            "id": "five-weekly-pay-significant-changes-paid-employees-answer",
-                            "condition": "equals",
-                            "value": "No"
-                        }]
+                        "group": "five-weekly-pay-summary-group"
                     }
                 }]
             }, {

--- a/data/en/census_household.json
+++ b/data/en/census_household.json
@@ -142,12 +142,7 @@
                     }
                 }, {
                     "goto": {
-                        "block": "else-permanent-or-family-home",
-                        "when": [{
-                            "id": "permanent-or-family-home-answer",
-                            "condition": "equals",
-                            "value": "No"
-                        }]
+                        "block": "else-permanent-or-family-home"
                     }
                 }]
             }, {
@@ -187,12 +182,7 @@
                     }
                 }, {
                     "goto": {
-                        "block": "overnight-visitors",
-                        "when": [{
-                            "id": "else-permanent-or-family-home-answer",
-                            "condition": "equals",
-                            "value": "No one lives here as their permanent home"
-                        }]
+                        "block": "overnight-visitors"
                     }
                 }]
             }, {

--- a/data/en/lms_1.json
+++ b/data/en/lms_1.json
@@ -937,12 +937,7 @@
                             },
                             {
                                 "goto": {
-                                    "block": "arrive-in-uk",
-                                    "when": [{
-                                        "id": "arrive-date-in-uk-invalid-answer",
-                                        "condition": "equals",
-                                        "value": "change arrival"
-                                    }]
+                                    "block": "arrive-in-uk"
                                 }
                             }
                         ]
@@ -1184,12 +1179,7 @@
                             },
                             {
                                 "goto": {
-                                    "block": "camyr2-block",
-                                    "when": [{
-                                        "id": "first-arrive-date-in-uk-invalid-answer",
-                                        "condition": "equals",
-                                        "value": "change first arrival"
-                                    }]
+                                    "block": "camyr2-block"
                                 }
                             }
                         ]

--- a/data/en/test_address_playback.json
+++ b/data/en/test_address_playback.json
@@ -75,12 +75,7 @@
                     }
                 }, {
                     "goto": {
-                        "block": "address-check-block",
-                        "when": [{
-                            "id": "confirm-address-answer",
-                            "condition": "equals",
-                            "value": "Yes"
-                        }]
+                        "block": "address-check-block"
                     }
                 }]
             }, {

--- a/data/en/test_conditional_routing.json
+++ b/data/en/test_conditional_routing.json
@@ -57,12 +57,7 @@
                     }
                 }, {
                     "goto": {
-                        "block": "response-no",
-                        "when": [{
-                            "id": "conditional-routing-answer",
-                            "condition": "equals",
-                            "value": "no"
-                        }]
+                        "block": "response-no"
                     }
                 }]
             }, {

--- a/data/en/test_difference_in_years.json
+++ b/data/en/test_difference_in_years.json
@@ -69,12 +69,7 @@
                     }
                 }, {
                     "goto": {
-                        "block": "summary",
-                        "when": [{
-                            "id": "date-test-answer",
-                            "condition": "equals",
-                            "value": "Yes"
-                        }]
+                        "block": "summary"
                     }
                 }]
             }, {

--- a/data/en/test_difference_in_years_month_year.json
+++ b/data/en/test_difference_in_years_month_year.json
@@ -69,12 +69,7 @@
                     }
                 }, {
                     "goto": {
-                        "block": "summary",
-                        "when": [{
-                            "id": "date-test-answer",
-                            "condition": "equals",
-                            "value": "Yes"
-                        }]
+                        "block": "summary"
                     }
                 }]
             }, {

--- a/data/en/test_difference_in_years_month_year_range.json
+++ b/data/en/test_difference_in_years_month_year_range.json
@@ -74,12 +74,7 @@
                     }
                 }, {
                     "goto": {
-                        "block": "summary",
-                        "when": [{
-                            "id": "date-test-answer",
-                            "condition": "equals",
-                            "value": "Yes"
-                        }]
+                        "block": "summary"
                     }
                 }]
             }, {

--- a/data/en/test_difference_in_years_range.json
+++ b/data/en/test_difference_in_years_range.json
@@ -74,12 +74,7 @@
                     }
                 }, {
                     "goto": {
-                        "block": "summary",
-                        "when": [{
-                            "id": "date-test-answer",
-                            "condition": "equals",
-                            "value": "Yes"
-                        }]
+                        "block": "summary"
                     }
                 }]
             }, {

--- a/data/en/test_household_question.json
+++ b/data/en/test_household_question.json
@@ -96,12 +96,7 @@
                     }
                 }, {
                     "goto": {
-                        "block": "summary",
-                        "when": [{
-                            "id": "household-composition-add-another",
-                            "condition": "equals",
-                            "value": "Yes"
-                        }]
+                        "block": "summary"
                     }
                 }],
                 "id": "household-summary",

--- a/data/en/test_navigation_completeness.json
+++ b/data/en/test_navigation_completeness.json
@@ -61,12 +61,7 @@
                     }
                 }, {
                     "goto": {
-                        "block": "response-no",
-                        "when": [{
-                            "id": "coffee-answer",
-                            "condition": "equals",
-                            "value": "no"
-                        }]
+                        "block": "response-no"
                     }
                 }]
             }, {

--- a/data/en/test_navigation_routing.json
+++ b/data/en/test_navigation_routing.json
@@ -69,6 +69,10 @@
                             "value": "question2"
                         }]
                     }
+                }, {
+                    "goto": {
+                        "block": "question2"
+                    }
                 }]
             }, {
                 "type": "Question",

--- a/data/en/test_repeating_and_conditional_routing.json
+++ b/data/en/test_repeating_and_conditional_routing.json
@@ -83,12 +83,7 @@
                     }
                 }, {
                     "goto": {
-                        "block": "shoe-size-block",
-                        "when": [{
-                            "id": "conditional-answer",
-                            "condition": "equals",
-                            "value": "Shoe Size Only"
-                        }]
+                        "block": "shoe-size-block"
                     }
                 }]
             }, {

--- a/data/en/test_routing_group.json
+++ b/data/en/test_routing_group.json
@@ -58,12 +58,7 @@
                     }
                 }, {
                     "goto": {
-                        "group": "group2",
-                        "when": [{
-                            "id": "which-group-answer",
-                            "condition": "equals",
-                            "value": "group2"
-                        }]
+                        "group": "group2"
                     }
                 }]
             }]

--- a/tests/app/questionnaire/test_path_finder.py
+++ b/tests/app/questionnaire/test_path_finder.py
@@ -366,21 +366,6 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
 
         self.assertEqual(next_location, expected_next_location)
 
-    def test_interstitial_post_blocks(self):
-        schema = load_schema_from_params('0', 'star_wars')
-
-        answer = Answer(
-            answer_id='choose-your-side-answer',
-            value='Light Side'
-        )
-
-        answers = AnswerStore()
-        answers.add(answer)
-
-        path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
-
-        self.assertFalse(Location('star-wars', 0, 'summary') in path_finder.get_full_routing_path())
-
     def test_repeating_groups(self):
         schema = load_schema_from_params('test', 'repeating_household')
         schema.answer_is_in_repeating_group = MagicMock(return_value=False)


### PR DESCRIPTION
### What is the context of this PR?

This is associated with https://github.com/ONSdigital/eq-schema-validator/pull/99

I've updated all of our schemas to include default routing rules in all cases.

Most of the changes here apply to questions that are mandatory and include exhaustive routing rules, but we should still include a default.

Two (live?) surveys are affected, `lms_1.json` and `1_0005.json`. These should be checked carefully.

For `1_0005.json` I've added defaults to be on the safe side (rather than removing when rules).

### How to review 


### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
