### PR TITLE
Group answers by answer ID in answer store - mk2

### DIFF
--- a/.ebextensions/enable_mod_deflate.conf
+++ b/.ebextensions/enable_mod_deflate.conf
@@ -23,10 +23,9 @@ BrowserMatch ^Mozilla/4\.0[678] no-gzip
 
 # MSIE masquerades as Netscape, but it is fine
 BrowserMatch \bMSI[E] !no-gzip !gzip-only-text/html
+</IfModule>
 
 <IfModule mod_headers.c>
 # Make sure proxies don't deliver the wrong content
 Header append Vary User-Agent env=!dont-vary
-</IfModule>
-
 </IfModule>

--- a/app/data_model/answer.py
+++ b/app/data_model/answer.py
@@ -1,0 +1,44 @@
+from structlog import get_logger
+
+logger = get_logger()
+
+
+class Answer:
+    def __init__(self, answer_id, value, group_instance_id=None, group_instance=0, answer_instance=0):
+        if answer_id is None or value is None:
+            raise ValueError("Both 'answer_id' and 'value' must be set for Answer")
+
+        self.answer_id = answer_id
+        self.group_instance_id = group_instance_id
+        self.group_instance = group_instance
+        self.answer_instance = answer_instance
+        self.value = value
+
+    def matches(self, answer):
+        """
+        Check to see if two answers match.
+        Two answers are considered to match if they share the same answer_id, answer_instance and group_instance_id.
+
+        :param answer: An answer to compare
+        :return: True if both answers match, otherwise False.
+        """
+        return self.answer_id == answer.answer_id and \
+            self.group_instance_id == answer.group_instance_id and \
+            self.group_instance == answer.group_instance and \
+            self.answer_instance == answer.answer_instance
+
+    def matches_dict(self, answer_dict):
+        """
+        Check to see if a dict describes an answer the same as this object.
+
+        :param answer_dict: A dictionary representation of the answer.
+        :return: True if both answers match, otherwise False.
+        """
+
+        return self.matches(Answer(
+            answer_dict.get('answer_id'),
+            answer_dict.get('value'),
+            answer_dict.get('group_instance_id'),
+            answer_dict.get('group_instance', 0),
+            answer_dict.get('answer_instance', 0),
+        ))

--- a/app/data_model/questionnaire_store.py
+++ b/app/data_model/questionnaire_store.py
@@ -52,14 +52,14 @@ class QuestionnaireStore:
         completed_blocks = [Location.from_dict(location_dict=completed_block) for completed_block in
                             json_data.get('COMPLETED_BLOCKS', [])]
         self.set_metadata(json_data.get('METADATA', {}))
-        self.answer_store.answers = json_data.get('ANSWERS', [])
+        self.answer_store = AnswerStore(json_data.get('ANSWERS'))
         self.completed_blocks = completed_blocks
         self.collection_metadata = json_data.get('COLLECTION_METADATA', {})
 
     def _serialise(self):
         data = {
             'METADATA': self._metadata,
-            'ANSWERS': self.answer_store.answers,
+            'ANSWERS': list(self.answer_store),
             'COMPLETED_BLOCKS': self.completed_blocks,
             'COLLECTION_METADATA': self.collection_metadata,
         }

--- a/app/forms/fields.py
+++ b/app/forms/fields.py
@@ -262,10 +262,10 @@ def get_schema_defined_limit(answer_id, definition, answer_store):
         else:
             source_answer_id = definition.get('answer_id')
             answer_list = answer_store.filter(answer_ids=[source_answer_id])
-            value = answer_list[0].get('value')
+            value = next(iter(answer_list)).get('value')
             if not isinstance(value, int) and not isinstance(value, Decimal):
                 raise Exception('answer: {} value: {} for answer id: {} is not a valid number'
-                                .format(answer_list[0].get('answer_id'), value, answer_id))
+                                .format(source_answer_id, value, answer_id))
 
         exclusive = definition.get('exclusive', False)
 

--- a/app/helpers/form_helper.py
+++ b/app/helpers/form_helper.py
@@ -1,10 +1,9 @@
+import re
 from collections import OrderedDict
 
 from structlog import get_logger
 from werkzeug.datastructures import MultiDict
 
-
-from app.data_model.answer_store import natural_order
 from app.forms.household_composition_form import generate_household_composition_form, deserialise_composition_answers
 from app.forms.household_relationship_form import build_relationship_choices, deserialise_relationship_answers, generate_relationship_form
 from app.forms.questionnaire_form import generate_form
@@ -170,4 +169,23 @@ def get_mapped_answers(schema, answer_store, block_id, group_instance, group_ins
 
         result[answer_id] = answer['value']
 
-    return OrderedDict(sorted(result.items(), key=lambda t: natural_order(t[0])))
+    return OrderedDict(sorted(result.items(), key=lambda t: answer_instance_order(t[0])))
+
+
+def number_else_string(text):
+    """
+    Converts number to an integer if possible.
+    :param text: Text to be converted
+    :return: Integer representation of text if a number.  Otherwise, it returns the text as is
+    """
+    return int(text) if text.isdigit() else text
+
+
+def answer_instance_order(key):
+    """
+    Returns a list of integers or string to be used for ordering
+
+    :param key:
+    :return:
+    """
+    return [number_else_string(c) for c in re.split(r'(\d+)', key)]

--- a/app/questionnaire/rules.py
+++ b/app/questionnaire/rules.py
@@ -158,7 +158,7 @@ def evaluate_repeat(repeat_rule, answer_store, schema, routing_path):
                                    group_instance_id=(answer['group_instance_id'] or None)):
                 break
 
