### PR TITLE
Flask Babel issue with dates < 1902.

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,2 @@
+[bandit]
+exclude: /tests,/node_modules

--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -147,8 +147,10 @@ def format_date(context, value):
         date_format = 'MMMM YYYY'
     if value and re.match(r'\d{4}$', value):
         date_format = 'YYYY'
+
+    date_to_format = convert_to_datetime(value).date()
     result = "<span class='date'>{date}</span>".format(
-        date=flask_babel.format_date(convert_to_datetime(value), format=date_format))
+        date=flask_babel.format_date(date_to_format, format=date_format))
 
     return mark_safe(context, result)
 
@@ -168,7 +170,8 @@ def format_date_custom(context, value, date_format='EEEE d MMMM YYYY'):
 def format_datetime(context, value):
 
     london_date_time = datetime.strptime(value, '%Y-%m-%dT%H:%M:%S.%f')
-    formatted_date = flask_babel.format_date(london_date_time, format='d MMMM YYYY')
+    london_date = london_date_time.date()
+    formatted_date = flask_babel.format_date(london_date, format='d MMMM YYYY')
     formatted_time = flask_babel.format_time(london_date_time, format='HH:mm')
 
     result = "<span class='date'>{date}</span>".format(

--- a/application.py
+++ b/application.py
@@ -65,5 +65,5 @@ application = create_app()
 if __name__ == '__main__':
     manager = Manager(application)
     port = int(os.environ.get('PORT', 5000))
-    manager.add_command("runserver", Server(host='0.0.0.0', port=port, threaded=True))
+    manager.add_command("runserver", Server(host='0.0.0.0', port=port, threaded=True))  # nosec
     manager.run()

--- a/data/en/test_dates.json
+++ b/data/en/test_dates.json
@@ -98,7 +98,13 @@
                 "description": "",
                 "content": [{
                     "title": "",
-                    "list": ["The most recent Date Range value entered was <em>{{ max_value(answers['date-range-from-answer'], answers['date-range-to-answer'])|format_date }}</em>", "The least recent Date Range value entered was <em>{{ min_value(answers['date-range-from-answer'], answers['date-range-to-answer'])|format_date }}</em>", "The most recent of the dates <em>Date with month and year</em> and <em>Period From</em> is <em>{{ max_value(answers['date-range-from-answer'], answers['month-year-answer'])|format_date }}</em>", "The most recent of the dates <em>Single date</em> and <em>Non-mandatory date</em>: <em>{{ max_value(answers['single-date-answer'], answers['non-mandatory-date-answer']) }}</em>", "The least recent of the dates <em>Single date</em> and <em>Non-mandatory date</em> (if non-mandatory date is unset this will be blank): <em>{{ min_value(answers['single-date-answer'], answers['non-mandatory-date-answer']) }}</em>"]
+                    "list": [
+                        "The most recent Date Range value entered was <em>{{ max_value(answers['date-range-from-answer'], answers['date-range-to-answer'])|format_date }}</em>",
+                        "The least recent Date Range value entered was <em>{{ min_value(answers['date-range-from-answer'], answers['date-range-to-answer'])|format_date }}</em>",
+                        "The most recent of the dates <em>Date with month and year</em> and <em>Period From</em> is <em>{{ max_value(answers['date-range-from-answer'], answers['month-year-answer'])|format_date }}</em>",
+                        "The most recent of the dates <em>Single date</em> and <em>Non-mandatory date</em>: <em>{{ max_value(answers['single-date-answer'], answers['non-mandatory-date-answer']) }}</em>",
+                        "The least recent of the dates <em>Single date</em> and <em>Non-mandatory date</em> (if non-mandatory date is unset this will be blank): <em>{{ min_value(answers['single-date-answer'], answers['non-mandatory-date-answer']) }}</em>"
+                    ]
                 }]
             }, {
                 "type": "Summary",

--- a/tests/app/test_jinja_filters.py
+++ b/tests/app/test_jinja_filters.py
@@ -144,6 +144,19 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
         # Then
         self.assertEqual(format_value, "<span class='date'>1 January 2017</span>")
 
+    def test_format_old_date_does_not_change_timezone(self):
+        """ Flask Babel shows some strange behaviour with dates prior to 1902.
+        This appears to be because of a bug in pytz relating to 32 bit time_t types
+        To avoid it, `datetimes` are converted to `date` objects before being passed
+        to `flask_babel.format_date()`.
+        """
+        date = '1901-01-01'
+
+        with self.app_request_context('/'):
+            format_value = format_date(self.autoescape_context, date)
+
+        assert format_value.striptags() == '1 January 1901'
+
     def test_format_date_month_year(self):
         # Given
         date = '2017-01'
@@ -187,7 +200,7 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
         self.assertIsNone(format_value)
 
     def test_format_date_time_in_bst(self):
-        # Given
+        # Given a date after DST started
         date_time = '2018-03-29T11:59:13.528680'
 
         # When

--- a/tests/functional/spec/dates.spec.js
+++ b/tests/functional/spec/dates.spec.js
@@ -14,8 +14,8 @@ describe('Date checks', function() {
 
         // When dates are entered
         .setValue(DatesPage.dateRangeFromday(), 1)
-        .selectByValue(DatesPage.dateRangeFrommonth(), 3)
-        .setValue(DatesPage.dateRangeFromyear(), 2016)
+        .selectByValue(DatesPage.dateRangeFrommonth(), 1)
+        .setValue(DatesPage.dateRangeFromyear(), 1901)
 
         .setValue(DatesPage.dateRangeToday(), 3)
         .selectByValue(DatesPage.dateRangeTomonth(), 5)
@@ -34,7 +34,7 @@ describe('Date checks', function() {
         .getUrl().should.eventually.contain(SummaryPage.pageName)
 
         // Then the summary screen shows the dates entered formatted
-        .getText(SummaryPage.dateRangeFromAnswer()).should.eventually.contain('1 March 2016 to 3 May 2017')
+        .getText(SummaryPage.dateRangeFromAnswer()).should.eventually.contain('1 January 1901 to 3 May 2017')
         .getText(SummaryPage.monthYearAnswer()).should.eventually.contain('April 2018')
         .getText(SummaryPage.singleDateAnswer()).should.eventually.contain('4 January 1999')
         .getText(SummaryPage.nonMandatoryDateAnswer()).should.eventually.contain('No answer provided');


### PR DESCRIPTION
### What is the context of this PR?
The original issue stems from: [trello](https://trello.com/c/Fy8nWytY/2575-issue-piping-incorrect-date). If a date was passed to format_date before December 14 1901 then format_date would change the hour by -1, meaning that 1902 would become 1901 when piped into another question.

I originally thought we needed to set `rebase=False` on `flask_babel.format_date`, this did fix the issue, but we were not converting dates to BST anymore, breaking a test. 

Investigating further, I found that 1901 coincides with the earliest possible unix timestamp, e.g. minimum value of a signed 32 bit integer. If you run `zdump -v Europe/London` you can actually see a couple of BST transitions in 1901, which shouldn't really be there, since it was introduced in 1916. I found a few vague references to similar problems on stack overflow which suggested issues with the Olsen database (used by `pytz`).

One fix for the issue was to fork flask-babel (fork [here](https://github.com/ONSdigital/flask-babel/tree/replace-pytz-with-pendulum) can be removed if this is merged.) and replace their [use of pytz](https://github.com/python-babel/flask-babel/blob/master/flask_babel/__init__.py#L23) with [pendulum](https://github.com/sdispater/pendulum). Pendulum fixes the issue found in `pytz` with dates before 1902 (and potentially a few others). This solution is problematic because flask-babel isn't well maintained and we are unlikely to be able to merge any changes upstream. The issue would probably need to be fixed upstream in `pytz`, which lives on sourceforge and has a mailing list. 

An alternate fix is to skirt the issue in flask babel by avoiding the [`to_user_timezone`](https://github.com/python-babel/flask-babel/blob/master/flask_babel/__init__.py#L360) function in flask_babel, which is where the issue comes into play. I did this by calling `flask_babel.format_datetime` with a `date` object rather than a `datetime` object. This fixes our use of format_date and doesn't rely on maintaining a fork of flask_babel. I think it's the better solution in the short term.

As a part of this, I did have a look at replacing our use of datetime with pendulum, which on the face of it looks like it would fix some common datetime issues we have. I found that the `now()` method is a local time object and there is no `utcnow()` method, additionally, the datetime.strptime() function is not replicated exactly (different format strings etc.). Having investigated a little, I don't think there are any major advantages *for us* switching at the moment. Though it could become useful in future if we start doing complex manipulations of timezones etc.


### How to review 
Enter a date of e.g. January 1 1901 on the test_dates schema. The playback on the next page should show 1901, not December 1900. This is replicated in the functional test.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
