### PR TITLE
Ensure decimals places are defined for surveys that use totaliser

### DIFF
--- a/data/en/ecommerce_0001.json
+++ b/data/en/ecommerce_0001.json
@@ -1975,6 +1975,7 @@
                                     "label": "Total",
                                     "mandatory": false,
                                     "type": "Percentage",
+                                    "decimal_places": 2,
                                     "min_value": {
                                         "value": 100
                                     },

--- a/data/en/ukis_0001.json
+++ b/data/en/ukis_0001.json
@@ -4216,6 +4216,7 @@
                                     "label": "Total",
                                     "mandatory": false,
                                     "type": "Percentage",
+                                    "decimal_places": 2,
                                     "max_value": {
                                         "value": 100
                                     },

--- a/tests/app/parser/test_schemas/calculated-answer.json
+++ b/tests/app/parser/test_schemas/calculated-answer.json
@@ -82,6 +82,7 @@
                                             "mandatory": false,
                                             "q_code": "10002",
                                             "type": "Percentage",
+                                            "decimal_places": 2,
                                             "max_value": {
                                               "value": 100
                                             },


### PR DESCRIPTION
### What is the context of this PR?
To fix: https://github.com/ONSdigital/eq-survey-runner/issues/1907

Will also make a validator change to enforce this.
### How to review 
Can you proceed in the survey?

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
