### PR TITLE
Remove hardcoding of trad_as_or_ru_name

### DIFF
--- a/app/storage/metadata_parser.py
+++ b/app/storage/metadata_parser.py
@@ -99,9 +99,7 @@ def _validate_metadata_values_are_valid(claims, required_metadata):
         for metadata_field in required_metadata:
             name = metadata_field['name']
             claim = claims.get(name)
-            if name == 'trad_as_or_ru_name':
-                claim = claims.get('ru_name') or claims.get('trad_as')
-            elif name not in claims:
+            if name not in claims:
                 raise InvalidTokenException('Missing required key {} from claims'.format(name))
 
             logger.debug('parsing metadata', key=name, value=claim)

--- a/app/templating/schema_context.py
+++ b/app/templating/schema_context.py
@@ -64,19 +64,9 @@ def _build_group_instances(answer_store, answer_ids_on_path):
 
 
 def build_schema_metadata(metadata, schema):
-
     schema_metadata = schema.json['metadata']
     parsed = {metadata_field['name']: json_and_html_safe(metadata[metadata_field['name']])
               for metadata_field in schema_metadata if metadata_field['name'] in metadata}
-    parsed_schema_metadata = [metadata_field['name'] for metadata_field in schema_metadata]
-    trad_as = json_and_html_safe(metadata.get('trad_as'))
-    ru_name = json_and_html_safe(metadata.get('ru_name'))
-
-    if trad_as:
-        parsed['trad_as'] = trad_as
-
-    if 'trad_as_or_ru_name' in parsed_schema_metadata:
-        parsed['trad_as_or_ru_name'] = trad_as or ru_name
 
     return parsed
 

--- a/app/templating/template_renderer.py
+++ b/app/templating/template_renderer.py
@@ -1,8 +1,8 @@
 # coding: utf-8
 
 import re
-import simplejson as json
 
+import simplejson as json
 from jinja2 import Environment
 
 import app.jinja_filters as filters
@@ -11,27 +11,31 @@ import app.jinja_filters as filters
 class TemplateRenderer:
     def __init__(self):
         env = Environment(autoescape=True)
+
+        env.filters['concatenated_list'] = filters.concatenated_list
         env.filters['format_date'] = filters.format_date
+        env.filters['format_date_custom'] = filters.format_date_custom
         env.filters['format_household_name'] = filters.format_household_member_name
         env.filters['format_household_name_possessive'] = filters.format_household_member_name_possessive
         env.filters['format_household_summary'] = filters.format_household_summary
+        env.filters['format_number'] = filters.format_number
+        env.filters['format_repeating_summary'] = filters.format_repeating_summary
         env.filters['format_unordered_list'] = filters.format_unordered_list
-        env.globals['format_unordered_list_missing_items'] = filters.format_unordered_list_missing_items
+        env.filters['get_currency_symbol'] = filters.get_currency_symbol
+
+        env.globals['calculate_offset_from_weekday_in_last_whole_week'] = filters.calculate_offset_from_weekday_in_last_whole_week
+        env.globals['calculate_years_difference'] = filters.calculate_years_difference
+        env.globals['first_non_empty_item'] = filters.first_non_empty_item
+        env.globals['format_address_list'] = filters.format_address_list
         env.globals['format_conditional_date'] = filters.format_conditional_date
         env.globals['format_currency'] = filters.format_currency
-        env.filters['format_number'] = filters.format_number
-        env.globals['format_address_list'] = filters.format_address_list
-        env.filters['get_currency_symbol'] = filters.get_currency_symbol
         env.globals['format_date_range'] = filters.format_date_range
-        env.filters['concatenated_list'] = filters.concatenated_list
-        env.globals['calculate_years_difference'] = filters.calculate_years_difference
-        env.globals['get_current_date'] = filters.get_current_date
-        env.globals['min_value'] = filters.min_value
-        env.globals['max_value'] = filters.max_value
-        env.filters['format_date_custom'] = filters.format_date_custom
         env.globals['format_date_range_no_repeated_month_year'] = filters.format_date_range_no_repeated_month_year
-        env.globals['calculate_offset_from_weekday_in_last_whole_week'] = filters.calculate_offset_from_weekday_in_last_whole_week
-        env.filters['format_repeating_summary'] = filters.format_repeating_summary
+        env.globals['format_unordered_list_missing_items'] = filters.format_unordered_list_missing_items
+        env.globals['get_current_date'] = filters.get_current_date
+        env.globals['max_value'] = filters.max_value
+        env.globals['min_value'] = filters.min_value
+
         self.environment = env
 
     def render(self, renderable, **context):

--- a/data/en/1_0005.json
+++ b/data/en/1_0005.json
@@ -26,8 +26,8 @@
         "name": "ref_p_end_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "introduction-section",
@@ -412,7 +412,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a ‘significant change’ is dependent on your own interpretation of whether there has been a significant change in {{metadata['trad_as_or_ru_name']}}\u2019s figures compared with the previous month."
+                            "description": "What constitutes a ‘significant change’ is dependent on your own interpretation of whether there has been a significant change in {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures compared with the previous month."
                         }, {
                             "description": "Also consider whether there has been a significant change from the same month in the previous year."
                         }]
@@ -783,7 +783,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a ‘significant change’ is dependent on your own interpretation of whether there has been a significant change in {{metadata['trad_as_or_ru_name']}}\u2019s figures compared with the previous month."
+                            "description": "What constitutes a ‘significant change’ is dependent on your own interpretation of whether there has been a significant change in {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures compared with the previous month."
                         }, {
                             "description": "Also consider whether there has been a significant change from the same month in the previous year."
                         }]
@@ -1145,7 +1145,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a ‘significant change’ is dependent on your own interpretation of whether there has been a significant change in {{metadata['trad_as_or_ru_name']}}\u2019s figures compared with the previous month."
+                            "description": "What constitutes a ‘significant change’ is dependent on your own interpretation of whether there has been a significant change in {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures compared with the previous month."
                         }, {
                             "description": "Also consider whether there has been a significant change from the same month in the previous year."
                         }]
@@ -1505,7 +1505,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a ‘significant change’ is dependent on your own interpretation of whether there has been a significant change in {{metadata['trad_as_or_ru_name']}}\u2019s figures compared with the previous month."
+                            "description": "What constitutes a ‘significant change’ is dependent on your own interpretation of whether there has been a significant change in {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures compared with the previous month."
                         }, {
                             "description": "Also consider whether there has been a significant change from the same month in the previous year."
                         }]
@@ -1865,7 +1865,7 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a ‘significant change’ is dependent on your own interpretation of whether there has been a significant change in {{metadata['trad_as_or_ru_name']}}\u2019s figures compared with the previous month."
+                            "description": "What constitutes a ‘significant change’ is dependent on your own interpretation of whether there has been a significant change in {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures compared with the previous month."
                         }, {
                             "description": "Also consider whether there has been a significant change from the same month in the previous year."
                         }]

--- a/data/en/1_0102.json
+++ b/data/en/1_0102.json
@@ -30,8 +30,8 @@
         "name": "ref_p_end_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "default-section",
@@ -182,7 +182,7 @@
                         "default": 0
                     }],
                     "id": "total-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}\u2019s <em>total retail turnover</em>?",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total retail turnover</em>?",
                     "type": "General"
                 }],
                 "title": "Retail Turnover"
@@ -295,13 +295,13 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
                     }],
                     "id": "significant-change-question",
-                    "title": "Did any significant changes occur to the total retail turnover for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the total retail turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "type": "General"
                 }],
                 "title": "Changes in total retail turnover",
@@ -345,7 +345,7 @@
                         "type": "Checkbox"
                     }],
                     "id": "reason-for-change-question",
-                    "title": "Please indicate the reasons for any changes in the total retail turnover for {{metadata['trad_as_or_ru_name']}}",
+                    "title": "Please indicate the reasons for any changes in the total retail turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                     "type": "General"
                 }],
                 "title": "Changes in total retail turnover"
@@ -378,7 +378,7 @@
                     }],
                     "description": "We rely on your commentary to \u2018tell the story\u2019 behind changes in figures. By commenting here it will reduce the need for us to call you.",
                     "id": "change-comment-question",
-                    "title": "Please describe the changes in total retail turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes in total retail turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "type": "General"
                 }],
                 "title": "Changes in total retail turnover"

--- a/data/en/1_0112.json
+++ b/data/en/1_0112.json
@@ -30,8 +30,8 @@
         "name": "employment_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "default-section",
@@ -203,7 +203,7 @@
                         "default": 0
                     }],
                     "id": "total-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}\u2019s <em>total retail turnover</em>?",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total retail turnover</em>?",
                     "type": "General"
                 }],
                 "title": "Retail Turnover"
@@ -303,13 +303,13 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
                     }],
                     "id": "significant-change-question",
-                    "title": "Did any significant changes occur to the total retail turnover for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the total retail turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "type": "General"
                 }],
                 "title": "Changes in total retail turnover"
@@ -359,7 +359,7 @@
                         "type": "Checkbox"
                     }],
                     "id": "reason-for-change-question",
-                    "title": "Please indicate the reasons for any changes in the total retail turnover for {{metadata['trad_as_or_ru_name']}}",
+                    "title": "Please indicate the reasons for any changes in the total retail turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                     "type": "General"
                 }],
                 "title": "Changes in total retail turnover"
@@ -399,7 +399,7 @@
                     }],
                     "description": "We rely on your commentary to \u2018tell the story\u2019 behind changes in figures. By commenting here it will reduce the need for us to call you.",
                     "id": "change-comment-question",
-                    "title": "Please describe the changes in total retail turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes in total retail turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "type": "General"
                 }],
                 "title": "Changes in total retail turnover"
@@ -426,7 +426,7 @@
                     }],
                     "description": "<p>An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.</p>",
                     "id": "total-number-employees-question",
-                    "title": "On {{metadata['employment_date']|format_date}} what was the number of employees for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "On {{metadata['employment_date']|format_date}} what was the number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "type": "General"
                 }],
                 "title": "Employees"
@@ -457,7 +457,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-zero-employees-question",
-                    "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{metadata['trad_as_or_ru_name']}} was <em>0</em>, is this correct?"
+                    "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} was <em>0</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {

--- a/data/en/1_0203.json
+++ b/data/en/1_0203.json
@@ -30,8 +30,8 @@
         "name": "ref_p_end_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "default-section",
@@ -218,7 +218,7 @@
                     }],
                     "description": "",
                     "id": "total-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}\u2019s <em>total retail turnover</em>?",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total retail turnover</em>?",
                     "type": "General"
                 }],
                 "title": "Retail Turnover"
@@ -483,13 +483,13 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
                     }],
                     "id": "significant-change-question",
-                    "title": "Did any significant changes occur to the total retail turnover for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the total retail turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "type": "General"
                 }],
                 "title": "Changes in total retail turnover",
@@ -535,7 +535,7 @@
                         "type": "Checkbox"
                     }],
                     "id": "reason-for-change-question",
-                    "title": "Please indicate the reasons for any changes in the total retail turnover for {{metadata['trad_as_or_ru_name']}}",
+                    "title": "Please indicate the reasons for any changes in the total retail turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                     "type": "General"
                 }],
                 "title": "Changes in total retail turnover"
@@ -568,7 +568,7 @@
                     }],
                     "description": "We rely on your commentary to \u2018tell the story\u2019 behind changes in figures. By commenting here it will reduce the need for us to call you.",
                     "id": "change-comment-question",
-                    "title": "Please describe the changes in total retail turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes in total retail turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "type": "General"
                 }],
                 "title": "Changes in total retail turnover"

--- a/data/en/1_0205.json
+++ b/data/en/1_0205.json
@@ -30,8 +30,8 @@
         "name": "ref_p_end_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "default-section",
@@ -227,7 +227,7 @@
                     }],
                     "description": "",
                     "id": "total-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}\u2019s <em>total retail turnover</em>?",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total retail turnover</em>?",
                     "type": "General"
                 }],
                 "title": "Retail Turnover"
@@ -515,13 +515,13 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
                     }],
                     "id": "significant-change-question",
-                    "title": "Did any significant changes occur to the total retail turnover for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the total retail turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "type": "General"
                 }],
                 "title": "Changes in total retail turnover",
@@ -566,7 +566,7 @@
                         "type": "Checkbox"
                     }],
                     "id": "reason-for-change-question",