-            no_of_repeats = no_of_repeats + 1
+            no_of_repeats += 1
     else:
         repeat_functions = {
             'answer_value': _get_answer_value,
@@ -211,7 +211,7 @@ def _get_answers_on_path(answers, schema, routing_path) -> AnswerStore:
     answers_on_path = answers.copy()
 
     for answer in answers_to_remove:
-        answers_on_path.answers.remove(answer)
+        answers_on_path.remove_answer(answer)
 
     return answers_on_path
 
@@ -225,7 +225,7 @@ def _is_answer_on_path(schema, answer, routing_path):
 
 
 def _get_answer_value(filtered_answers):
-    return int(filtered_answers[0]['value'] if len(filtered_answers) == 1 and filtered_answers[0]['value'] else 0)
+    return int(filtered_answers.values()[0] if len(filtered_answers) == 1 and filtered_answers.values()[0] else 0)
 
 
 def _get_answer_count_minus_one(filtered_answers):
@@ -332,7 +332,7 @@ def get_answer_store_value(answer_id, answer_store, schema, group_instance, grou
     if not answers_on_path.count():
         return None
 
-    if all([answer.get('group_instance_id') for answer in answers_on_path.answers]) and group_instance_id:
+    if all([answer.get('group_instance_id') for answer in answers_on_path]) and group_instance_id:
         # If all of the matching answers have a group_instance_id, then we know the answer has this group_instance_id
         group_instance = None
         answer_block_id = schema.get_block_id_for_answer_id(answer_id)
@@ -355,7 +355,7 @@ def get_answer_store_value(answer_id, answer_store, schema, group_instance, grou
         raise Exception('Multiple answers ({:d}) found evaluating when rule for answer ({})'
                         .format(filtered.count(), answer_id))
 
-    return filtered[0]['value'] if filtered.count() == 1 else None
+    return next(iter(filtered))['value'] if filtered.count() == 1 else None
 
 
 def get_number_of_repeats(group, schema, routing_path, answer_store):

--- a/app/submitter/convert_payload_0_0_1.py
+++ b/app/submitter/convert_payload_0_0_1.py
@@ -72,7 +72,7 @@ def _get_checkbox_answer_data(answer_store, answer_schema, value):
 
                 # if the user has selected 'other' we need to find the child value it refers to.
                 # the child value can be empty, in this case we just use the main value (e.g. other)
-                user_answer = filtered[0]['value'] or user_answer
+                user_answer = filtered.values()[0] or user_answer
 
             qcodes_and_values.append((option.get('q_code'), user_answer))
 

--- a/app/templating/schema_context.py
+++ b/app/templating/schema_context.py
@@ -42,7 +42,7 @@ def _build_answers(answer_store, schema, answer_ids_on_path):
             value = _create_answers_list(matching_answers, 'group_instance')
 
         elif matching_answers:
-            value = json_and_html_safe(matching_answers[0]['value'])
+            value = json_and_html_safe(next(iter(matching_answers))['value'])
         else:
             value = ''
 

--- a/app/templating/view_context.py
+++ b/app/templating/view_context.py
@@ -165,7 +165,17 @@ def build_view_context_for_answer_summary(metadata, schema, answer_store, block_
         'answers': [],
     }
 
-    for answer in answer_store.filter(answer_ids=summary_block.get('answer_ids')):
+    def group_instance(answer):
+        return answer['group_instance']
+
+    summary_answers = []
+
+    for answer_id in summary_block.get('answer_ids'):
+        answers = list(answer_store.filter(answer_ids=[answer_id]))
+        answers.sort(key=group_instance)
+        summary_answers.extend(answers)
+
+    for answer in summary_answers:
         question_id = schema.get_answer(answer['answer_id']).get('parent_id')
         block_id = schema.get_question(question_id).get('parent_id')
         group_id = schema.get_block(block_id).get('parent_id')

--- a/app/views/dump.py
+++ b/app/views/dump.py
@@ -18,7 +18,7 @@ dump_blueprint = Blueprint('dump', __name__)
 @login_required
 @role_required('dumper')
 def dump_answers():
-    response = {'answers': get_answer_store(current_user).answers or []}
+    response = {'answers': list(get_answer_store(current_user)) or []}
     return jsonify(response), 200
 
 

--- a/app/views/flush.py
+++ b/app/views/flush.py
@@ -45,7 +45,7 @@ def _submit_data(user):
 
     answer_store = get_answer_store(user)
 
-    if answer_store.answers:
+    if answer_store:
         metadata = get_metadata(user)
         collection_metadata = get_collection_metadata(user)
         schema = load_schema_from_metadata(metadata)

--- a/tests/app/confirmation_page/test_confirmation_page.py
+++ b/tests/app/confirmation_page/test_confirmation_page.py
@@ -14,7 +14,7 @@ class TestConfirmationPage(AppContextTestCase):
             value='Orson Krennic',
         )
         answer_store = AnswerStore()
-        answer_store.add(answer)
+        answer_store.add_or_update(answer)
 
         schema = load_schema_from_params('0', 'rogue_one')
         navigator = PathFinder(schema, answer_store, {}, [])

--- a/tests/app/data_model/test_answer_store.py
+++ b/tests/app/data_model/test_answer_store.py
@@ -103,14 +103,14 @@ class TestAnswerStore(unittest.TestCase):  # pylint: disable=too-many-public-met
             value=25,
         )
 
-        self.store.add(answer)
+        self.store.add_or_update(answer)
 
-        self.assertEqual(len(self.store.answers), 1)
+        self.assertEqual(len(self.store), 1)
 
     def test_raises_error_on_invalid(self):
 
         with self.assertRaises(TypeError) as ite:
-            self.store.add({
+            self.store.add_or_update({
                 'answer_id': '4',
                 'answer_instance': 1,
                 'group_instance': 1,
@@ -119,35 +119,6 @@ class TestAnswerStore(unittest.TestCase):  # pylint: disable=too-many-public-met
 
         self.assertIn('Method only supports Answer argument type', str(ite.exception))
 
-    def test_raises_error_on_add_existing(self):
-        answer_1 = Answer(
-            answer_id='4',
-            answer_instance=1,
-            group_instance=1,
-            group_instance_id='group-1',
-            value=25,
-        )
-        self.store.add(answer_1)
-
-        with self.assertRaises(ValueError) as ite:
-            self.store.add(answer_1)
-
-        self.assertIn('Answer instance already exists in store', str(ite.exception))
-
-    def test_raises_error_on_update_nonexisting(self):
-        answer_1 = Answer(
-            answer_id='4',
-            answer_instance=1,
-            group_instance=1,
-            group_instance_id='group-1',
-            value=25,
-        )
-
-        with self.assertRaises(ValueError) as ite:
-            self.store.update(answer_1)
-
-        self.assertIn('Answer instance does not exist in store', str(ite.exception))
-
     def test_add_inserts_instances(self):
         answer_1 = Answer(
             answer_id='4',
@@ -155,17 +126,17 @@ class TestAnswerStore(unittest.TestCase):  # pylint: disable=too-many-public-met
             group_instance=1,
             value=25,
         )
-        self.store.add(answer_1)
+        self.store.add_or_update(answer_1)
 
         answer_1.answer_instance = 2
 
-        self.store.add(answer_1)
+        self.store.add_or_update(answer_1)
 
         answer_1.answer_instance = 3
 
-        self.store.add(answer_1)
+        self.store.add_or_update(answer_1)
 
-        self.assertEqual(len(self.store.answers), 3)
+        self.assertEqual(len(self.store), 3)
 
     def test_updates_answer(self):
         answer_1 = Answer(
@@ -181,10 +152,10 @@ class TestAnswerStore(unittest.TestCase):  # pylint: disable=too-many-public-met
             value=65,
         )
 
-        self.store.add(answer_1)
-        self.store.update(answer_2)
+        self.store.add_or_update(answer_1)
+        self.store.add_or_update(answer_2)
 
-        self.assertEqual(len(self.store.answers), 1)
+        self.assertEqual(len(self.store), 1)
 
         store_match = self.store.filter(
             answer_ids=['4'],
@@ -192,7 +163,7 @@ class TestAnswerStore(unittest.TestCase):  # pylint: disable=too-many-public-met
             group_instance=1,
         )
 
-        self.assertEqual(store_match.answers, [answer_2.__dict__])
+        self.assertEqual(store_match, AnswerStore([answer_2.__dict__]))
 
     def test_filters_answers(self):
 
@@ -209,17 +180,17 @@ class TestAnswerStore(unittest.TestCase):  # pylint: disable=too-many-public-met
             value=65,
         )
 
-        self.store.add(answer_1)
-        self.store.add(answer_2)
+        self.store.add_or_update(answer_1)
+        self.store.add_or_update(answer_2)
 
         filtered = self.store.filter(answer_ids=['5'])
 
-        self.assertEqual(len(filtered.answers), 1)
+        self.assertEqual(len(filtered), 1)
 
     def test_filters_answers_with_limit(self):
 
         for i in range(1, 50):
-            self.store.add(Answer(
+            self.store.add_or_update(Answer(
                 answer_id='2',
                 answer_instance=i,
                 group_instance=1,
@@ -228,18 +199,18 @@ class TestAnswerStore(unittest.TestCase):  # pylint: disable=too-many-public-met
 
         filtered = self.store.filter(answer_ids=['2'], limit=True)
 
-        self.assertEqual(len(filtered.answers), 25)
+        self.assertEqual(len(filtered), 25)
 
     def test_escaped(self):
 
-        self.store.add(Answer(
+        self.store.add_or_update(Answer(
             answer_id='1',
             answer_instance=0,
             group_instance=1,
             value=25,
         ))
 
-        self.store.add(Answer(
+        self.store.add_or_update(Answer(
             answer_id='2',
             answer_instance=0,
             group_instance=1,
@@ -248,24 +219,24 @@ class TestAnswerStore(unittest.TestCase):  # pylint: disable=too-many-public-met
 
         escaped = self.store.escaped()
 
-        self.assertEqual(len(escaped.answers), 2)
-        self.assertEqual(escaped[0]['value'], 25)
-        self.assertEqual(escaped[1]['value'], '&#39;Twenty Five&#39;')
+        self.assertEqual(len(escaped), 2)
+        self.assertEqual(escaped.filter(answer_ids=['1']).values()[0], 25)
+        self.assertEqual(escaped.filter(answer_ids=['2']).values()[0], '&#39;Twenty Five&#39;')
 
         # answers in the store have not been escaped
-        self.assertEqual(self.store.answers[0]['value'], 25)
-        self.assertEqual(self.store.answers[1]['value'], "'Twenty Five'")
+        self.assertEqual(self.store.filter(answer_ids=['1']).values()[0], 25)
+        self.assertEqual(self.store.filter(answer_ids=['2']).values()[0], "'Twenty Five'")
 
     def test_filter_answers_does_not_escapes_values(self):
 
-        self.store.add(Answer(
+        self.store.add_or_update(Answer(
             answer_id='1',
             answer_instance=0,
             group_instance=1,
             value=25,
         ))
 
-        self.store.add(Answer(
+        self.store.add_or_update(Answer(
             answer_id='2',
             answer_instance=0,
             group_instance=1,
@@ -274,20 +245,20 @@ class TestAnswerStore(unittest.TestCase):  # pylint: disable=too-many-public-met
 
         filtered = self.store.filter(['1', '2'])
 
-        self.assertEqual(len(filtered.answers), 2)
-        self.assertEqual(filtered[0]['value'], 25)
-        self.assertEqual(filtered[1]['value'], "'Twenty Five'")
+        self.assertEqual(len(filtered), 2)
+        self.assertEqual(filtered.filter(answer_ids=['1']).values()[0], 25)
+        self.assertEqual(filtered.filter(answer_ids=['2']).values()[0], "'Twenty Five'")
 
     def test_filter_chaining_escaped(self):
 
-        self.store.add(Answer(
+        self.store.add_or_update(Answer(
             answer_id='1',
             answer_instance=0,
             group_instance=1,
             value=25,
         ))
 
-        self.store.add(Answer(
+        self.store.add_or_update(Answer(
             answer_id='2',
             answer_instance=0,
             group_instance=1,
@@ -296,12 +267,12 @@ class TestAnswerStore(unittest.TestCase):  # pylint: disable=too-many-public-met
 
         escaped = self.store.filter(answer_ids=['2']).escaped()
 
-        self.assertEqual(len(escaped.answers), 1)
-        self.assertEqual(escaped[0]['value'], '&#39;Twenty Five&#39;')
+        self.assertEqual(len(escaped), 1)
+        self.assertEqual(escaped.values()[0], '&#39;Twenty Five&#39;')
 
         # answers in the store have not been escaped
-        self.assertEqual(self.store[0]['value'], 25)
-        self.assertEqual(self.store[1]['value'], "'Twenty Five'")
+        self.assertEqual(self.store.filter(answer_ids=['1']).values()[0], 25)
+        self.assertEqual(self.store.filter(answer_ids=['2']).values()[0], "'Twenty Five'")
 
         values = self.store.filter(answer_ids=['2']).escaped().values()
 
@@ -310,14 +281,14 @@ class TestAnswerStore(unittest.TestCase):  # pylint: disable=too-many-public-met
 
     def test_filter_chaining_count(self):
 
-        self.store.add(Answer(
+        self.store.add_or_update(Answer(
             answer_id='1',
             answer_instance=0,
             group_instance=1,
             value=25,
         ))
 
-        self.store.add(Answer(
+        self.store.add_or_update(Answer(
             answer_id='2',
             answer_instance=0,
             group_instance=1,
@@ -365,7 +336,7 @@ class TestAnswerStore(unittest.TestCase):  # pylint: disable=too-many-public-met
 
         upgrade_0_to_1_update_date_formats(self.store, QuestionnaireSchema(questionnaire))
 
-        self.assertEqual(self.store.answers[0]['value'], '2017-12-25')
+        self.assertEqual(self.store.values()[0], '2017-12-25')
 
     def tests_upgrade_reformats_month_year_date(self):
         questionnaire = {
@@ -404,7 +375,7 @@ class TestAnswerStore(unittest.TestCase):  # pylint: disable=too-many-public-met
 
         upgrade_0_to_1_update_date_formats(self.store, QuestionnaireSchema(questionnaire))
 
-        self.assertEqual(self.store.answers[0]['value'], '2017-12')
+        self.assertEqual(self.store.values()[0], '2017-12')
 
     def tests_upgrade_when_answer_no_longer_in_schema_does_not_reformat(self):
         questionnaire = {
@@ -439,7 +410,7 @@ class TestAnswerStore(unittest.TestCase):  # pylint: disable=too-many-public-met
 
         upgrade_0_to_1_update_date_formats(self.store, QuestionnaireSchema(questionnaire))
 
-        self.assertEqual(self.store.answers[0]['value'], '12/2017')
+        self.assertEqual(self.store.values()[0], '12/2017')
 
     def tests_upgrade_when_block_no_longer_in_schema_does_not_reformat(self):
         questionnaire = {
@@ -467,7 +438,7 @@ class TestAnswerStore(unittest.TestCase):  # pylint: disable=too-many-public-met
 
         upgrade_0_to_1_update_date_formats(self.store, QuestionnaireSchema(questionnaire))
 
-        self.assertEqual(self.store.answers[0]['value'], '12/2017')
+        self.assertEqual(self.store.values()[0], '12/2017')
 
 
     def test_upgrade_add_group_instance_id(self):
@@ -533,8 +504,11 @@ class TestAnswerStore(unittest.TestCase):  # pylint: disable=too-many-public-met
 
         upgrade_1_to_2_add_group_instance_id(answer_store, QuestionnaireSchema(survey))
 
-        self.assertEqual(answer_store[0]['group_instance_id'], answer_store[1]['group_instance_id'])
-        self.assertNotEqual(answer_store[0]['group_instance_id'], answer_store[2]['group_instance_id'])
+        filtered = iter(answer_store.filter(answer_ids=['answer1']))
+        first_group_instance_id = next(filtered)['group_instance_id']
+
+        self.assertEqual(first_group_instance_id, next(filtered)['group_instance_id'])
+        self.assertNotEqual(first_group_instance_id, next(filtered)['group_instance_id'])
 
 
     def test_upgrade_multiple_versions(self):  # pylint: disable=no-self-use
@@ -595,8 +569,24 @@ class TestAnswerStore(unittest.TestCase):  # pylint: disable=too-many-public-met
             value=20,
         )
 
-        self.store.add(answer_1)
-        self.store.add(answer_2)
+        self.store.add_or_update(answer_1)
+        self.store.add_or_update(answer_2)
 
-        self.store.remove()
-        self.assertEqual(len(self.store.answers), 0)
+        self.store.clear()
+        self.assertEqual(len(self.store), 0)
+
+    def test_remove_answer(self):
+        answer_1 = Answer(
+            answer_id='answer1',
+            value=10,
+        )
+        answer_2 = Answer(
+            answer_id='answer2',
+            value=20,
+        )
+
+        self.store.add_or_update(answer_1)
+        self.store.add_or_update(answer_2)
+
+        self.store.remove_answer(vars(answer_1))
+        self.assertEqual(len(self.store), 1)

--- a/tests/app/data_model/test_questionnaire_store.py
+++ b/tests/app/data_model/test_questionnaire_store.py
@@ -3,8 +3,10 @@ from unittest.mock import MagicMock
 
 import simplejson as json
 
+from app.data_model.answer_store import AnswerStore
 from app.data_model.questionnaire_store import QuestionnaireStore
 from app.questionnaire.location import Location
+
 
 def get_basic_input():
     return {
@@ -12,9 +14,33 @@ def get_basic_input():
             'test': True
         },
         'ANSWERS': [{
-            'answer-id': 'test',
+            'answer_id': 'test',
             'value': 'test',
         }],
+        'COMPLETED_BLOCKS': [
+            {
+                'group_id': 'a-test-group',
+                'group_instance': 0,
+                'block_id': 'a-test-block',
+            }
+        ],
+        'COLLECTION_METADATA': {
+            'test-meta': 'test'
+        },
+    }
+
+
+def get_input_answers_dict():
+    return {
+        'METADATA': {
+            'test': True
+        },
+        'ANSWERS': {
+            'test': [{
+                'answer_id': 'test',
+                'value': 'test'
+            }]
+        },
         'COMPLETED_BLOCKS': [
             {
                 'group_id': 'a-test-group',
@@ -57,7 +83,21 @@ class TestQuestionnaireStore(TestCase):
         # Then
         self.assertEqual(store.metadata.copy(), expected['METADATA'])
         self.assertEqual(store.collection_metadata, expected['COLLECTION_METADATA'])
-        self.assertEqual(store.answer_store.answers, expected['ANSWERS'])
+        self.assertEqual(store.answer_store, AnswerStore(expected['ANSWERS']))
+        expected_location = expected['COMPLETED_BLOCKS'][0]
+        self.assertEqual(len(store.completed_blocks), 1)
+        self.assertEqual(store.completed_blocks[0], Location.from_dict(location_dict=expected_location))
+
+    def test_questionnaire_store_loads_answers_as_dict(self):
+        # Given
+        expected = get_input_answers_dict()
+        self.input_data = json.dumps(expected)
+        # When
+        store = QuestionnaireStore(self.storage, 3)
+        # Then
+        self.assertEqual(store.metadata.copy(), expected['METADATA'])
+        self.assertEqual(store.collection_metadata, expected['COLLECTION_METADATA'])
+        self.assertEqual(store.answer_store, AnswerStore(expected['ANSWERS']))
         expected_location = expected['COMPLETED_BLOCKS'][0]
         self.assertEqual(len(store.completed_blocks), 1)
         self.assertEqual(store.completed_blocks[0], Location.from_dict(location_dict=expected_location))
@@ -72,7 +112,7 @@ class TestQuestionnaireStore(TestCase):
         # Then
         self.assertEqual(store.metadata.copy(), expected['METADATA'])
         self.assertEqual(store.collection_metadata, expected['COLLECTION_METADATA'])
-        self.assertEqual(store.answer_store.answers, expected['ANSWERS'])
+        self.assertEqual(store.answer_store, AnswerStore(expected['ANSWERS']))
         expected_location = expected['COMPLETED_BLOCKS'][0]
         self.assertEqual(len(store.completed_blocks), 1)
         self.assertEqual(store.completed_blocks[0], Location.from_dict(location_dict=expected_location))
@@ -87,7 +127,7 @@ class TestQuestionnaireStore(TestCase):
         # Then
         self.assertEqual(store.metadata.copy(), expected['METADATA'])
         self.assertEqual(store.collection_metadata, expected['COLLECTION_METADATA'])
-        self.assertEqual(store.answer_store.answers, expected['ANSWERS'])
+        self.assertEqual(store.answer_store, AnswerStore(expected['ANSWERS']))
         self.assertEqual(len(store.completed_blocks), 0)
 
     def test_questionnaire_store_updates_storage(self):
@@ -95,7 +135,7 @@ class TestQuestionnaireStore(TestCase):
         expected = get_basic_input()
         store = QuestionnaireStore(self.storage)
         store.set_metadata(expected['METADATA'])
-        store.answer_store.answers = expected['ANSWERS']
+        store.answer_store = AnswerStore(expected['ANSWERS'])
         store.collection_metadata = expected['COLLECTION_METADATA']
         store.completed_blocks = [Location.from_dict(expected['COMPLETED_BLOCKS'][0])]
 
@@ -118,7 +158,7 @@ class TestQuestionnaireStore(TestCase):
         store = QuestionnaireStore(self.storage)
         store.set_metadata(non_serializable_metadata)
         store.collection_metadata = expected['COLLECTION_METADATA']
-        store.answer_store.answers = expected['ANSWERS']
+        store.answer_store = AnswerStore(expected['ANSWERS'])
         store.completed_blocks = [Location.from_dict(expected['COMPLETED_BLOCKS'][0])]
 
         # When / Then
@@ -130,7 +170,7 @@ class TestQuestionnaireStore(TestCase):
         store = QuestionnaireStore(self.storage)
         store.set_metadata(expected['METADATA'])
         store.collection_metadata = expected['COLLECTION_METADATA']
-        store.answer_store.answers = expected['ANSWERS']
+        store.answer_store = AnswerStore(expected['ANSWERS'])
         store.completed_blocks = [Location.from_dict(expected['COMPLETED_BLOCKS'][0])]
 
         # When

--- a/tests/app/forms/test_date_form.py
+++ b/tests/app/forms/test_date_form.py
@@ -223,7 +223,7 @@ class TestDateForm(AppContextTestCase):
             group_instance=0,
             value='2018-03-20',
         )
-        store.add(test_answer_id)
+        store.add_or_update(test_answer_id)
 
         answer_maximum = {
             'answer_id': 'date',
@@ -257,7 +257,7 @@ class TestDateForm(AppContextTestCase):
             group_instance=0,
             value='2018-03-20',
         )
-        store.add(test_answer_id)
+        store.add_or_update(test_answer_id)
 
         answer = {
             'id': 'date_answer',

--- a/tests/app/forms/test_household_relationship_form.py
+++ b/tests/app/forms/test_household_relationship_form.py
@@ -236,12 +236,12 @@ class TestHouseholdRelationshipForm(AppContextTestCase):
         answer_store = AnswerStore()
 
         for i in range(0, 50):
-            answer_store.add(Answer(
+            answer_store.add_or_update(Answer(
                 answer_id='first-name',
                 answer_instance=i,
                 value='Joe' + str(i),
             ))
-            answer_store.add(Answer(
+            answer_store.add_or_update(Answer(
                 answer_id='last-name',
                 answer_instance=i,
                 value='Bloggs' + str(i),

--- a/tests/app/forms/test_questionnaire_form.py
+++ b/tests/app/forms/test_questionnaire_form.py
@@ -615,7 +615,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
                 group_instance=0,
                 value='2017-03-20',
             )
-            store.add(test_answer_id)
+            store.add_or_update(test_answer_id)
 
             schema = load_schema_from_params('test', 'date_validation_range')
 
@@ -681,7 +681,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             value=10,
         )
 
-        store.add(answer_total)
+        store.add_or_update(answer_total)
 
         with self.app_request_context():
             schema = load_schema_from_params('test', 'sum_equal_validation_against_total')
@@ -736,7 +736,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             value=10,
         )
 
-        store.add(answer_total)
+        store.add_or_update(answer_total)
 
         with self.app_request_context():
             schema = load_schema_from_params('test', 'sum_equal_validation_against_total')
@@ -795,7 +795,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             value=10,
         )
 
-        store.add(answer_total)
+        store.add_or_update(answer_total)
 
         with self.app_request_context():
             schema = load_schema_from_params('test', 'sum_equal_validation_against_total')
@@ -833,7 +833,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             value=10,
         )
 
-        store.add(answer_total)
+        store.add_or_update(answer_total)
 
         with self.app_request_context():
             schema = load_schema_from_params('test', 'sum_equal_validation_against_total')
@@ -869,7 +869,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             value=10,
         )
 
-        store.add(answer_total)
+        store.add_or_update(answer_total)
 
         with self.app_request_context():
             schema = load_schema_from_params('test', 'sum_equal_validation_against_total')
@@ -907,7 +907,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             value=10,
         )
 
-        store.add(answer_total)
+        store.add_or_update(answer_total)
 
         with self.app_request_context():
             schema = load_schema_from_params('test', 'sum_multi_validation_against_total')
@@ -957,7 +957,7 @@ class TestQuestionnaireForm(AppContextTestCase):  # noqa: C901  pylint: disable=
             value='chad',
         )
 
-        store.add(conditional_answer)
+        store.add_or_update(conditional_answer)
 
         with self.app_request_context():
             schema = load_schema_from_params('test', 'titles')

--- a/tests/app/helpers/test_form_helper.py
+++ b/tests/app/helpers/test_form_helper.py
@@ -260,45 +260,45 @@ class TestFormHelper(AppContextTestCase):
             repeating_group_2_instance_id = str(uuid.uuid4())
 
             answer_store = AnswerStore({})
-            answer_store.add(Answer(
+            answer_store.add_or_update(Answer(
                 answer_id='primary-name',
                 value='Jon',
                 group_instance=0,
                 group_instance_id=primary_group_instance_id
             ))
-            answer_store.add(Answer(
+            answer_store.add_or_update(Answer(
                 answer_id='primary-live-here',
                 value='No',
                 group_instance=0,
                 group_instance_id=primary_group_instance_id
             ))
-            answer_store.add(Answer(
+            answer_store.add_or_update(Answer(
                 answer_id='repeating-anyone-else',
                 answer_instance=0,
                 value='Yes',
                 group_instance=0,
             ))
-            answer_store.add(Answer(
+            answer_store.add_or_update(Answer(
                 answer_id='repeating-name',
                 answer_instance=0,
                 value='Adam',
                 group_instance=0,
                 group_instance_id=repeating_group_1_instance_id
             ))
-            answer_store.add(Answer(
+            answer_store.add_or_update(Answer(
                 answer_id='repeating-anyone-else',
                 answer_instance=0,
                 value='Yes',
                 group_instance=1,
             ))
-            answer_store.add(Answer(
+            answer_store.add_or_update(Answer(
                 answer_id='repeating-name',
                 answer_instance=0,
                 value='Ben',
                 group_instance=1,
                 group_instance_id=repeating_group_2_instance_id
             ))
-            answer_store.add(Answer(
+            answer_store.add_or_update(Answer(
                 answer_id='repeating-anyone-else',
                 answer_instance=0,
                 value='No',
@@ -328,45 +328,45 @@ class TestFormHelper(AppContextTestCase):
             repeating_group_2_instance_id = str(uuid.uuid4())
 
             answer_store = AnswerStore({})
-            answer_store.add(Answer(
+            answer_store.add_or_update(Answer(
                 answer_id='primary-name',
                 value='Jon',
                 group_instance=0,
                 group_instance_id=primary_group_instance_id
             ))
-            answer_store.add(Answer(
+            answer_store.add_or_update(Answer(
                 answer_id='primary-live-here',
                 value='No',
                 group_instance=0,
                 group_instance_id=primary_group_instance_id
             ))
-            answer_store.add(Answer(
+            answer_store.add_or_update(Answer(
                 answer_id='repeating-anyone-else',
                 answer_instance=0,
                 value='Yes',
                 group_instance=0,
             ))
-            answer_store.add(Answer(
+            answer_store.add_or_update(Answer(
                 answer_id='repeating-name',
                 answer_instance=0,
                 value='Adam',
                 group_instance=0,
                 group_instance_id=repeating_group_1_instance_id
             ))
-            answer_store.add(Answer(
+            answer_store.add_or_update(Answer(
                 answer_id='repeating-anyone-else',
                 answer_instance=0,
                 value='Yes',
                 group_instance=1,
             ))
-            answer_store.add(Answer(
+            answer_store.add_or_update(Answer(
                 answer_id='repeating-name',
                 answer_instance=0,
                 value='Ben',
                 group_instance=1,
                 group_instance_id=repeating_group_2_instance_id
             ))
-            answer_store.add(Answer(
+            answer_store.add_or_update(Answer(
                 answer_id='repeating-anyone-else',
                 answer_instance=0,
                 value='No',
@@ -513,8 +513,8 @@ class TestGetMappedAnswers(unittest.TestCase):
             value=65,
         )
 
-        self.store.add(answer_1)
-        self.store.add(answer_2)
+        self.store.add_or_update(answer_1)
+        self.store.add_or_update(answer_2)
 
         expected_answers = {
             'answer1_1': 65
@@ -556,11 +556,11 @@ class TestGetMappedAnswers(unittest.TestCase):
         for i in range(0, 100):
             answer.answer_instance = i
 
-            self.store.add(answer)
+            self.store.add_or_update(answer)
 
         last_instance = -1
 
-        self.assertEqual(len(self.store.answers), 100)
+        self.assertEqual(len(self.store), 100)
 
         mapped = get_mapped_answers(schema, self.store, block_id='block1', group_instance=1, group_instance_id='group-1')
 

--- a/tests/app/helpers/test_schema_helpers.py
+++ b/tests/app/helpers/test_schema_helpers.py
@@ -73,8 +73,8 @@ class TestFormHelper(AppContextTestCase):
         )
 
         store = AnswerStore(None)
-        store.add(answer_1)
-        store.add(answer_2)
+        store.add_or_update(answer_1)
+        store.add_or_update(answer_2)
 
         location = Location('group2', 0, 'block2')
         self.assertEqual(get_group_instance_id(schema, store, location), 'group1-aaa')

--- a/tests/app/questionnaire/test_completeness.py
+++ b/tests/app/questionnaire/test_completeness.py
@@ -423,17 +423,17 @@ class TestCompleteness(AppContextTestCase): # pylint: disable=too-many-public-me
         ]
 
         answer_store = AnswerStore()
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_instance=0,
             answer_id='first-name',
             value='Person1'
         ))
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_instance=1,
             answer_id='first-name',
             value='Person2'
         ))
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_instance=0,
             answer_id='extra-cover-answer',
             value=2

--- a/tests/app/questionnaire/test_date_rules.py
+++ b/tests/app/questionnaire/test_date_rules.py
@@ -116,7 +116,7 @@ class TestDateRules(AppContextTestCase):
         }
 
         answer_store = AnswerStore({})
-        answer_store.add(Answer(answer_id='compare_date_answer', value='2018-02-03'))
+        answer_store.add_or_update(Answer(answer_id='compare_date_answer', value='2018-02-03'))
 
         answer_value = '2018-02-04'
         result = evaluate_date_rule(when, answer_store, get_schema_mock(), 0, None, answer_value)
@@ -140,6 +140,6 @@ class TestDateRules(AppContextTestCase):
         }
 
         answer_store = AnswerStore({})
-        answer_store.add(Answer(answer_id='date_answer', value='2018-02-01'))
+        answer_store.add_or_update(Answer(answer_id='date_answer', value='2018-02-01'))
 
         self.assertFalse(evaluate_goto(goto_rule, get_schema_mock(), {}, answer_store, 0))

--- a/tests/app/questionnaire/test_navigation.py
+++ b/tests/app/questionnaire/test_navigation.py
@@ -92,7 +92,7 @@ class TestNavigation(AppContextTestCase):
             answer_id='insurance-type-answer'
         )
 
-        answer_store.add(answer_1)
+        answer_store.add_or_update(answer_1)
 
         completed_blocks = [
             Location('property-details', 0, 'insurance-type'),
@@ -181,12 +181,10 @@ class TestNavigation(AppContextTestCase):
             Location('skip-payment-group', 0, 'skip-payment')
         ]
 
-        navigation = _create_navigation(schema, AnswerStore(), metadata, completed_blocks, routing_path)
-
         person1_uuid = uuid.uuid4()
         person2_uuid = uuid.uuid4()
 
-        navigation.answer_store.answers = [
+        answer_store = AnswerStore(existing_answers=[
             {
                 'group_instance': 0,
                 'answer_instance': 0,
@@ -229,7 +227,9 @@ class TestNavigation(AppContextTestCase):
                 'value': None,
                 'group_instance_id': person2_uuid,
             }
-        ]
+        ])
+
+        navigation = _create_navigation(schema, answer_store, metadata, completed_blocks, routing_path)
 
         user_navigation = [
             {
@@ -282,7 +282,9 @@ class TestNavigation(AppContextTestCase):
                 'link_url': Location('final-section-routed-group', 0, 'final-interstitial').url(metadata)
             }
         ]
-        self.assertEqual(navigation.build_navigation('property-details', 0), user_navigation)
+
+        built_navigation = navigation.build_navigation('property-details', 0)
+        self.assertEqual(built_navigation, user_navigation)
 
     def test_navigation_repeating_group_extra_answered_not_completed(self):
         schema = load_schema_from_params('test', 'navigation')
@@ -326,9 +328,9 @@ class TestNavigation(AppContextTestCase):
             group_instance_id=person2_uuid
         )
 
-        answer_store.add(answer_1)
-        answer_store.add(answer_2)
-        answer_store.add(answer_3)
+        answer_store.add_or_update(answer_1)
+        answer_store.add_or_update(answer_2)
+        answer_store.add_or_update(answer_3)
 
         routing_path = [
             Location('property-details', 0, 'insurance-type'),
@@ -458,11 +460,11 @@ class TestNavigation(AppContextTestCase):
             answer_instance=0
         )
 
-        answer_store.add(answer_1)
-        answer_store.add(answer_2)
-        answer_store.add(answer_3)
-        answer_store.add(answer_4)
-        answer_store.add(answer_5)
+        answer_store.add_or_update(answer_1)
+        answer_store.add_or_update(answer_2)
+        answer_store.add_or_update(answer_3)
+        answer_store.add_or_update(answer_4)
+        answer_store.add_or_update(answer_5)
 
         routing_path = [
             Location('property-details', 0, 'insurance-type'),
@@ -571,10 +573,10 @@ class TestNavigation(AppContextTestCase):
             group_instance_id=person2_uuid
         )
 
-        answer_store.add(answer_1)
-        answer_store.add(answer_2)
-        answer_store.add(answer_3)
-        answer_store.add(answer_4)
+        answer_store.add_or_update(answer_1)
+        answer_store.add_or_update(answer_2)
+        answer_store.add_or_update(answer_3)
+        answer_store.add_or_update(answer_4)
 
         routing_path = [
             Location('property-details', 0, 'insurance-type'),
@@ -659,7 +661,7 @@ class TestNavigation(AppContextTestCase):
             answer_id='insurance-type-answer'
         )
 
-        answer_store.add(answer_1)
+        answer_store.add_or_update(answer_1)
         navigation = _create_navigation(schema, answer_store, metadata, completed_blocks, [])
         user_navigation = navigation.build_navigation('property-details', 0)
         link_names = [d['link_name'] for d in user_navigation]
@@ -686,7 +688,7 @@ class TestNavigation(AppContextTestCase):
             answer_id='insurance-type-answer'
         )
 
-        answer_store.add(answer_1)
+        answer_store.add_or_update(answer_1)
 
         navigation = _create_navigation(schema, answer_store, metadata, completed_blocks, [])
 
@@ -716,7 +718,7 @@ class TestNavigation(AppContextTestCase):
             answer_id='insurance-type-answer'
         )
 
-        answer_store.add(answer_1)
+        answer_store.add_or_update(answer_1)
         navigation = _create_navigation(schema, answer_store, metadata, completed_blocks, [])
 
         user_navigation = navigation.build_navigation('property-details', 0)
@@ -731,8 +733,9 @@ class TestNavigation(AppContextTestCase):
             answer_id='insurance-type-answer'
         )
 
-        answer_store.update(change_answer)
+        answer_store.add_or_update(change_answer)
 
+        navigation = _create_navigation(schema, answer_store, metadata, completed_blocks, [])
         user_navigation = navigation.build_navigation('property-details', 0)
 
         link_names = [d['link_name'] for d in user_navigation]
@@ -1261,28 +1264,28 @@ class TestNavigation(AppContextTestCase):
         person1_uuid = uuid.uuid4()
         person2_uuid = uuid.uuid4()
 
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_instance=0,
             answer_id='first-name',
             group_instance=0,
             value='Person1',
             group_instance_id=person1_uuid
             ))
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_instance=1,
             answer_id='first-name',
             group_instance=0,
             value='Person2',
             group_instance_id=person2_uuid
             ))
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_instance=0,
             answer_id='what-is-your-age',
             group_instance=0,
             value=42,
             group_instance_id=person1_uuid
             ))
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_instance=0,
             answer_id='what-is-your-shoe-size',
             group_instance=0,
@@ -1474,7 +1477,7 @@ class TestNavigation(AppContextTestCase):
 
         answer_store = AnswerStore()
 
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_instance=0,
             answer_id='insurance-type-answer',
             group_instance=0,

--- a/tests/app/questionnaire/test_path_finder.py
+++ b/tests/app/questionnaire/test_path_finder.py
@@ -88,8 +88,8 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         )
 
         answers = AnswerStore()
-        answers.add(answer_1)
-        answers.add(answer_2)
+        answers.add_or_update(answer_1)
+        answers.add_or_update(answer_2)
 
         current_location = expected_path[1]
         expected_next_location = expected_path[2]
@@ -163,8 +163,8 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         )
 
         answers = AnswerStore()
-        answers.add(answer_1)
-        answers.add(answer_2)
+        answers.add_or_update(answer_1)
+        answers.add_or_update(answer_2)
         schema.answer_is_in_repeating_group = MagicMock(return_value=False)
 
         # When
@@ -200,8 +200,8 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         )
 
         answers = AnswerStore()
-        answers.add(answer_1)
-        answers.add(answer_2)
+        answers.add_or_update(answer_1)
+        answers.add_or_update(answer_2)
 
         path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
@@ -256,8 +256,8 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         )
 
         answers = AnswerStore()
-        answers.add(answer_1)
-        answers.add(answer_2)
+        answers.add_or_update(answer_1)
+        answers.add_or_update(answer_2)
 
         current_location = expected_path[3]
         expected_previous_location = expected_path[2]
@@ -300,8 +300,8 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         )
 
         answers = AnswerStore()
-        answers.add(answer_1)
-        answers.add(answer_2)
+        answers.add_or_update(answer_1)
+        answers.add_or_update(answer_2)
 
         path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
@@ -324,7 +324,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
             value='I prefer Star Trek',
         )
         answers = AnswerStore()
-        answers.add(answer)
+        answers.add_or_update(answer)
         path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
         current_location = expected_path[1]
@@ -354,8 +354,8 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         )
 
         answers = AnswerStore()
-        answers.add(answer_1)
-        answers.add(answer_2)
+        answers.add_or_update(answer_1)
+        answers.add_or_update(answer_2)
 
         path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
@@ -391,7 +391,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
             value='2'
         )
         answers = AnswerStore()
-        answers.add(answer)
+        answers.add_or_update(answer)
 
         path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
@@ -416,7 +416,7 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
             value='0'
         )
         answers = AnswerStore()
-        answers.add(answer)
+        answers.add_or_update(answer)
         path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
         self.assertEqual(expected_path, path_finder.get_full_routing_path())
 
@@ -461,9 +461,9 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
 
         answers = AnswerStore()
 
-        answers.add(answer)
-        answers.add(answer_2)
-        answers.add(answer_3)
+        answers.add_or_update(answer)
+        answers.add_or_update(answer_2)
+        answers.add_or_update(answer_3)
 
         path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
@@ -500,8 +500,8 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
 
         answers = AnswerStore()
 
-        answers.add(answer)
-        answers.add(answer_2)
+        answers.add_or_update(answer)
+        answers.add_or_update(answer_2)
 
         path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
@@ -556,8 +556,8 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
 
         answers = AnswerStore()
 
-        answers.add(answer)
-        answers.add(answer_2)
+        answers.add_or_update(answer)
+        answers.add_or_update(answer_2)
 
         path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
@@ -592,8 +592,8 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         current_location = expected_path[-1]
 
         answers = AnswerStore()
-        answers.add(answer)
-        answers.add(answer_2)
+        answers.add_or_update(answer)
+        answers.add_or_update(answer_2)
 
         path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
@@ -636,9 +636,9 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         )
 
         answers = AnswerStore()
-        answers.add(answer_1)
-        answers.add(answer_2)
-        answers.add(answer_3)
+        answers.add_or_update(answer_1)
+        answers.add_or_update(answer_2)
+        answers.add_or_update(answer_3)
 
         path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
@@ -662,12 +662,12 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         answer_store = AnswerStore()
 
         # Set up some first names
-        answer_store.add(Answer(answer_id='first-name', value='aaa', group_instance=0, group_instance_id='group-1-0'))
-        answer_store.add(Answer(answer_id='first-name', value='bbb', group_instance=1, group_instance_id='group-1-1'))
-        answer_store.add(Answer(answer_id='first-name', value='ccc', group_instance=2, group_instance_id='group-1-2'))
+        answer_store.add_or_update(Answer(answer_id='first-name', value='aaa', group_instance=0, group_instance_id='group-1-0'))
+        answer_store.add_or_update(Answer(answer_id='first-name', value='bbb', group_instance=1, group_instance_id='group-1-1'))
+        answer_store.add_or_update(Answer(answer_id='first-name', value='ccc', group_instance=2, group_instance_id='group-1-2'))
 
         # Set up the independent answer
-        answer_store.add(Answer(answer_id='an-independent-answer', value=independent_answer, group_instance=0, group_instance_id='group-1-0'))
+        answer_store.add_or_update(Answer(answer_id='an-independent-answer', value=independent_answer, group_instance=0, group_instance_id='group-1-0'))
 
         path_finder = PathFinder(schema, answer_store=answer_store, metadata={}, completed_blocks=[])
 
@@ -700,12 +700,12 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         answer_store = AnswerStore()
 
         # Set up some first names
-        answer_store.add(Answer(answer_id='first-name', value='aaa', answer_instance=0, group_instance_id='group-1-0'))
-        answer_store.add(Answer(answer_id='first-name', value='bbb', answer_instance=1, group_instance_id='group-1-1'))
-        answer_store.add(Answer(answer_id='first-name', value='ccc', answer_instance=2, group_instance_id='group-1-2'))
+        answer_store.add_or_update(Answer(answer_id='first-name', value='aaa', answer_instance=0, group_instance_id='group-1-0'))
+        answer_store.add_or_update(Answer(answer_id='first-name', value='bbb', answer_instance=1, group_instance_id='group-1-1'))
+        answer_store.add_or_update(Answer(answer_id='first-name', value='ccc', answer_instance=2, group_instance_id='group-1-2'))
 
         # Set up the independent answer
-        answer_store.add(Answer(answer_id='an-independent-answer', value=independent_answer, group_instance=0, group_instance_id='group-1-0'))
+        answer_store.add_or_update(Answer(answer_id='an-independent-answer', value=independent_answer, group_instance=0, group_instance_id='group-1-0'))
 
         # When
         with patch('app.questionnaire.path_finder.evaluate_skip_conditions', return_value=False):
@@ -748,17 +748,17 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
 
                 # Set up some first names
 
-                answer_store.add(Answer(answer_id='first-name', value='aaa', answer_instance=0, group_instance_id='group-1-0'))
-                answer_store.add(Answer(answer_id='first-name', value='bbb', answer_instance=1, group_instance_id='group-1-1'))
-                answer_store.add(Answer(answer_id='first-name', value='ccc', answer_instance=2, group_instance_id='group-1-2'))
-                answer_store.add(Answer(answer_id='first-name', value='ddd', answer_instance=3, group_instance_id='group-1-3'))
+                answer_store.add_or_update(Answer(answer_id='first-name', value='aaa', answer_instance=0, group_instance_id='group-1-0'))
+                answer_store.add_or_update(Answer(answer_id='first-name', value='bbb', answer_instance=1, group_instance_id='group-1-1'))
+                answer_store.add_or_update(Answer(answer_id='first-name', value='ccc', answer_instance=2, group_instance_id='group-1-2'))
+                answer_store.add_or_update(Answer(answer_id='first-name', value='ddd', answer_instance=3, group_instance_id='group-1-3'))
 
                 # Now set a date of birth for the two group instances
 
-                answer_store.add(Answer(answer_id='date-of-birth-answer', value='01-01-1980',
-                                        group_instance=first_group_instance, group_instance_id='group-1-{}'.format(first_group_instance)))
-                answer_store.add(Answer(answer_id='date-of-birth-answer', value='01-01-1980',
-                                        group_instance=second_group_instance, group_instance_id='group-1-{}'.format(second_group_instance)))
+                answer_store.add_or_update(Answer(answer_id='date-of-birth-answer', value='01-01-1980',
+                                                  group_instance=first_group_instance, group_instance_id='group-1-{}'.format(first_group_instance)))
+                answer_store.add_or_update(Answer(answer_id='date-of-birth-answer', value='01-01-1980',
+                                                  group_instance=second_group_instance, group_instance_id='group-1-{}'.format(second_group_instance)))
 
                 path_finder = PathFinder(schema, answer_store=answer_store, metadata={}, completed_blocks=[])
 
@@ -777,45 +777,45 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         repeating_group_2_instance_id = str(uuid.uuid4())
 
         answer_store = AnswerStore({})
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_id='primary-name',
             value='Jon',
             group_instance=0,
             group_instance_id=primary_group_instance_id
         ))
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_id='primary-live-here',
             value='No',
             group_instance=0,
             group_instance_id=primary_group_instance_id
         ))
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_id='repeating-anyone-else',
             answer_instance=0,
             value='Yes',
             group_instance=0,
         ))
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_id='repeating-name',
             answer_instance=0,
             value='Adam',
             group_instance=0,
             group_instance_id=repeating_group_1_instance_id
         ))
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_id='repeating-anyone-else',
             answer_instance=0,
             value='Yes',
             group_instance=1,
         ))
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_id='repeating-name',
             answer_instance=0,
             value='Ben',
             group_instance=1,
             group_instance_id=repeating_group_2_instance_id
         ))
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_id='repeating-anyone-else',
             answer_instance=0,
             value='No',
@@ -846,13 +846,13 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
 
         answers = AnswerStore()
 
-        answers.add(Answer(
+        answers.add_or_update(Answer(
             answer_id='no-of-repeats-answer',
             value='10000'
         ))
 
         for i in range(50):
-            answers.add(Answer(
+            answers.add_or_update(Answer(
                 group_instance=i,
                 group_instance_id=None,
                 answer_id='conditional-answer',
@@ -938,9 +938,9 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
             value='No'
         )
 
-        answers.add(answer_1)
-        answers.add(answer_2)
-        answers.add(answer_3)
+        answers.add_or_update(answer_1)
+        answers.add_or_update(answer_2)
+        answers.add_or_update(answer_3)
 
         path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
@@ -984,9 +984,9 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
             value='Yes'
         )
 
-        answers.add(answer_1)
-        answers.add(answer_2)
-        answers.add(answer_3)
+        answers.add_or_update(answer_1)
+        answers.add_or_update(answer_2)
+        answers.add_or_update(answer_3)
 
         path_finder = PathFinder(schema, answer_store=answers, metadata={}, completed_blocks=[])
 
@@ -998,8 +998,8 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         schema = load_schema_from_params('test', 'skip_condition_block')
         current_location = Location('do-you-want-to-skip-group', 0, 'do-you-want-to-skip')
         answer_store = AnswerStore()
-        answer_store.add(Answer(answer_id='do-you-want-to-skip-answer',
-                                value='Yes'))
+        answer_store.add_or_update(Answer(answer_id='do-you-want-to-skip-answer',
+                                          value='Yes'))
 
         # When
         path_finder = PathFinder(schema, answer_store=answer_store, metadata={}, completed_blocks=[])
@@ -1015,8 +1015,8 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         schema = load_schema_from_params('test', 'skip_condition_group')
         current_location = Location('do-you-want-to-skip-group', 0, 'do-you-want-to-skip')
         answer_store = AnswerStore()
-        answer_store.add(Answer(answer_id='do-you-want-to-skip-answer',
-                                value='Yes'))
+        answer_store.add_or_update(Answer(answer_id='do-you-want-to-skip-answer',
+                                          value='Yes'))
 
         # When
         path_finder = PathFinder(schema, answer_store=answer_store, metadata={}, completed_blocks=[])
@@ -1032,8 +1032,8 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         schema = load_schema_from_params('test', 'skip_condition_group')
         current_location = Location('do-you-want-to-skip-group', 0, 'do-you-want-to-skip')
         answer_store = AnswerStore()
-        answer_store.add(Answer(answer_id='do-you-want-to-skip-answer',
-                                value='No'))
+        answer_store.add_or_update(Answer(answer_id='do-you-want-to-skip-answer',
+                                          value='No'))
 
         # When
         path_finder = PathFinder(schema, answer_store=answer_store, metadata={}, completed_blocks=[])
@@ -1048,8 +1048,8 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         # Given
         schema = load_schema_from_params('test', 'skip_condition_group')
         answer_store = AnswerStore()
-        answer_store.add(Answer(answer_id='do-you-want-to-skip-answer',
-                                value='Yes'))
+        answer_store.add_or_update(Answer(answer_id='do-you-want-to-skip-answer',
+                                          value='Yes'))
 
         # When
         path_finder = PathFinder(schema, answer_store=answer_store, metadata={}, completed_blocks=[])
@@ -1077,8 +1077,8 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         schema.answer_is_in_repeating_group = MagicMock(return_value=False)
 
         answer_store = AnswerStore()
-        answer_store.add(Answer(answer_id='which-group-answer',
-                                value='group2'))
+        answer_store.add_or_update(Answer(answer_id='which-group-answer',
+                                          value='group2'))
 
         # When i build the path
         path_finder = PathFinder(schema, answer_store=answer_store, metadata={}, completed_blocks=[])
@@ -1099,9 +1099,9 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         ]
 
         answer_store = AnswerStore()
-        answer_store.add(Answer(answer_id='radio-answer', value='Bacon'))
-        answer_store.add(Answer(answer_id='test-currency', value='123'))
-        answer_store.add(Answer(answer_id='dessert', value='Cake'))
+        answer_store.add_or_update(Answer(answer_id='radio-answer', value='Bacon'))
+        answer_store.add_or_update(Answer(answer_id='test-currency', value='123'))
+        answer_store.add_or_update(Answer(answer_id='dessert', value='Cake'))
 
         summary_location = Location('dessert-group', 0, 'summary')
 
@@ -1121,9 +1121,9 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         ]
 
         answer_store = AnswerStore()
-        answer_store.add(Answer(answer_id='insurance-type-answer', value='Contents'))
-        answer_store.add(Answer(answer_id='insurance-address-answer', value='123 Test Road'))
-        answer_store.add(Answer(answer_id='address-duration-answer', value='No'))
+        answer_store.add_or_update(Answer(answer_id='insurance-type-answer', value='Contents'))
+        answer_store.add_or_update(Answer(answer_id='insurance-address-answer', value='123 Test Road'))
+        answer_store.add_or_update(Answer(answer_id='address-duration-answer', value='No'))
 
         summary_location = Location('property-details-summary-group', 0, 'property-details-summary')
 
@@ -1144,9 +1144,9 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         ]
 
         answer_store = AnswerStore()
-        answer_store.add(Answer(answer_id='insurance-type-answer', value='Both'))
-        answer_store.add(Answer(answer_id='insurance-address-answer', value='123 Test Road'))
-        answer_store.add(Answer(answer_id='address-duration-answer', value='No'))
+        answer_store.add_or_update(Answer(answer_id='insurance-type-answer', value='Both'))
+        answer_store.add_or_update(Answer(answer_id='insurance-address-answer', value='123 Test Road'))
+        answer_store.add_or_update(Answer(answer_id='address-duration-answer', value='No'))
 
         second_section_location = Location('house-details', 0, 'house-type')
 
@@ -1167,17 +1167,17 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         answer_store = AnswerStore()
         number_of_employees_answer = Answer(answer_id='number-of-employees-total', value=0)
         confirm_zero_answer = Answer(answer_id='confirm-zero-employees-answer', value='No')
-        answer_store.add(number_of_employees_answer)
-        answer_store.add(confirm_zero_answer)
+        answer_store.add_or_update(number_of_employees_answer)
+        answer_store.add_or_update(confirm_zero_answer)
 
         path_finder = PathFinder(schema, answer_store, metadata={}, completed_blocks=completed_blocks)
         self.assertEqual(len(path_finder.completed_blocks), 2)
-        self.assertEqual(len(path_finder.answer_store.answers), 2)
+        self.assertEqual(len(path_finder.answer_store), 2)
 
         self.assertEqual(path_finder.get_next_location(current_location=completed_blocks[1]), completed_blocks[0])
 
         self.assertEqual(path_finder.completed_blocks, [completed_blocks[0]])
-        self.assertEqual(len(path_finder.answer_store.answers), 1)
+        self.assertEqual(len(path_finder.answer_store), 1)
 
     def test_route_based_on_answer_count(self):
         schema = load_schema_from_params('test', 'routing_answer_count')
@@ -1185,12 +1185,12 @@ class TestPathFinder(AppContextTestCase):  # pylint: disable=too-many-public-met
         answer_group_id = 'first-name'
 
         answer_store = AnswerStore({})
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_id=answer_group_id,
             answer_instance=0,
             value='alice',
         ))
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_id=answer_group_id,
             answer_instance=1,
             value='bob',

--- a/tests/app/questionnaire/test_rules.py
+++ b/tests/app/questionnaire/test_rules.py
@@ -189,7 +189,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         }
         answer_store = AnswerStore({})
 
-        answer_store.add(Answer(answer_id='my_answer', value='Yes'))
+        answer_store.add_or_update(Answer(answer_id='my_answer', value='Yes'))
 
         self.assertTrue(evaluate_goto(goto, get_schema_mock(), {}, answer_store, 0))
 
@@ -207,7 +207,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         }
         answer_store = AnswerStore({})
 
-        answer_store.add(Answer(answer_id='my_answer', value='No'))
+        answer_store.add_or_update(Answer(answer_id='my_answer', value='No'))
 
         self.assertFalse(evaluate_goto(goto_rule, get_schema_mock(), {}, answer_store, 0))
 
@@ -224,7 +224,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
             ]
         }
         answer_store = AnswerStore({})
-        answer_store.add(Answer(answer_id='my_answers', value=['answer1', 'answer2', 'answer3']))
+        answer_store.add_or_update(Answer(answer_id='my_answers', value=['answer1', 'answer2', 'answer3']))
 
         self.assertTrue(evaluate_goto(goto, get_schema_mock(), {}, answer_store, 0))
 
@@ -241,7 +241,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
             ]
         }
         answer_store = AnswerStore({})
-        answer_store.add(Answer(answer_id='my_answers', value=['answer2', 'answer3']))
+        answer_store.add_or_update(Answer(answer_id='my_answers', value=['answer2', 'answer3']))
 
         self.assertTrue(evaluate_goto(goto, get_schema_mock(), {}, answer_store, 0))
 
@@ -268,7 +268,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
             }
         ]
         answer_store = AnswerStore({})
-        answer_store.add(Answer(answer_id='this', value='value'))
+        answer_store.add_or_update(Answer(answer_id='this', value='value'))
 
         # When
         condition = evaluate_skip_conditions(skip_conditions, get_schema_mock(), {}, answer_store)
@@ -300,7 +300,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         ]
         answer_store = AnswerStore({})
 
-        answer_store.add(Answer(answer_id='that', value='other value'))
+        answer_store.add_or_update(Answer(answer_id='that', value='other value'))
 
         self.assertTrue(evaluate_skip_conditions(skip_conditions, get_schema_mock(), {}, answer_store))
 
@@ -327,8 +327,8 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
             }
         ]
         answer_store = AnswerStore({})
-        answer_store.add(Answer(answer_id='this', value='value'))
-        answer_store.add(Answer(answer_id='that', value='other value'))
+        answer_store.add_or_update(Answer(answer_id='this', value='value'))
+        answer_store.add_or_update(Answer(answer_id='that', value='other value'))
 
         # When
         condition = evaluate_skip_conditions(skip_conditions, get_schema_mock(), {}, answer_store)
@@ -359,8 +359,8 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
             }
         ]
         answer_store = AnswerStore({})
-        answer_store.add(Answer(answer_id='this', value='not correct'))
-        answer_store.add(Answer(answer_id='that', value='not correct'))
+        answer_store.add_or_update(Answer(answer_id='this', value='not correct'))
+        answer_store.add_or_update(Answer(answer_id='that', value='not correct'))
 
         # When
         condition = evaluate_skip_conditions(skip_conditions, get_schema_mock(), {}, answer_store)
@@ -409,8 +409,8 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
             ]
         }
         answer_store = AnswerStore({})
-        answer_store.add(Answer(answer_id='my_answer', value='Yes'))
-        answer_store.add(Answer(answer_id='my_other_answer', value='2'))
+        answer_store.add_or_update(Answer(answer_id='my_answer', value='Yes'))
+        answer_store.add_or_update(Answer(answer_id='my_other_answer', value='2'))
 
         self.assertTrue(evaluate_goto(goto, get_schema_mock(), {}, answer_store, 0))
 
@@ -432,7 +432,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
             ]
         }
         answer_store = AnswerStore({})
-        answer_store.add(Answer(answer_id='my_answer', value='No'))
+        answer_store.add_or_update(Answer(answer_id='my_answer', value='No'))
 
         self.assertFalse(evaluate_goto(goto_rule, get_schema_mock(), {}, answer_store, 0))
 
@@ -454,7 +454,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
             ]
         }
         answer_store = AnswerStore({})
-        answer_store.add(Answer(answer_id='my_answer', value='Yes'))
+        answer_store.add_or_update(Answer(answer_id='my_answer', value='Yes'))
         metadata = {'sexual_identity': True}
 
         # When
@@ -476,7 +476,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
             ]
         }
         answer_store = AnswerStore({})
-        answer_store.add(Answer(answer_id='my_answer', value='Yes'))
+        answer_store.add_or_update(Answer(answer_id='my_answer', value='Yes'))
         metadata = {'varient_flags': {'sexual_identity': True}}
 
         # When
@@ -503,7 +503,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
             ]
         }
         answer_store = AnswerStore({})
-        answer_store.add(Answer(answer_id='my_answer', value='Yes'))
+        answer_store.add_or_update(Answer(answer_id='my_answer', value='Yes'))
         metadata = {'sexual_identity': True}
 
         # When
@@ -561,10 +561,10 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         with patch.object(schema, 'answer_is_in_repeating_group', return_value=True):
             self.assertEqual(evaluate_repeat(repeat, answer_store, schema, current_path), 1)
 
-            answer_store.add(Answer(answer_id='my_answer', value='Not Done', group_instance=0, group_instance_id=None))
+            answer_store.add_or_update(Answer(answer_id='my_answer', value='Not Done', group_instance=0, group_instance_id=None))
             self.assertEqual(evaluate_repeat(repeat, answer_store, schema, current_path), 2)
 
-            answer_store.add(Answer(answer_id='my_answer', value='Done', group_instance=1, group_instance_id=None))
+            answer_store.add_or_update(Answer(answer_id='my_answer', value='Done', group_instance=1, group_instance_id=None))
             self.assertEqual(evaluate_repeat(repeat, answer_store, schema, current_path), 2)
 
     def test_should_repeat_for_answer_answer_value(self):
@@ -603,7 +603,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
             'type': 'answer_value'
         }
         answer_store = AnswerStore({})
