### PR TITLE
Compress and remove base64 encoding on answer store

### DIFF
--- a/.ebextensions/deploy.config
+++ b/.ebextensions/deploy.config
@@ -3,6 +3,10 @@ packages:
         libffi-devel: []
         openssl-devel: []
         postgresql94-devel: []
+        snappy-devel: []
+        gcc: []
+        gcc-c++: []
+        make: []
 
 commands:
     01-upgrade-pip:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
       - google-chrome
     packages:
       - google-chrome-stable
+      - libsnappy-dev
 language: node_js
 node_js: 6
 env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.4
 
 RUN pip install pipenv==8.2.7 \
   && pip install awscli==1.11.174
+RUN apt update && apt install -y libsnappy-dev
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/Pipfile
+++ b/Pipfile
@@ -52,6 +52,7 @@ blinker = "*"
 humanize = "*"
 flask-talisman = "*"
 marshmallow = "*"
+python-snappy = "*"
 
 [requires]
 python_version = "3.4"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f647686cf1ae009460d9c28a200f5c4d9a1162b5a414ff428342d872d73859d7"
+            "sha256": "17b88a7f527024980b53826b50ef30da1d1d802f7b2012a2204b82c4cb6688fd"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -402,6 +402,14 @@
             "markers": "python_version >= '2.7'",
             "version": "==2.7.5"
         },
+        "python-snappy": {
+            "hashes": [
+                "sha256:59c79d83350f931ad5cf8f06ccb1c9bd1087a77c3ca7e00806884cda654a6faf",
+                "sha256:8a7f803f06083d4106d55387d2daa32c12b5e376c3616b0e2da8b8a87a27d74a"
+            ],
+            "index": "pypi",
+            "version": "==0.5.3"
+        },
         "pytz": {
             "hashes": [
                 "sha256:31cb35c89bd7d333cd32c5f278fca91b523b0834369e757f4c5641ea252236ca",
@@ -497,10 +505,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:41c3db2fc01e5b907288010dec72f9d0a74e37d6994e6eb56849f59fea2265ae",
-                "sha256:8819bba37a02d143296a4d032373c4dd4aca11f6d4c9973335ca75f9c8475f59"
+                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
+                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
             ],
-            "version": "==1.24"
+            "version": "==1.24.1"
         },
         "werkzeug": {
             "hashes": [
@@ -1107,11 +1115,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:a9e5e8d7ab9d5b0747f37740276eb362e6a76275d76cebbb52c6049d93b475db",
-                "sha256:bf47e8ed20d03764f963f0070ff1c8fda6e2671fc5dd562a4d3b7148ad60f5ca"
+                "sha256:630ff1dbe04f469ee78faa5660f712e58b953da7df22ea5d828c9012e134da43",
+                "sha256:a2b5232735dd0b736cbea9c0f09e5070d78fcaba2823a4f6f09d9a81bd19415c"
             ],
             "index": "pypi",
-            "version": "==3.9.3"
+            "version": "==3.10.0"
         },
         "pytest-cov": {
             "hashes": [
@@ -1274,10 +1282,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:41c3db2fc01e5b907288010dec72f9d0a74e37d6994e6eb56849f59fea2265ae",
-                "sha256:8819bba37a02d143296a4d032373c4dd4aca11f6d4c9973335ca75f9c8475f59"
+                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
+                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
             ],
-            "version": "==1.24"
+            "version": "==1.24.1"
         },
         "websocket-client": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pipenv run scripts/run_tests_unit.sh
 
 
 ## Pre-Requisites
-In order to run locally you'll need PostgreSQL and Node.js installed
+In order to run locally you'll need PostgreSQL, Node.js and snappy installed
 
 PostgreSQL
 ```
@@ -48,6 +48,11 @@ brew install postgres
 npm
 ```
 brew install npm
