### PR TITLE
Don't save state in new format as it won't work during deployment

### DIFF
--- a/app/data_model/questionnaire_store.py
+++ b/app/data_model/questionnaire_store.py
@@ -10,10 +10,8 @@ class QuestionnaireStore:
     The QuestionnaireStore is versioned to provide a way to migrate existing state. Versions are:
     1 - Reformat date answers from d/m/y to y-m-d
     2 - Add group_instance_id to all answers
-    3 - Compress state using snappy before encryption. Also removes base64 encoding and
-        unnecessary json wrapper around encrypted data.
     """
-    LATEST_VERSION = 3
+    LATEST_VERSION = 2
 
     def __init__(self, storage, version=None):
         self._storage = storage

--- a/app/storage/encrypted_questionnaire_storage.py
+++ b/app/storage/encrypted_questionnaire_storage.py
@@ -20,8 +20,8 @@ class EncryptedQuestionnaireStorage:
         self.encrypter = StorageEncryption(user_id, user_ik, pepper)
 
     def add_or_update(self, data, version):
-        compressed_data = snappy.compress(data)
-        encrypted_data = self.encrypter.encrypt_data(compressed_data)
+        encrypted_data = self.encrypter.encrypt_data(data)
+        encrypted_data = json.dumps({'data': encrypted_data})
         questionnaire_state = self._find_questionnaire_state()
         if questionnaire_state:
             logger.debug('updating questionnaire data', user_id=self._user_id)
@@ -38,7 +38,7 @@ class EncryptedQuestionnaireStorage:
         if questionnaire_state and questionnaire_state.state_data:
             version = questionnaire_state.version or 0
 
-            if version < 3:
+            if version <= 2:
                 decrypted_data = self._get_base64_encoded_data(questionnaire_state.state_data)
             else:
                 decrypted_data = self._get_snappy_compressed_data(questionnaire_state.state_data)

--- a/app/storage/storage_encryption.py
+++ b/app/storage/storage_encryption.py
@@ -50,7 +50,7 @@ class StorageEncryption:
         }
 
         jwe_token = jwe.JWE(
-            plaintext=data,
+            plaintext=base64url_encode(data),
             protected=protected_header,
             recipient=self.key,
         )

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -420,7 +420,7 @@ def submit_answers(routing_path, eq_id, form_type, schema):
     _store_submitted_time_in_session(submitted_time)
 
     if is_view_submitted_response_enabled(schema.json):
-        _store_viewable_submission(answer_store.answer_map, metadata, submitted_time)
+        _store_viewable_submission(list(answer_store), metadata, submitted_time)
 
     get_questionnaire_store(current_user.user_id, current_user.user_ik).delete()
 

--- a/tests/app/storage/test_storage_encryption.py
+++ b/tests/app/storage/test_storage_encryption.py
@@ -1,7 +1,9 @@
 from unittest import TestCase
+from jwcrypto.common import base64url_decode
 import simplejson as json
 
 from app.storage.storage_encryption import StorageEncryption
+
 
 # pylint: disable=W0212
 class TestStorageEncryption(TestCase):
@@ -52,6 +54,7 @@ class TestStorageEncryption(TestCase):
         self.assertIsInstance(encrypted_data, str)
 
         decrypted_data = self.encrypter.decrypt_data(encrypted_data)
+        decrypted_data = base64url_decode(decrypted_data.decode()).decode()
         decrypted_data = json.loads(decrypted_data)
         self.assertEqual(data, decrypted_data)
 

--- a/tests/integration/session/test_questionnaire_store_upgrade.py
+++ b/tests/integration/session/test_questionnaire_store_upgrade.py
@@ -28,16 +28,15 @@ class TestLogin(IntegrationTestCase):
 
     def test_questionnaire_store_is_upgraded(self):
         # Given
+        previous_version = QuestionnaireStore.LATEST_VERSION - 1
 
-        # Creates a QuestionnaireStore with latest version
-        self.launchSurvey('test', '0205')
+        # Creates a QuestionnaireStore with previous version
+        with patch('app.data_model.questionnaire_store.QuestionnaireStore.get_latest_version_number', return_value=previous_version):
+            self.launchSurvey('test', '0205')
 
-        # Increment LATEST_VERSION so the `upgrade` method of answer_store is called when fetching
-        # the questionnaire_store
-        next_version = QuestionnaireStore.LATEST_VERSION + 1
-        with patch('app.data_model.questionnaire_store.QuestionnaireStore.get_latest_version_number', return_value=next_version):
-            with patch('app.data_model.questionnaire_store.AnswerStore.upgrade') as upgrade:
-                self.post(action='start_questionnaire')
+        # On a subsequent request the `upgrade` method of answer_store should be called
+        with patch('app.data_model.questionnaire_store.AnswerStore.upgrade') as upgrade:
+            self.post(action='start_questionnaire')
 
         upgrade.assert_called_once()
 


### PR DESCRIPTION
### What is the context of this PR?

As there is a chance of requests going to a new version of the app
and then back to an old version during deployment, we can't persist
any format changes to state in the next release. This release should
however have all the code required to understand the new state
formats, which are:
  - Questionnaire store compressed via snappy, and base64
    encoding and json data wrapper removed
  - Removal of base64 encoding for session data
  - View submission data in answer map format

So, to be clear, anything written (questionnaire state, session or
view submission data) in this version of the app should be readable
by the currently released version (v2.73.0).