-        answer_store.add(Answer(answer_id='my_answer', value='3'))
+        answer_store.add_or_update(Answer(answer_id='my_answer', value='3'))
 
         current_path = [Location('group-1', 0, 'block-1')]
 
@@ -648,8 +648,8 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
             'type': 'answer_count'
         }
         answer_store = AnswerStore({})
-        answer_store.add(Answer(answer_id='my_answer', value='3'))
-        answer_store.add(Answer(answer_id='my_answer', value='4', answer_instance=1))
+        answer_store.add_or_update(Answer(answer_id='my_answer', value='3'))
+        answer_store.add_or_update(Answer(answer_id='my_answer', value='4', answer_instance=1))
 
         current_path = [Location('group-1', 0, 'block-1')]
 
@@ -694,8 +694,8 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
             'type': 'answer_count_minus_one'
         }
         answer_store = AnswerStore({})
-        answer_store.add(Answer(answer_id='my_answer', value='3'))
-        answer_store.add(Answer(answer_id='my_answer', value='4', answer_instance=1))
+        answer_store.add_or_update(Answer(answer_id='my_answer', value='3'))
+        answer_store.add_or_update(Answer(answer_id='my_answer', value='4', answer_instance=1))
 
         current_path = [Location('group-1', 0, 'block-1')]
 
