### PR TITLE
Add description to number fields

### DIFF
--- a/app/templates/partials/answers/number.html
+++ b/app/templates/partials/answers/number.html
@@ -2,7 +2,8 @@
 <div class="field">
     {% set label = {
       'for': answer.id,
-      'text': answer.label
+      'text': answer.label,
+      'description': answer.description
     } %}
 
     {% include 'partials/forms/label.html' %}

--- a/data/en/test_numbers.json
+++ b/data/en/test_numbers.json
@@ -26,8 +26,8 @@
                 "questions": [{
                     "answers": [{
                         "id": "set-minimum",
-                        "description": "",
                         "label": "Minimum Value",
+                        "description": "This is a description of the minimum value",
                         "mandatory": true,
                         "type": "Number",
                         "decimal_places": 2,
@@ -39,7 +39,7 @@
                         }
                     }, {
                         "id": "set-maximum",
-                        "description": "",
+                        "description": "This is a description of the maximum value",
                         "label": "Maximum Value",
                         "mandatory": true,
                         "type": "Number",

--- a/tests/functional/generate_pages.py
+++ b/tests/functional/generate_pages.py
@@ -67,6 +67,10 @@ ANSWER_LABEL_GETTER = Template(r"""  ${answerName}Label() { return '#label-${ans
 
 """)
 
+ANSWER_LABEL_DESCRIPTION_GETTER = Template(r"""  ${answerName}LabelDescription() { return '#label-${answerId} > .label__description'; }
+
+""")
+
 ANSWER_GETTER = Template(r"""  ${answerName}() {
     return '#${answerId}';
   }
@@ -248,6 +252,7 @@ def process_answer(question_type, answer, page_spec, long_names, page_name):
         else:
             page_spec.write(ANSWER_GETTER.substitute(answer_context))
             page_spec.write(ANSWER_LABEL_GETTER.substitute(answer_context))
+            page_spec.write(ANSWER_LABEL_DESCRIPTION_GETTER.substitute(answer_context))
 
         if answer['type'] == 'Unit':
             page_spec.write(ANSWER_UNIT_TYPE_GETTER.substitute(answer_context))

--- a/tests/functional/pages/surveys/numbers/set-min-max-block.page.js
+++ b/tests/functional/pages/surveys/numbers/set-min-max-block.page.js
@@ -13,11 +13,15 @@ class SetMinMaxBlockPage extends QuestionPage {
 
   setMinimumLabel() { return '#label-set-minimum'; }
 
+  setMinimumLabelDescription() { return '#label-set-minimum > .label__description'; }
+
   setMaximum() {
     return '#set-maximum';
   }
 
   setMaximumLabel() { return '#label-set-maximum'; }
+
+  setMaximumLabelDescription() { return '#label-set-maximum > .label__description'; }
 
 }
 module.exports = new SetMinMaxBlockPage();

--- a/tests/functional/pages/surveys/numbers/summary.page.js
+++ b/tests/functional/pages/surveys/numbers/summary.page.js
@@ -15,9 +15,15 @@ class SummaryPage extends QuestionPage {
 
   setMaximumEdit(index = 0) { return '[data-qa="set-maximum-' + index + '-edit"]'; }
 
+  setMinQuestion(index = 0) { return '#set-min-question-' + index; }
+
   testRange(index = 0) { return '#test-range-' + index + '-answer'; }
 
   testRangeEdit(index = 0) { return '[data-qa="test-range-' + index + '-edit"]'; }
+
+  testRangeExclusive(index = 0) { return '#test-range-exclusive-' + index + '-answer'; }
+
+  testRangeExclusiveEdit(index = 0) { return '[data-qa="test-range-exclusive-' + index + '-edit"]'; }
 
   testMin(index = 0) { return '#test-min-' + index + '-answer'; }
 
@@ -27,6 +33,14 @@ class SummaryPage extends QuestionPage {
 
   testMaxEdit(index = 0) { return '[data-qa="test-max-' + index + '-edit"]'; }
 
+  testMinExclusive(index = 0) { return '#test-min-exclusive-' + index + '-answer'; }
+
+  testMinExclusiveEdit(index = 0) { return '[data-qa="test-min-exclusive-' + index + '-edit"]'; }
+
+  testMaxExclusive(index = 0) { return '#test-max-exclusive-' + index + '-answer'; }
+
+  testMaxExclusiveEdit(index = 0) { return '[data-qa="test-max-exclusive-' + index + '-edit"]'; }
+
   testPercent(index = 0) { return '#test-percent-' + index + '-answer'; }
 
   testPercentEdit(index = 0) { return '[data-qa="test-percent-' + index + '-edit"]'; }
@@ -34,6 +48,12 @@ class SummaryPage extends QuestionPage {
   testDecimal(index = 0) { return '#test-decimal-' + index + '-answer'; }
 
   testDecimalEdit(index = 0) { return '[data-qa="test-decimal-' + index + '-edit"]'; }
+
+  testMinMaxRangeQuestion(index = 0) { return '#test-min-max-range-question-' + index; }
+
+  testTitle(index = 0) { return '#test-' + index; }
+
+  summaryGroupTitle(index = 0) { return '#summary-group-' + index; }
 
 }
 module.exports = new SummaryPage();

--- a/tests/functional/pages/surveys/numbers/test-min-max-block.page.js
+++ b/tests/functional/pages/surveys/numbers/test-min-max-block.page.js
@@ -13,12 +13,15 @@ class TestMinMaxBlockPage extends QuestionPage {
 
   testRangeLabel() { return '#label-test-range'; }
 
+  testRangeLabelDescription() { return '#label-test-range > .label__description'; }
+
   testRangeExclusive() {
     return '#test-range-exclusive';
   }
 
-  testRangeLabelExclusive() { return '#label-test-range-exclusive'; }
+  testRangeExclusiveLabel() { return '#label-test-range-exclusive'; }
 
+  testRangeExclusiveLabelDescription() { return '#label-test-range-exclusive > .label__description'; }
 
   testMin() {
     return '#test-min';
@@ -26,24 +29,31 @@ class TestMinMaxBlockPage extends QuestionPage {
 
   testMinLabel() { return '#label-test-min'; }
 
+  testMinLabelDescription() { return '#label-test-min > .label__description'; }
+
   testMax() {
     return '#test-max';
   }
 
   testMaxLabel() { return '#label-test-max'; }
 
+  testMaxLabelDescription() { return '#label-test-max > .label__description'; }
+
   testMinExclusive() {
     return '#test-min-exclusive';
   }
 
-  testMinLabelExclusive() { return '#label-test-min-exclusive'; }
+  testMinExclusiveLabel() { return '#label-test-min-exclusive'; }
+
+  testMinExclusiveLabelDescription() { return '#label-test-min-exclusive > .label__description'; }
 
   testMaxExclusive() {
     return '#test-max-exclusive';
   }
 
-  testMaxLabelExclusive() { return '#label-test-max-exclusive'; }
+  testMaxExclusiveLabel() { return '#label-test-max-exclusive'; }
 
+  testMaxExclusiveLabelDescription() { return '#label-test-max-exclusive > .label__description'; }
 
   testPercent() {
     return '#test-percent';
@@ -51,11 +61,15 @@ class TestMinMaxBlockPage extends QuestionPage {
 
   testPercentLabel() { return '#label-test-percent'; }
 
+  testPercentLabelDescription() { return '#label-test-percent > .label__description'; }
+
   testDecimal() {
     return '#test-decimal';
   }
 
   testDecimalLabel() { return '#label-test-decimal'; }
+
+  testDecimalLabelDescription() { return '#label-test-decimal > .label__description'; }
 
 }
 module.exports = new TestMinMaxBlockPage();

--- a/tests/functional/spec/numbers.spec.js
+++ b/tests/functional/spec/numbers.spec.js
@@ -7,61 +7,62 @@ describe('NumericRange', function() {
 
   const number_schema = 'test_numbers.json';
 
+  beforeEach(function() {
+    return helpers.openQuestionnaire(number_schema);
+  });
+
+  it ('Answer labels should have descriptions displayed', function() {
+    return browser
+      .getText(SetMinMax.setMinimumLabelDescription()).should.eventually.contain("This is a description of the minimum value")
+      .getText(SetMinMax.setMaximumLabelDescription()).should.eventually.contain("This is a description of the maximum value");
+  });
+
   it('Given a max and min set, a user should be able to complete the survey obeying those ranges', function() {
-    return helpers.openQuestionnaire(number_schema)
-      .then(() => {
-        return browser
-          .setValue(SetMinMax.setMinimum(), '10')
-          .setValue(SetMinMax.setMaximum(), '1020')
-          .click(SetMinMax.submit())
-          .setValue(TestMinMax.testRange(), '10')
-          .setValue(TestMinMax.testMin(), '123')
-          .setValue(TestMinMax.testMax(), '456')
-          .setValue(TestMinMax.testPercent(), '100')
-          .click(TestMinMax.submit())
-          .getUrl().should.eventually.contain(SummaryPage.pageName);
-      });
+    return browser
+      .setValue(SetMinMax.setMinimum(), '10')
+      .setValue(SetMinMax.setMaximum(), '1020')
+      .click(SetMinMax.submit())
+      .setValue(TestMinMax.testRange(), '10')
+      .setValue(TestMinMax.testMin(), '123')
+      .setValue(TestMinMax.testMax(), '456')
+      .setValue(TestMinMax.testPercent(), '100')
+      .click(TestMinMax.submit())
+      .getUrl().should.eventually.contain(SummaryPage.pageName);
   });
 
   it('Given values outside of the allowed range then the correct error messages are displayed', function() {
-    return helpers.openQuestionnaire(number_schema)
-      .then(() => {
-        return browser
-          .setValue(SetMinMax.setMinimum(), '10')
-          .setValue(SetMinMax.setMaximum(), '1020')
-          .click(SetMinMax.submit())
-          .setValue(TestMinMax.testRange(), '9')
-          .setValue(TestMinMax.testRangeExclusive(), '10')
-          .setValue(TestMinMax.testMin(), '0')
-          .setValue(TestMinMax.testMax(), '12345')
-          .setValue(TestMinMax.testMinExclusive(), '123')
-          .setValue(TestMinMax.testMaxExclusive(), '12345')
-          .setValue(TestMinMax.testPercent(), '101')
-          .setValue(TestMinMax.testDecimal(), '5.4')
-          .click(TestMinMax.submit())
-          .getText(TestMinMax.errorNumber(1)).should.eventually.contain("Enter an answer more than or equal to 10.")
-          .getText(TestMinMax.errorNumber(2)).should.eventually.contain("Enter an answer more than 10.")
-          .getText(TestMinMax.errorNumber(3)).should.eventually.contain("Enter an answer more than or equal to 123.")
-          .getText(TestMinMax.errorNumber(4)).should.eventually.contain("Enter an answer less than or equal to 1,234.")
-          .getText(TestMinMax.errorNumber(5)).should.eventually.contain("Enter an answer more than 123.")
-          .getText(TestMinMax.errorNumber(6)).should.eventually.contain("Enter an answer less than 1,234.")
-          .getText(TestMinMax.errorNumber(7)).should.eventually.contain("Enter an answer less than or equal to 100.")
-          .getText(TestMinMax.errorNumber(8)).should.eventually.contain("Enter an answer more than or equal to £10.00.");
-      });
+    return browser
+      .setValue(SetMinMax.setMinimum(), '10')
+      .setValue(SetMinMax.setMaximum(), '1020')
+      .click(SetMinMax.submit())
+      .setValue(TestMinMax.testRange(), '9')
+      .setValue(TestMinMax.testRangeExclusive(), '10')
+      .setValue(TestMinMax.testMin(), '0')
+      .setValue(TestMinMax.testMax(), '12345')
+      .setValue(TestMinMax.testMinExclusive(), '123')
+      .setValue(TestMinMax.testMaxExclusive(), '12345')
+      .setValue(TestMinMax.testPercent(), '101')
+      .setValue(TestMinMax.testDecimal(), '5.4')
+      .click(TestMinMax.submit())
+      .getText(TestMinMax.errorNumber(1)).should.eventually.contain("Enter an answer more than or equal to 10.")
+      .getText(TestMinMax.errorNumber(2)).should.eventually.contain("Enter an answer more than 10.")
+      .getText(TestMinMax.errorNumber(3)).should.eventually.contain("Enter an answer more than or equal to 123.")
+      .getText(TestMinMax.errorNumber(4)).should.eventually.contain("Enter an answer less than or equal to 1,234.")
+      .getText(TestMinMax.errorNumber(5)).should.eventually.contain("Enter an answer more than 123.")
+      .getText(TestMinMax.errorNumber(6)).should.eventually.contain("Enter an answer less than 1,234.")
+      .getText(TestMinMax.errorNumber(7)).should.eventually.contain("Enter an answer less than or equal to 100.")
+      .getText(TestMinMax.errorNumber(8)).should.eventually.contain("Enter an answer more than or equal to £10.00.");
   });
 
   it('Given values outside of the allowed decimal places then the correct error messages are displayed', function() {
-    return helpers.openQuestionnaire(number_schema)
-      .then(() => {
-        return browser
-          .setValue(SetMinMax.setMinimum(), '10')
-          .setValue(SetMinMax.setMaximum(), '1020')
-          .click(SetMinMax.submit())
-          .setValue(TestMinMax.testRange(), '12.344')
-          .setValue(TestMinMax.testDecimal(), '11.234')
-          .click(TestMinMax.submit())
-          .getText(TestMinMax.errorNumber(1)).should.eventually.contain("Enter a number rounded to 2 decimal places.")
-          .getText(TestMinMax.errorNumber(2)).should.eventually.contain("Enter a number rounded to 2 decimal places.");
-      });
+    return browser
+      .setValue(SetMinMax.setMinimum(), '10')
+      .setValue(SetMinMax.setMaximum(), '1020')
+      .click(SetMinMax.submit())
+      .setValue(TestMinMax.testRange(), '12.344')
+      .setValue(TestMinMax.testDecimal(), '11.234')
+      .click(TestMinMax.submit())
+      .getText(TestMinMax.errorNumber(1)).should.eventually.contain("Enter a number rounded to 2 decimal places.")
+      .getText(TestMinMax.errorNumber(2)).should.eventually.contain("Enter a number rounded to 2 decimal places.");
   });
 });


### PR DESCRIPTION
### What is the context of this PR?
UKIS need a description on number field / unit / percentage labels. It's already on unit / percentage. I've added it to numbers.

[trello](https://trello.com/c/fpnqaYrZ/2553-answer-description-on-number-and-unit-answers)

### How to review 
Check the `test_numbers.json` schema

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
