### PR TITLE
Playback unselected options

### DIFF
--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -350,6 +350,17 @@ def format_unordered_list(context, list_items):
     return mark_safe(context, summary_list)
 
 
+@evalcontextfunction
+def format_unordered_list_missing_items(context, possible_items, list_items):
+
+    if list_items and list_items[0]:
+        missing_items = [item for item in possible_items if item not in list_items[0]]
+    else:
+        missing_items = possible_items
+
+    return format_unordered_list(context, [missing_items])
+
+
 @blueprint.app_template_filter()
 def concatenated_list(list_items, delimiter=', '):
     stripped_items = list(item.strip() for item in list_items if item)

--- a/app/templating/template_renderer.py
+++ b/app/templating/template_renderer.py
@@ -16,6 +16,7 @@ class TemplateRenderer:
         env.filters['format_household_name_possessive'] = filters.format_household_member_name_possessive
         env.filters['format_household_summary'] = filters.format_household_summary
         env.filters['format_unordered_list'] = filters.format_unordered_list
+        env.globals['format_unordered_list_missing_items'] = filters.format_unordered_list_missing_items
         env.globals['format_conditional_date'] = filters.format_conditional_date
         env.globals['format_currency'] = filters.format_currency
         env.filters['format_number'] = filters.format_number

--- a/tests/app/test_jinja_filters.py
+++ b/tests/app/test_jinja_filters.py
@@ -13,10 +13,10 @@ from app.jinja_filters import (
     format_multilined_string, format_percentage, format_date_range,
     format_household_member_name, format_datetime,
     format_number_to_alphabetic_letter, format_unit, format_currency_for_input,
-    format_number, format_unordered_list, format_unit_input_label,
-    format_household_member_name_possessive, concatenated_list,
-    calculate_years_difference, get_current_date, as_london_tz, max_value,
-    min_value, get_question_title, get_answer_label,
+    format_number, format_unordered_list, format_unordered_list_missing_items,
+    format_unit_input_label, format_household_member_name_possessive,
+    concatenated_list, calculate_years_difference, get_current_date, as_london_tz,
+    max_value, min_value, get_question_title, get_answer_label,
     format_duration, calculate_offset_from_weekday_in_last_whole_week, format_date_custom,
     format_date_range_no_repeated_month_year, format_repeating_summary, format_address_list)
 from tests.app.app_context_test_case import AppContextTestCase
@@ -549,6 +549,44 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
         list_items = [[]]
 
         formatted_value = format_unordered_list(self.autoescape_context, list_items)
+
+        self.assertEqual('', formatted_value)
+
+    def test_format_unordered_list_missing_items(self):
+        possible_items = ['item 1', 'item 2', 'item 3', 'item 4']
+        list_items = [['item 1', 'item 3']]
+
+        formatted_value = format_unordered_list_missing_items(self.autoescape_context, possible_items, list_items)
+
+        expected_value = '<ul><li>item 2</li><li>item 4</li></ul>'
+
+        self.assertEqual(expected_value, formatted_value)
+
+    def test_format_unordered_list_missing_items_with_no_input(self):
+        possible_items = ['item 1', 'item 2']
+        list_items = []
+
+        formatted_value = format_unordered_list_missing_items(self.autoescape_context, possible_items, list_items)
+
+        expected_value = '<ul><li>item 1</li><li>item 2</li></ul>'
+
+        self.assertEqual(expected_value, formatted_value)
+
+    def test_format_unordered_list_missing_items_with_empty_list(self):
+        possible_items = ['item 1', 'item 2']
+        list_items = [[]]
+
+        formatted_value = format_unordered_list_missing_items(self.autoescape_context, possible_items, list_items)
+
+        expected_value = '<ul><li>item 1</li><li>item 2</li></ul>'
+
+        self.assertEqual(expected_value, formatted_value)
+
+    def test_format_unordered_list_missing_items_with_all_selected(self):
+        possible_items = ['item 1', 'item 2']
+        list_items = [['item 1', 'item 2']]
+
+        formatted_value = format_unordered_list_missing_items(self.autoescape_context, possible_items, list_items)
 
         self.assertEqual('', formatted_value)
 


### PR DESCRIPTION
New filter that will take two lists and return a list of missing items

### What is the context of this PR?
As a user
I want a playback/confirmation of the response options I didn't select from the previous question
So that I can confirm that I selected the correct options in the previous question

### How to review 
In 1_0005.json it currently plays back answered Pay Periods. Changing the description of `pay-pattern-frequency-confirmation-question` with the following will allow the opposite to be shown.
`"description": "{{ format_unordered_list_missing_items(['Weekly','Fortnightly','Calendar monthly','Four weekly','Five weekly'], answers['pay-pattern-frequency-answer']) }}",` 

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