@@ -741,7 +741,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         }
         answer_store = AnswerStore({})
         for i in range(27):
-            answer_store.add(Answer(answer_id='my_answer', value='3', answer_instance=i))
+            answer_store.add_or_update(Answer(answer_id='my_answer', value='3', answer_instance=i))
 
         current_path = [Location('group-1', 0, 'block-1')]
 
@@ -765,8 +765,8 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
             value=20,
         )
         answer_store = AnswerStore({})
-        answer_store.add(answer_1)
-        answer_store.add(answer_2)
+        answer_store.add_or_update(answer_1)
+        answer_store.add_or_update(answer_2)
 
         when = {
             'id': 'next-question',
@@ -844,7 +844,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
             with self.subTest(lhs=lhs, comparison=comparison, rhs=rhs, group_instance=group_instance, expected_result=expected_result):
                 answer_store = AnswerStore({})
                 for answer in answers.values():
-                    answer_store.add(answer)
+                    answer_store.add_or_update(answer)
 
                 when = [{
                     'id': lhs.answer_id,
@@ -865,7 +865,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         }]
 
         answer_store = AnswerStore({})
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_id=answer_group_id,
             group_instance=0,
             value=10,
@@ -885,13 +885,13 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         }]
 
         answer_store = AnswerStore({})
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_id=answer_group_id,
             group_instance=0,
             group_instance_id='group-1-0',
             value=10,
         ))
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_id=answer_group_id,
             group_instance=1,
             group_instance_id='group-1-1',