-                    "title": "Please indicate the reasons for any changes in the total retail turnover for {{metadata['trad_as_or_ru_name']}}",
+                    "title": "Please indicate the reasons for any changes in the total retail turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                     "type": "General"
                 }],
                 "title": "Changes in total retail turnover"
@@ -599,7 +599,7 @@
                     }],
                     "description": "We rely on your commentary to \u2018tell the story\u2019 behind changes in figures. By commenting here it will reduce the need for us to call you.",
                     "id": "change-comment-question",
-                    "title": "Please describe the changes in total retail turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes in total retail turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "type": "General"
                 }],
                 "title": "Changes in total retail turnover"

--- a/data/en/1_0213.json
+++ b/data/en/1_0213.json
@@ -30,8 +30,8 @@
         "name": "employment_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "default-section",
@@ -239,7 +239,7 @@
                         "default": 0
                     }],
                     "id": "total-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}\u2019s <em>total retail turnover</em>?",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total retail turnover</em>?",
                     "type": "General"
                 }],
                 "title": "Retail Turnover"
@@ -484,13 +484,13 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
                     }],
                     "id": "significant-change-question",
-                    "title": "Did any significant changes occur to the total retail turnover for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the total retail turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "type": "General"
                 }],
                 "title": "Changes in total retail turnover",
@@ -542,7 +542,7 @@
                         "type": "Checkbox"
                     }],
                     "id": "reason-for-change-question",
-                    "title": "Please indicate the reasons for any changes in the total retail turnover for {{metadata['trad_as_or_ru_name']}}",
+                    "title": "Please indicate the reasons for any changes in the total retail turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                     "type": "General"
                 }],
                 "title": "Changes in total retail turnover"
@@ -582,7 +582,7 @@
                     }],
                     "description": "We rely on your commentary to \u2018tell the story\u2019 behind changes in figures. By commenting here it will reduce the need for us to call you.",
                     "id": "change-comment-question",
-                    "title": "Please describe the changes in total retail turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes in total retail turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "type": "General"
                 }],
                 "title": "Changes in total retail turnover"
@@ -609,7 +609,7 @@
                     }],
                     "description": "<p>An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.</p>",
                     "id": "total-number-employees-question",
-                    "title": "On {{metadata['employment_date']|format_date}} what was the number of employees for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "On {{metadata['employment_date']|format_date}} what was the number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "type": "General"
                 }],
                 "title": "Employees"
@@ -640,7 +640,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-zero-employees-question",
-                    "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{metadata['trad_as_or_ru_name']}} was <em>0</em>, is this correct?"
+                    "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} was <em>0</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {

--- a/data/en/1_0215.json
+++ b/data/en/1_0215.json
@@ -30,8 +30,8 @@
         "name": "employment_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "default-section",
@@ -248,7 +248,7 @@
                         "default": 0
                     }],
                     "id": "total-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}\u2019s <em>total retail turnover</em>?",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total retail turnover</em>?",
                     "type": "General"
                 }],
                 "title": "Retail Turnover"
@@ -538,13 +538,13 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
                     }],
                     "id": "significant-change-question",
-                    "title": "Did any significant changes occur to the total retail turnover for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the total retail turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "type": "General"
                 }],
                 "title": "Changes in total retail turnover",
@@ -589,7 +589,7 @@
                         "type": "Checkbox"
                     }],
                     "id": "reason-for-change-question",
-                    "title": "Please indicate the reasons for any changes in the total retail turnover for {{metadata['trad_as_or_ru_name']}}",
+                    "title": "Please indicate the reasons for any changes in the total retail turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                     "type": "General"
                 }],
                 "title": "Changes in total retail turnover"
@@ -625,7 +625,7 @@
                     }],
                     "description": "We rely on your commentary to \u2018tell the story\u2019 behind changes in figures. By commenting here it will reduce the need for us to call you.",
                     "id": "change-comment-question",
-                    "title": "Please describe the changes in total retail turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes in total retail turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "type": "General"
                 }],
                 "title": "Changes in total retail turnover"
@@ -652,7 +652,7 @@
                     }],
                     "description": "<p>An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.</p>",
                     "id": "total-number-employees-question",
-                    "title": "On {{metadata['employment_date']|format_date}} what was the number of employees for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "On {{metadata['employment_date']|format_date}} what was the number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "type": "General"
                 }],
                 "title": "Employees"
@@ -683,7 +683,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-zero-employees-question",
-                    "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{metadata['trad_as_or_ru_name']}} was <em>0</em>, is this correct?"
+                    "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} was <em>0</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {

--- a/data/en/2_0001.json
+++ b/data/en/2_0001.json
@@ -18,8 +18,8 @@
         "name": "ref_p_start_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "default-section",
@@ -73,7 +73,7 @@
                         }]
                     },
                     "id": "number-of-employees-total-question",
-                    "title": "On {{metadata['ref_p_start_date']|format_date}}, what was the number of employees for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "On {{metadata['ref_p_start_date']|format_date}}, what was the number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "type": "General"
                 }],
                 "title": "Quarterly Business Survey",
@@ -105,7 +105,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-zero-employees-question",
-                    "title": "On {{metadata['ref_p_start_date']|format_date}}, the number of employees for {{metadata['trad_as_or_ru_name']}} was <em>0</em>, is this correct?"
+                    "title": "On {{metadata['ref_p_start_date']|format_date}}, the number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} was <em>0</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {

