### PR TITLE
Add light caching to completeness module

### DIFF
--- a/tests/app/questionnaire/test_completeness.py
+++ b/tests/app/questionnaire/test_completeness.py
@@ -498,4 +498,4 @@ class TestCompleteness(AppContextTestCase): # pylint: disable=too-many-public-me
         """
         with patch('app.questionnaire.completeness.Completeness.get_state_for_group', side_effect=['SKIPPED', 'INVALID']):
             completeness = Completeness([], [], [], [], [])
-            self.assertEqual(completeness.get_state_for_section({'groups': [1, 1]}), 'SKIPPED')
+            self.assertEqual(completeness.get_state_for_section({'id': 'section_id', 'groups': [1, 1]}), 'SKIPPED')

--- a/tests/app/questionnaire/test_navigation.py
+++ b/tests/app/questionnaire/test_navigation.py
@@ -733,6 +733,9 @@ class TestNavigation(AppContextTestCase):
 
         answer_store.update(change_answer)
 
+        # create navigation object again as completeness state is cached
+        navigation = _create_navigation(schema, answer_store, metadata, completed_blocks, [])
+
         user_navigation = navigation.build_navigation('property-details', 0)
 
         link_names = [d['link_name'] for d in user_navigation]


### PR DESCRIPTION
### What is the context of this PR?
The `Completeness` object handles some reasonably costly logic. It derives states for sections, groups and blocks; each type's state being composed from its children's states.

At some points during the request cycle the methods which calculate the states for these types were found to be getting called multiple times from different callers. This PR allows the `Completeness` object to persist its states and avoid this unnecessary processing.

### How to review 
Check that the application still functions correctly. Pay particular attention to schemas which use navigation, skip conditions and/or routing.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