@@ -926,7 +926,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
             'value': 10,
         }]
         answer_store = AnswerStore({})
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_id=ref_id,
             group_instance=0,
             value=10,
@@ -975,25 +975,25 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         }]
 
         answer_store = AnswerStore({})
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_id=answer_group_id,
             group_instance=0,
             group_instance_id='group-1-0',
             value=2,
         ))
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_id=answer_group_id,
             group_instance=1,
             group_instance_id='group-1-1',
             value=20,
         ))
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_id='other',
             group_instance=0,
             group_instance_id='group-1-0',
             value=0,
         ))
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_id='other',
             group_instance=1,
             group_instance_id='group-1-1',
@@ -1011,39 +1011,39 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         repeating_group_2_instance_id = str(uuid.uuid4())
 
         answer_store = AnswerStore({})
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_id='primary-name',
             value='Jon',
             group_instance=0,
             group_instance_id=primary_group_instance_id
         ))
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_id='repeating-anyone-else',
             answer_instance=0,
             value='Yes',
             group_instance=0,
         ))
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_id='repeating-name',
             answer_instance=0,
             value='Adam',
             group_instance=0,
             group_instance_id=repeating_group_1_instance_id
         ))
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_id='repeating-anyone-else',
             answer_instance=0,
             value='No',
             group_instance=1,
         ))
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_id='repeating-name',
             answer_instance=0,
             value='Ben',
             group_instance=1,
             group_instance_id=repeating_group_2_instance_id
         ))
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_id='repeating-anyone-else',
             answer_instance=0,
             value='No',