--- a/data/en/ecommerce_0041.json
+++ b/data/en/ecommerce_0041.json
@@ -27,8 +27,8 @@
             "validator": "string"
         },
         {
-            "name": "trad_as_or_ru_name",
-            "validator": "string"
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "title": "E-commerce",
@@ -116,7 +116,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question1355",
-                            "title": "Does {{ metadata['trad_as_or_ru_name'] }} use computers?",
+                            "title": "Does {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} use computers?",
                             "guidance": {
                                 "content": [{
                                         "title": "Include"
@@ -238,7 +238,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question1358",
-                            "title": "Does {{ metadata['trad_as_or_ru_name'] }} employ ICT or IT specialists?",
+                            "title": "Does {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} employ ICT or IT specialists?",
                             "definitions": [{
                                 "title": "Definition of ICT/IT",
                                 "content": [{
@@ -332,7 +332,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question1360",
-                            "title": "During 2018, did {{ metadata['trad_as_or_ru_name'] }} recruit or try to recruit ICT or IT specialists?",
+                            "title": "During 2018, did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} recruit or try to recruit ICT or IT specialists?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -435,7 +435,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question1362",
-                            "title": "Does {{ metadata['trad_as_or_ru_name'] }} have internet access?",
+                            "title": "Does {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} have internet access?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -527,7 +527,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question1364",
-                            "title": "Does {{ metadata['trad_as_or_ru_name'] }} use a fixed broadband connection to the internet, for example DSL (ADSL, SDSL, VDSL), fibre optic technology (FTTP), cable technology?",
+                            "title": "Does {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} use a fixed broadband connection to the internet, for example DSL (ADSL, SDSL, VDSL), fibre optic technology (FTTP), cable technology?",
                             "guidance": {
                                 "content": [{
                                     "title": "Include public Wi-Fi "
@@ -614,7 +614,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question1366",
-                            "title": "Does {{ metadata['trad_as_or_ru_name'] }} provide the people employed in the business with portable devices that allow a mobile telephone network connection to the internet for business purposes?",
+                            "title": "Does {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} provide the people employed in the business with portable devices that allow a mobile telephone network connection to the internet for business purposes?",
                             "guidance": {
                                 "content": [{
                                         "title": "Include"
@@ -705,7 +705,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question1368",
-                            "title": "Does {{ metadata['trad_as_or_ru_name'] }} have a website, either it’s own or third party?",
+                            "title": "Does {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} have a website, either it’s own or third party?",
                             "guidance": {
                                 "content": [{
                                     "title": "Exclude any online directory listings"
@@ -863,7 +863,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question1370",
-                            "title": "Which social media does {{ metadata['trad_as_or_ru_name'] }} use for purposes other than posting paid adverts?",
+                            "title": "Which social media does {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} use for purposes other than posting paid adverts?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -1089,7 +1089,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question1388",
-                            "title": "Does {{ metadata['trad_as_or_ru_name'] }} use an Enterprise Resource Planning (ERP) software package?",
+                            "title": "Does {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} use an Enterprise Resource Planning (ERP) software package?",
                             "description": "",
                             "type": "General",
                             "definitions": [{
@@ -1122,7 +1122,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question1885",
-                            "title": "Does {{ metadata['trad_as_or_ru_name'] }} use Customer Relationship Management (CRM) software to <em>collect, store and make information available about customers with other internal systems</em>?",
+                            "title": "Does {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} use Customer Relationship Management (CRM) software to <em>collect, store and make information available about customers with other internal systems</em>?",
                             "description": "",
                             "type": "General",
                             "definitions": [{
@@ -1207,7 +1207,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question1390",
-                            "title": "Which ICT security <em>measures</em> does {{ metadata['trad_as_or_ru_name'] }} use?",
+                            "title": "Which ICT security <em>measures</em> does {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} use?",
                             "description": "",
                             "type": "General",
                             "definitions": [{
@@ -1418,7 +1418,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question1887",
-                            "title": "During 2018, did {{ metadata['trad_as_or_ru_name'] }} make it’s employees aware of their obligations in ICT security issues by <em>voluntary training or internally available information</em>?",
+                            "title": "During 2018, did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} make it’s employees aware of their obligations in ICT security issues by <em>voluntary training or internally available information</em>?",
                             "description": "For example, information on the intranet.",
                             "type": "General",
                             "answers": [{
@@ -1499,7 +1499,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question1392",
-                            "title": "Who carries out the ICT security related activities in {{ metadata['trad_as_or_ru_name'] }}?",
+                            "title": "Who carries out the ICT security related activities in {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                             "guidance": {
                                 "content": [{
                                     "title": "Exclude upgrades of pre-packaged software"
@@ -1596,7 +1596,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question1394",
-                            "title": "When was {{ metadata['trad_as_or_ru_name'] }}’s ICT security policy defined or most recently reviewed?",
+                            "title": "When was {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s ICT security policy defined or most recently reviewed?",
                             "description": "For example, risk assessment, evaluation of ICT security incidents etc.",
                             "type": "General",
                             "answers": [{
@@ -1708,7 +1708,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question1396",
-                            "title": "Does {{ metadata['trad_as_or_ru_name'] }} have insurance covering ICT security risks, threats, or incidents?",
+                            "title": "Does {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} have insurance covering ICT security risks, threats, or incidents?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -1767,7 +1767,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question1397",
-                            "title": "During 2018, did {{ metadata['trad_as_or_ru_name'] }} receive any orders from customers for goods or services via a website or ‘app’?",
+                            "title": "During 2018, did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} receive any orders from customers for goods or services via a website or ‘app’?",
                             "guidance": {
                                 "content": [{
                                         "title": "Include"
@@ -1911,7 +1911,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question1400",
-                            "title": "During 2018 via which websites or ‘apps’ did {{ metadata['trad_as_or_ru_name'] }} receive orders for goods or services?",
+                            "title": "During 2018 via which websites or ‘apps’ did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} receive orders for goods or services?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -1991,7 +1991,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question1402",
-                            "title": "From which geographical areas did {{ metadata['trad_as_or_ru_name'] }} receive orders for goods or services placed via a website or ‘app’ in 2018?",
+                            "title": "From which geographical areas did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} receive orders for goods or services placed via a website or ‘app’ in 2018?",
                             "description": "",
                             "type": "General",
                             "definitions": [{
@@ -2144,7 +2144,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question1404",
-                            "title": "During 2018, did {{ metadata['trad_as_or_ru_name'] }} receive any orders from customers for goods or services via EDI type messages?",
+                            "title": "During 2018, did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} receive any orders from customers for goods or services via EDI type messages?",
                             "guidance": {
                                 "content": [{
                                         "title": "Include"

--- a/data/en/mbs_0106.json
+++ b/data/en/mbs_0106.json
@@ -27,8 +27,8 @@
         "name": "ref_p_end_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "section",
@@ -178,7 +178,7 @@
                         "mandatory": true
                     }],
                     "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}\u2019s <em>total turnover</em>, excluding VAT?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total turnover</em>, excluding VAT?"
                 }],
                 "title": "Total turnover"
             }, {
@@ -221,12 +221,12 @@
                 "id": "changes-in-total-turnover-block",
                 "type": "Question",
                 "questions": [{
-                    "title": "Did any significant changes occur to the total turnover for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "id": "changes-in-total-turnover-question",
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
@@ -271,7 +271,7 @@
                 "id": "changes-in-total-turnover-block-2",
                 "type": "Question",
                 "questions": [{
-                    "title": "Please indicate the reasons for any changes in the total turnover for {{metadata['trad_as_or_ru_name']}}",
+                    "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                     "answers": [{
                         "options": [{
                             "q_code": "146a",
@@ -317,7 +317,7 @@
                 "questions": [{
                     "type": "General",
                     "id": "changes-in-total-turnover-question-3",
-                    "title": "Please describe the changes in total turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "answers": [{
                         "guidance": {
                             "hide_guidance": "Hide examples of commentary on changes to turnover",

--- a/data/en/mbs_0111.json
+++ b/data/en/mbs_0111.json
@@ -29,8 +29,8 @@
         "name": "ref_p_end_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "section",
@@ -180,7 +180,7 @@
                         "mandatory": true
                     }],
                     "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}\u2019s <em>total turnover</em>, excluding VAT?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total turnover</em>, excluding VAT?"
                 }],
                 "title": "Total Turnover"
             }, {
@@ -223,12 +223,12 @@
                 "id": "changes-in-turnover-block",
                 "type": "Question",
                 "questions": [{
-                    "title": "Did any significant changes occur to the total turnover for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "id": "changes-in-turnover-question",
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
@@ -273,7 +273,7 @@
                 "id": "changes-in-turnover-block-2",
                 "type": "Question",
                 "questions": [{
-                    "title": "Please indicate the reasons for any changes in the total turnover for {{metadata['trad_as_or_ru_name']}}",
+                    "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                     "answers": [{
                         "options": [{
                             "q_code": "146a",
@@ -319,7 +319,7 @@
                 "questions": [{
                     "type": "General",
                     "id": "changes-in-turnover-question-3",
-                    "title": "Please describe the changes in total turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "answers": [{
                         "guidance": {
                             "hide_guidance": "Hide examples of commentary on changes to total turnover",

--- a/data/en/mbs_0117.json
+++ b/data/en/mbs_0117.json
@@ -28,8 +28,8 @@
         "name": "ref_p_end_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "section",
@@ -185,7 +185,7 @@
                         "mandatory": true
                     }],
                     "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}\u2019s <em>turnover</em>, excluding VAT?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>turnover</em>, excluding VAT?"
                 }],
                 "title": "Turnover"
             }, {
@@ -247,12 +247,12 @@
                 "id": "changes-in-turnover-block",
                 "type": "Question",
                 "questions": [{
-                    "title": "Did any significant changes occur to the turnover for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "id": "changes-in-turnover-question",
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
@@ -297,7 +297,7 @@
                 "id": "changes-in-turnover-block-2",
                 "type": "Question",
                 "questions": [{
-                    "title": "Please indicate the reasons for any changes in the turnover for {{metadata['trad_as_or_ru_name']}}",
+                    "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                     "answers": [{
                         "options": [{
                             "q_code": "146a",
@@ -343,7 +343,7 @@
                 "questions": [{
                     "type": "General",
                     "id": "changes-in-turnover-question-3",
-                    "title": "Please describe the changes in turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "answers": [{
                         "guidance": {
                             "hide_guidance": "Hide examples of commentary on changes to turnover",

--- a/data/en/mbs_0123.json
+++ b/data/en/mbs_0123.json
@@ -29,8 +29,8 @@
         "name": "ref_p_end_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "section",
@@ -166,7 +166,7 @@
                     "description": "For example, as a travel agent, where you do not hold title to goods/services",
                     "id": "commission-and-fees-question",
                     "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}\u2019s <em>commission and fees</em>, excluding VAT?",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>commission and fees</em>, excluding VAT?",
                     "answers": [{
                         "id": "commission-and-fees-answer",
                         "label": "Total commission and fees excluding VAT",
@@ -228,7 +228,7 @@
                     "id": "sales-on-own-account-question",
                     "type": "General",
                     "description": "For example, as a tour operator",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}\u2019s <em>sales on own account and turnover from other activities</em>, excluding VAT?",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>sales on own account and turnover from other activities</em>, excluding VAT?",
                     "answers": [{
                         "id": "sales-on-own-account-answer",
                         "label": "Total Sales on own account and turnover from other activities  excluding VAT",
@@ -244,12 +244,12 @@
                 "id": "changes-block",
                 "type": "Question",
                 "questions": [{
-                    "title": "Did any significant changes occur to the figures provided for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the figures provided for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "id": "changes-question",
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
@@ -294,7 +294,7 @@
                 "id": "changes-block-2",
                 "type": "Question",
                 "questions": [{
-                    "title": "Please indicate the reasons for any changes in the turnover for {{metadata['trad_as_or_ru_name']}}",
+                    "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                     "type": "General",
                     "id": "changes-question-2",
                     "answers": [{
@@ -340,7 +340,7 @@
                 "questions": [{
                     "type": "General",
                     "id": "changes-question-3",
-                    "title": "Please describe the changes in turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "answers": [{
                         "guidance": {
                             "hide_guidance": "Hide examples of commentary on changes to turnover",

--- a/data/en/mbs_0158.json
+++ b/data/en/mbs_0158.json
@@ -32,8 +32,8 @@
         "name": "employment_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "section",
@@ -187,7 +187,7 @@
                 "title": "Total turnover",
                 "questions": [{
                     "type": "General",
-                    "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}\u2019s <em>total turnover</em>, excluding VAT?",
+                    "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total turnover</em>, excluding VAT?",
                     "guidance": {
                         "content": [{
                             "title": "Include:",
@@ -251,7 +251,7 @@
                 "type": "Question",
                 "questions": [{
                     "id": "number-of-employees-total-question",
-                    "title": "On {{metadata['employment_date']|format_date}}, what was the number of employees for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "On {{metadata['employment_date']|format_date}}, what was the number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "type": "General",
                     "description": "An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.",
                     "answers": [{
@@ -286,7 +286,7 @@
                 "questions": [{
                     "type": "General",
                     "id": "confirm-zero-employees-question",
-                    "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{metadata['trad_as_or_ru_name']}} was <em>0</em>, is this correct?",
+                    "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} was <em>0</em>, is this correct?",
                     "answers": [{
                         "type": "Radio",
                         "id": "confirm-zero-employees-answer",
@@ -387,12 +387,12 @@
                 "title": "Changes in total turnover",
                 "questions": [{
                     "type": "General",
-                    "title": "Did any significant changes occur to the total turnover for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "id": "changes-in-turnover-question",
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
@@ -438,7 +438,7 @@
                 "questions": [{
                     "type": "General",
                     "id": "changes-in-turnover-question-2",
-                    "title": "Please indicate the reasons for any changes in the total turnover for {{metadata['trad_as_or_ru_name']}}",
+                    "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                     "answers": [{
                         "id": "changes-in-turnover-answer-2",
                         "type": "Checkbox",
@@ -481,7 +481,7 @@
                 "questions": [{
                     "type": "General",
                     "id": "changes-in-turnover-question-3",
-                    "title": "Please describe the changes in total turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "description": "<p>We rely on your commentary to \u2018tell the story\u2019 behind changes in figures. By commenting here it will reduce the need for us to call you.</p>",
                     "answers": [{
                         "type": "TextArea",

--- a/data/en/mbs_0161.json
+++ b/data/en/mbs_0161.json
@@ -32,8 +32,8 @@
         "name": "employment_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "section",
@@ -206,7 +206,7 @@
                         "mandatory": true
                     }],
                     "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}\u2019s <em>total turnover</em>, excluding VAT?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total turnover</em>, excluding VAT?"
                 }],
                 "title": "Total Turnover"
             }, {
@@ -267,7 +267,7 @@
                         }]
                     },
                     "id": "number-of-employees-total-question",
-                    "title": "On {{metadata['employment_date']|format_date}}, what was the number of employees for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "On {{metadata['employment_date']|format_date}}, what was the number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "type": "General"
                 }],
                 "title": "Employees",
@@ -299,7 +299,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-zero-employees-question",
-                    "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{metadata['trad_as_or_ru_name']}} was <em>0</em>, is this correct?"
+                    "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} was <em>0</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {
@@ -385,12 +385,12 @@
                 "id": "changes-in-turnover-block",
                 "type": "Question",
                 "questions": [{
-                    "title": "Did any significant changes occur to the total turnover for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "id": "changes-in-turnover-question",
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
@@ -435,7 +435,7 @@
                 "id": "changes-in-turnover-block-2",
                 "type": "Question",
                 "questions": [{
-                    "title": "Please indicate the reasons for any changes in the total turnover for {{metadata['trad_as_or_ru_name']}}",
+                    "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                     "answers": [{
                         "options": [{
                             "q_code": "146a",
@@ -481,7 +481,7 @@
                 "questions": [{
                     "type": "General",
                     "id": "changes-in-turnover-question-3",
-                    "title": "Please describe the changes in total turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "answers": [{
                         "guidance": {
                             "hide_guidance": "Hide examples of commentary on changes to total turnover",

--- a/data/en/mbs_0167.json
+++ b/data/en/mbs_0167.json
@@ -31,8 +31,8 @@
         "name": "employment_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "section",
@@ -211,7 +211,7 @@
                         "mandatory": true
                     }],
                     "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}\u2019s <em>turnover</em>, excluding VAT?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>turnover</em>, excluding VAT?"
                 }],
                 "title": "Turnover"
             }, {
@@ -291,7 +291,7 @@
                         }]
                     },
                     "id": "number-of-employees-total-question",
-                    "title": "On {{metadata['employment_date']|format_date}}, what was the number of employees for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "On {{metadata['employment_date']|format_date}}, what was the number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "type": "General"
                 }],
                 "routing_rules": [{
@@ -337,7 +337,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-zero-employees-question",
-                    "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{metadata['trad_as_or_ru_name']}} was <em>0</em>, is this correct?"
+                    "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} was <em>0</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {
@@ -423,12 +423,12 @@
                 "id": "changes-in-turnover-block",
                 "type": "Question",
                 "questions": [{
-                    "title": "Did any significant changes occur to the turnover for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "id": "changes-in-turnover-question",
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
@@ -473,7 +473,7 @@
                 "id": "changes-in-turnover-block-2",
                 "type": "Question",
                 "questions": [{
-                    "title": "Please indicate the reasons for any changes in the turnover for {{metadata['trad_as_or_ru_name']}}",
+                    "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                     "answers": [{
                         "options": [{
                             "q_code": "146a",
@@ -519,7 +519,7 @@
                 "questions": [{
                     "type": "General",
                     "id": "changes-in-turnover-question-3",
-                    "title": "Please describe the changes in turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "answers": [{
                         "guidance": {
                             "hide_guidance": "Hide examples of commentary on changes to turnover",

--- a/data/en/mbs_0173.json
+++ b/data/en/mbs_0173.json
@@ -32,8 +32,8 @@
         "name": "employment_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "section",
@@ -188,7 +188,7 @@
                 "questions": [{
                     "id": "commission-and-fees-question",
                     "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}\u2019s <em>commission and fees</em>, excluding VAT?",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>commission and fees</em>, excluding VAT?",
                     "description": "For example, as a travel agent, where you do not hold title to goods/services",
                     "answers": [{
                         "id": "commission-and-fees-answer",
@@ -251,7 +251,7 @@
                     },
                     "id": "sales-on-own-account-question",
                     "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}\u2019s <em>sales on own account and turnover from other activities</em>, excluding VAT?",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>sales on own account and turnover from other activities</em>, excluding VAT?",
                     "answers": [{
                         "id": "sales-on-own-account-answer",
                         "label": "Total Sales on own account and turnover from other activities  excluding VAT",
@@ -279,7 +279,7 @@
                     },
                     "id": "employees-question",
                     "type": "General",
-                    "title": "On {{metadata['employment_date']|format_date}}, what was the number of employees for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "On {{metadata['employment_date']|format_date}}, what was the number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "description": "An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.",
                     "answers": [{
                         "id": "number-of-employees-total",
@@ -317,7 +317,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-zero-employees-question",
-                    "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{metadata['trad_as_or_ru_name']}} was <em>0</em>, is this correct?"
+                    "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} was <em>0</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {
@@ -403,12 +403,12 @@
                 "id": "changes-block",
                 "type": "Question",
                 "questions": [{
-                    "title": "Did any significant changes occur to the figures provided for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the figures provided for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "id": "changes-question",
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
@@ -453,7 +453,7 @@
                 "id": "changes-block-2",
                 "type": "Question",
                 "questions": [{
-                    "title": "Please indicate the reasons for any changes in the turnover for {{metadata['trad_as_or_ru_name']}}",
+                    "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                     "type": "General",
                     "id": "changes-question-2",
                     "answers": [{
@@ -499,7 +499,7 @@
                 "questions": [{
                     "type": "General",
                     "id": "changes-question-3",
-                    "title": "Please describe the changes in turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "answers": [{
                         "guidance": {
                             "hide_guidance": "Hide examples of commentary on changes to turnover",

--- a/data/en/mbs_0201.json
+++ b/data/en/mbs_0201.json
@@ -28,8 +28,8 @@
         "name": "ref_p_end_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "section",
@@ -187,7 +187,7 @@
                         "default": 0
                     }],
                     "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}\u2019s <em>total turnover</em>, excluding VAT?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total turnover</em>, excluding VAT?"
                 }],
                 "routing_rules": [{
                     "goto": {
@@ -307,12 +307,12 @@
                 "id": "changes-in-turnover-block",
                 "type": "Question",
                 "questions": [{
-                    "title": "Did any significant changes occur to the total turnover for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "id": "changes-in-turnover-question",
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
@@ -357,7 +357,7 @@
                 "id": "changes-in-turnover-block-2",
                 "type": "Question",
                 "questions": [{
-                    "title": "Please indicate the reasons for any changes in the total turnover for {{metadata['trad_as_or_ru_name']}}",
+                    "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                     "answers": [{
                         "options": [{
                             "q_code": "146a",
@@ -403,7 +403,7 @@
                 "questions": [{
                     "type": "General",
                     "id": "changes-in-turnover-question-3",
-                    "title": "Please describe the changes in total turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "answers": [{
                         "guidance": {
                             "hide_guidance": "Hide examples of commentary on changes to total turnover",

--- a/data/en/mbs_0202.json
+++ b/data/en/mbs_0202.json
@@ -28,8 +28,8 @@
         "name": "ref_p_end_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "section",
@@ -187,7 +187,7 @@
                         "default": 0
                     }],
                     "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}\u2019s <em>total turnover</em>, excluding VAT?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total turnover</em>, excluding VAT?"
                 }],
                 "routing_rules": [{
                     "goto": {
@@ -307,12 +307,12 @@
                 "id": "changes-in-turnover-block",
                 "type": "Question",
                 "questions": [{
-                    "title": "Did any significant changes occur to the total turnover for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "id": "changes-in-turnover-question",
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
@@ -357,7 +357,7 @@
                 "id": "changes-in-turnover-block-2",
                 "type": "Question",
                 "questions": [{
-                    "title": "Please indicate the reasons for any changes in the total turnover for {{metadata['trad_as_or_ru_name']}}",
+                    "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                     "answers": [{
                         "options": [{
                             "q_code": "146a",
@@ -403,7 +403,7 @@
                 "questions": [{
                     "type": "General",
                     "id": "changes-in-turnover-question-3",
-                    "title": "Please describe the changes in total turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "answers": [{
                         "guidance": {
                             "hide_guidance": "Hide examples of commentary on changes to total turnover",

--- a/data/en/mbs_0203.json
+++ b/data/en/mbs_0203.json
@@ -27,8 +27,8 @@
         "name": "ref_p_end_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "section",
@@ -145,7 +145,7 @@
                 "questions": [{
                     "id": "water-volume-question",
                     "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the total volume of {{metadata['trad_as_or_ru_name']}}\u2019s <em>potable water that was supplied to customers</em>, in megalitres?",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the total volume of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>potable water that was supplied to customers</em>, in megalitres?",
                     "answers": [{
                         "id": "water-volume",
                         "mandatory": true,
@@ -163,11 +163,11 @@
                 "questions": [{
                     "type": "General",
                     "id": "significant-change-question",
-                    "title": "Did any significant changes occur to the figures provided for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the figures provided for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
@@ -214,7 +214,7 @@
                     }],
                     "description": "We rely on your commentary to \u2018tell the story\u2019 behind changes in figures. By commenting here it will reduce the need for us to call you.",
                     "id": "change-comment-question",
-                    "title": "Please describe the changes for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "type": "General"
                 }],
                 "title": "Significant changes"

--- a/data/en/mbs_0204.json
+++ b/data/en/mbs_0204.json
@@ -27,8 +27,8 @@
         "name": "ref_p_end_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "section",
@@ -145,7 +145,7 @@
                 "questions": [{
                     "id": "water-volume-question",
                     "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the total volume of {{metadata['trad_as_or_ru_name']}}\u2019s <em>potable water that was supplied to customers</em>, in megalitres?",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the total volume of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>potable water that was supplied to customers</em>, in megalitres?",
                     "answers": [{
                         "id": "water-volume",
                         "mandatory": true,
@@ -163,11 +163,11 @@
                 "questions": [{
                     "type": "General",
                     "id": "significant-change-question",
-                    "title": "Did any significant changes occur to the figures provided for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the figures provided for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
@@ -214,7 +214,7 @@
                     }],
                     "description": "We rely on your commentary to \u2018tell the story\u2019 behind changes in figures. By commenting here it will reduce the need for us to call you.",
                     "id": "change-comment-question",
-                    "title": "Please describe the changes for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "type": "General"
                 }],
                 "title": "Significant changes"

--- a/data/en/mbs_0205.json
+++ b/data/en/mbs_0205.json
@@ -27,8 +27,8 @@
         "name": "ref_p_end_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "section",
@@ -186,7 +186,7 @@
                         "mandatory": true
                     }],
                     "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}\u2019s <em>turnover</em>, excluding VAT?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>turnover</em>, excluding VAT?"
                 }],
                 "title": "Turnover"
             }, {
@@ -273,12 +273,12 @@
                 "id": "changes-in-turnover-block",
                 "type": "Question",
                 "questions": [{
-                    "title": "Did any significant changes occur to the turnover for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "id": "changes-in-turnover-question",
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
@@ -323,7 +323,7 @@
                 "id": "changes-in-turnover-block-2",
                 "type": "Question",
                 "questions": [{
-                    "title": "Please indicate the reasons for any changes in the turnover for {{metadata['trad_as_or_ru_name']}}",
+                    "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                     "answers": [{
                         "options": [{
                             "q_code": "146a",
@@ -369,7 +369,7 @@
                 "questions": [{
                     "type": "General",
                     "id": "changes-in-turnover-question-3",
-                    "title": "Please describe the changes in turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "answers": [{
                         "guidance": {
                             "hide_guidance": "Hide examples of commentary on changes to turnover",

--- a/data/en/mbs_0216.json
+++ b/data/en/mbs_0216.json
@@ -27,8 +27,8 @@
         "name": "ref_p_end_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "section",
@@ -186,7 +186,7 @@
                         "mandatory": true
                     }],
                     "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}\u2019s <em>turnover</em>, excluding VAT?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>turnover</em>, excluding VAT?"
                 }],
                 "title": "Turnover"
             }, {
@@ -273,12 +273,12 @@
                 "id": "changes-in-turnover-block",
                 "type": "Question",
                 "questions": [{
-                    "title": "Did any significant changes occur to the turnover for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "id": "changes-in-turnover-question",
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
@@ -323,7 +323,7 @@
                 "id": "changes-in-turnover-block-2",
                 "type": "Question",
                 "questions": [{
-                    "title": "Please indicate the reasons for any changes in the turnover for {{metadata['trad_as_or_ru_name']}}",
+                    "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                     "answers": [{
                         "options": [{
                             "q_code": "146a",
@@ -369,7 +369,7 @@
                 "questions": [{
                     "type": "General",
                     "id": "changes-in-turnover-question-3",
-                    "title": "Please describe the changes in turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "answers": [{
                         "guidance": {
                             "hide_guidance": "Hide examples of commentary on changes to turnover",

--- a/data/en/mbs_0251.json
+++ b/data/en/mbs_0251.json
@@ -31,8 +31,8 @@
         "name": "employment_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "section",
@@ -213,7 +213,7 @@
                         "default": 0
                     }],
                     "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}\u2019s <em>total turnover</em>, excluding VAT?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total turnover</em>, excluding VAT?"
                 }],
                 "routing_rules": [{
                     "goto": {
@@ -360,7 +360,7 @@
                         }]
                     },
                     "id": "number-of-employees-total-question",
-                    "title": "On {{metadata['employment_date']|format_date}}, what was the number of employees for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "On {{metadata['employment_date']|format_date}}, what was the number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "type": "General"
                 }],
                 "title": "Employees",
@@ -392,7 +392,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-zero-employees-question",
-                    "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{metadata['trad_as_or_ru_name']}} was <em>0</em>, is this correct?"
+                    "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} was <em>0</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {
@@ -478,12 +478,12 @@
                 "id": "changes-in-turnover-block",
                 "type": "Question",
                 "questions": [{
-                    "title": "Did any significant changes occur to the total turnover for {{ metadata['trad_as_or_ru_name'] }}?",
+                    "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "id": "changes-in-turnover-question",
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
@@ -528,7 +528,7 @@
                 "id": "changes-in-turnover-block-2",
                 "type": "Question",
                 "questions": [{
-                    "title": "Please indicate the reasons for any changes in the total turnover for {{ metadata['trad_as_or_ru_name'] }}",
+                    "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                     "answers": [{
                         "options": [{
                             "q_code": "146a",
@@ -574,7 +574,7 @@
                 "questions": [{
                     "type": "General",
                     "id": "changes-in-turnover-question-3",
-                    "title": "Please describe the changes in total turnover for {{ metadata['trad_as_or_ru_name'] }} in more detail",
+                    "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "answers": [{
                         "guidance": {
                             "hide_guidance": "Hide examples of commentary on changes to total turnover",

--- a/data/en/mbs_0253.json
+++ b/data/en/mbs_0253.json
@@ -30,8 +30,8 @@
         "name": "employment_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "section",
@@ -175,7 +175,7 @@
                 "questions": [{
                     "id": "water-volume-question",
                     "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the total volume of {{metadata['trad_as_or_ru_name']}}\u2019s <em>potable water that was supplied to customers</em>, in megalitres?",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the total volume of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>potable water that was supplied to customers</em>, in megalitres?",
                     "answers": [{
                         "id": "water-volume",
                         "mandatory": true,
@@ -199,7 +199,7 @@
                         "default": 0
                     }],
                     "id": "total-number-employees-question",
-                    "title": "On {{metadata['employment_date']|format_date}} what was the number of employees for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "On {{metadata['employment_date']|format_date}} what was the number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "description": "An employee is anyone aged 16 years or over that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job or being on a training scheme.",
                     "guidance": {
                         "content": [{
@@ -240,7 +240,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-zero-employees-question",
-                    "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{metadata['trad_as_or_ru_name']}} was <em>0</em>, is this correct?"
+                    "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} was <em>0</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {
@@ -329,11 +329,11 @@
                 "questions": [{
                     "type": "General",
                     "id": "significant-change-question",
-                    "title": "Did any significant changes occur to the figures provided for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the figures provided for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
@@ -380,7 +380,7 @@
                     }],
                     "description": "We rely on your commentary to \u2018tell the story\u2019 behind changes in figures. By commenting here it will reduce the need for us to call you.",
                     "id": "change-comment-question",
-                    "title": "Please describe the changes for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "type": "General"
                 }],
                 "title": "Significant changes"

--- a/data/en/mbs_0255.json
+++ b/data/en/mbs_0255.json
@@ -32,8 +32,8 @@
         "name": "employment_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "section",
@@ -214,7 +214,7 @@
                         "mandatory": true
                     }],
                     "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}\u2019s <em>turnover</em>, excluding VAT?"
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>turnover</em>, excluding VAT?"
                 }],
                 "title": "Turnover"
             }, {
@@ -319,7 +319,7 @@
                         }]
                     },
                     "id": "number-of-employees-total-question",
-                    "title": "On {{metadata['employment_date']|format_date}}, what was the number of employees for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "On {{metadata['employment_date']|format_date}}, what was the number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "type": "General"
                 }],
                 "title": "Employees",
@@ -351,7 +351,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-zero-employees-question",
-                    "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{metadata['trad_as_or_ru_name']}} was <em>0</em>, is this correct?"
+                    "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} was <em>0</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {
@@ -437,12 +437,12 @@
                 "id": "changes-in-turnover-block",
                 "type": "Question",
                 "questions": [{
-                    "title": "Did any significant changes occur to the turnover for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "id": "changes-in-turnover-question",
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
@@ -487,7 +487,7 @@
                 "id": "changes-in-turnover-block-2",
                 "type": "Question",
                 "questions": [{
-                    "title": "Please indicate the reasons for any changes in the turnover for {{metadata['trad_as_or_ru_name']}}",
+                    "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                     "answers": [{
                         "options": [{
                             "q_code": "146a",
@@ -533,7 +533,7 @@
                 "questions": [{
                     "type": "General",
                     "id": "changes-in-turnover-question-3",
-                    "title": "Please describe the changes in turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "answers": [{
                         "guidance": {
                             "hide_guidance": "Hide examples of commentary on changes to turnover",

--- a/data/en/mbs_0817.json
+++ b/data/en/mbs_0817.json
@@ -27,8 +27,8 @@
         "name": "ref_p_end_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "section",
@@ -178,7 +178,7 @@
                         "mandatory": true
                     }],
                     "type": "General",
-                    "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}\u2019s <em>total turnover</em>, excluding VAT?"
+                    "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total turnover</em>, excluding VAT?"
                 }],
                 "title": "Total turnover"
             }, {
@@ -221,12 +221,12 @@
                 "id": "changes-in-turnover-block",
                 "type": "Question",
                 "questions": [{
-                    "title": "Did any significant changes occur to the turnover for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "id": "changes-in-turnover-question",
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
@@ -271,7 +271,7 @@
                 "id": "changes-in-turnover-block-2",
                 "type": "Question",
                 "questions": [{
-                    "title": "Please indicate the reasons for any changes in the turnover for {{metadata['trad_as_or_ru_name']}}",
+                    "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                     "answers": [{
                         "options": [{
                             "q_code": "146a",
@@ -317,7 +317,7 @@
                 "questions": [{
                     "type": "General",
                     "id": "changes-in-turnover-question-3",
-                    "title": "Please describe the changes in turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "answers": [{
                         "guidance": {
                             "hide_guidance": "Hide examples of commentary on changes to turnover",

--- a/data/en/mbs_0823.json
+++ b/data/en/mbs_0823.json
@@ -27,8 +27,8 @@
         "name": "ref_p_end_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "section",
@@ -178,7 +178,7 @@
                         "mandatory": true
                     }],
                     "type": "General",
-                    "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}\u2019s <em>total turnover</em>, excluding VAT?"
+                    "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total turnover</em>, excluding VAT?"
                 }],
                 "title": "Total Turnover"
             }, {
@@ -221,12 +221,12 @@
                 "id": "changes-in-turnover-block",
                 "type": "Question",
                 "questions": [{
-                    "title": "Did any significant changes occur to the total turnover for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "id": "changes-in-turnover-question",
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
@@ -271,7 +271,7 @@
                 "id": "changes-in-turnover-block-2",
                 "type": "Question",
                 "questions": [{
-                    "title": "Please indicate the reasons for any changes in the total turnover for {{metadata['trad_as_or_ru_name']}}",
+                    "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                     "answers": [{
                         "options": [{
                             "q_code": "146a",
@@ -317,7 +317,7 @@
                 "questions": [{
                     "type": "General",
                     "id": "changes-in-turnover-question-3",
-                    "title": "Please describe the changes in total turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "answers": [{
                         "guidance": {
                             "hide_guidance": "Hide examples of commentary on changes to total turnover",

--- a/data/en/mbs_0867.json
+++ b/data/en/mbs_0867.json
@@ -30,8 +30,8 @@
         "name": "employment_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "section",
@@ -204,7 +204,7 @@
                         "mandatory": true
                     }],
                     "type": "General",
-                    "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}\u2019s <em>total turnover</em>, excluding VAT?"
+                    "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total turnover</em>, excluding VAT?"
                 }],
                 "title": "Total turnover"
             }, {
@@ -265,7 +265,7 @@
                         }]
                     },
                     "id": "number-of-employees-total-question",
-                    "title": "On {{metadata['employment_date']|format_date}}, what was the number of employees for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "On {{metadata['employment_date']|format_date}}, what was the number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "type": "General"
                 }],
                 "title": "Employees",
@@ -297,7 +297,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-zero-employees-question",
-                    "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{metadata['trad_as_or_ru_name']}} was <em>0</em>, is this correct?"
+                    "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} was <em>0</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {
@@ -383,12 +383,12 @@
                 "id": "changes-in-turnover-block",
                 "type": "Question",
                 "questions": [{
-                    "title": "Did any significant changes occur to the turnover for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "id": "changes-in-turnover-question",
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
@@ -433,7 +433,7 @@
                 "id": "changes-in-turnover-block-2",
                 "type": "Question",
                 "questions": [{
-                    "title": "Please indicate the reasons for any changes in the turnover for {{metadata['trad_as_or_ru_name']}}",
+                    "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                     "answers": [{
                         "options": [{
                             "q_code": "146a",
@@ -479,7 +479,7 @@
                 "questions": [{
                     "type": "General",
                     "id": "changes-in-turnover-question-3",
-                    "title": "Please describe the changes in turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "answers": [{
                         "guidance": {
                             "hide_guidance": "Hide examples of commentary on changes to turnover",

--- a/data/en/mbs_0873.json
+++ b/data/en/mbs_0873.json
@@ -30,8 +30,8 @@
         "name": "employment_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "section",
@@ -204,7 +204,7 @@
                         "mandatory": true
                     }],
                     "type": "General",
-                    "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{metadata['trad_as_or_ru_name']}}\u2019s <em>total turnover</em>, excluding VAT?"
+                    "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total turnover</em>, excluding VAT?"
                 }],
                 "title": "Total Turnover"
             }, {
@@ -265,7 +265,7 @@
                         }]
                     },
                     "id": "number-of-employees-total-question",
-                    "title": "On {{metadata['employment_date']|format_date}}, what was the number of employees for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "On {{metadata['employment_date']|format_date}}, what was the number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "type": "General"
                 }],
                 "title": "Employees",
@@ -297,7 +297,7 @@
                         "mandatory": true
                     }],
                     "id": "confirm-zero-employees-question",
-                    "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{metadata['trad_as_or_ru_name']}} was <em>0</em>, is this correct?"
+                    "title": "On {{metadata['employment_date']|format_date}}, the number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} was <em>0</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {
@@ -383,12 +383,12 @@
                 "id": "changes-in-turnover-block",
                 "type": "Question",
                 "questions": [{
-                    "title": "Did any significant changes occur to the total turnover for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "id": "changes-in-turnover-question",
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
@@ -433,7 +433,7 @@
                 "id": "changes-in-turnover-block-2",
                 "type": "Question",
                 "questions": [{
-                    "title": "Please indicate the reasons for any changes in the total turnover for {{metadata['trad_as_or_ru_name']}}",
+                    "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                     "answers": [{
                         "options": [{
                             "q_code": "146a",
@@ -479,7 +479,7 @@
                 "questions": [{
                     "type": "General",
                     "id": "changes-in-turnover-question-3",
-                    "title": "Please describe the changes in total turnover for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "answers": [{
                         "guidance": {
                             "hide_guidance": "Hide examples of commentary on changes to total turnover",

--- a/data/en/mci_transformation.json
+++ b/data/en/mci_transformation.json
@@ -29,8 +29,8 @@
         "name": "ref_p_end_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "default-section",
@@ -223,7 +223,7 @@
                 "title": "Total turnover excluding VAT",
                 "questions": [{
                     "id": "total-turnover-question",
-                    "title": "For the period {{format_conditional_date(answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date(answers['period-to'], metadata['ref_p_end_date'])}}, how much was {{metadata['trad_as_or_ru_name']}}\u2019s <em>total turnover excluding VAT</em>?",
+                    "title": "For the period {{format_conditional_date(answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date(answers['period-to'], metadata['ref_p_end_date'])}}, how much was {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total turnover excluding VAT</em>?",
                     "type": "General",
                     "guidance": {
                         "content": [{
@@ -547,12 +547,12 @@
                 "type": "Question",
                 "questions": [{
                     "id": "significant-change-question",
-                    "title": "Did any significant changes occur to the <em>retail sales</em> for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the <em>retail sales</em> for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "type": "General",
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
@@ -597,7 +597,7 @@
                 "title": "Changes in retail sales",
                 "questions": [{
                     "id": "reason-for-change-question",
-                    "title": "Please indicate the reasons for any changes in the <em>retail sales</em> for {{metadata['trad_as_or_ru_name']}}",
+                    "title": "Please indicate the reasons for any changes in the <em>retail sales</em> for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                     "type": "General",
                     "answers": [{
                         "id": "reason-for-change-answer",
@@ -640,7 +640,7 @@
                 "title": "Changes in retail sales",
                 "questions": [{
                     "id": "significant-change-comment-question",
-                    "title": "Please describe the changes in <em>retail sales</em> for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes in <em>retail sales</em> for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "type": "General",
                     "description": "We rely on your commentary to \u2018tell the story\u2019 behind changes in figures. By commenting here it will reduce the need for us to call you.",
                     "answers": [{

--- a/data/en/mts_0001.json
+++ b/data/en/mts_0001.json
@@ -24,8 +24,8 @@
             "validator": "string"
         },
         {
-            "name": "trad_as_or_ru_name",
-            "validator": "string"
+            "name": "trad_as",
+            "validator": "optional_string"
         },
         {
             "name": "ru_name",
@@ -377,7 +377,7 @@
                             "type": "Question",
                             "questions": [{
                                 "id": "question2936",
-                                "title": "Did any significant changes occur to the <em>retail sales</em> for {{ metadata['trad_as_or_ru_name'] }}?",
+                                "title": "Did any significant changes occur to the <em>retail sales</em> for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                                 "guidance": {
                                     "content": [{
                                             "description": "<strong>For example</strong>"
@@ -396,7 +396,7 @@
                                 "definitions": [{
                                     "title": "What constitutes a significant change?",
                                     "content": [{
-                                            "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ metadata['trad_as_or_ru_name'] }}’s figures from the previous reporting period and the same reporting period last year."
+                                            "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
                                         },
                                         {
                                             "description": "This information will help us to validate your data and should reduce the need for us to query any figures with you."
@@ -448,7 +448,7 @@
                             "type": "Question",
                             "questions": [{
                                 "id": "question2937",
-                                "title": "Please indicate the reasons for any changes in the <em>retail sales</em> for {{ metadata['trad_as_or_ru_name'] }}",
+                                "title": "Please indicate the reasons for any changes in the <em>retail sales</em> for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                                 "description": "",
                                 "type": "General",
                                 "answers": [{
@@ -494,7 +494,7 @@
                             "type": "Question",
                             "questions": [{
                                 "id": "question2938",
-                                "title": "Please describe the changes in <em>retail sales</em> for {{ metadata['trad_as_or_ru_name'] }} in more detail.",
+                                "title": "Please describe the changes in <em>retail sales</em> for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail.",
                                 "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here, it will reduce the need for us to call you.",
                                 "type": "General",
                                 "answers": [{
@@ -525,14 +525,14 @@
                             "type": "Question",
                             "questions": [{
                                 "id": "question2939",
-                                "title": "For the period {{ format_conditional_date (answers['period-from-answer'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to-answer'], metadata['ref_p_end_date'])}}, did {{ metadata['trad_as_or_ru_name'] }} have turnover from <em>any activities other than retail sales</em>?",
+                                "title": "For the period {{ format_conditional_date (answers['period-from-answer'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to-answer'], metadata['ref_p_end_date'])}}, did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} have turnover from <em>any activities other than retail sales</em>?",
                                 "type": "General",
                                 "answers": [{
                                     "id": "answer3820",
                                     "guidance": {
                                         "show_guidance": "Why your answer is important",
                                         "content": [{
-                                            "description": "We want to understand if we are missing any turnover from other activities for {{ metadata['trad_as_or_ru_name'] }} outside of retail sales"
+                                            "description": "We want to understand if we are missing any turnover from other activities for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} outside of retail sales"
                                         }]
                                     },
                                     "mandatory": true,
@@ -577,7 +577,7 @@
                             "type": "Question",
                             "questions": [{
                                 "id": "question2940",
-                                "title": "For the period {{ format_conditional_date (answers['period-from-answer'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to-answer'], metadata['ref_p_end_date'])}}, <em>approximately what percentage</em> of {{ metadata['trad_as_or_ru_name'] }} turnover was <em>from other activities</em>?",
+                                "title": "For the period {{ format_conditional_date (answers['period-from-answer'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to-answer'], metadata['ref_p_end_date'])}}, <em>approximately what percentage</em> of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} turnover was <em>from other activities</em>?",
                                 "guidance": {
                                     "content": [{
                                             "description": "Exclude:"

--- a/data/en/mts_1.json
+++ b/data/en/mts_1.json
@@ -32,8 +32,8 @@
             "validator": "date"
         },
         {
-            "name": "trad_as_or_ru_name",
-            "validator": "string"
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "sections": [{
@@ -247,7 +247,7 @@
                                 "mandatory": true
                             }],
                             "type": "General",
-                            "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, how much was {{metadata['trad_as_or_ru_name']}}’s <em>total turnover, excluding VAT</em>?"
+                            "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, how much was {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>total turnover, excluding VAT</em>?"
                         }],
                         "title": "Total Turnover"
                     },
@@ -345,9 +345,9 @@
                         "id": "changes-in-turnover-block",
                         "type": "Question",
                         "questions": [{
-                            "title": "Did any significant changes occur to the <em>turnover</em> for {{metadata['trad_as_or_ru_name']}}?",
+                            "title": "Did any significant changes occur to the <em>turnover</em> for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                             "id": "changes-in-turnover-question",
-                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
+                            "description": "<p>Please note: what constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year. </p><p>This information will help us to validate your data and should reduce the need to query any figures with you. </p>",
                             "answers": [{
                                 "options": [{
                                         "value": "Yes",
@@ -400,7 +400,7 @@
                         "id": "changes-in-turnover-block-2",
                         "type": "Question",
                         "questions": [{
-                            "title": "Please indicate the reasons for any changes in the <em>turnover</em> for {{metadata['trad_as_or_ru_name']}}",
+                            "title": "Please indicate the reasons for any changes in the <em>turnover</em> for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                             "answers": [{
                                 "options": [{
                                         "q_code": "146a",
@@ -454,7 +454,7 @@
                         "questions": [{
                             "type": "General",
                             "id": "changes-in-turnover-question-3",
-                            "title": "Please describe the changes in <em>turnover</em> for {{metadata['trad_as_or_ru_name']}} in more detail",
+                            "title": "Please describe the changes in <em>turnover</em> for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                             "answers": [{
                                 "guidance": {
                                     "hide_guidance": "Hide examples of commentary on changes to total turnover",

--- a/data/en/qcas_0018.json
+++ b/data/en/qcas_0018.json
@@ -33,8 +33,8 @@
             "validator": "date"
         },
         {
-            "name": "trad_as_or_ru_name",
-            "validator": "string"
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "sections": [{
@@ -749,11 +749,11 @@
                         "type": "Question",
                         "questions": [{
                             "id": "any-significant-changes-question",
-                            "title": "Did any significant changes occur to the total investment for {{ metadata['trad_as_or_ru_name'] }}?",
+                            "title": "Did any significant changes occur to the total investment for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                             "definitions": [{
                                 "title": "What constitutes a significant change?",
                                 "content": [{
-                                    "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ metadata['trad_as_or_ru_name'] }}’s figures from the previous reporting period and the same reporting period last year."
+                                    "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
                                 }]
                             }],
                             "type": "General",
@@ -796,7 +796,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "significant-changes-reason-question-1",
-                            "title": "Please indicate the reasons for any changes in the total investment for {{ metadata['trad_as_or_ru_name'] }}",
+                            "title": "Please indicate the reasons for any changes in the total investment for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                             "type": "General",
                             "answers": [{
                                 "id": "significant-changes-reason-answer",
@@ -862,7 +862,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "significant-changes-reason-question-2",
-                            "title": "Please describe the changes in total investment for {{ metadata['trad_as_or_ru_name'] }} in more detail.",
+                            "title": "Please describe the changes in total investment for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail.",
                             "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
                             "type": "General",
                             "answers": [{

--- a/data/en/qcas_0019.json
+++ b/data/en/qcas_0019.json
@@ -33,8 +33,8 @@
             "validator": "date"
         },
         {
-            "name": "trad_as_or_ru_name",
-            "validator": "string"
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "sections": [{
@@ -749,11 +749,11 @@
                         "type": "Question",
                         "questions": [{
                             "id": "any-significant-changes-question",
-                            "title": "Did any significant changes occur to the total investment for {{ metadata['trad_as_or_ru_name'] }}?",
+                            "title": "Did any significant changes occur to the total investment for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                             "definitions": [{
                                 "title": "What constitutes a significant change?",
                                 "content": [{
-                                    "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ metadata['trad_as_or_ru_name'] }}’s figures from the previous reporting period and the same reporting period last year."
+                                    "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
                                 }]
                             }],
                             "type": "General",
@@ -796,7 +796,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "significant-changes-reason-question-1",
-                            "title": "Please indicate the reasons for any changes in the total investment for {{ metadata['trad_as_or_ru_name'] }}",
+                            "title": "Please indicate the reasons for any changes in the total investment for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                             "type": "General",
                             "answers": [{
                                 "id": "significant-changes-reason-answer",
@@ -862,7 +862,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "significant-changes-reason-question-2",
-                            "title": "Please describe the changes in total investment for {{ metadata['trad_as_or_ru_name'] }} in more detail.",
+                            "title": "Please describe the changes in total investment for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail.",
                             "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
                             "type": "General",
                             "answers": [{

--- a/data/en/qcas_0020.json
+++ b/data/en/qcas_0020.json
@@ -33,8 +33,8 @@
             "validator": "date"
         },
         {
-            "name": "trad_as_or_ru_name",
-            "validator": "string"
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "sections": [{
@@ -800,11 +800,11 @@
                         "type": "Question",
                         "questions": [{
                             "id": "any-significant-changes-question",
-                            "title": "Did any significant changes occur to the total investment for {{ metadata['trad_as_or_ru_name'] }}?",
+                            "title": "Did any significant changes occur to the total investment for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                             "definitions": [{
                                 "title": "What constitutes a significant change?",
                                 "content": [{
-                                    "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ metadata['trad_as_or_ru_name'] }}’s figures from the previous reporting period and the same reporting period last year."
+                                    "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
                                 }]
                             }],
                             "type": "General",
@@ -847,7 +847,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "significant-changes-reason-question-1",
-                            "title": "Please indicate the reasons for any changes in the total investment for {{ metadata['trad_as_or_ru_name'] }}",
+                            "title": "Please indicate the reasons for any changes in the total investment for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                             "type": "General",
                             "answers": [{
                                 "id": "significant-changes-reason-answer",
@@ -913,7 +913,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "significant-changes-reason-question-2",
-                            "title": "Please describe the changes in total investment for {{ metadata['trad_as_or_ru_name'] }} in more detail.",
+                            "title": "Please describe the changes in total investment for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail.",
                             "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
                             "type": "General",
                             "answers": [{

--- a/data/en/rsi_transformation.json
+++ b/data/en/rsi_transformation.json
@@ -29,8 +29,8 @@
         "name": "ref_p_end_date",
         "validator": "date"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "default-section",
@@ -195,7 +195,7 @@
                         "default": 0
                     }],
                     "id": "total-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, how much was {{metadata['trad_as_or_ru_name']}}\u2019s <em>total turnover excluding VAT</em>?",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, how much was {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total turnover excluding VAT</em>?",
                     "type": "General"
                 }],
                 "title": "Total turnover excluding VAT"
@@ -370,13 +370,13 @@
                     "definitions": [{
                         "title": "What constitutes a significant change?",
                         "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{metadata['trad_as_or_ru_name']}}\u2019s figures from the previous reporting period and the same reporting period last year."
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
                         }, {
                             "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
                         }]
                     }],
                     "id": "significant-change-question",
-                    "title": "Did any significant changes occur to the retail sales for {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "Did any significant changes occur to the retail sales for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "type": "General"
                 }],
                 "title": "Changes in retail sales",
@@ -434,7 +434,7 @@
                         "type": "Checkbox"
                     }],
                     "id": "reason-for-change-question",
-                    "title": "Please indicate the reasons for any changes in the retail sales for {{metadata['trad_as_or_ru_name']}}",
+                    "title": "Please indicate the reasons for any changes in the retail sales for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                     "type": "General"
                 }],
                 "title": "Changes in retail sales"
@@ -465,7 +465,7 @@
                     }],
                     "description": "We rely on your commentary to \u2018tell the story\u2019 behind changes in figures. By commenting here it will reduce the need for us to call you.",
                     "id": "change-comment-question",
-                    "title": "Please describe the changes in retail sales for {{metadata['trad_as_or_ru_name']}} in more detail",
+                    "title": "Please describe the changes in retail sales for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
                     "type": "General"
                 }],
                 "title": "Changes in retail sales"

--- a/data/en/test_confirmation_question.json
+++ b/data/en/test_confirmation_question.json
@@ -23,8 +23,8 @@
         "name": "ru_name",
         "validator": "string"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
+        "name": "trad_as",
+        "validator": "optional_string"
     }],
     "sections": [{
         "id": "default-section",
@@ -44,7 +44,7 @@
                         "default": 0
                     }],
                     "id": "number-of-employees-total-question",
-                    "title": "How many employees work at {{metadata['trad_as_or_ru_name']}}?",
+                    "title": "How many employees work at {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                     "type": "General"
                 }],
                 "type": "Question"
@@ -75,7 +75,7 @@
                         "q_code": "d50"
                     }],
                     "id": "confirm-zero-employees-question",
-                    "title": "The current number of employees for {{metadata['trad_as_or_ru_name']}} is <em>0</em>, is this correct?"
+                    "title": "The current number of employees for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} is <em>0</em>, is this correct?"
                 }],
                 "routing_rules": [{
                     "goto": {

--- a/data/en/test_metadata_validation.json
+++ b/data/en/test_metadata_validation.json
@@ -18,10 +18,6 @@
             "validator": "string"
         },
         {
-            "name": "trad_as_or_ru_name",
-            "validator": "string"
-        },
-        {
             "name": "ru_name",
             "validator": "string"
         },
@@ -43,9 +39,6 @@
                     "primary_content": [{
                         "content": [{
                                 "title": "(String) trad_as: {{ metadata['trad_as'] }}"
-                            },
-                            {
-                                "title": "(Computed String) trad_as_or_ru_name: {{ metadata['trad_as_or_ru_name'] }}"
                             },
                             {
                                 "title": "(Date) ref_p_start_date: {{ metadata['ref_p_start_date'] }}"

--- a/data/en/test_schema_context.json
+++ b/data/en/test_schema_context.json
@@ -22,9 +22,6 @@
         "name": "trad_as",
         "validator": "string"
     }, {
-        "name": "trad_as_or_ru_name",
-        "validator": "string"
-    }, {
         "name": "ref_p_start_date",
         "validator": "date"
     }, {
@@ -56,8 +53,6 @@
                         "title": "ru_name: {{ metadata['ru_name'] }}"
                     }, {
                         "title": "trad_as: {{ metadata['trad_as'] }}"
-                    }, {
-                        "title": "trad_as_or_ru_name: {{ metadata['trad_as_or_ru_name'] }}"
                     }, {
                         "title": "ref_p_start_date: {{ metadata['ref_p_start_date'] }}"
                     }, {

--- a/data/en/ukis_0001.json
+++ b/data/en/ukis_0001.json
@@ -27,8 +27,8 @@
             "validator": "string"
         },
         {
-            "name": "trad_as_or_ru_name",
-            "validator": "string"
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "sections": [{
@@ -44,7 +44,7 @@
                         "id": "get-started",
                         "content": [{
                                 "list": [
-                                    "Please complete this voluntary questionnaire for {{ metadata.trad_as_or_ru_name }}.",
+                                    "Please complete this voluntary questionnaire for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}.",
                                     "If this business is part of an enterprise group, please answer all questions for this business in the UK only.",
                                     "Do not include results for subsidiaries or parent enterprises.",
                                     "You can provide informed estimates if actual figures aren’t available.",
@@ -56,7 +56,7 @@
                                 "list": [
                                     "Innovation, for the purpose of this survey, is defined as <strong>new</strong> or <strong>significantly improved goods or services</strong> as well as <strong>processes</strong> used to produce or supply all goods or services that has introduced, regardless of their origin.",
                                     "These innovations may be new to you or new to the market.",
-                                    "Investments for future innovation and changes that {{ metadata.trad_as_or_ru_name }} has introduced at a <strong>strategic</strong> level (in organisation and practices) are also covered."
+                                    "Investments for future innovation and changes that {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} has introduced at a <strong>strategic</strong> level (in organisation and practices) are also covered."
                                 ]
                             },
                             {
@@ -90,7 +90,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2396",
-                            "title": "In which geographic markets did {{ metadata.trad_as_or_ru_name }} offer goods and/or services?",
+                            "title": "In which geographic markets did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} offer goods and/or services?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -124,7 +124,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2397",
-                            "title": "Did any of the following significant events or changes occur to {{ metadata.trad_as_or_ru_name }}?",
+                            "title": "Did any of the following significant events or changes occur to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                             "description": "",
                             "type": "MutuallyExclusive",
                             "mandatory": false,
@@ -135,8 +135,8 @@
                                     "label": "",
                                     "description": "",
                                     "options": [{
-                                            "label": "{{ metadata.trad_as_or_ru_name }} was established",
-                                            "value": "{{ metadata.trad_as_or_ru_name }} was established"
+                                            "label": "{{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} was established",
+                                            "value": "{{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} was established"
                                         },
                                         {
                                             "label": "Turnover increased by at least 10% due to merger with another business or part of it",
@@ -182,7 +182,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2400",
-                            "title": "Did {{ metadata.trad_as_or_ru_name }} make changes in any of the following areas?",
+                            "title": "Did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} make changes in any of the following areas?",
                             "guidance": {
                                 "content": [{
                                         "description": "<strong>Include:</strong>"
@@ -283,7 +283,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2428",
-                            "title": "Did {{ metadata.trad_as_or_ru_name }} invest in <em>internal Research and Development</em> for the purposes of current or future innovation?",
+                            "title": "Did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} invest in <em>internal Research and Development</em> for the purposes of current or future innovation?",
                             "description": "",
                             "type": "General",
                             "definitions": [{
@@ -331,7 +331,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2426",
-                            "title": "In which of the following years did {{ metadata.trad_as_or_ru_name }} invest in <em>internal Research & Development?</em>",
+                            "title": "In which of the following years did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} invest in <em>internal Research & Development?</em>",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -411,7 +411,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2430",
-                            "title": "Did {{ metadata.trad_as_or_ru_name }} invest in the <em>acquisition of Research and Development</em> for the purposes of current or future innovation?",
+                            "title": "Did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} invest in the <em>acquisition of Research and Development</em> for the purposes of current or future innovation?",
                             "guidance": {
                                 "content": [{
                                         "description": "<strong>Include:</strong>"
@@ -498,7 +498,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2437",
-                            "title": "Did {{ metadata.trad_as_or_ru_name }} invest in <em>acquisition of advanced machinery, equipment or software</em> for the purposes of current or future innovation?",
+                            "title": "Did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} invest in <em>acquisition of advanced machinery, equipment or software</em> for the purposes of current or future innovation?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -540,7 +540,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2438",
-                            "title": "Which of the following did {{ metadata.trad_as_or_ru_name }} invest in for the purposes of current or future innovation?",
+                            "title": "Which of the following did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} invest in for the purposes of current or future innovation?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -604,7 +604,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2440",
-                            "title": "Did {{ metadata.trad_as_or_ru_name }} invest in the <em>acquisition of existing knowledge</em> for the purposes of current or future innovation?",
+                            "title": "Did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} invest in the <em>acquisition of existing knowledge</em> for the purposes of current or future innovation?",
                             "guidance": {
                                 "content": [{
                                         "description": "<strong>Include: </strong>"
@@ -664,7 +664,7 @@
                                     },
                                     {
                                         "list": [
-                                            "internal costs and purchase from outside {{ metadata.trad_as_or_ru_name }}."
+                                            "internal costs and purchase from outside {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}."
                                         ]
                                     }
                                 ]
@@ -691,7 +691,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2442",
-                            "title": "Did {{ metadata.trad_as_or_ru_name }} invest in <em>training for innovative activities</em> for the purposes of current or future innovation?",
+                            "title": "Did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} invest in <em>training for innovative activities</em> for the purposes of current or future innovation?",
                             "guidance": {
                                 "content": [{
                                         "description": "<strong>Include:</strong>"
@@ -778,7 +778,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2444",
-                            "title": "Did {{ metadata.trad_as_or_ru_name }} invest in <em>any form of design activity</em> for the purposes of current or future innovation?",
+                            "title": "Did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} invest in <em>any form of design activity</em> for the purposes of current or future innovation?",
                             "guidance": {
                                 "content": [{
                                         "description": "<strong>Include:</strong>"
@@ -865,7 +865,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2446",
-                            "title": "Did {{ metadata.trad_as_or_ru_name }} invest in <em>market introduction of innovations</em> for the purposes of current or future innovation?",
+                            "title": "Did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} invest in <em>market introduction of innovations</em> for the purposes of current or future innovation?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -907,7 +907,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2447",
-                            "title": "Which of the following did {{ metadata.trad_as_or_ru_name }} invest in for the purposes of current or future innovation?",
+                            "title": "Which of the following did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} invest in for the purposes of current or future innovation?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -997,7 +997,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2449",
-                            "title": "Did {{ metadata.trad_as_or_ru_name }} introduce new or significantly improved <em>goods</em>?",
+                            "title": "Did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} introduce new or significantly improved <em>goods</em>?",
                             "guidance": {
                                 "content": [{
                                         "description": "<strong>Include:</strong>"
@@ -1090,7 +1090,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2451",
-                            "title": "Did {{ metadata.trad_as_or_ru_name }} introduce new or significantly improved <em>services</em>?",
+                            "title": "Did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} introduce new or significantly improved <em>services</em>?",
                             "guidance": {
                                 "content": [{
                                         "description": "<strong>Include:</strong>"
@@ -1247,7 +1247,7 @@
                         }],
                         "questions": [{
                             "id": "question2454",
-                            "title": "Were any of your <em>goods and services innovations</em> only new to {{ metadata.trad_as_or_ru_name }}?",
+                            "title": "Were any of your <em>goods and services innovations</em> only new to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
                             "guidance": {
                                 "content": [{
                                         "description": "<strong>Include:</strong>"
@@ -1302,7 +1302,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2466",
-                            "title": "Did {{ metadata.trad_as_or_ru_name }} introduce any new or significantly improved <em>processes</em> for producing or supplying goods or services?",
+                            "title": "Did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} introduce any new or significantly improved <em>processes</em> for producing or supplying goods or services?",
                             "guidance": {
                                 "content": [{
                                         "description": "<strong>Include:</strong>"
@@ -1387,7 +1387,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2467",
-                            "title": "Did {{ metadata.trad_as_or_ru_name }} introduce any new or significantly improved processes for producing or supplying goods or services which were new to your industry?",
+                            "title": "Did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} introduce any new or significantly improved processes for producing or supplying goods or services which were new to your industry?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -1428,7 +1428,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2469",
-                            "title": "Did {{ metadata.trad_as_or_ru_name }} have any innovation activities that were abandoned, scaled back or ongoing at the end of 2018?",
+                            "title": "Did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} have any innovation activities that were abandoned, scaled back or ongoing at the end of 2018?",
                             "description": "",
                             "type": "MutuallyExclusive",
                             "mandatory": false,
@@ -1472,7 +1472,7 @@
                         "questions": [{
                             "id": "question2471",
                             "title": "How important was any excessive perceived economic risk in constraining innovation activities?",
-                            "description": "What constitutes an answer of ‘high’, ‘medium’, ‘low’ or ‘not important’ is dependent on your own interpretation in relation to {{ metadata.trad_as_or_ru_name }}.",
+                            "description": "What constitutes an answer of ‘high’, ‘medium’, ‘low’ or ‘not important’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}.",
                             "type": "General",
                             "answers": [{
                                 "id": "answer3218",
@@ -2086,7 +2086,7 @@
                         ],
                         "questions": [{
                             "id": "question2483",
-                            "title": "If {{ metadata.trad_as_or_ru_name }} had no innovation activity, why has it not been necessary or possible to innovate?",
+                            "title": "If {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} had no innovation activity, why has it not been necessary or possible to innovate?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -2690,7 +2690,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2497",
-                            "title": "How important to {{ metadata.trad_as_or_ru_name }}’s innovation activities was information from <em>within your business or enterprise group</em>?",
+                            "title": "How important to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s innovation activities was information from <em>within your business or enterprise group</em>?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -2724,7 +2724,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2498",
-                            "title": "How important to {{ metadata.trad_as_or_ru_name }}’s innovation activities was information from <em>suppliers of equipment, materials, services or software</em>?",
+                            "title": "How important to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s innovation activities was information from <em>suppliers of equipment, materials, services or software</em>?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -2758,7 +2758,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2499",
-                            "title": "How important to {{ metadata.trad_as_or_ru_name }}’s innovation activities was information from <em>clients or customers from the public sector</em>?",
+                            "title": "How important to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s innovation activities was information from <em>clients or customers from the public sector</em>?",
                             "description": "",
                             "type": "General",
                             "definitions": [{
@@ -2798,7 +2798,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2500",
-                            "title": "How important to {{ metadata.trad_as_or_ru_name }}’s innovation activities was information from <em>clients or customers from the private sector</em>?",
+                            "title": "How important to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s innovation activities was information from <em>clients or customers from the private sector</em>?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -2832,7 +2832,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2501",
-                            "title": "How important to {{ metadata.trad_as_or_ru_name }}’s innovation activities was information from <em>competitors or other businesses in your industry</em>?",
+                            "title": "How important to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s innovation activities was information from <em>competitors or other businesses in your industry</em>?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -2866,7 +2866,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2496",
-                            "title": "How important to {{ metadata.trad_as_or_ru_name }}’s innovation activities was information from <em>consultants, commercial labs or private Research and Development institutes</em>?",
+                            "title": "How important to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s innovation activities was information from <em>consultants, commercial labs or private Research and Development institutes</em>?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -2900,7 +2900,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2502",
-                            "title": "How important to {{ metadata.trad_as_or_ru_name }}’s innovation activities was information from <em>universities or other higher education institutes</em>?",
+                            "title": "How important to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s innovation activities was information from <em>universities or other higher education institutes</em>?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -2934,7 +2934,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2503",
-                            "title": "How important to {{ metadata.trad_as_or_ru_name }}’s innovation activities was information from <em>government or public research institutes</em>?",
+                            "title": "How important to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s innovation activities was information from <em>government or public research institutes</em>?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -2968,7 +2968,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2504",
-                            "title": "How important to {{ metadata.trad_as_or_ru_name }}’s innovation activities was information from <em>conferences, trade fairs or exhibitions</em>?",
+                            "title": "How important to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s innovation activities was information from <em>conferences, trade fairs or exhibitions</em>?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -3002,7 +3002,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2505",
-                            "title": "How important to {{ metadata.trad_as_or_ru_name }}’s innovation activities was information from <em>professional and industry associations</em>?",
+                            "title": "How important to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s innovation activities was information from <em>professional and industry associations</em>?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -3036,7 +3036,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2506",
-                            "title": "How important to {{ metadata.trad_as_or_ru_name }}’s innovation activities was information from <em>technical, industry or service standards</em>?",
+                            "title": "How important to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s innovation activities was information from <em>technical, industry or service standards</em>?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -3070,7 +3070,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2507",
-                            "title": "How important to {{ metadata.trad_as_or_ru_name }}’s innovation activities was information from <em>scientific journals and trade or technical publications</em>?",
+                            "title": "How important to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s innovation activities was information from <em>scientific journals and trade or technical publications</em>?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -3192,7 +3192,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2528",
-                            "title": "If {{ metadata.trad_as_or_ru_name }} co-operated on any innovation activities with <em>other businesses within your enterprise group</em>, what was their location?",
+                            "title": "If {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} co-operated on any innovation activities with <em>other businesses within your enterprise group</em>, what was their location?",
                             "description": "",
                             "type": "MutuallyExclusive",
                             "mandatory": false,
@@ -3239,7 +3239,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2529",
-                            "title": "If {{ metadata.trad_as_or_ru_name }} co-operated on innovation activities with <em>suppliers of equipment, materials, services or software</em>, what was their location?",
+                            "title": "If {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} co-operated on innovation activities with <em>suppliers of equipment, materials, services or software</em>, what was their location?",
                             "description": "",
                             "type": "MutuallyExclusive",
                             "mandatory": false,
@@ -3286,7 +3286,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2530",
-                            "title": "If {{ metadata.trad_as_or_ru_name }} co-operated on any innovation activities with <em>clients or customers from the private sector</em>, what was their location?",
+                            "title": "If {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} co-operated on any innovation activities with <em>clients or customers from the private sector</em>, what was their location?",
                             "description": "",
                             "type": "MutuallyExclusive",
                             "mandatory": false,
@@ -3333,7 +3333,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2531",
-                            "title": "If {{ metadata.trad_as_or_ru_name }} co-operated on any innovation activities with <em>clients or customers from the public sector</em>, what was their location?",
+                            "title": "If {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} co-operated on any innovation activities with <em>clients or customers from the public sector</em>, what was their location?",
                             "description": "",
                             "type": "MutuallyExclusive",
                             "mandatory": false,
@@ -3386,7 +3386,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2532",
-                            "title": "If {{ metadata.trad_as_or_ru_name }} co-operated on any innovation activities with <em>competitors or other businesses in your industry</em>, what was their location?",
+                            "title": "If {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} co-operated on any innovation activities with <em>competitors or other businesses in your industry</em>, what was their location?",
                             "description": "",
                             "type": "MutuallyExclusive",
                             "mandatory": false,
@@ -3433,7 +3433,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2533",
-                            "title": "If {{ metadata.trad_as_or_ru_name }} co-operated on any innovation activities with <em>consultants, commercial labs or private research and development institutes</em>, what was their location?",
+                            "title": "If {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} co-operated on any innovation activities with <em>consultants, commercial labs or private research and development institutes</em>, what was their location?",
                             "description": "",
                             "type": "MutuallyExclusive",
                             "mandatory": false,
@@ -3480,7 +3480,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2534",
-                            "title": "If {{ metadata.trad_as_or_ru_name }} co-operated on any innovation activities with <em>universities or other higher education institutions</em>, what was their location?",
+                            "title": "If {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} co-operated on any innovation activities with <em>universities or other higher education institutions</em>, what was their location?",
                             "description": "",
                             "type": "MutuallyExclusive",
                             "mandatory": false,
@@ -3527,7 +3527,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2535",
-                            "title": "If {{ metadata.trad_as_or_ru_name }} co-operated on any innovation activities with <em>government or public research institutes</em>, what was their location?",
+                            "title": "If {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} co-operated on any innovation activities with <em>government or public research institutes</em>, what was their location?",
                             "description": "",
                             "type": "MutuallyExclusive",
                             "mandatory": false,
@@ -3574,7 +3574,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question9-9",
-                            "title": "If {{ metadata.trad_as_or_ru_name }} co-operated on any innovation activities with <em>other businesses outside your enterprise group</em>, what was their location?",
+                            "title": "If {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} co-operated on any innovation activities with <em>other businesses outside your enterprise group</em>, what was their location?",
                             "description": "",
                             "type": "MutuallyExclusive",
                             "mandatory": false,
@@ -3621,7 +3621,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question9-10",
-                            "title": "If {{ metadata.trad_as_or_ru_name }} co-operated on any innovation activities with <em>Non-profit organisations</em>, what was their location?",
+                            "title": "If {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} co-operated on any innovation activities with <em>Non-profit organisations</em>, what was their location?",
                             "description": "",
                             "type": "MutuallyExclusive",
                             "mandatory": false,
@@ -3929,7 +3929,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2515",
-                            "title": "Did {{ metadata.trad_as_or_ru_name }} receive public financial support for innovation activities from the following levels of government?",
+                            "title": "Did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} receive public financial support for innovation activities from the following levels of government?",
                             "guidance": {
                                 "content": [{
                                         "description": "<strong>Include:</strong>"
@@ -4008,7 +4008,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2516",
-                            "title": "What kind of financial support was received by {{ metadata.trad_as_or_ru_name }} from <em>UK central government</em>?",
+                            "title": "What kind of financial support was received by {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} from <em>UK central government</em>?",
                             "description": "",
                             "type": "MutuallyExclusive",
                             "mandatory": false,
@@ -4067,7 +4067,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2518",
-                            "title": "What was {{ metadata.trad_as_or_ru_name }}’s estimated total turnover for the calendar years 2016 and 2018, excluding VAT?",
+                            "title": "What was {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s estimated total turnover for the calendar years 2016 and 2018, excluding VAT?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -4130,7 +4130,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2455",
-                            "title": "What was the estimated percentage of {{ metadata.trad_as_or_ru_name }}’s <em>total turnover</em> in <em>2018</em> from goods and services for each of the following definitions?",
+                            "title": "What was the estimated percentage of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>total turnover</em> in <em>2018</em> from goods and services for each of the following definitions?",
                             "guidance": {
                                 "content": [{
                                         "description": "<strong>Include:</strong>"
@@ -4138,7 +4138,7 @@
                                     {
                                         "list": [
                                             "turnover for goods and services introduced during the calendar year 2018 only",
-                                            "100% in the ‘Unchanged or only marginally modified’ answer field if {{ metadata.trad_as_or_ru_name }} did not introduce any new or significantly improved goods or services"
+                                            "100% in the ‘Unchanged or only marginally modified’ answer field if {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} did not introduce any new or significantly improved goods or services"
                                         ]
                                     }
                                 ]
@@ -4235,7 +4235,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2520",
-                            "title": "What was {{ metadata.trad_as_or_ru_name }}’s total estimated value of exports for the <em>calendar year 2018 only</em>, excluding VAT?",
+                            "title": "What was {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s total estimated value of exports for the <em>calendar year 2018 only</em>, excluding VAT?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -4273,7 +4273,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2523",
-                            "title": "What was {{ metadata.trad_as_or_ru_name }}’s estimated number of employees for the <em>calendar years 2016 and 2018</em>?",
+                            "title": "What was {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s estimated number of employees for the <em>calendar years 2016 and 2018</em>?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -4351,7 +4351,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2524",
-                            "title": "Did {{ metadata.trad_as_or_ru_name }} employ individuals in-house with the following skills at any level, or obtain these skills from external sources?",
+                            "title": "Did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} employ individuals in-house with the following skills at any level, or obtain these skills from external sources?",
                             "description": "",
                             "type": "General",
                             "answers": [{
@@ -4475,7 +4475,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question2527",
-                            "title": "Would {{ metadata.trad_as_or_ru_name }} be willing to be approached by telephone by the Department for Business, Energy and Industrial Strategy or its appointed agents, to ask some further questions about innovation?",
+                            "title": "Would {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} be willing to be approached by telephone by the Department for Business, Energy and Industrial Strategy or its appointed agents, to ask some further questions about innovation?",
                             "description": "",
                             "type": "General",
                             "answers": [{

--- a/tests/app/parser/test_metadata_parser.py
+++ b/tests/app/parser/test_metadata_parser.py
@@ -236,28 +236,6 @@ class TestMetadataParser(SurveyRunnerTestCase):  # pylint: disable=too-many-publ
 
         self.assertEqual('incorrect data in token for return_by', str(ite_value.exception))
 
-    def test_required_metadata_trad_as_or_ru_name_in_token(self):
-        metadata = {
-            'jti': str(uuid.uuid4()),
-            'user_id': '1',
-            'form_type': 'a',
-            'collection_exercise_sid': 'test-sid',
-            'eq_id': '2',
-            'period_id': '3',
-            'ru_ref': '2016-04-04'
-        }
-
-        self.schema_metadata.append({'name': 'trad_as_or_ru_name', 'validator': 'string'})
-
-        metadata['ru_name'] = 'ESSENTIAL ENTERPRISE LIMITED'
-        validate_metadata(metadata, self.schema_metadata)
-
-        metadata['trad_as_or_ru_name'] = ''
-        metadata['ru_name'] = ''
-        with self.assertRaises(InvalidTokenException) as ite:
-            validate_metadata(metadata, self.schema_metadata)
-        self.assertEqual('incorrect data in token for trad_as_or_ru_name', ite.exception.args[0])
-
     def test_invalid_required_ref_p_start_date(self):
         metadata = {
             'jti': str(uuid.uuid4()),

--- a/tests/app/templating/test_metadata_context.py
+++ b/tests/app/templating/test_metadata_context.py
@@ -61,6 +61,5 @@ class TestMetadataContext(AppContextTestCase):
         self.assertEqual(escaped_bad_characters, metadata_context['ru_ref'])
         self.assertEqual(escaped_bad_characters, metadata_context['ru_name'])
         self.assertEqual(escaped_bad_characters, metadata_context['trad_as'])
-        self.assertEqual(escaped_bad_characters, metadata_context['trad_as_or_ru_name'])
         self.assertEqual(escaped_bad_characters, metadata_context['region_code'])
         self.assertEqual(escaped_bad_characters, metadata_context['collection_id'])

--- a/tests/app/templating/test_schema_context.py
+++ b/tests/app/templating/test_schema_context.py
@@ -313,35 +313,6 @@ class TestBuildSchemaMetadata(TestCase):
         self.assertEqual('2016-10-19', metadata_context['employment_date'])
         self.assertEqual('Steve', metadata_context['user_id'])
 
-    def test_metadata_display_name_is_trad_as_when_trad_as_supplied(self):
-        # Given
-
-        # When
-        metadata_context = build_schema_metadata(self.metadata, self.schema)
-
-        # Then
-        self.assertEqual(metadata_context['trad_as_or_ru_name'], self.metadata['trad_as'])
-
-    def test_metadata_display_name_is_ru_name_as_when_trad_as_not_supplied(self):
-        # Given
-        self.metadata['trad_as'] = None
-
-        # When
-        metadata_context = build_schema_metadata(self.metadata, self.schema)
-
-        # Then
-        self.assertEqual(metadata_context['trad_as_or_ru_name'], self.metadata['ru_name'])
-
-    def test_metadata_display_name_is_ru_name_as_when_trad_as_empty(self):
-        # Given
-        self.metadata['trad_as'] = ''
-
-        # When
-        metadata_context = build_schema_metadata(self.metadata, self.schema)
-
-        # Then
-        self.assertEqual(metadata_context['trad_as_or_ru_name'], self.metadata['ru_name'])
-
     def test_given_quotes_in_trading_name_when_create_context_then_quotes_are_html_encoded(self):
         # Given
         self.metadata['trad_as'] = '\"trading name\"'
@@ -381,24 +352,3 @@ class TestBuildSchemaMetadata(TestCase):
 
         # Then
         self.assertEqual(metadata_context['ru_name'], r'\\ru name\\')
-
-    def test_given_quotes_in_ru_name_or_trading_name_when_create_context_then_quotes_are_html_encoded(self):
-        # Given
-        self.metadata['ru_name'] = '\"ru_name\"'
-        self.metadata['trad_as'] = None
-
-        # When
-        metadata_context = build_schema_metadata(self.metadata, self.schema)
-
-        # Then
-        self.assertEqual(metadata_context['trad_as_or_ru_name'], r'&#34;ru_name&#34;')
-
-    def test_given_backslash_in_ru_name_or_trading_name_when_create_context_then_backslash_are_escaped(self):
-        # Given
-        self.metadata['trad_as'] = '\\trading name\\'
-
-        # When
-        metadata_context = build_schema_metadata(self.metadata, self.schema)
-
-        # Then
-        self.assertEqual(metadata_context['trad_as_or_ru_name'], r'\\trading name\\')


### PR DESCRIPTION
### What is the context of this PR?
Banished `trad_as_or_ru_name`!
The same behaviour is achieved through the use of a jinja filter `display_first_valid_item`, feel free to suggest a better name.

This filter can also be reused to return `one of` any number of arguments. The filter returns the first valid value. I didn't want to make this `trad_as` specifc, so for the purposes of `trad_as_or_ru_name`, `trad_as` must be passed before `ru_name`.

[Trello](https://trello.com/c/DNQvLV4f/2345-removing-hardcoding-of-tradasorruname-logic-from-runner-s)

***Author:***
*Spoke to @samiwel and he is happy for this to go in as is since it doesn't break author. A card also on thier backlog to allow this new style.
For the time being, authors will use `ru_name` instead. This ofcouse will mean, for the time being, a manual change is required.*

### How to review 
Ensure:
- New filter allows same behaviours as before without the hardcoded logic.
- All references to the old style has been replaced with the new style. ***(Affects live surveys)***
- All `trad_as_or_ru_name` logic is removed from runner.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
