### PR TITLE
Add browser caching for static assets

### DIFF
--- a/.ebextensions/enable_mod_deflate.conf
+++ b/.ebextensions/enable_mod_deflate.conf
@@ -29,3 +29,8 @@ BrowserMatch \bMSI[E] !no-gzip !gzip-only-text/html
 # Make sure proxies don't deliver the wrong content
 Header append Vary User-Agent env=!dont-vary
 </IfModule>
+
+# One day for most static assets
+<filesMatch ".(css|jpg|jpeg|png|gif|js|ico)$">
+Header set Cache-Control "max-age=86400, public"
+</filesMatch>

--- a/app/setup.py
+++ b/app/setup.py
@@ -157,8 +157,11 @@ def create_app(setting_overrides=None):  # noqa: C901  pylint: disable=too-compl
 
     @application.after_request
     def apply_caching(response):  # pylint: disable=unused-variable
-        for k, v in CACHE_HEADERS.items():
-            response.headers[k] = v
+        if 'text/html' in response.content_type:
+            for k, v in CACHE_HEADERS.items():
+                response.headers[k] = v
+        else:
+            response.headers['Cache-Control'] = 'max-age=2628000, public'
 
         return response
 

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -114,13 +114,6 @@ def before_post_submission_request():
                        session_collection_id='')
 
 
-@questionnaire_blueprint.after_request
-def add_cache_control(response):
-    response.cache_control.no_cache = True
-
-    return response
-
-
 def save_questionnaire_store(func):
     @wraps(func)
     def save_questionnaire_store_wrapper(*args, **kwargs):


### PR DESCRIPTION
### What is the context of this PR?
Allow browser to cache static assets.
A unique value is appended to the end of the url for static assets so browser cache shouldn't be an issue between application versions

### How to review 
Run functional tests and see that static assets are not being requested on every request
Run the app and check only static assets are cached.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