+```
+
+snappy
+```
+brew install snappy
 ```
 
 Note that npm currently requires Python 2.x for some of the setup steps,

--- a/app/data_model/questionnaire_store.py
+++ b/app/data_model/questionnaire_store.py
@@ -6,7 +6,14 @@ from app.questionnaire.location import Location
 
 
 class QuestionnaireStore:
-    LATEST_VERSION = 2
+    """
+    The QuestionnaireStore is versioned to provide a way to migrate existing state. Versions are:
+    1 - Reformat date answers from d/m/y to y-m-d
+    2 - Add group_instance_id to all answers
+    3 - Compress state using snappy before encryption. Also removes base64 encoding and
+        unnecessary json wrapper around encrypted data.
+    """
+    LATEST_VERSION = 3
 
     def __init__(self, storage, version=None):
         self._storage = storage

--- a/app/data_model/session_store.py
+++ b/app/data_model/session_store.py
@@ -1,4 +1,5 @@
 import simplejson as json
+from jwcrypto.common import base64url_decode
 from structlog import get_logger
 
 from app.data_model.app_models import EQSession
@@ -87,6 +88,14 @@ class SessionStore:
                 encrypted_session_data = self._eq_session.session_data
                 session_data = StorageEncryption(self.user_id, self.user_ik, self.pepper) \
                     .decrypt_data(encrypted_session_data)
+
+                session_data = session_data.decode()
+                # for backwards compatibility
+                # session data used to be base64 encoded before encryption
+                try:
+                    session_data = base64url_decode(session_data).decode()
+                except ValueError:
+                    pass
 
                 self.session_data = json.loads(session_data, object_hook=lambda d: SessionData(**d))
 

--- a/app/storage/encrypted_questionnaire_storage.py
+++ b/app/storage/encrypted_questionnaire_storage.py
@@ -1,6 +1,8 @@
-import simplejson as json
+import json
+import snappy
 
 from structlog import get_logger
+from jwcrypto.common import base64url_decode
 
 from app.data_model.app_models import QuestionnaireState
 from app.storage import data_access
@@ -18,28 +20,30 @@ class EncryptedQuestionnaireStorage:
         self.encrypter = StorageEncryption(user_id, user_ik, pepper)
 
     def add_or_update(self, data, version):
-        encrypted_data = self.encrypter.encrypt_data(data)
-        encrypted_data_json = json.dumps({'data': encrypted_data})
+        compressed_data = snappy.compress(data)
+        encrypted_data = self.encrypter.encrypt_data(compressed_data)
         questionnaire_state = self._find_questionnaire_state()
         if questionnaire_state:
             logger.debug('updating questionnaire data', user_id=self._user_id)
-            questionnaire_state.state_data = encrypted_data_json
+            questionnaire_state.state_data = encrypted_data
             questionnaire_state.version = version
         else:
             logger.debug('creating questionnaire data', user_id=self._user_id)
-            questionnaire_state = QuestionnaireState(self._user_id, encrypted_data_json, version)
+            questionnaire_state = QuestionnaireState(self._user_id, encrypted_data, version)
 
         data_access.put(questionnaire_state)
 
     def get_user_data(self):
         questionnaire_state = self._find_questionnaire_state()
-        if questionnaire_state:
-            data = json.loads(questionnaire_state.state_data)
+        if questionnaire_state and questionnaire_state.state_data:
             version = questionnaire_state.version or 0
 
-            if 'data' in data:
-                decrypted_data = self.encrypter.decrypt_data(data['data'])
-                return decrypted_data, version
+            if version < 3:
+                decrypted_data = self._get_base64_encoded_data(questionnaire_state.state_data)
+            else:
+                decrypted_data = self._get_snappy_compressed_data(questionnaire_state.state_data)
+
+            return decrypted_data, version
 
         return None, None
 
@@ -52,3 +56,16 @@ class EncryptedQuestionnaireStorage:
     def _find_questionnaire_state(self):
         logger.debug('getting questionnaire data', user_id=self._user_id)
         return data_access.get_by_key(QuestionnaireState, self._user_id)
+
+    def _get_base64_encoded_data(self, data):
+        """
+        Legacy data was stored in a dict, base64-encoded, and not compressed:
+        { 'data': '<base 64 encoded and encrypted data' }
+        """
+        data = json.loads(data).get('data')
+        decrypted_data = self.encrypter.decrypt_data(data)
+        return base64url_decode(decrypted_data.decode()).decode()
+
+    def _get_snappy_compressed_data(self, data):
+        decrypted_data = self.encrypter.decrypt_data(data)
+        return snappy.uncompress(decrypted_data).decode()


### PR DESCRIPTION
### What is the context of this PR?
Tests showed that the latency of some datastores increased significantly with the payload of the data being saved to/retrieved from it. DynamoDB slowed down almost linearly with the size of the payload.

This PR seeks to reduce that payload using two changes:
- Compress the questionnaire store prior to encryption
- No longer base64-encode the data prior to encryption (this didn't appear to be beneficial and increased the size of the payload)

The changes have been implemented to be backwards compatible. Existing questionnaire stores (base64-encoded and not compressed) should be still be readable by the application but will be written back using the new format.

### How to review 
- Manually test the application
- Attempt to resume a survey that was started using the old format and ensure that it can still be completed

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