@@ -1081,7 +1081,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
             ]
         }
         answer_store = AnswerStore({})
-        answer_store.add(Answer(
+        answer_store.add_or_update(Answer(
             answer_id='some-answer',
             value='some value',
             group_instance=0,

--- a/tests/app/submitter/test_convert_payload_0_0_2.py
+++ b/tests/app/submitter/test_convert_payload_0_0_2.py
@@ -327,7 +327,26 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
                             'type': 'Date'
                         }
                     ]
-                },
+                }
+            ])
+
+            # When
+            answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
+
+            # Then
+            self.assertEqual(len(answer_object['data']), 1)
+
+            self.assertEqual(answer_object['data'][0]['value'], '01-01-1990')
+            self.assertEqual(answer_object['data'][0]['group_instance'], 0)
+            self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
+
+    def test_month_year_date_answer(self):
+        with self._app.test_request_context():
+            routing_path = [Location(group_id='date-group', group_instance=0, block_id='date-block')]
+            user_answer = [create_answer('single-date-answer', '01-01-1990', group_id='date-group', block_id='date-block'),
+                           create_answer('month-year-answer', '01-1990', group_id='date-group', block_id='date-block')]
+
+            questionnaire = make_schema('0.0.2', 'section-1', 'date-group', 'date-block', [
                 {
                     'id': 'month-year-question',
                     'answers': [
@@ -343,14 +362,11 @@ class TestConvertPayload002(TestConverter):  # pylint: disable=too-many-public-m
             answer_object = convert_answers(self.metadata, self.collection_metadata, QuestionnaireSchema(questionnaire), AnswerStore(user_answer), routing_path)
 
             # Then
-            self.assertEqual(len(answer_object['data']), 2)
-            self.assertEqual(answer_object['data'][0]['value'], '01-01-1990')
+            self.assertEqual(len(answer_object['data']), 1)
+
+            self.assertEqual(answer_object['data'][0]['value'], '01-1990')
             self.assertEqual(answer_object['data'][0]['group_instance'], 0)
             self.assertEqual(answer_object['data'][0]['answer_instance'], 0)
-
-            self.assertEqual(answer_object['data'][1]['value'], '01-1990')
-            self.assertEqual(answer_object['data'][1]['group_instance'], 0)
-            self.assertEqual(answer_object['data'][1]['answer_instance'], 0)
 
     def test_unit_answer(self):
         with self._app.test_request_context():

--- a/tests/app/templating/summary/test_question.py
+++ b/tests/app/templating/summary/test_question.py
@@ -44,7 +44,7 @@ class TestQuestion(AppContextTestCase):   # pylint: disable=too-many-public-meth
 
     def test_create_question_with_conditional_title(self):
         # Given
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='answer_1',
             value='Han',
         ))
@@ -82,11 +82,11 @@ class TestQuestion(AppContextTestCase):   # pylint: disable=too-many-public-meth
 
     def test_create_question_with_multiple_answers(self):
         # Given
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='answer_1',
             value='Han',
         ))
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='answer_2',
             value='Solo',
         ))
