### PR TITLE
Update Apache timeout settings to resolve ELB timeout issues

### DIFF
--- a/app-httpd.conf
+++ b/app-httpd.conf
@@ -3,3 +3,10 @@ Alias /s /opt/python/current/app/static
 Order allow,deny
 Allow from all
 </Directory>
+
+# Recommended config from https://aws.amazon.com/premiumsupport/knowledge-center/504-error-classic/
+Timeout 65
+KeepAliveTimeout 65
+MaxKeepAliveRequests 10000
+AcceptFilter http none
+AcceptFilter https none


### PR DESCRIPTION
### What is the context of this PR?
We have seen intermittent HTTP 504 errors from the ELB in front of the Elastic Beanstalk instances in both pre-production and production environments. Amazon support have provided two possible causes:
- Cause 1: The application takes longer to respond than the configured idle timeout.
- Cause 2: Registered instances closing the connection to Elastic Load Balancing.

There are no observed instances of the application taking longer to respond than the idle timeout, so the cause is probably the Apache servers that sit behind the ELB are disconnecting before the ELB timeout. 

This pull request implements the recommended Apache settings from https://aws.amazon.com/premiumsupport/knowledge-center/504-error-classic/ to _hopefully_ resolve the issue.

### How to review 
Spin up an AWS environment, deploy runner to elastic beanstalk from this pr and run some load through survey runner. I used https://github.com/ONSdigital/census-performance-test to do this.