### PR TITLE
Latest LMS wording changes

### DIFF
--- a/data/cy/lms_2.json
+++ b/data/cy/lms_2.json
@@ -615,11 +615,11 @@
                                     "id": "share-cooking-answer",
                                     "mandatory": false,
                                     "options": [{
-                                            "label": "Ydyn",
+                                            "label": "Oes",
                                             "value": "Yes"
                                         },
                                         {
-                                            "label": "Nac ydyn",
+                                            "label": "Nac oes",
                                             "value": "No"
                                         }
                                     ],
@@ -639,11 +639,11 @@
                                     "id": "share-living-answer",
                                     "mandatory": false,
                                     "options": [{
-                                            "label": "Ydyn",
+                                            "label": "Ydynt",
                                             "value": "Yes"
                                         },
                                         {
-                                            "label": "Nac ydyn",
+                                            "label": "Nac ydynt",
                                             "value": "No"
                                         }
                                     ],
@@ -693,11 +693,11 @@
                                     "id": "share-cooking-answer-no-primary",
                                     "mandatory": false,
                                     "options": [{
-                                            "label": "Ydyn",
+                                            "label": "Oes",
                                             "value": "Yes"
                                         },
                                         {
-                                            "label": "Nac ydyn",
+                                            "label": "Nac oes",
                                             "value": "No"
                                         }
                                     ],
@@ -717,11 +717,11 @@
                                     "id": "share-living-answer-no-primary",
                                     "mandatory": false,
                                     "options": [{
-                                            "label": "Ydyn",
+                                            "label": "Ydynt",
                                             "value": "Yes"
                                         },
                                         {
-                                            "label": "Nac ydyn",
+                                            "label": "Nac ydynt",
                                             "value": "No"
                                         }
                                     ],