@@ -160,11 +160,11 @@ class TestQuestion(AppContextTestCase):   # pylint: disable=too-many-public-meth
 
     def test_merge_date_range_answers(self):
         # Given
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='answer_1',
             value='13/02/2016',
         ))
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='answer_2',
             value='13/09/2016',
         ))
@@ -184,19 +184,19 @@ class TestQuestion(AppContextTestCase):   # pylint: disable=too-many-public-meth
 
     def test_merge_multiple_date_range_answers(self):
         # Given
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='answer_1',
             value='13/02/2016',
         ))
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='answer_2',
             value='13/09/2016',
         ))
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='answer_3',
             value='13/03/2016',
         ))
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='answer_4',
             value='13/10/2016',
         ))
@@ -220,7 +220,7 @@ class TestQuestion(AppContextTestCase):   # pylint: disable=too-many-public-meth
 
     def test_checkbox_button_options(self):
         # Given
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='answer_1',
             value=['Light Side', 'Dark Side'],
         ))
@@ -246,7 +246,7 @@ class TestQuestion(AppContextTestCase):   # pylint: disable=too-many-public-meth
 
     def test_checkbox_button_other_option_empty(self):
         # Given
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='answer_1',
             value=['other', ''],
         ))
@@ -275,11 +275,11 @@ class TestQuestion(AppContextTestCase):   # pylint: disable=too-many-public-meth
 
     def test_checkbox_answer_with_other_value_returns_the_value(self):
         # Given
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='answer_1',
             value=['Light Side', 'Other'],
         ))
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='child_answer',
             value='Test',
         ))
@@ -315,11 +315,11 @@ class TestQuestion(AppContextTestCase):   # pylint: disable=too-many-public-meth
 
     def test_checkbox_button_other_option_text(self):
         # Given
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='answer_1',
             value=['Light Side', 'other'],
         ))
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='child_answer',
             value='Neither',
         ))
