### PR TITLE
Remove Flask login which adds user_id to cookie

### DIFF
--- a/app/authentication/authenticator.py
+++ b/app/authentication/authenticator.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 from blinker import ANY
 from dateutil.tz import tzutc
 from flask import session as cookie_session, current_app
-from flask_login import LoginManager, user_logged_out, login_user
+from flask_login import LoginManager, user_logged_out
 from sdc.crypto.decrypter import decrypt
 from structlog import get_logger
 
@@ -143,10 +143,6 @@ def store_session(metadata):
     questionnaire_store = get_questionnaire_store(user_id, user_ik)
     questionnaire_store.set_metadata(metadata)
     questionnaire_store.add_or_update()
-
-    # Set the user in Flask such that anyone calling current_user for the duration of this request doesn't have to
-    # load it from the db.
-    login_user(User(user_id, user_ik))
 
     logger.info('user authenticated')
 

--- a/app/authentication/user.py
+++ b/app/authentication/user.py
@@ -8,6 +8,3 @@ class User(UserMixin):
             self.user_ik = user_ik
         else:
             raise ValueError('No user_id or user_ik found in session')
-
-    def get_id(self):
-        return self.user_id

--- a/tests/integration/views/test_cookie.py
+++ b/tests/integration/views/test_cookie.py
@@ -1,0 +1,19 @@
+from tests.integration.integration_test_case import IntegrationTestCase
+
+class TestCookie(IntegrationTestCase):
+
+    def test_cookie_contents(self):
+        self.launchSurvey()
+        cookie = self.getCookie()
+
+        self.assertIsNotNone(cookie.get('_fresh'))
+        self.assertIsNotNone(cookie.get('_permanent'))
+        self.assertIsNotNone(cookie.get('csrf_token'))
+        self.assertIsNotNone(cookie.get('eq-session-id'))
+        self.assertIsNotNone(cookie.get('expires_in'))
+        self.assertIsNotNone(cookie.get('survey_title'))
+        self.assertIsNotNone(cookie.get('theme'))
+        self.assertIsNotNone(cookie.get('user_ik'))
+        self.assertEqual(len(cookie), 8)
+
+        self.assertIsNone(cookie.get('user_id'))


### PR DESCRIPTION
### What is the context of this PR?
PR #1657 causes the user_id to get stored in the session cookie.

EQ's current encryption model for questionnaire state intends for the user_id to not be exposed to the user, only the user_ik.

This [line](https://github.com/ONSdigital/eq-survey-runner/commit/92f54df0160c2f15aa2afcc1024847de769a2fc8#diff-38d589711ca2d8ef50e47c9f2cf2ae0fR116) was only added as an optimisation to save an extra DB hit and therefore I have removed it.

### How to review 
The cookie can be verified by copying the value of a session cookie to https://www.kirsle.net/wizards/flask-session.cgi and decoding it).

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