@@ -3630,7 +3630,7 @@
                         "questions": [{
                             "id": "two-jobs-j1-emp-status-emp-or-self-proxy-question",
                             "titles": [{
-                                "value": "<em>{{[group_instances[group_instance_id]['primary-household-member-first-name'], group_instances[group_instance_id]['primary-household-member-last-name'], group_instances[group_instance_id]['other-household-member-first-name'], group_instances[group_instance_id]['other-household-member-last-name'], group_instances[group_instance_id]['student-household-member-first-name'], group_instances[group_instance_id]['student-household-member-last-name'], group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> statws cyflogaeth"
+                                "value": "Statws cyflogaeth <em>{{[group_instances[group_instance_id]['primary-household-member-first-name'], group_instances[group_instance_id]['primary-household-member-last-name'], group_instances[group_instance_id]['other-household-member-first-name'], group_instances[group_instance_id]['other-household-member-last-name'], group_instances[group_instance_id]['student-household-member-first-name'], group_instances[group_instance_id]['student-household-member-last-name'], group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em>"
                             }],
                             "type": "General",
                             "answers": [{
@@ -6378,7 +6378,7 @@
                         "questions": [{
                             "id": "two-jobs-j1-actual-hours-question",
                             "titles": [{
-                                    "value": "Mae {{[group_instances[group_instance_id]['primary-household-member-first-name'], group_instances[group_instance_id]['primary-household-member-last-name'], group_instances[group_instance_id]['other-household-member-first-name'], group_instances[group_instance_id]['other-household-member-last-name'], group_instances[group_instance_id]['student-household-member-first-name'], group_instances[group_instance_id]['student-household-member-last-name'], group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} fel arfer yn gweithio {{answers['two-jobs-j1-usual-hours-answer'][group_instance]}} yn ei prif swydd. Yn yr wythnos {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}, faint o oriau wnaeth e/hi weithio <em>mewn gwirionedd</em> yn ei <em>prif</em> swydd, ac eithrio goramser?",
+                                    "value": "Mae {{[group_instances[group_instance_id]['primary-household-member-first-name'], group_instances[group_instance_id]['primary-household-member-last-name'], group_instances[group_instance_id]['other-household-member-first-name'], group_instances[group_instance_id]['other-household-member-last-name'], group_instances[group_instance_id]['student-household-member-first-name'], group_instances[group_instance_id]['student-household-member-last-name'], group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} fel arfer yn gweithio {{answers['two-jobs-j1-usual-hours-answer'][group_instance]}} o oriau yn ei prif swydd. Yn yr wythnos {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}, faint o oriau wnaeth e/hi weithio <em>mewn gwirionedd</em> yn ei <em>prif</em> swydd, ac eithrio goramser?",
                                     "when": [{
                                         "id": "proxy-check-answer",
                                         "condition": "equals",
@@ -11267,7 +11267,7 @@
                         "questions": [{
                             "id": "no-primary-two-jobs-j1-emp-status-emp-or-self-proxy-question",
                             "titles": [{
-                                "value": "<em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em> statws cyflogaeth"
+                                "value": "Statws cyflogaeth <em>{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}}</em>"
                             }],
                             "type": "General",
                             "answers": [{
@@ -14015,7 +14015,7 @@
                         "questions": [{
                             "id": "no-primary-two-jobs-j1-actual-hours-question",
                             "titles": [{
-                                    "value": "Mae {{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} fel arfer yn gweithio {{answers['no-primary-two-jobs-j1-usual-hours-answer'][group_instance]}} yn ei prif swydd. Yn yr wythnos {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}, faint o oriau wnaeth e/hi weithio <em>mewn gwirionedd</em> yn ei <em>prif</em> swydd, ac eithrio goramser?",
+                                    "value": "Mae {{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} fel arfer yn gweithio {{answers['no-primary-two-jobs-j1-usual-hours-answer'][group_instance]}} o oriau yn ei prif swydd. Yn yr wythnos {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}, faint o oriau wnaeth e/hi weithio <em>mewn gwirionedd</em> yn ei <em>prif</em> swydd, ac eithrio goramser?",
                                     "when": [{
                                         "id": "no-primary-proxy-check-answer",
                                         "condition": "equals",

--- a/data/en/lms_2.json
+++ b/data/en/lms_2.json
@@ -4563,7 +4563,7 @@
                                     }]
                                 },
                                 {
-                                    "value": "Many jobs or businesses have usual hours. Not including your overtime, how many hours do you <em>usually</em> work in your job or business?"
+                                    "value": "Many jobs or businesses have usual hours. Not including your overtime, how many hours do you <em>usually</em> work a week in your job or business?"
                                 }
                             ],
                             "type": "General",
@@ -6373,7 +6373,7 @@
                         "questions": [{
                             "id": "two-jobs-j1-actual-hours-question",
                             "titles": [{
-                                    "value": "{{[group_instances[group_instance_id]['primary-household-member-first-name'], group_instances[group_instance_id]['primary-household-member-last-name'], group_instances[group_instance_id]['other-household-member-first-name'], group_instances[group_instance_id]['other-household-member-last-name'], group_instances[group_instance_id]['student-household-member-first-name'], group_instances[group_instance_id]['student-household-member-last-name'], group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} usually works {{answers['two-jobs-j1-usual-hours-answer'][group_instance]}} in their main job. In the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}, how many hours did they <em>actually</em> work in their <em>main</em> job, excluding overtime?",
+                                    "value": "{{[group_instances[group_instance_id]['primary-household-member-first-name'], group_instances[group_instance_id]['primary-household-member-last-name'], group_instances[group_instance_id]['other-household-member-first-name'], group_instances[group_instance_id]['other-household-member-last-name'], group_instances[group_instance_id]['student-household-member-first-name'], group_instances[group_instance_id]['student-household-member-last-name'], group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} usually works {{answers['two-jobs-j1-usual-hours-answer'][group_instance]}} hours in their main job. In the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}, how many hours did they <em>actually</em> work in their <em>main</em> job, excluding overtime?",
                                     "when": [{
                                         "id": "proxy-check-answer",
                                         "condition": "equals",
@@ -12190,7 +12190,7 @@
                                     }]
                                 },
                                 {
-                                    "value": "Many jobs or businesses have usual hours. Not including your overtime, how many hours do you <em>usually</em> work in your job or business?"
+                                    "value": "Many jobs or businesses have usual hours. Not including your overtime, how many hours do you <em>usually</em> work a week in your job or business?"
                                 }
                             ],
                             "type": "General",
@@ -14000,7 +14000,7 @@
                         "questions": [{
                             "id": "no-primary-two-jobs-j1-actual-hours-question",
                             "titles": [{
-                                    "value": "{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} usually works {{answers['no-primary-two-jobs-j1-usual-hours-answer'][group_instance]}} in their main job. In the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}, how many hours did they <em>actually</em> work in their <em>main</em> job, excluding overtime?",
+                                    "value": "{{[ group_instances[group_instance_id]['other-household-member-first-name-no-primary'], group_instances[group_instance_id]['other-household-member-last-name-no-primary'], group_instances[group_instance_id]['student-household-member-first-name-no-primary'], group_instances[group_instance_id]['student-household-member-last-name-no-primary']] | format_household_name}} usually works {{answers['no-primary-two-jobs-j1-usual-hours-answer'][group_instance]}} hours in their main job. In the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}, how many hours did they <em>actually</em> work in their <em>main</em> job, excluding overtime?",
                                     "when": [{
                                         "id": "no-primary-proxy-check-answer",
                                         "condition": "equals",


### PR DESCRIPTION
### What is the context of this PR?
- "Statws cyflogaeth" should appear before the person's name (`two-jobs-j1-emp-status-emp-or-self-proxy-question + no-primary`)
- Adds missing "hours" text after the number of hours in `two-jobs-j1-actual-hours-question + no-primary` and the Welsh translation
- Adds missing "a week" in `one-job-usual-hours-question`
- Fixes Welsh yes/no answers to shared cooking/living space questions (`share-cooking-question + no-primary` and `share-living-question + no-primary`)

### How to review 
Check new wording and ensure jinja filters have been unaffected