### PR TITLE
Add RoutingPath object to optimize path lookups

### DIFF
--- a/app/questionnaire/location.py
+++ b/app/questionnaire/location.py
@@ -20,7 +20,7 @@ class Location:
         return isinstance(other, Location) and self.__dict__ == other.__dict__
 
     def __hash__(self):
-        return hash(self.__dict__.values())
+        return hash(frozenset(self.__dict__.values()))
 
     def __str__(self):
         """

--- a/app/questionnaire/path_finder.py
+++ b/app/questionnaire/path_finder.py
@@ -3,6 +3,7 @@ from structlog import get_logger
 
 from app.helpers.schema_helpers import get_group_instance_id
 from app.questionnaire.location import Location
+from app.questionnaire.routing_path import RoutingPath
 from app.questionnaire.rules import (
     evaluate_goto,
     evaluate_skip_conditions,
@@ -90,7 +91,7 @@ class PathFinder:
                 if blocks:
                     path, block_index = self._build_path_within_group(blocks, block_index, this_location, path)
 
-        return path
+        return RoutingPath(path)
 
     def _get_first_group_in_section(self):
         return [

--- a/app/questionnaire/routing_path.py
+++ b/app/questionnaire/routing_path.py
@@ -1,0 +1,34 @@
+class RoutingPath:
+    """Holds a list of locations and optimizes for `in` comparisons
+    """
+    def __init__(self, path):
+        self._values = tuple(path)
+        self._set = frozenset(path)
+
+    def __len__(self):
+        return len(self._values)
+
+    def __getitem__(self, key):
+        return self._values[key]
+
+    def __iter__(self):
+        return iter(self._values)
+
+    def __reversed__(self):
+        return reversed(self._values)
+
+    def __contains__(self, key):
+        return key in self._set
+
+    def __eq__(self, other):
+        other_values = other
+        if isinstance(other, RoutingPath):
+            other_values = other._values  # pylint: disable=protected-access
+
+        elif isinstance(other, list):
+            other_values = tuple(other)
+
+        return self._values == other_values
+
+    def index(self, *args):
+        return self._values.index(*args)

--- a/tests/app/questionnaire/test_location.py
+++ b/tests/app/questionnaire/test_location.py
@@ -20,4 +20,4 @@ class TestLocation(AppContextTestCase):
     def test_location_hash(self):
         location = Location('some-group', 0, 'some-block')
 
-        self.assertEqual(hash(location), hash(location.__dict__.values()))
+        self.assertEqual(hash(location), hash(frozenset(location.__dict__.values())))

--- a/tests/app/questionnaire/test_path_finder.py
+++ b/tests/app/questionnaire/test_path_finder.py
@@ -861,7 +861,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
 
         path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
-        self.assertEqual('summary', path_finder.get_full_routing_path().pop().block_id)
+        self.assertEqual('summary', path_finder.get_full_routing_path()[-1].block_id)
 
     def test_next_with_conditional_path_based_on_metadata(self):
         schema = load_schema_from_params('test', 'metadata_routing')

--- a/tests/app/questionnaire/test_routing_path.py
+++ b/tests/app/questionnaire/test_routing_path.py
@@ -1,0 +1,41 @@
+from unittest import TestCase
+from app.questionnaire.routing_path import RoutingPath
+from app.questionnaire.location import Location
+
+
+class TestRouter(TestCase):
+    def setUp(self):
+        self.blocks = [
+            Location('group-a', 0, 'block-a'),
+            Location('group-b', 0, 'block-b'),
+            Location('group-b', 0, 'block-c'),
+            Location('group-b', 1, 'block-b'),
+            Location('group-b', 1, 'block-c')
+        ]
+        self.routing_path = RoutingPath(self.blocks)
+        super().setUp()
+
+    def test_eq_to_routing_path(self):
+        self.assertEqual(self.routing_path, self.routing_path)
+
+    def test_eq_to_list(self):
+        self.assertEqual(self.blocks, self.routing_path)
+
+    def test_len(self):
+        self.assertEqual(len(self.blocks), len(self.routing_path))
+
+    def test_reversed(self):
+        self.assertEqual(
+            list(reversed(self.blocks)),
+            list(reversed(self.routing_path))
+        )
+
+    def test_contains_true(self):
+        self.assertIn(self.blocks[0], self.routing_path)
+        self.assertNotIn(Location('group-z', 0, 'block-z'), self.routing_path)
+
+    def test_iter(self):
+        self.assertEqual(self.blocks[0], next(iter(self.routing_path)))
+
+    def test_getitem(self):
+        self.assertEqual(self.blocks[0], self.routing_path[0])


### PR DESCRIPTION
### What is the context of this PR?
During performance investigation it was found that a significant amount of time was spent in checking if a given `Location` object is present in the built routing path (a list of locations). On average each call to run this would be `O(n)`.

Given that the routing path list is static once generated it's possible to easily create a wrapper for the list to store a set alongside it which should average `O(1)`.

During testing this took about 10ms off of the average response time.

NB - it wasn't possible to simply return the routing path as a `set` because:
a) the path is ordered
b) locations may need to appear twice (for routing backwards)

### How to review 
- General application check functions correctly
- Does routing backwards work?
- Check the code for logical issues 

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