@@ -345,7 +345,7 @@ class TestQuestion(AppContextTestCase):   # pylint: disable=too-many-public-meth
 
     def test_checkbox_button_none_selected_should_be_none(self):
         # Given
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='answer_1',
             value=[],
         ))
@@ -365,7 +365,7 @@ class TestQuestion(AppContextTestCase):   # pylint: disable=too-many-public-meth
 
     def test_radio_button_other_option_empty(self):
         # Given
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='answer_1',
             value='',
         ))
@@ -391,7 +391,7 @@ class TestQuestion(AppContextTestCase):   # pylint: disable=too-many-public-meth
 
     def test_radio_button_other_option_text(self):
         # Given
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='answer_1',
             value='I want to be on the dark side',
         ))
@@ -433,11 +433,11 @@ class TestQuestion(AppContextTestCase):   # pylint: disable=too-many-public-meth
 
     def test_radio_answer_with_other_value_returns_the_value(self):
         # Given
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='answer_1',
             value='Other',
         ))
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='child_answer',
             value='Test',
         ))
@@ -468,17 +468,17 @@ class TestQuestion(AppContextTestCase):   # pylint: disable=too-many-public-meth
 
     def test_build_answers_repeating_answers(self):
         # Given
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='answer',
             value='Value',
         ))
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='answer',
             value='Value 2',
             group_instance=1,
             group_instance_id='group-1',
         ))
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='answer',
             value='Value 3',
             group_instance=2,
@@ -533,7 +533,7 @@ class TestQuestion(AppContextTestCase):   # pylint: disable=too-many-public-meth
         answer_schema = {'id': 'answer_1', 'label': 'Which side?', 'type': 'Dropdown', 'options': options}
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
 
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='answer_1',
             value='Dark Side',
         ))

--- a/tests/app/templating/test_schema_context.py
+++ b/tests/app/templating/test_schema_context.py
@@ -65,7 +65,7 @@ class TestBuildAnswersContext(TestCase):
 
     def test_build_answers(self):
         # Given
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='first_name',
             value='Joe Bloggs',
         ))
@@ -80,16 +80,16 @@ class TestBuildAnswersContext(TestCase):
 
     def test_build_answers_context_repeating_answers(self):
         # Given
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='full_name_answer',
             value='Person One',
         ))
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='full_name_answer',
             value='Person Two',
             answer_instance=1,
         ))
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='full_name_answer',
             value='Person One',
             answer_instance=2
@@ -107,7 +107,7 @@ class TestBuildAnswersContext(TestCase):
 
     def test_build_answers_single_answer_should_not_return_list(self):
         # Given
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='full_name_answer',
             value='Person One',
         ))
@@ -122,7 +122,7 @@ class TestBuildAnswersContext(TestCase):
 
     def test_build_answers_alias_for_repeating_answer_returns_list(self):
         # Given
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='repeating_answer_id',
             value='Some Value',
         ))
@@ -137,7 +137,7 @@ class TestBuildAnswersContext(TestCase):
 
     def test_alias_for_non_repeating_answer_returns_string(self):
         # Given
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='non_repeating_answer_id',
             value='Some Value',
         ))
@@ -152,7 +152,7 @@ class TestBuildAnswersContext(TestCase):
 
     def test_alias_for_answer_in_repeating_group_returns_list(self):
         # Given
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='answer_id',
             value='Some Value',
         ))
@@ -168,7 +168,7 @@ class TestBuildAnswersContext(TestCase):
     def test_maximum_answers_must_be_limited_to_system_max(self):
         # Given
         for instance in range(26):
-            self.answer_store.add(Answer(
+            self.answer_store.add_or_update(Answer(
                 answer_id='repeating_answer_id',
                 value='Some Value',
                 answer_instance=instance,
@@ -185,7 +185,7 @@ class TestBuildAnswersContext(TestCase):
 
     def test_given_quotes_in_answers_when_create_context_quotes_then_are_html_encoded(self):
         # Given
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='first_name',
             value='"'
         ))
@@ -200,7 +200,7 @@ class TestBuildAnswersContext(TestCase):
 
     def test_given_backslash_in_answers_when_create_context_then_backslash_are_escaped(self):
         # Given
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='first_name',
             value='\\'
         ))
@@ -215,11 +215,11 @@ class TestBuildAnswersContext(TestCase):
 
     def test_build_answers_excludes_answers_not_in_routing_path(self):
         # Given
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='first_name',
             value='Joe',
         ))
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='lastname',
             value='Bloggs',
         ))
@@ -237,7 +237,7 @@ class TestBuildAnswersContext(TestCase):
         correct position
         """
         # Given
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='first_name',
             value='Joe',
             group_instance=1,
@@ -258,7 +258,7 @@ class TestBuildAnswersContext(TestCase):
         correct position
         """
         # Given
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='first_name',
             value='Joe',
             answer_instance=1,
@@ -275,12 +275,12 @@ class TestBuildAnswersContext(TestCase):
 
     def test_build_answers_puts_answers_in_repeating_group(self):
         # Given
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='first_name',
             value='Bloggs',
             answer_instance=1,
         ))
-        self.answer_store.add(Answer(
+        self.answer_store.add_or_update(Answer(
             answer_id='first_name',
             value='Joe',
             answer_instance=0, # answer_instance deliberately in inverse order

--- a/tests/app/templating/test_summary_context.py
+++ b/tests/app/templating/test_summary_context.py
@@ -451,14 +451,14 @@ class TestAnswerSummaryContext(TestStandardSummaryContext):
         primary_uuid = uuid.uuid4()
         repeating_0_uuid = uuid.uuid4()
         repeating_1_uuid = uuid.uuid4()
-        self.answer_store.add(Answer('primary-first-name', 'Bob', primary_uuid, 0, 0))
-        self.answer_store.add(Answer('primary-last-name', 'Smith', primary_uuid, 0, 0))
-        self.answer_store.add(Answer('primary-anyone-else', 'Yes', primary_uuid, 0, 0))
-        self.answer_store.add(Answer('repeating-first-name', 'Mary', repeating_0_uuid, 0, 0))
-        self.answer_store.add(Answer('repeating-last-name', 'Smith', repeating_0_uuid, 0, 0))
-        self.answer_store.add(Answer('repeating-anyone-else', 'Yes', repeating_0_uuid, 0, 0))
-        self.answer_store.add(Answer('repeating-first-name', 'Sally', repeating_1_uuid, 1, 0))
-        self.answer_store.add(Answer('repeating-last-name', 'Smith', repeating_1_uuid, 1, 0))
+        self.answer_store.add_or_update(Answer('primary-first-name', 'Bob', primary_uuid, 0, 0))
+        self.answer_store.add_or_update(Answer('primary-last-name', 'Smith', primary_uuid, 0, 0))
+        self.answer_store.add_or_update(Answer('primary-anyone-else', 'Yes', primary_uuid, 0, 0))
+        self.answer_store.add_or_update(Answer('repeating-first-name', 'Mary', repeating_0_uuid, 0, 0))
+        self.answer_store.add_or_update(Answer('repeating-last-name', 'Smith', repeating_0_uuid, 0, 0))
+        self.answer_store.add_or_update(Answer('repeating-anyone-else', 'Yes', repeating_0_uuid, 0, 0))
+        self.answer_store.add_or_update(Answer('repeating-first-name', 'Sally', repeating_1_uuid, 1, 0))
+        self.answer_store.add_or_update(Answer('repeating-last-name', 'Smith', repeating_1_uuid, 1, 0))
 
         current_location = Location(
             block_id='household-summary',
@@ -476,6 +476,9 @@ class TestAnswerSummaryContext(TestStandardSummaryContext):
         self.assertTrue('icon' in context['summary'])
         self.assertEqual('person', context['summary']['icon'])
         self.assertEqual(1, len(context['summary']['groups']))
-        self.assertEqual('Bob Smith', context['summary']['groups'][0]['answers'][0]['label'])
-        self.assertEqual('Mary Smith', context['summary']['groups'][0]['answers'][1]['label'])
-        self.assertEqual('Sally Smith', context['summary']['groups'][0]['answers'][2]['label'])
+
+        summary_answers = context['summary']['groups'][0]['answers']
+        labels = [summary_answer['label'] for summary_answer in summary_answers]
+        self.assertIn('Bob Smith', labels)
+        self.assertIn('Mary Smith', labels)
+        self.assertIn('Sally Smith', labels)

--- a/tests/app/validation/test_number_range_validator.py
+++ b/tests/app/validation/test_number_range_validator.py
@@ -38,9 +38,9 @@ class TestNumberRangeValidator(unittest.TestCase):
             value='cat',
         )
 
-        self.store.add(answer1)
-        self.store.add(answer2)
-        self.store.add(answer3)
+        self.store.add_or_update(answer1)
+        self.store.add_or_update(answer2)
+        self.store.add_or_update(answer3)
 
     def tearDown(self):
         self.store.clear()

--- a/tests/integration/session/test_questionnaire_store_upgrade.py
+++ b/tests/integration/session/test_questionnaire_store_upgrade.py
@@ -99,8 +99,9 @@ class TestLogin(IntegrationTestCase):
 
         answers = dumped['answers']
 
-        # Then
-        for i in range(0, 6, 2):
-            self.assertIsNotNone(
-                answers[i]['group_instance_id']
-            )
+        for answer in answers:
+            if answer['answer_id'] in ('primary-name', 'repeating-name'):
+                # Then
+                self.assertIsNotNone(
+                    answer['group_instance_id']
+                )

--- a/tests/integration/views/test_questionnaire.py
+++ b/tests/integration/views/test_questionnaire.py
@@ -54,7 +54,7 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
             'answer_id': 'total-retail-turnover-answer',
             'answer_instance': 0,
             'value': '1000'
-        }, self.question_store.answer_store.answers)
+        }, self.question_store.answer_store)
 
     def test_update_questionnaire_store_with_default_value(self):
 
@@ -78,7 +78,7 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
             'answer_id': 'answer',
             'answer_instance': 0,
             'value': 0
-        }, self.question_store.answer_store.answers)
+        }, self.question_store.answer_store)
 
     def test_update_questionnaire_store_with_answer_data(self):
         schema = load_schema_from_params('census', 'household')
@@ -125,7 +125,7 @@ class TestQuestionnaire(IntegrationTestCase): # pylint: disable=too-many-public-
         self.assertEqual(self.question_store.completed_blocks, [location])
 
         for answer in answers:
-            self.assertIn(answer.__dict__, self.question_store.answer_store.answers)
+            self.assertIn(answer.__dict__, self.question_store.answer_store)
 
     def test_remove_empty_household_members_from_answer_store(self):
         schema = load_schema_from_params('census', 'household')


### PR DESCRIPTION
### What is the context of this PR?
My variation on https://github.com/ONSdigital/eq-survey-runner/pull/1890
Removed the answers list completly so we only hold a map.
This removed the complexity around maintaining two stores

### How to review 
Does it work? is it faster?
